### PR TITLE
Estimate matExp()/indLin() models in focei/nlm/saem

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # nlmixr2est (development version)
 
+- Matrix-exponential / inductive-linearization models (`matExp()` with optional
+  `indLin()` forcing) now estimate with the focei family (focei/foce/foi/posthoc),
+  the nlm family (nlm/nlminb/...), and SAEM, matching the equivalent ODE model.
+  A hand-written `matExp()` model that used `indLin()` previously registered the
+  forcing state as compartment 1, reversing it relative to the ODE and misplacing
+  default (compartment-1) dosing; the generated cmt()/d/dt() declarations now
+  order compartments source-first from the `k_<from>_<to>` graph.  SAEM also now
+  materializes the implied `d/dt()` for these models instead of erroring
+
 - Added `sensMethod` to the nlm-family controls (`nlmControl()`,
   `nlminbControl()`, `optimControl()`, `n1qn1Control()`, `lbfgsb3cControl()`)
   and to `foceiControl()` (focei/foce inner ETA sensitivities); ODE parameter

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,9 @@
 # nlmixr2est (development version)
 
-- Matrix-exponential / inductive-linearization models (`matExp()` with optional
-  `indLin()` forcing) now estimate with the focei family (focei/foce/foi/posthoc),
-  the nlm family (nlm/nlminb/...), and SAEM, matching the equivalent ODE model.
-  A hand-written `matExp()` model that used `indLin()` previously registered the
-  forcing state as compartment 1, reversing it relative to the ODE and misplacing
-  default (compartment-1) dosing; the generated cmt()/d/dt() declarations now
-  order compartments source-first from the `k_<from>_<to>` graph.  SAEM also now
-  materializes the implied `d/dt()` for these models instead of erroring
+- `matExp()`/`indLin()` models now estimate with the focei family, the nlm
+  family, and SAEM, matching the equivalent ODE model; compartments are
+  ordered source-first from the `k_<from>_<to>` graph so default dosing is
+  placed correctly
 
 - Added `sensMethod` to the nlm-family controls (`nlmControl()`,
   `nlminbControl()`, `optimControl()`, `n1qn1Control()`, `lbfgsb3cControl()`)

