### PR TITLE
Clarify keep argument to vpcSim()

### DIFF
--- a/R/vpc.R
+++ b/R/vpc.R
@@ -3,7 +3,7 @@
 #'
 #' @param object This is the nlmixr2 fit object
 #' @param ... Other arguments sent to `rxSolve()`
-#' @param keep Keep character vector
+#' @param keep Column names to keep in the output simulated dataset
 #' @param n Number of simulations
 #' @param pred Should predictions be added to the simulation
 #' @param seed Seed to set for the VPC simulation

--- a/man/vpcSim.Rd
+++ b/man/vpcSim.Rd
@@ -20,7 +20,7 @@ vpcSim(
 
 \item{...}{Other arguments sent to `rxSolve()`}
 
-\item{keep}{Keep character vector}
+\item{keep}{Column names to keep in the output simulated dataset}
 
 \item{n}{Number of simulations}
 


### PR DESCRIPTION
This is a minor documentation update to clarify the argument call.