### PR TITLE
Error in  `saem` code generation when all fixed effect parameters are fixed

### DIFF
--- a/R/saem.R
+++ b/R/saem.R
@@ -437,6 +437,11 @@
       .ini <- .ini[!is.na(.ini$ntheta), ]
       .ini <- .ini[!.ini$fix, ]
       .ini <- paste(.ini$name)
+      if (.calcCov && .nth == 0) {
+        warning("no population parameters in the model, no covariance matrix",
+                call.=FALSE)
+        .calcCov <- FALSE
+      }
       if (.calcCov) {
         .covm <- .saem$Ha[1:.nth, 1:.nth]
         .covm <- try(calc.COV(.saem))

--- a/R/saem.R
+++ b/R/saem.R
@@ -441,8 +441,11 @@
         warning("no population parameters in the model, no covariance matrix calculated",
                 call.=FALSE)
         .calcCov <- FALSE
-      }
-      if (.calcCov) {
+        .addCov <- FALSE
+        env$cov <- NULL
+        .cov <- NULL
+        env$covMethod <- "none"
+      } else if (.calcCov) {
         .covm <- .saem$Ha[1:.nth, 1:.nth]
         .covm <- try(calc.COV(.saem))
         .doIt <- !inherits(.covm, "try-error")

--- a/R/saem.R
+++ b/R/saem.R
@@ -438,7 +438,7 @@
       .ini <- .ini[!.ini$fix, ]
       .ini <- paste(.ini$name)
       if (.calcCov && .nth == 0) {
-        warning("no population parameters in the model, no covariance matrix",
+        warning("no population parameters in the model, no covariance matrix calculated",
                 call.=FALSE)
         .calcCov <- FALSE
       }

--- a/R/saemRxUiGet.R
+++ b/R/saemRxUiGet.R
@@ -456,7 +456,7 @@ rxUiGet.saemParHistOmegaKeep <- function(x, ...) {
   .etaNames <- .ui$iniDf[!is.na(.ui$iniDf$neta1), ]
   .etaNames <- .etaNames[.etaNames$neta1 == .etaNames$neta2,]
   .names <- rxUiGet.saemEtaNames(x, ...)
-  vapply(.names, function(etaName){
+  vapply(.names, function(etaName) {
     .w <- which(.etaNames$name == etaName)
     if (length(.w) == 1) {
       return(1L - as.integer(.etaNames$fix[.w]))

--- a/R/saemRxUiGetModel.R
+++ b/R/saemRxUiGetModel.R
@@ -332,7 +332,12 @@ rxUiGet.saemModelPredReplaceLst <- function(x, ...) {
   .ui <- x[[1]]
   .iniDf <- .ui$iniDf
   .thetaNames <- .iniDf[!is.na(.iniDf$ntheta) & is.na(.iniDf$err), ]
-  .thetaValue <- setNames(paste0("THETA[", .thetaNames$ntheta, "]"), .thetaNames$name)
+  if (length(.thetaNames$name) == 0L) {
+    .thetaValue <- character(0L)
+  } else {
+    .thetaValue <- setNames(paste0("THETA[", .thetaNames$ntheta, "]"), .thetaNames$name)
+  }
+
   if (length(.ui$nonMuEtas) > 0) {
     .nonMuThetas <- setNames(rep("", length(.ui$nonMuEtas)), .ui$nonMuEtas)
     .thetaValue <- c(.thetaValue, .nonMuThetas)

--- a/tests/testthat/test-saem-no-pop.R
+++ b/tests/testthat/test-saem-no-pop.R
@@ -23,5 +23,13 @@ test_that("all theta parameters are fixed", {
 
   expect_true(inherits(f, "nlmixr2FitData"))
 
+  m2 <- rxode2::rxFixPop(one.compartment)
+
+  expect_error(m2$saemModelPred, NA)
+
+  f <- nlmixr2(
+    one.compartment, data = theo_sd, est="saem", control = saemControl(print=0, nEm=10, nBurn=10, literalFix=TRUE))
+
+  expect_true(inherits(f, "nlmixr2FitData"))
 
 })

--- a/tests/testthat/test-saem-no-pop.R
+++ b/tests/testthat/test-saem-no-pop.R
@@ -1,0 +1,27 @@
+test_that("all theta parameters are fixed", {
+
+  one.compartment <- function() {
+    ini({
+      tka <- fixed(log(1.57))
+      tcl <- fixed(log(2.72))
+      tv <- fixed(log(31.5))
+      eta.ka ~ 0.6
+      add.sd <- 0.7
+    })
+    # and a model block with the error specification and model specification
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      cp <- linCmt()
+      cp ~ add(add.sd)
+    })
+  }
+
+  f <- nlmixr2(
+    one.compartment, data = theo_sd, est="saem", control = saemControl(print=0, nEm=10, nBurn=10, literalFix=FALSE))
+
+  expect_true(inherits(f, "nlmixr2FitData"))
+
+
+})


### PR DESCRIPTION
When I fixed all the parameters in a model and then tried to estimate it, I got the below error.

(Why would you do this Bill?  It was while working on likelihood profiling.)

``` r
library(nlmixr2)
#> Loading required package: nlmixr2data
one.compartment <- function() {
  ini({
    tka <- fixed(log(1.57))
    tcl <- fixed(log(2.72))
    tv <- fixed(log(31.5))
    eta.ka ~ 0.6
    add.sd <- 0.7
  })
  # and a model block with the error specification and model specification
  model({
    ka <- exp(tka + eta.ka)
    cl <- exp(tcl)
    v <- exp(tv)
    cp <- linCmt()
    cp ~ add(add.sd)
  })
}

nlmixr2(
  one.compartment, data = theo_sd, est="saem", control = saemControl(print=0)
)
#> → loading into symengine environment...
#> → pruning branches (`if`/`else`) of saem model...
#> ✔ done
#> → finding duplicate expressions in saem model...
#> [====|====|====|====|====|====|====|====|====|====] 0:00:00
#> ✔ done
#> using C compiler: 'gcc.exe (GCC) 13.2.0'
#> ℹ calculate uninformed etas
#> ℹ done
#> rxode2 2.1.3.9000 using 8 threads (see ?getRxThreads)
#>   no cache: create with `rxCreateCache()`
#> Calculating covariance matrix
#> Error : Error calculating covariance via linearization
#> → loading into symengine environment...
#> → pruning branches (`if`/`else`) of saem model...
#> ✔ done
#> → finding duplicate expressions in saem predOnly model 0...
#> → finding duplicate expressions in saem predOnly model 1...
#> → finding duplicate expressions in saem predOnly model 2...
#> → optimizing duplicate expressions in saem predOnly model 2...
#> ✔ done
#> Error : rxode2 syntax error:
#> :005: NA <- THETA[] + ETA[1]
#>                   ^
#> more errors could be listed above
#> Error: rxode2 syntax error:
#> :005: NA <- THETA[] + ETA[1]
#>                   ^
#> more errors could be listed above
```

<sup>Created on 2024-08-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>