### PR TITLE
Warnings suppressed when using `nlmixr2` with "rxSolve" estimation method.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,11 @@
 
 - Add back the warnings when estimation methods ignore the boundaries
 
+## Bug fixes
+
+- Will emit warnings when the return object is not a nlmixr2 fit
+  (#453)
+
 # nlmixr2est 2.2.1
 
 - Align with the possibility that linCmt sensitivities may not be

--- a/R/nlmixr2Est.R
+++ b/R/nlmixr2Est.R
@@ -273,10 +273,18 @@ nlmixr2Est0 <- function(env, ...) {
   }
   .lst <- get("ret", envir=.envReset)
   .ret <- .lst[[1]]
-  if (is.environment(.ret)) {
-    try(assign("runInfo", .lst[[2]], .ret), silent=TRUE)
+  if (inherits(.ret, "nlmixr2FitCore") ||
+        inherits(.ret, "nlmixr2Fit")) {
+    if (is.environment(.ret)) {
+      try(assign("runInfo", .lst[[2]], .ret), silent=TRUE)
+    } else {
+      try(assign("runInfo", .lst[[2]], .ret$env), silent=TRUE)
+    }
   } else {
-    try(assign("runInfo", .lst[[2]], .ret$env), silent=TRUE)
+    .w <-.lst[[2]]
+    lapply(seq_along(.w), function(i) {
+      warning(.w[[i]])
+    })
   }
   .nlmixrEstUpdatesOrigModel(.ret)
   .ret

--- a/tests/testthat/test-rxsolve.R
+++ b/tests/testthat/test-rxsolve.R
@@ -61,4 +61,46 @@ nmTest({
 
   })
 
+  test_that("rxSolve will warn when necessary", {
+    library(rxode2)
+    eventTable <- et(amt=320, evid=1, cmt=20, time = 0) %>% # nolint: object_name_linter.
+      et(2, 4)
+
+    # Now define the nlmixr2/rxode2 model used for both estimation and simulation
+    mod <- function() {
+      # Parameters
+      ini({
+        tka <- 0.45; label("Ka (first order absorption)")
+        trate <- 0.4 ; label("Zero order rate")
+        tcl <- 1; label("Cl")
+        tv <- 3.45; label("V")
+        fDepot <- logit(0.5) ; label("amount of dose in first order absorption")
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      # and a model block with the error specification and model specification
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        d/dt(depot) = -ka * depot
+        d/dt(center) = ka * depot - cl / v * center
+
+        f(depot) <- expit(fDepot)
+        f(center) <- 1-expit(fDepot)
+        rate(center) <- exp(trate)
+
+        cp = center / v
+        cp ~ add(add.sd)
+      })
+    }
+
+    mod <- mod()
+
+    expect_warning(nlmixr2(mod, eventTable, "rxSolve", control = rxControl(addDosing = TRUE)))
+
+  })
+
 })


### PR DESCRIPTION
``` r
# This is an example to simulate and estimate dual first order
# and zero order absorption

library(nlmixr2)
#> Warning: package 'nlmixr2' was built under R version 4.3.3
#> Loading required package: nlmixr2data
#> Warning: package 'nlmixr2data' was built under R version 4.3.3
```

``` r

library(rxode2)
#> Warning: package 'rxode2' was built under R version 4.3.3
#> rxode2 2.1.3 using 4 threads (see ?getRxThreads)
#>   no cache: create with `rxCreateCache()`
```

``` r
set.seed(123)
rxSetSeed(123)

# Setup the rxode2 event table
eventTable <- et(amt=320, evid=1, cmt=20, time = 0) %>% # nolint: object_name_linter.
  et(2, 4)

# Now define the nlmixr2/rxode2 model used for both estimation and simulation
mod <- function() {
  # Parameters
  ini({
    tka <- 0.45; label("Ka (first order absorption)")
    trate <- 0.4 ; label("Zero order rate")
    tcl <- 1; label("Cl")
    tv <- 3.45; label("V")
    fDepot <- logit(0.5) ; label("amount of dose in first order absorption")
    eta.ka ~ 0.6
    eta.cl ~ 0.3
    eta.v ~ 0.1
    add.sd <- 0.7
  })
  # and a model block with the error specification and model specification
  model({
    ka <- exp(tka + eta.ka)
    cl <- exp(tcl + eta.cl)
    v <- exp(tv + eta.v)
    d/dt(depot) = -ka * depot
    d/dt(center) = ka * depot - cl / v * center
    
    f(depot) <- expit(fDepot)
    f(center) <- 1-expit(fDepot)
    rate(center) <- exp(trate)
    
    cp = center / v
    cp ~ add(add.sd)
  })
}

mod <- mod()

# Solving data with nlmixr2 suppresses all warnings
d <- nlmixr2(mod, eventTable, "rxSolve", control = rxControl(addDosing = TRUE))

# But solving with rxSolve does not
d2 <- rxSolve(mod, eventTable, addDosing=TRUE)
#> Warning: dose to compartment 20 ignored (not in system; 'id=1')
```

<sup>Created on 2024-07-22 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
