### PR TITLE
tableControl() incompatible options should error with addDosing items

### DIFF
--- a/R/resid.R
+++ b/R/resid.R
@@ -641,7 +641,7 @@ tableControl <- function(npde = NULL,
                              any.missing = FALSE,min.chars=1)
   .invalidKeep <- c("nlmixrRowNums", "id", "sim.id", "resetno", "evid", "cmt", "ss", "amt",
                     "rate", "dur", "ii", "time", "rxLambda",
-                    "rxYj", "rxLow", "rxHi", "rxLambda", "rxYj", "rxLow", "rxHi")
+                    "rxYj", "rxLow", "rxHi")
   .invalidKeep <- intersect(tolower(keep), tolower(.invalidKeep))
   if (length(.invalidKeep) > 0) {
     stop("'keep' cannot contain ", paste(.invalidKeep, collapse=", "), "\nconsider either addDosing=TRUE or $dataMergeLeft $dataMergeRight or $dataMergeInner", call.=FALSE)

--- a/R/resid.R
+++ b/R/resid.R
@@ -637,7 +637,16 @@ tableControl <- function(npde = NULL,
   checkmate::assertLogical(covariates, len=1, any.missing=FALSE)
   checkmate::assertLogical(addDosing, len=1, any.missing=FALSE)
   checkmate::assertLogical(subsetNonmem, len=1, any.missing=FALSE)
-  checkmate::assertCharacter(keep, null.ok=TRUE)
+  checkmate::assertCharacter(keep, null.ok=TRUE, pattern = "^[.]*[a-zA-Z]+[a-zA-Z0-9._]*$",
+                             any.missing = FALSE,min.chars=1)
+  .invalidKeep <- c("nlmixrRowNums", "id", "sim.id", "resetno", "evid", "cmt", "ss", "amt",
+                    "rate", "dur", "ii", "time", "rxLambda",
+                    "rxYj", "rxLow", "rxHi", "rxLambda", "rxYj", "rxLow", "rxHi")
+  .invalidKeep <- intersect(tolower(keep), tolower(.invalidKeep))
+  if (length(.invalidKeep) > 0) {
+    stop("'keep' cannot contain ", paste(.invalidKeep, collapse=", "), "\nconsider either addDosing=TRUE or $dataMergeLeft $dataMergeRight or $dataMergeInner", call.=FALSE)
+  }
+
   checkmate::assertCharacter(drop, null.ok=TRUE)
   if (inherits(censMethod, "character")) {
     .censMethod <- setNames(c("truncated-normal"=3L, "cdf"=2L, "omit"=1L, "pred"=5L, "ipred"=4L, "epred"=6L)[match.arg(censMethod)], NULL)

--- a/R/resid.R
+++ b/R/resid.R
@@ -639,12 +639,22 @@ tableControl <- function(npde = NULL,
   checkmate::assertLogical(subsetNonmem, len=1, any.missing=FALSE)
   checkmate::assertCharacter(keep, null.ok=TRUE, pattern = "^[.]*[a-zA-Z]+[a-zA-Z0-9._]*$",
                              any.missing = FALSE,min.chars=1)
-  .invalidKeep <- c("nlmixrRowNums", "id", "sim.id", "resetno", "evid", "cmt", "ss", "amt",
-                    "rate", "dur", "ii", "time", "rxLambda",
-                    "rxYj", "rxLow", "rxHi")
+  .invalidKeep <- c("id", "sim.id", "resetno", "time", "nlmixrRowNums")
   .invalidKeep <- intersect(tolower(keep), tolower(.invalidKeep))
   if (length(.invalidKeep) > 0) {
-    stop("'keep' cannot contain ", paste(.invalidKeep, collapse=", "), "\nconsider either addDosing=TRUE or $dataMergeLeft $dataMergeRight or $dataMergeInner", call.=FALSE)
+    .w <- which(tolower(keep) %in% .invalidKeep)
+    keep <- keep[-.w]
+    warning("'keep' contains ", paste(.invalidKeep, collapse=", "), "\nwhich are output when needed, ignoring these items", call.=FALSE)
+  }
+  .invalidKeep <- c("evid",  "ss", "amt", "rate", "dur", "ii")
+  .invalidKeep <- intersect(tolower(keep), tolower(.invalidKeep))
+  if (length(.invalidKeep) > 0) {
+    stop("'keep' cannot contain ", paste(.invalidKeep, collapse=", "), "\nconsider using addDosing=TRUE or merging to original dataset\nfor a fit the merge can be called by fit$dataMergeLeft fit$dataMergeRight or fit$dataMergeInner", call.=FALSE)
+  }
+  .invalidKeep <- c ("rxLambda", "rxYj", "rxLow", "rxHi")
+  .invalidKeep <- intersect(tolower(keep), tolower(.invalidKeep))
+  if (length(.invalidKeep) > 0) {
+    stop("'keep' cannot contain ", paste(.invalidKeep, collapse=", "), call.=FALSE)
   }
 
   checkmate::assertCharacter(drop, null.ok=TRUE)

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -1,3 +1,35 @@
+#' Get Control Settings for nlmixr
+#'
+#' This function retrieves and sets control settings for the `nlmixr`
+#' package from the given environment.  It ensures that the control
+#' settings are valid and, if necessary, uses default settings from
+#' `rxode2::rxControl()`.
+#'
+#' @param env Environment from which to retrieve control settings.
+#' @return A list of control settings for `rxSolve`.
+#' @details
+#' The function performs the following steps:
+#'
+#' - Retrieves the `ui` object from the provided environment.
+#'
+#' - Checks if a `control` object exists in the environment and
+#' retrieves it.
+#'
+#' - Validates if the retrieved `control` object is of class
+#' `rxControl`. If not, it attempts to retrieve the `rxControl`
+#' element from the `control` object.
+#'
+#' - If the `rxControl` object is still not valid, it uses default
+#' solving options from `rxode2::rxControl()`.
+#'
+#' - Determines if the model is a prediction model based on the `omega` and `sigma` values.
+#'
+#' - If additional simulation information (`.nlmixr2SimInfo`) is
+#' available, it updates the `rxControl` object with population
+#' uncertainty, number of observations, number of subjects, and
+#' diagonal `sigma` based on the fitted model.
+#'
+#' @noRd
 .rxSolveGetControlForNlmixr <- function(env) {
   .ui <- get("ui", envir=env)
   if (exists("control", envir=env)) {


### PR DESCRIPTION
See #297

It should also error with items like:

- `id`
- `evid`

and other named items in `rxode2` and `nlmixr2` outputs