### PR TITLE
Allow for babelmixr2::pkncaControl() not to set genRxControl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
 
 - A bug in model piping which did not allow models to be appended to was fixed
   (rxode2#364)
+  
+- An internal change was made in `nlmixr2.rxUi()` to better support the
+  babelmixr2 PKNCA estimation method (babelmixr2#75)
 
 # nlmixr2est 2.1.3
 

--- a/R/nlmixr2.R
+++ b/R/nlmixr2.R
@@ -250,7 +250,10 @@ nlmixr2.rxUi <- function(object, data=NULL, est = NULL, control = NULL, table = 
     .minfo("use {.code control} from pipeline")
   } else {
     .ctl <- getValidNlmixrControl(control, est)
-    if (.ctl$genRxControl) {
+    # The isTRUE() in the if below allows for the fact that
+    # babelmixr2::pkncaControl() does not have a genRxControl element, so it is
+    # NULL.
+    if (isTRUE(.ctl$genRxControl)) {
       if (is.numeric(.uif$atol)) {
         .minfo("use rxControl(atol=) from $atol")
         .ctl$rxControl$atol <- .uif$atol


### PR DESCRIPTION
Fix nlmixr2/babelmixr2#75