--- a/R/focei.R
+++ b/R/focei.R
@@ -259,13 +259,9 @@ is.latex <- function() {
 
 #' Order matExp() compartments source-first from the k_from_to graph
 #'
-#' A hand-written `matExp()` model that also uses `indLin()` registers the
-#' `indLin()` state as compartment 1 during parsing, which reverses it relative
-#' to the equivalent ODE model (whose dosed/source compartment comes first).
-#' That misplaces default (compartment-1) dosing.  This restores a source-first
-#' order via a topological sort of the `k_<from>_<to>` transfer graph so the
-#' generated cmt()/d/dt() declarations -- which set the compiled compartment
-#' numbering the solver and data cmt-mapping use -- match the ODE formulation.
+#' With `indLin()` the forcing state parses as compartment 1, misplacing
+#' default dosing; a topological sort of the `k_<from>_<to>` graph restores
+#' the ODE-equivalent order.
 #'
 #' @param states character vector of compartment names (no "output")
 #' @param kNames character vector of model lhs names (the k_from_to constants)

--- a/R/focei.R
+++ b/R/focei.R
@@ -257,6 +257,46 @@ is.latex <- function() {
   setdiff(rxode2stateOde(x), "output")
 }
 
+#' Order matExp() compartments source-first from the k_from_to graph
+#'
+#' A hand-written `matExp()` model that also uses `indLin()` registers the
+#' `indLin()` state as compartment 1 during parsing, which reverses it relative
+#' to the equivalent ODE model (whose dosed/source compartment comes first).
+#' That misplaces default (compartment-1) dosing.  This restores a source-first
+#' order via a topological sort of the `k_<from>_<to>` transfer graph so the
+#' generated cmt()/d/dt() declarations -- which set the compiled compartment
+#' numbering the solver and data cmt-mapping use -- match the ODE formulation.
+#'
+#' @param states character vector of compartment names (no "output")
+#' @param kNames character vector of model lhs names (the k_from_to constants)
+#' @return `states` reordered source-first; unchanged when no graph is available
+#' @noRd
+.rxMatExpStateOrder <- function(states, kNames) {
+  if (length(states) < 2L) return(states)
+  .from <- character(0)
+  .to <- character(0)
+  for (.k in kNames) {
+    .m <- regmatches(.k, regexec("^k[_.]([^_.]+)[_.]([^_.]+)$", .k))[[1L]]
+    if (length(.m) == 3L && .m[2L] %in% states && .m[3L] %in% states) {
+      .from <- c(.from, .m[2L])
+      .to <- c(.to, .m[3L])
+    }
+  }
+  if (length(.from) == 0L) return(states)
+  .indeg <- stats::setNames(integer(length(states)), states)
+  for (.t in .to) .indeg[.t] <- .indeg[.t] + 1L
+  .ord <- character(0)
+  .rem <- states
+  while (length(.rem) > 0L) {
+    .ready <- .rem[.indeg[.rem] == 0L]
+    .pick <- if (length(.ready) > 0L) .ready[1L] else .rem[1L]
+    .ord <- c(.ord, .pick)
+    .rem <- setdiff(.rem, .pick)
+    for (.t in .to[.from == .pick]) .indeg[.t] <- .indeg[.t] - 1L
+  }
+  .ord
+}
+
 .rxInjectMatExpDdt <- function(s) {
   .mv <- rxode2::rxModelVars(s)
   if (!is.list(.mv$indLin) || length(.mv$indLin) != 4L) {
@@ -266,6 +306,7 @@ is.latex <- function() {
   if (length(.states) == 0L) {
     return(invisible(FALSE))
   }
+  .states <- .rxMatExpStateOrder(.states, ls(envir = s, all.names = TRUE))
   rxode2::.rxInjectMatExpOdes(s)
   .ddt <- stats::setNames(rep("0", length(.states)), .states)
   for (.p in ls(envir = s, all.names = TRUE)) {
@@ -371,6 +412,10 @@ rxUiGet.foceiCmtPreModel <- function(x, ...) {
   .ui <- x[[1]]
   .state <- .rxode2stateOdeNoOutput(.ui$mv0)
   if (length(.state) == 0) return("")
+  .mv <- .ui$mv0
+  if (is.list(.mv$indLin) && length(.mv$indLin) == 4L) {
+    .state <- .rxMatExpStateOrder(.state, .mv$lhs)
+  }
   paste(paste0("cmt(", .state, ")"), collapse="\n")
 }
 attr(rxUiGet.foceiCmtPreModel, "rstudio") <- ""

--- a/R/saemRxUiGetModel.R
+++ b/R/saemRxUiGetModel.R
@@ -312,10 +312,8 @@ attr(rxUiGet.saemParams, "rstudio") <- "params(tka)"
 rxUiGet.saemModel <- function(x, ...) {
   .s <- rxUiGet.loadPruneSaem(x, ...)
 
-  # matExp() models carry no d/dt(): materialize it from the k_from_to rate
-  # constants (source-first order) and emit the model LHS (which defines those
-  # constants) ahead of the d/dt() lines so the derivatives can resolve them.
-  # The LHS is suppressed ('~') so it adds no output column.
+  # matExp() has no d/dt(): materialize it from the k_from_to constants and
+  # emit the defining LHS first, suppressed ('~') so it adds no output column
   .isMatExp <- isTRUE(.rxInjectMatExpDdt(.s))
 
   .prd <- get("rx_pred_", envir = .s)

--- a/R/saemRxUiGetModel.R
+++ b/R/saemRxUiGetModel.R
@@ -312,15 +312,28 @@ attr(rxUiGet.saemParams, "rstudio") <- "params(tka)"
 rxUiGet.saemModel <- function(x, ...) {
   .s <- rxUiGet.loadPruneSaem(x, ...)
 
+  # matExp() models carry no d/dt(): materialize it from the k_from_to rate
+  # constants (source-first order) and emit the model LHS (which defines those
+  # constants) ahead of the d/dt() lines so the derivatives can resolve them.
+  # The LHS is suppressed ('~') so it adds no output column.
+  .isMatExp <- isTRUE(.rxInjectMatExpDdt(.s))
+
   .prd <- get("rx_pred_", envir = .s)
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))
   ## .lhs0 <- .s$..lhs0
   ## if (is.null(.lhs0)) .lhs0 <- ""
   .ddt <- .s$..ddt
   if (is.null(.ddt)) .ddt <- ""
+  .preLhs <- character(0)
+  if (.isMatExp) {
+    .lhs <- .s$..lhs
+    if (is.null(.lhs)) .lhs <- character(0)
+    .preLhs <- sub("^([^=]+)=", "\\1~", .lhs)
+  }
   .ret <- paste(c(
     #.s$..stateInfo["state"],
     #.lhs0,
+    .preLhs,
     .ddt,
     .prd,
     #.s$..stateInfo["statef"],

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -130,7 +130,7 @@ foceiControl(
   agqLow = -Inf,
   agqHi = Inf,
   eventSens = c("jump", "fd"),
-  sensMethod = c("default", "auto", "forward", "adjoint"),
+  sensMethod = c("default", "forward", "adjoint"),
   boundedTransform = TRUE
 )
 }
@@ -621,11 +621,10 @@ uses the legacy finite-difference behavior.}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities:
 `"default"` (the default) defers to the global option
-`getOption("nlmixr2est.adjoint")`; `"forward"` uses the classic variational
-(forward) sensitivity ODEs; `"adjoint"` uses the in-engine discrete adjoint
-with the matching adjoint (`s`) method; `"auto"` selects `"adjoint"` when
-the estimated parameters exceed the number of ODE states and `"forward"`
-otherwise.}
+`getOption("nlmixr2est.adjoint")` (itself `"forward"` by default);
+`"forward"` uses the classic variational (forward) sensitivity ODEs;
+`"adjoint"` uses the in-engine discrete adjoint with the matching adjoint
+(`s`) method.}
 
 \item{boundedTransform}{When `TRUE` (default), bounded parameters are
 transformed for unbounded optimization methods and back-transformed

--- a/man/lbfgsb3cControl.Rd
+++ b/man/lbfgsb3cControl.Rd
@@ -34,7 +34,7 @@ lbfgsb3cControl(
   literalFixRes = TRUE,
   addProp = c("combined2", "combined1"),
   eventSens = c("jump", "fd"),
-  sensMethod = c("default", "auto", "forward", "adjoint"),
+  sensMethod = c("default", "forward", "adjoint"),
   calcTables = TRUE,
   compress = FALSE,
   covMethod = c("r", ""),
@@ -169,11 +169,10 @@ uses the legacy finite-difference behavior.}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities:
 `"default"` (the default) defers to the global option
-`getOption("nlmixr2est.adjoint")`; `"forward"` uses the classic variational
-(forward) sensitivity ODEs; `"adjoint"` uses the in-engine discrete adjoint
-with the matching adjoint (`s`) method; `"auto"` selects `"adjoint"` when
-the estimated parameters exceed the number of ODE states and `"forward"`
-otherwise.}
+`getOption("nlmixr2est.adjoint")` (itself `"forward"` by default);
+`"forward"` uses the classic variational (forward) sensitivity ODEs;
+`"adjoint"` uses the in-engine discrete adjoint with the matching adjoint
+(`s`) method.}
 
 \item{calcTables}{This boolean is to determine if the foceiFit
 will calculate tables. By default this is \code{TRUE}}

--- a/man/n1qn1Control.Rd
+++ b/man/n1qn1Control.Rd
@@ -32,7 +32,7 @@ n1qn1Control(
   literalFixRes = TRUE,
   addProp = c("combined2", "combined1"),
   eventSens = c("jump", "fd"),
-  sensMethod = c("default", "auto", "forward", "adjoint"),
+  sensMethod = c("default", "forward", "adjoint"),
   calcTables = TRUE,
   compress = FALSE,
   covMethod = c("r", "n1qn1", ""),
@@ -160,11 +160,10 @@ uses the legacy finite-difference behavior.}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities:
 `"default"` (the default) defers to the global option
-`getOption("nlmixr2est.adjoint")`; `"forward"` uses the classic variational
-(forward) sensitivity ODEs; `"adjoint"` uses the in-engine discrete adjoint
-with the matching adjoint (`s`) method; `"auto"` selects `"adjoint"` when
-the estimated parameters exceed the number of ODE states and `"forward"`
-otherwise.}
+`getOption("nlmixr2est.adjoint")` (itself `"forward"` by default);
+`"forward"` uses the classic variational (forward) sensitivity ODEs;
+`"adjoint"` uses the in-engine discrete adjoint with the matching adjoint
+(`s`) method.}
 
 \item{calcTables}{This boolean is to determine if the foceiFit
 will calculate tables. By default this is \code{TRUE}}

