### PR TITLE
Fix rxode2 #364

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # nlmixr2est (development version)
 
+- A bug in model piping which did not allow models to be appended to was fixed
+  (rxode2#364)
+
 # nlmixr2est 2.1.3
 
 - Allows `$etaH` and related family to be integrated into a `saem` fit

--- a/R/model.R
+++ b/R/model.R
@@ -1,13 +1,19 @@
 #' @export
 model.nlmixr2FitCore <- function(x, ..., append = FALSE,
-                                 auto = getOption("rxode2.autoVarPiping",TRUE),
+                                 auto = getOption("rxode2.autoVarPiping", TRUE),
                                  envir = parent.frame()) {
   .nlmixr2savePipe(x)
   .modelLines <- rxode2::.quoteCallInfoLines(match.call(expand.dots = TRUE)[-(1:2)],
                                              envir = envir)
   .ret <- rxode2::.copyUi(x$ui)
-  rxode2::.modelHandleModelLines(.modelLines, .ret, modifyIni = FALSE,
-                                 envir=envir)
+  rxode2::.modelHandleModelLines(
+    modelLines = .modelLines,
+    rxui = .ret,
+    append = append,
+    auto = auto,
+    modifyIni = FALSE,
+    envir=envir
+  )
 }
 
 #' @export

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -1,0 +1,61 @@
+nmTest({
+  test_that("model piping", {
+
+    KA1Lode <- function() {
+      ini({
+        ltlag <- log(0.2)
+        lka  <- log(1.15)
+        lcl  <- log(0.135)
+        lv   <- log(8)
+        prop.err <- 0.15
+        add.err  <- 0.6
+        eta.tlag ~ 0.5
+        eta.ka ~ 0.5
+        eta.cl ~ 0.1
+        eta.v  ~ 0.1
+      })
+      model({
+        tlag <- exp(ltlag + eta.tlag)
+        ka <- exp(lka + eta.ka)
+        cl <- exp(lcl + eta.cl)
+        v  <- exp(lv + eta.v)
+        d/dt(gut) <- -ka*gut
+        d/dt(central) <- ka*gut - (cl/v)*central
+        lag(gut) <- tlag
+        cp <- central/v
+        cp ~ prop(prop.err) + add(add.err)
+      })
+    }
+
+    d <- nlmixr2data::warfarin %>%
+      dplyr::filter(dvid=="cp")
+
+    suppressMessages(
+      f <- nlmixr(KA1Lode, data = d, est = "saem", control = saemControl(nBurn = 1, nEm = 1))
+    )
+
+    # General piping model updates work
+    suppressMessages(expect_error(
+      fUpV <-
+        f %>%
+        model(v <- exp(lv)),
+      NA
+    ))
+    expect_equal(
+      methods::functionBody(as.function(fUpV))[[3]][[2]][[5]],
+      str2lang("v <- exp(lv)")
+    )
+
+    # piping model updates work with append
+    suppressMessages(expect_error(
+      fUpFoo <-
+        f %>%
+        model(foo <- exp(lv), append = TRUE),
+      NA
+    ))
+    expect_equal(
+      methods::functionBody(as.function(fUpFoo))[[3]][[2]][[11]],
+      str2lang("foo <- exp(lv)")
+    )
+  })
+})


### PR DESCRIPTION
Fix nlmixr2/rxode2#364

The underlying issue was that the `append` argument was not passed to the model modification function.  The `auto` argument was also not passed, so I added that, too.