### PR TITLE
Fix #359

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: nlmixr2est
 Title: Nonlinear Mixed Effects Models in Population PK/PD, Estimation
     Routines
-Version: 2.1.6
+Version: 2.1.6.9000
 Authors@R: c(
     person("Matthew", "Fidler", , "matt.fidler@novartis.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8538-6691")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# nlmixr2est (2.1.6.9000)
+
+## Bug fixes
+
+- Printing models with correlated omega values and omega values fixed
+  to zero no longer fails (#359)
+
 # nlmixr2est 2.1.6
 
 ## Breaking changes

--- a/R/print.R
+++ b/R/print.R
@@ -26,7 +26,9 @@
       .lt <- c(setNames(diag(x), paste0("sd", getOption("broom.mixed.sep1", "__"), .dn1)), .lt)
     }
   }
-  return(.lt)
+  # Omit NA values that may be present with one eta fixed as zero and other etas
+  # with estimated correlations.
+  .lt[!is.na(.lt)]
 }
 
 .getCorPrint <- function(x) {

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -24,6 +24,8 @@ test_that("print works with combined zero and correlated etas (#359)", {
     fit <- nlmixr2(one.compartment, theo_sd,  est="saem", saemControl(print=0, nBurn = 10, nEm = 10))
   )
   expect_output(
-    .getCorPrint(fit$omegaR)
+    .getCorPrint(fit$omegaR),
+    regexp = "cor:eta.v,eta.cl",
+    fixed = TRUE
   )
 })

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -1,0 +1,29 @@
+test_that("print works with combined zero and correlated etas (#359)", {
+  one.compartment <- function() {
+    ini({
+      tka <- log(1.57); label("Ka")
+      tcl <- log(2.72); label("Cl")
+      tv <- log(31.5); label("V")
+      eta.ka ~ 0
+      eta.cl + eta.v ~ c(0.3, 0.01, 0.1)
+      add.sd <- 0.7
+    })
+    # and a model block with the error specification and model specification
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  suppressMessages(
+    fit <- nlmixr2(one.compartment, theo_sd,  est="saem", saemControl(print=0, nBurn = 10, nEm = 10))
+  )
+  expect_output(
+    .getCorPrint(fit$omegaR)
+  )
+})


### PR DESCRIPTION
Fix #359

The `.getR()` function now no longer returns `NA` values.  If there is a scenario where it should return `NA` values, then the fix should be moved to the `.getCorPrint()` function.