--- a/man/nlmControl.Rd
+++ b/man/nlmControl.Rd
@@ -27,7 +27,7 @@ nlmControl(
   hessErr = (.Machine$double.eps)^(1/3),
   shi21maxHess = 20L,
   eventSens = c("jump", "fd"),
-  sensMethod = c("default", "auto", "forward", "adjoint"),
+  sensMethod = c("default", "forward", "adjoint"),
   useColor = NULL,
   printNcol = NULL,
   print = 1L,
@@ -148,11 +148,10 @@ uses the legacy finite-difference behavior.}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities:
 `"default"` (the default) defers to the global option
-`getOption("nlmixr2est.adjoint")`; `"forward"` uses the classic variational
-(forward) sensitivity ODEs; `"adjoint"` uses the in-engine discrete adjoint
-with the matching adjoint (`s`) method; `"auto"` selects `"adjoint"` when
-the estimated `THETA` parameters exceed the number of ODE states and
-`"forward"` otherwise.}
+`getOption("nlmixr2est.adjoint")` (itself `"forward"` by default);
+`"forward"` uses the classic variational (forward) sensitivity ODEs;
+`"adjoint"` uses the in-engine discrete adjoint with the matching adjoint
+(`s`) method.}
 
 \item{useColor}{Logical (or `NULL`) emit ANSI bold/color escapes in the
 iteration print. `NULL` (default) defers to [crayon::has_color()].}

