### PR TITLE
Don't give a warning or error when eta values are NULL or not estimated

### DIFF
--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -127,6 +127,13 @@
 #' @author Matthew L. Fidler and Bill Denney
 #' @noRd
 .updateParFixedGetEtaRow <- function(.eta, .env, .ome, .omegaFix, .muRefCurEval, .sigdig) {
+  if (is.null(.ome)) {
+    # This can happen if there are no BSV parameters in a model
+    return("")
+  } else if (!(.eta %in% rownames(.ome))) {
+    # This can happen if .eta is a fixed BSV parameter
+    return("")
+  }
   .v <- .ome[.eta, .eta]
   .w <- which(.muRefCurEval$parameter == .eta)
   if (.muRefCurEval$curEval[.w] == "exp") {


### PR DESCRIPTION
This resolves two issues that I have seen.  But, I worry that this is a hackish way to fix it when really the `.updateParFixedGetEtaRow()` function should not be called if there are no `.eta` values that need rows.

Also, I haven't yet found a good test for these.