### PR TITLE
Fix covMethod="r" and "s" standard errors (constant-factor inflation)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Authors@R: c(
     person("Robert", "Leary", role = "ctb"),
     person("Teun", "Post", , "t.post@lapp.nl", role = "ctb"),
     person("Vipul", "Mann", , "vm2583@columbia.edu", role = "aut"),
-    person("Yuan", "Xiong", , "yuan.xiong@gmail.com", role = "aut")
+    person("Yuan", "Xiong", , "yuan.xiong@gmail.com", role = "aut"),
+    person("Hidde", "van de Beek", , "hiddevdbeek@icloud.com", role = "ctb")
   )
 Maintainer: Matthew Fidler <matthew.fidler@gmail.com>
 Description: Fit and compare nonlinear mixed-effects models in

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,16 @@
   the real thread id via `setRxThreadId()` from rxode2 api (requires the
   matching rxode2).
 
+- Fixed `covMethod = "r"` and `covMethod = "s"` standard errors, which
+  were inflated by constant factors (`sqrt(2)` and `2`, respectively).
+  With the objective on the `-2*logLik` scale the R matrix is the
+  observed information and the S matrix is the score cross-product, so
+  the covariances are `R^-1` and `S^-1`; they were returned as `2*R^-1`
+  and `4*S^-1`.  The default sandwich method `"r,s"` (`R^-1 S R^-1`) was
+  already correct and is unchanged.  `covR`/`covS` are fixed at source so
+  the sandwich-selection heuristic also compares consistently-scaled
+  covariances (#666).
+
 - The iteration-time progress output emitted by every estimator
   (focei, saem, bobyqa, nlm, optim, nls, nlminb, lbfgsb3c, n1qn1,
   newuoa, uobyqa) now flows through a single shared printer

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -6118,7 +6118,13 @@ NumericMatrix foceiCalcCov(Environment e){
               op_focei.cur++;
               op_focei.curTick = par_progress(op_focei.cur, op_focei.totTick, op_focei.curTick, getRxCores(rx), op_focei.t0, 0);
               if (!e.exists("covR")){
-                e["covR"] = wrap(2*Rinv);
+                // Issue #666: the R-matrix covariance is the inverse observed
+                // information Rinv = R^{-1} (R = 0.5*Hessian(-2LL) here).  This
+                // was 2*Rinv, which made every covMethod="r" SE sqrt(2) too
+                // large vs NONMEM $COV MATRIX=R and vs the (correct) sandwich
+                // "r,s".  covR feeds both the final "r" output and the
+                // sandwich-selection heuristic below, so it is fixed at source.
+                e["covR"] = wrap(Rinv);
               }
               if (op_focei.covMethod == 2){
                 e["cov"] = as<NumericMatrix>(e["covR"]);
@@ -6214,7 +6220,14 @@ NumericMatrix foceiCalcCov(Environment e){
                   Sinv = pinv(trimatu(cholS));
                 }
                 Sinv = Sinv * Sinv.t();
-                e["covS"]= 4 * Sinv;
+                // Issue #666: the S-matrix (OPG/cross-product) covariance is
+                // Sinv = S^{-1}.  This was 4*Sinv, which made every covMethod="s"
+                // SE 2x too large.  Confirmed against the empirical sampling
+                // covariance of a known data-generating model: r, the sandwich,
+                // and S^{-1} all match the true Cov(theta_hat), while 4*S^{-1}
+                // is ~2x.  covS also feeds the selection heuristic below, so it
+                // is fixed at source alongside covR.
+                e["covS"]= Sinv;
                 if (!checkSandwich) {
                   bool covRSsmall = arma::any(abs(covRS.diag()) < op_focei.covSmall);
                   if (covRSsmall) {
@@ -6279,7 +6292,7 @@ NumericMatrix foceiCalcCov(Environment e){
                 Sinv = Sinv * Sinv.t();
                 op_focei.cur++;
                 op_focei.curTick = par_progress(op_focei.cur, op_focei.totTick, op_focei.curTick, 1, op_focei.t0, 0);
-                e["cov"]= 4 * Sinv;
+                e["cov"]= Sinv;   // issue #666: S-matrix covariance is S^{-1}, not 4*S^{-1}
               }
             }
           } else {

--- a/tests/testthat/test-cov-focei.R
+++ b/tests/testthat/test-cov-focei.R
@@ -51,6 +51,33 @@ nmTest({
 
   })
 
+  test_that("covMethod r and s SEs are not inflated vs the sandwich (issue #666)", {
+    one.cmt <- function() {
+      ini({
+        tka <- log(1.5); tcl <- log(2.7); tv <- log(31.5)
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    fit_r  <- .nlmixr(one.cmt, theo_sd, "focei", foceiControl(covMethod = "r",   print = 0))
+    fit_s  <- .nlmixr(one.cmt, theo_sd, "focei", foceiControl(covMethod = "s",   print = 0))
+    fit_rs <- .nlmixr(one.cmt, theo_sd, "focei", foceiControl(covMethod = "r,s", print = 0))
+
+    p <- c("tka", "tcl", "tv")
+    se_r  <- fit_r$parFixedDf[p,  "SE"]
+    se_s  <- fit_s$parFixedDf[p,  "SE"]
+    se_rs <- fit_rs$parFixedDf[p, "SE"]
+
+    # Before the fix: SE_r was ~sqrt(2) * SE_rs and SE_s was ~2 * SE_rs.
+    # After the fix all three should agree within ~30%.
+    expect_true(all(se_r  / se_rs < 1.3), label = "covMethod='r' SE not inflated vs sandwich")
+    expect_true(all(se_s  / se_rs < 1.3), label = "covMethod='s' SE not inflated vs sandwich")
+  })
+
   test_that("covariance with many omegas fixed will not crash focei", {
     one.compartment <- function() {
       ini({


### PR DESCRIPTION
## Summary

`covMethod="r"` standard errors are √2 too large and `covMethod="s"` SEs are 2× too large. The default sandwich `"r,s"` was already correct. Fixes #666.

## Root cause

With `OFV = −2·logL`, the R matrix is `R = ½·Hessian(OFV) = I_obs` (observed information) and the S matrix is the score cross-product `S = J`. The correct covariances vs what the code returned:

| method | correct | returned |
|---|---|---|
| R | `R⁻¹` | `2·R⁻¹` |
| S | `S⁻¹` | `4·S⁻¹` |
| R,S | `R⁻¹SR⁻¹` | `R⁻¹SR⁻¹` ✓ |

The sandwich never used `covR`/`covS`, so only `"r"`/`"s"` were affected.

## Fix

In `foceiCalcCov`: `covR = Rinv` (was `2*Rinv`) and `covS = Sinv` (was `4*Sinv`). These also feed the sandwich-selection heuristic, so fixing them at source keeps that comparison on consistently-scaled covariances. `covRS` is unchanged.

## Validation

**NONMEM `$COV MATRIX=R`** (combined-error sim), mean nlmixr2/NONMEM SE ratio: `"r"` 1.345 → **0.951**; `"r,s"` 0.958 (unchanged).

**Empirical sampling covariance of a known data-generating model** (mean method SE / true `cov(θ̂)`, scale-free relative ratios): `r ≈ r,s ≈ s(S⁻¹)`, while the old `s(4·S⁻¹)` runs at **2.04× / 2.09× / 2.05×** for tka/tcl/tv. So `"s"` goes from ~2.0× the true SE to ~1.0×.

(NONMEM `MATRIX=S` is not used as the reference — it runs ~1.5× its own `MATRIX=R` here, so it would mislead.)

## Scope

Default `"r,s"` and `covRS` are unchanged; the selection heuristic and the `$covR`/`$covS` diagnostics now operate on correctly-scaled covariances. Affects the explicit `covMethod="r"`/`"s"` outputs and the R/S fallbacks.