--- a/man/nlminbControl.Rd
+++ b/man/nlminbControl.Rd
@@ -47,7 +47,7 @@ nlminbControl(
   gradTo = 1,
   addProp = c("combined2", "combined1"),
   eventSens = c("jump", "fd"),
-  sensMethod = c("default", "auto", "forward", "adjoint"),
+  sensMethod = c("default", "forward", "adjoint"),
   calcTables = TRUE,
   compress = TRUE,
   covMethod = c("r", "nlminb", ""),
@@ -223,11 +223,10 @@ uses the legacy finite-difference behavior.}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities:
 `"default"` (the default) defers to the global option
-`getOption("nlmixr2est.adjoint")`; `"forward"` uses the classic variational
-(forward) sensitivity ODEs; `"adjoint"` uses the in-engine discrete adjoint
-with the matching adjoint (`s`) method; `"auto"` selects `"adjoint"` when
-the estimated parameters exceed the number of ODE states and `"forward"`
-otherwise.}
+`getOption("nlmixr2est.adjoint")` (itself `"forward"` by default);
+`"forward"` uses the classic variational (forward) sensitivity ODEs;
+`"adjoint"` uses the in-engine discrete adjoint with the matching adjoint
+(`s`) method.}
 
 \item{calcTables}{This boolean is to determine if the foceiFit
 will calculate tables. By default this is \code{TRUE}}

--- a/man/optimControl.Rd
+++ b/man/optimControl.Rd
@@ -50,7 +50,7 @@ optimControl(
   returnOptim = FALSE,
   addProp = c("combined2", "combined1"),
   eventSens = c("jump", "fd"),
-  sensMethod = c("default", "auto", "forward", "adjoint"),
+  sensMethod = c("default", "forward", "adjoint"),
   calcTables = TRUE,
   compress = FALSE,
   covMethod = c("r", "optim", ""),
@@ -256,11 +256,10 @@ uses the legacy finite-difference behavior.}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities:
 `"default"` (the default) defers to the global option
