### PR TITLE
Invalid index warning in nlmixr2 fits

### DIFF
--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -3121,7 +3121,8 @@ static inline void foceiSetupEta_(NumericMatrix etaMat0){
 
   if (inds_focei != NULL) R_Free(inds_focei);
   inds_focei = R_Calloc(rx->nsub, focei_ind);
-  etaMat0 = transpose(etaMat0);
+  RObject etaMat0s = transpose(etaMat0);
+  double *etaMat0d = REAL(etaMat0s);
   op_focei.gEtaGTransN=(op_focei.neta+1)*rx->nsub;
   int nz = ((op_focei.neta+1)*(op_focei.neta+2)/2+6*(op_focei.neta+1)+1)*rx->nsub;
 
@@ -3188,7 +3189,7 @@ static inline void foceiSetupEta_(NumericMatrix etaMat0){
 
     // Copy in etaMat0 to the inital eta stored (0 if unspecified)
     // std::copy(&etaMat0[i*op_focei.neta], &etaMat0[(i+1)*op_focei.neta], &fInd->saveEta[0]);
-    std::copy(&etaMat0[i*op_focei.neta], &etaMat0[(i+1)*op_focei.neta], &fInd->eta[0]);
+    std::copy(&etaMat0d[i*op_focei.neta], &etaMat0d[(i+1)*op_focei.neta], &fInd->eta[0]);
 
     fInd->eta[op_focei.neta] = i;
     fInd->saveEta[op_focei.neta] = i;


### PR DESCRIPTION
This was probably from combining rxode2 and is a bit concerning.

<details>

``` r
library(nlmixr2est)
#> Loading required package: nlmixr2data

one.compartment <- function() {
ini({
    tka <- fixed(log(1.57))
    tcl <- fixed(log(2.72))
    tv <- fixed(log(31.5))
    eta.ka ~ 0.6
    add.sd <- 0.7
    })
# and a model block with the error specification and model specification
model({
      ka <- exp(tka + eta.ka)
      cl <- exp(tcl)
      v <- exp(tv)
      cp <- linCmt()
      cp ~ add(add.sd)
      })
}

nlmixr2(
        one.compartment, data = theo_sd, est="saem", control = saemControl(print=0, literalFix=FALSE)
        )
#> → loading into symengine environment...
#> → pruning branches (`if`/`else`) of saem model...
#> ✔ done
#> → finding duplicate expressions in saem model...
#> [====|====|====|====|====|====|====|====|====|====] 0:00:00
#> ✔ done
#> ℹ calculate uninformed etas
#> ℹ done
#> rxode2 2.1.3.9000 using 8 threads (see ?getRxThreads)
#>   no cache: create with `rxCreateCache()`
#> → loading into symengine environment...
#> → pruning branches (`if`/`else`) of saem model...
#> ✔ done
#> → finding duplicate expressions in saem predOnly model 0...
#> [====|====|====|====|====|====|====|====|====|====] 0:00:00
#> → finding duplicate expressions in saem predOnly model 1...
#> [====|====|====|====|====|====|====|====|====|====] 0:00:00
#> → finding duplicate expressions in saem predOnly model 2...
#> [====|====|====|====|====|====|====|====|====|====] 0:00:00
#> → optimizing duplicate expressions in saem predOnly model 2...
#> [====|====|====|====|====|====|====|====|====|====] 0:00:00
#> ✔ done
#> ℹ covariance not in proper form, can access value in $covDebug
#> → Calculating residuals/tables
#> ✔ done
#> → compress origData in nlmixr2 object, save 5952
#> → compress phiM in nlmixr2 object, save 69656
#> → compress parHistData in nlmixr2 object, save 8496
#> → compress saem0 in nlmixr2 object, save 27792
#> ── nlmixr² SAEM OBJF by FOCEi approximation ──
#>
#>  Gaussian/Laplacian Likelihoods: AIC(x) or x$objf etc.
#>  FOCEi CWRES & Likelihoods: addCwres(x)
#>
#> ── Time (sec x$time): ──
#>
#>            setup covariance  saem table compress    other
#> elapsed 0.000991   0.002005 1.127 0.046    0.018 1.028004
#>
#> ── Population Parameters (x$parFixed or x$parFixedDf): ──
#>
#>         Est. Back-transformed BSV(CV%) Shrink(SD)%
#> tka    0.451             1.57     66.7      1.75%
#> tcl        1             2.72
#> tv      3.45             31.5
#> add.sd 0.935            0.935
#>
#>   Covariance Type (x$covMethod): |fim|
#>   No correlations in between subject variability (BSV) matrix
#>   Full BSV covariance (x$omega) or correlation (x$omegaR; diagonals=SDs)
#>   Distribution stats (mean/skewness/kurtosis/p-value) available in x$shrink
#>   Information about run found (x$runInfo):
#>    • subscript out of bounds (index 12 >= vector size 12)
#>    • covariance not in proper form, can access value in $covDebug
#>    • covariance matrix non-positive definite, corrected by sqrtm(fim %*% fim)
#>    • no population parameters in the model, no covariance matrix calculated
#>   Censoring (x$censInformation): No censoring
#>
#> ── Fit Data (object x is a modified tibble): ──
#> # A tibble: 132 × 15
#>   ID     TIME    DV  PRED    RES IPRED    IRES   IWRES eta.ka    cp    ka    cl
#>   <fct> <dbl> <dbl> <dbl>  <dbl> <dbl>   <dbl>   <dbl>  <dbl> <dbl> <dbl> <dbl>
#> 1 1      0     0.74  0     0.74   0     0.74    0.792   0.180  0     1.88  2.72
#> 2 1      0.25  2.84  3.26 -0.420  3.77 -0.926  -0.990   0.180  3.77  1.88  2.72
#> 3 1      0.57  6.57  5.84  0.729  6.49  0.0800  0.0856  0.180  6.49  1.88  2.72
#> # ℹ 129 more rows
#> # ℹ 3 more variables: v <dbl>, tad <dbl>, dosenum <dbl>
```

<sup>Created on 2024-08-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

</details>

In particular:

- `subscript out of bounds (index 12 >= vector size 12)`

Is coming from `Rcpp` and indicates a bad access somewhere