### PR TITLE
Fix 366

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - Printing models with correlated omega values and omega values fixed
   to zero no longer fails (#359)
+- Values in $parFixed for BSV without exponential transformation are now
+  correctly shown (#366)
 
 # nlmixr2est 2.1.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,8 @@
 
 - Printing models with correlated omega values and omega values fixed
   to zero no longer fails (#359)
-- Values in $parFixed for BSV without exponential transformation are now
+
+- Values in `$parFixed` for BSV without exponential transformation are now
   correctly shown (#366)
 
 # nlmixr2est 2.1.6
@@ -27,7 +28,7 @@
 
 - `augPred()` now consistently uses the simulation model (instead of
   the inner model used for `CWRES` calculation).
-  
+
 ## Other changes
 
 - Dropped dependence on orphaned package `ucminf`

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -113,7 +113,7 @@
     return(data.frame(
       ch = paste0(
         ifelse(.omegaFix[.eta], "fix(", ""),
-        formatC(signif(sqrt(.w), digits = .sigdig),
+        formatC(signif(sqrt(.v), digits = .sigdig),
                 digits = .sigdig, format = "fg", flag = "#"),
         ifelse(.omegaFix[.eta], ")", "")),
       v = .v))

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -39,7 +39,7 @@
 #'  This applies the manually specified back-transformations
 #'
 #' @param .ret focei environment
-#' @return Nothing, called for side effecs
+#' @return Nothing, called for side effects
 #' @author Matthew L. Fidler
 #' @noRd
 .updateParFixedApplyManualBacktransformations <- function(.ret, .ui) {

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -100,24 +100,29 @@
   .w <- which(.muRefCurEval$parameter == .eta)
   if (.muRefCurEval$curEval[.w] == "exp") {
     assign(".sdOnly", FALSE, envir=.env)
-    return(data.frame(
-      ch = paste0(
-        ifelse(.omegaFix[.eta], "fix(", ""),
-        formatC(signif(sqrt(exp(.v) - 1) * 100, digits = .sigdig),
-                digits = .sigdig, format = "fg", flag = "#"),
-        ifelse(.omegaFix[.eta], ")", "")
-      ),
-      v = sqrt(exp(.v) - 1) * 100))
+    valNumber <- sqrt(exp(.v) - 1) * 100
+    valCharPrep <- valNumber
   } else {
     assign(".cvOnly", FALSE, envir=.env)
-    return(data.frame(
-      ch = paste0(
-        ifelse(.omegaFix[.eta], "fix(", ""),
-        formatC(signif(sqrt(.v), digits = .sigdig),
-                digits = .sigdig, format = "fg", flag = "#"),
-        ifelse(.omegaFix[.eta], ")", "")),
-      v = .v))
+    valNumber <- .v
+    valCharPrep <- sqrt(.v)
   }
+  if (.omegaFix[.eta]) {
+    charPrefix <- "fix("
+    charSuffix <- ")"
+  } else {
+    charPrefix <- ""
+    charSuffix <- ""
+  }
+  valChar <-
+    formatC(
+      signif(valCharPrep, digits = .sigdig),
+      digits = .sigdig, format = "fg", flag = "#"
+    )
+  data.frame(
+    ch = paste0(charPrefix, valChar, charSuffix),
+    v = valNumber
+  )
 }
 
 #'  This will add the between subject variability to the mu-referenced theta.  It also expands the table to include non-mu referenced ETAs

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -91,8 +91,8 @@
 #' @param .env Environment where the indicators of `.sdOnly`, `.cvOnly` are stored so the column name can be changed to match the data
 #' @param .ome Omega fixed vector
 #' @param .muRefCurEval The current mu ref evaluation.  This determines if the ETA is logit normal and %CV should be calculated.
-#' @param .sigdig is the number of significant digits used in the evaulation
-#' @return Data frame row with ch= the charaacter representation and v is the vector representation of the CV or sd
+#' @param .sigdig is the number of significant digits used in the evaluation
+#' @return Data frame row with ch= the character representation and v is the vector representation of the CV or sd
 #' @author Matthew L. Fidler
 #' @noRd
 .updateParFixedGetEtaRow <- function(.eta, .env, .ome, .omegaFix, .muRefCurEval, .sigdig) {
@@ -120,7 +120,7 @@
   }
 }
 
-#'  This will add the between subject varaibility to the mu-referenced theta.  It also expands the table to include non-mu referenced ETAs
+#'  This will add the between subject variability to the mu-referenced theta.  It also expands the table to include non-mu referenced ETAs
 #'
 #'
 #' @param .ret The focei return environment

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -93,35 +93,35 @@
 #' @param .muRefCurEval The current mu ref evaluation.  This determines if the ETA is logit normal and %CV should be calculated.
 #' @param .sigdig is the number of significant digits used in the evaluation
 #' @return Data frame row with ch= the character representation and v is the vector representation of the CV or sd
-#' @author Matthew L. Fidler
+#' @author Matthew L. Fidler and Bill Denney
 #' @noRd
 .updateParFixedGetEtaRow <- function(.eta, .env, .ome, .omegaFix, .muRefCurEval, .sigdig) {
   .v <- .ome[.eta, .eta]
   .w <- which(.muRefCurEval$parameter == .eta)
   if (.muRefCurEval$curEval[.w] == "exp") {
     assign(".sdOnly", FALSE, envir=.env)
-    valNumber <- sqrt(exp(.v) - 1) * 100
-    valCharPrep <- valNumber
+    .valNumber <- sqrt(exp(.v) - 1) * 100
+    .valCharPrep <- .valNumber
   } else {
     assign(".cvOnly", FALSE, envir=.env)
-    valNumber <- .v
-    valCharPrep <- sqrt(.v)
+    .valNumber <- .v
+    .valCharPrep <- sqrt(.v)
   }
   if (.omegaFix[.eta]) {
-    charPrefix <- "fix("
-    charSuffix <- ")"
+    .charPrefix <- "fix("
+    .charSuffix <- ")"
   } else {
-    charPrefix <- ""
-    charSuffix <- ""
+    .charPrefix <- ""
+    .charSuffix <- ""
   }
-  valChar <-
+  .valChar <-
     formatC(
-      signif(valCharPrep, digits = .sigdig),
+      signif(.valCharPrep, digits = .sigdig),
       digits = .sigdig, format = "fg", flag = "#"
     )
   data.frame(
-    ch = paste0(charPrefix, valChar, charSuffix),
-    v = valNumber
+    ch = paste0(.charPrefix, .valChar, .charSuffix),
+    v = .valNumber
   )
 }
 

--- a/tests/testthat/test-nlmixr2output.R
+++ b/tests/testthat/test-nlmixr2output.R
@@ -1,0 +1,13 @@
+test_that(".updateParFixedGetEtaRow returns correct values", {
+  expect_equal(
+    .updateParFixedGetEtaRow(
+      .eta = "iivemax",
+      .env = new.env(),
+      .ome = matrix(25, nrow = 1, dimnames = list("iivemax", "iivemax")),
+      .omegaFix = c(iivemax = FALSE),
+      .muRefCurEval = data.frame(parameter = "iivemax", curEval = "", low = NA_real_, hi = NA_real_),
+      .sigdig = 3L
+    ),
+    data.frame(.ch = "5.00", .v = 25)
+  )
+})

--- a/tests/testthat/test-nlmixr2output.R
+++ b/tests/testthat/test-nlmixr2output.R
@@ -8,6 +8,6 @@ test_that(".updateParFixedGetEtaRow returns correct values", {
       .muRefCurEval = data.frame(parameter = "iivemax", curEval = "", low = NA_real_, hi = NA_real_),
       .sigdig = 3L
     ),
-    data.frame(.ch = "5.00", .v = 25)
+    data.frame(ch = "5.00", v = 25)
   )
 })

--- a/tests/testthat/test-nlmixr2output.R
+++ b/tests/testthat/test-nlmixr2output.R
@@ -1,8 +1,9 @@
 test_that(".updateParFixedGetEtaRow returns correct values", {
+  envPrep <- new.env()
   expect_equal(
     .updateParFixedGetEtaRow(
       .eta = "iivemax",
-      .env = new.env(),
+      .env = envPrep,
       .ome = matrix(25, nrow = 1, dimnames = list("iivemax", "iivemax")),
       .omegaFix = c(iivemax = FALSE),
       .muRefCurEval = data.frame(parameter = "iivemax", curEval = "", low = NA_real_, hi = NA_real_),
@@ -10,4 +11,19 @@ test_that(".updateParFixedGetEtaRow returns correct values", {
     ),
     data.frame(ch = "5.00", v = 25)
   )
+  expect_false(envPrep$.cvOnly)
+
+  envPrep <- new.env()
+  expect_equal(
+    .updateParFixedGetEtaRow(
+      .eta = "iivemax",
+      .env = envPrep,
+      .ome = matrix(0.4, nrow = 1, dimnames = list("iivemax", "iivemax")),
+      .omegaFix = c(iivemax = FALSE),
+      .muRefCurEval = data.frame(parameter = "iivemax", curEval = "exp", low = NA_real_, hi = NA_real_),
+      .sigdig = 3L
+    ),
+    data.frame(ch = "70.1", v = sqrt(exp(0.4) - 1) * 100)
+  )
+  expect_false(envPrep$.sdOnly)
 })


### PR DESCRIPTION
Fix #366 

The underlying issue was the `sqrt(.w)` on this line which is now a `sqrt(.v)` (as `valCharPrep`):

https://github.com/nlmixr2/nlmixr2est/blob/42589c538c722086fdd2d839f7230e2be10cf641/R/nlmixr2output.R#L116

I also simplified the function's complexity.