-`getOption("nlmixr2est.adjoint")`; `"forward"` uses the classic variational
-(forward) sensitivity ODEs; `"adjoint"` uses the in-engine discrete adjoint
-with the matching adjoint (`s`) method; `"auto"` selects `"adjoint"` when
-the estimated parameters exceed the number of ODE states and `"forward"`
-otherwise.}
+`getOption("nlmixr2est.adjoint")` (itself `"forward"` by default);
+`"forward"` uses the classic variational (forward) sensitivity ODEs;
+`"adjoint"` uses the in-engine discrete adjoint with the matching adjoint
+(`s`) method.}
 
 \item{calcTables}{This boolean is to determine if the foceiFit
 will calculate tables. By default this is \code{TRUE}}

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -1,0 +1,139 @@
+nmTest({
+  # Regression tests for matExp() / indLin() inductive-linearization model
+  # estimation.  A hand-written matExp() model that uses indLin() forcing must
+  # order its compartments source-first (like the equivalent ODE), otherwise
+  # default (compartment-1) dosing lands in the wrong compartment and the fit
+  # diverges from the ODE formulation.  Each test fits both the ODE model and
+  # its mathematically-identical matExp() form with *default* dosing (no cmt
+  # column) and asserts the objective and fixed effects agree.
+
+  .mkData <- function(model, params, sd = 0.3, nid = 6, seed = 1234) {
+    set.seed(seed)
+    .ev <- rxode2::et(amt = 320, cmt = "depot", id = seq_len(nid)) |>
+      rxode2::et(seq(0.5, 24, by = 1.5))
+    .sim <- rxode2::rxSolve(model, .ev, params = params)
+    .dat <- as.data.frame(.sim)[, c("id", "time", "cp")]
+    .dat$cp <- .dat$cp + stats::rnorm(nrow(.dat), 0, sd)
+    names(.dat) <- c("ID", "TIME", "DV")
+    .dat$AMT <- 0
+    .dat$EVID <- 0
+    # NOTE: dose row deliberately has NO cmt column -> defaults to compartment 1
+    .dose <- data.frame(ID = seq_len(nid), TIME = 0, DV = NA, AMT = 320, EVID = 1)
+    .dat <- rbind(.dose, .dat)
+    .dat[order(.dat$ID, .dat$TIME, -.dat$EVID), ]
+  }
+
+  test_that("matExp() linear model estimates identically to the ODE (focei/foce/nlm)", {
+    odeLin <- function() {
+      ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - cl / v * central
+        cp <- central / v
+        cp ~ add(add.sd)
+      })
+    }
+    matLin <- function() {
+      ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka + eta.ka)
+        k_central_output <- exp(tcl) / exp(tv)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .dat <- .mkData(odeLin, c(tka = 0.6, tcl = 1.1, tv = 3.6))
+    for (.met in c("focei", "foce")) {
+      .fO <- .nlmixr(odeLin, .dat, est = .met, control = foceiControl(print = 0))
+      .fM <- .nlmixr(matLin, .dat, est = .met, control = foceiControl(print = 0))
+      expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
+      expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
+    }
+  })
+
+  test_that("matExp() + indLin() Michaelis-Menten estimates identically to the ODE (focei)", {
+    odeMM <- function() {
+      ini({ tka <- 0.45; tvmax <- log(60); tkm <- log(40); tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        ka <- exp(tka + eta.ka); vmax <- exp(tvmax); km <- exp(tkm); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - vmax * central / (km + central)
+        cp <- central / v
+        cp ~ add(add.sd)
+      })
+    }
+    matMM <- function() {
+      ini({ tka <- 0.45; tvmax <- log(60); tkm <- log(40); tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka + eta.ka)
+        indLin(central) <- -exp(tvmax) * central / (exp(tkm) + central)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .dat <- .mkData(odeMM, c(tka = 0.6, tvmax = log(70), tkm = log(45), tv = 3.6))
+    .fO <- .nlmixr(odeMM, .dat, est = "focei", control = foceiControl(print = 0))
+    .fM <- .nlmixr(matMM, .dat, est = "focei", control = foceiControl(print = 0))
+    expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
+    expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
+  })
+
+  test_that("matExp() population model estimates identically to the ODE (nlm)", {
+    odeMM <- function() {
+      ini({ tka <- 0.45; tvmax <- log(60); tkm <- log(40); tv <- 3.45; add.sd <- 0.7 })
+      model({
+        ka <- exp(tka); vmax <- exp(tvmax); km <- exp(tkm); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - vmax * central / (km + central)
+        cp <- central / v
+        cp ~ add(add.sd)
+      })
+    }
+    matMM <- function() {
+      ini({ tka <- 0.45; tvmax <- log(60); tkm <- log(40); tv <- 3.45; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka)
+        indLin(central) <- -exp(tvmax) * central / (exp(tkm) + central)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .dat <- .mkData(odeMM, c(tka = 0.7, tvmax = log(80), tkm = log(55), tv = 3.6))
+    .fO <- .nlmixr(odeMM, .dat, est = "nlm", list(print = 0))
+    .fM <- .nlmixr(matMM, .dat, est = "nlm", list(print = 0))
+    expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
+    expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
+  })
+
+  test_that("matExp() estimates identically to the ODE (saem)", {
+    odeS <- function() {
+      ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.3; add.sd <- 0.7 })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - cl / v * central
+        cp <- central / v
+        cp ~ add(add.sd)
+      })
+    }
+    matS <- function() {
+      ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.3; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka + eta.ka)
+        k_central_output <- exp(tcl) / exp(tv)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .ctl <- saemControl(print = 0, nBurn = 100, nEm = 100, seed = 42)
+    .fO <- .nlmixr(odeS, nlmixr2data::theo_sd, est = "saem", control = .ctl)
+    .fM <- .nlmixr(matS, nlmixr2data::theo_sd, est = "saem", control = .ctl)
+    expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
+    expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
+  })
+})

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -1,11 +1,6 @@
 nmTest({
-  # Regression tests for matExp() / indLin() inductive-linearization model
-  # estimation.  A hand-written matExp() model that uses indLin() forcing must
-  # order its compartments source-first (like the equivalent ODE), otherwise
-  # default (compartment-1) dosing lands in the wrong compartment and the fit
-  # diverges from the ODE formulation.  Each test fits both the ODE model and
-  # its mathematically-identical matExp() form with *default* dosing (no cmt
-  # column) and asserts the objective and fixed effects agree.
+  # matExp()/indLin() fits with default (compartment-1) dosing must match the
+  # equivalent ODE model; source-first compartment order is the regression
 
   .mkData <- function(model, params, sd = 0.3, nid = 6, seed = 1234) {
     set.seed(seed)
@@ -17,7 +12,7 @@ nmTest({
     names(.dat) <- c("ID", "TIME", "DV")
     .dat$AMT <- 0
     .dat$EVID <- 0
-    # NOTE: dose row deliberately has NO cmt column -> defaults to compartment 1
+    # dose row deliberately lacks cmt so it defaults to compartment 1
     .dose <- data.frame(ID = seq_len(nid), TIME = 0, DV = NA, AMT = 320, EVID = 1)
     .dat <- rbind(.dose, .dat)
     .dat[order(.dat$ID, .dat$TIME, -.dat$EVID), ]
@@ -48,6 +43,37 @@ nmTest({
     for (.met in c("focei", "foce")) {
       .fO <- .nlmixr(odeLin, .dat, est = .met, control = foceiControl(print = 0))
       .fM <- .nlmixr(matLin, .dat, est = .met, control = foceiControl(print = 0))
+      expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
+      expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
+    }
+  })
+
+  test_that("matExp() linear model estimates identically to the ODE (agq/laplace)", {
+    odeLin <- function() {
+      ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - cl / v * central
+        cp <- central / v
+        cp ~ add(add.sd)
+      })
+    }
+    matLin <- function() {
+      ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka + eta.ka)
+        k_central_output <- exp(tcl) / exp(tv)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .dat <- .mkData(odeLin, c(tka = 0.6, tcl = 1.1, tv = 3.6))
+    for (.met in c("agq", "laplace")) {
+      .ctl <- if (.met == "agq") agqControl(print = 0) else laplaceControl(print = 0)
+      .fO <- .nlmixr(odeLin, .dat, est = .met, control = .ctl)
+      .fM <- .nlmixr(matLin, .dat, est = .met, control = .ctl)
       expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
       expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
     }


### PR DESCRIPTION
Matrix-exponential / inductive-linearization models now estimate with the focei family, the nlm family, and SAEM, matching the equivalent ODE model.

A hand-written matExp() model using indLin() registered the forcing state as compartment 1, reversing it relative to the ODE and misplacing default (compartment-1) dosing.  Add .rxMatExpStateOrder(), a source-first topological sort of the k_<from>_<to> graph, applied where the generated cmt()/d/dt() declarations set the compiled compartment numbering (foceiCmtPreModel, .rxInjectMatExpDdt).

SAEM never materialized the implied d/dt() for these models (cryptic dimnames error); saemModel now injects it and emits the k_ rate definitions ahead of the d/dt(), mirroring focei.