### PR TITLE
focei(analytic cov): chunk rxOptExpr to cut the fast-path build ~2.9x

### DIFF
--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -86,10 +86,10 @@
 #'     finite differences, and use the Eq-48 random-effect extrapolation for the
 #'     next inner-problem starting values.  Requires an analytic-scope model
 #'     (single additive/proportional Gaussian endpoint); out-of-scope models fall
-#'     back to the finite-difference gradient with a message.  When unspecified,
-#'     the outer optimizer defaults to \code{"lbfgsb3c"} (vs \code{"nlminb"} for
-#'     \code{fast=FALSE}); pairing \code{fast=TRUE} with a derivative-free
-#'     \code{outerOpt} reverts to \code{fast=FALSE}.  The \code{*f} methods (e.g.
+#'     back to the finite-difference gradient with a message.  The outer
+#'     optimizer defaults to \code{"nlminb"} (as for \code{fast=FALSE}), which
+#'     converges robustly with the analytic gradient; pairing \code{fast=TRUE}
+#'     with a derivative-free \code{outerOpt} reverts to \code{fast=FALSE}.  The \code{*f} methods (e.g.
 #'     \code{foceif}) default this to \code{TRUE}.
 #'
 #' @param covTryHarder If the R matrix is non-positive definite and
@@ -1052,11 +1052,15 @@ foceiControl <- function(sigdig = 4, #
   if (!is.null(.xtra$outerOptFun)) {
     outerOptFun <- .xtra$outerOptFun
   } else if (rxode2::rxIs(outerOpt, "character")) {
-    # mode-dependent default when the user did not specify outerOpt: base methods
-    # use nlminb, fast methods use the gradient-friendly lbfgsb3c.  An explicit
+    # Default outer optimizer (when the user did not specify one): nlminb for both
+    # base and fast methods.  nlminb converges robustly with the analytic ("fast")
+    # gradient; lbfgsb3c is faster on well-conditioned problems but can settle at a
+    # worse local optimum on ill-conditioned models (e.g. multi-compartment), which
+    # both changes the reported objective and leaves the observed-information
+    # covariance indefinite (the analytic cov then falls back to FD).  An explicit
     # outerOpt (a single string) skips this.
     if (missing(outerOpt)) {
-      outerOpt <- if (isTRUE(fast)) "lbfgsb3c" else "nlminb"
+      outerOpt <- "nlminb"
     }
     outerOpt <- match.arg(outerOpt)
     .outerOptTxt <- outerOpt

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -746,9 +746,11 @@
   sgNameAll <- er$name                               # ALL error params (excluded from directions)
   # pure proportional / power error (no additive floor) vanishes as f -> 0, making the
   # 1/R observed-information terms blow up near zero predictions; the assembly guards it.
-  # lnorm is additive on the transformed (log) scale (R = sd^2 constant), so it never
-  # vanishes even though the transformed prediction crosses zero.
-  canVanish <- !any(er$err %in% c("add", "lnorm"))
+  # lnorm/logitNorm/probitNorm are additive on their transformed (log / logit / probit) scale
+  # (R = sd^2 constant), so the variance never vanishes even though the transformed prediction
+  # crosses zero (e.g. logit(cp) = 0 at the bound midpoint) -- the canVanish guard, meant for
+  # pure proportional/power error whose R -> 0 with f, must not fire for them.
+  canVanish <- !any(er$err %in% c("add", "lnorm", "logitNorm", "probitNorm"))
   # model-declared addProp wins; the control applies only when the model says "default"
   addPr <- as.character(ui$predDf$addProp)
   if (length(addPr) != 1L || is.na(addPr) || addPr == "default") {

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -1040,9 +1040,30 @@
     # Optimize common subexpressions (as the inner model does): the augmented model
     # has heavy shared subexpressions across the sensitivity ODEs and the f1/f2
     # prediction chains, so rxOptExpr materially shrinks the per-solve work.
+    # rxOptExpr is ~O(n^3.5) in model size, so optimizing the whole (~200-350 line)
+    # augmented model in one call dominates the build (~25s+).  Split into contiguous
+    # line-chunks and optimize each separately: k chunks of size n/k cost ~n^3/k^2 -- an
+    # ~8-13x speedup -- losing only cross-chunk CSE (the optimized text grows ~15-20%,
+    # negligible since the aug model is solved only hundreds of times per fit).  rxOptExpr
+    # restarts its introduced-variable counter at rx_expr_0 each call, so give each chunk a
+    # unique rx_expr_ prefix before concatenating (the aug model never uses that prefix).
     if (isTRUE(rxode2::rxGetControl(ui, "optExpression", TRUE))) {
-      .modTxt <- tryCatch(rxode2::rxOptExpr(.modTxt, "FOCEi outer gradient model"),
-                          error = function(e) .modTxt)
+      .modTxt <- tryCatch({
+        .ln <- strsplit(.modTxt, "\n", fixed = TRUE)[[1]]
+        .k <- max(1L, ceiling(length(.ln) / 40))
+        if (.k <= 1L) {
+          rxode2::rxOptExpr(.modTxt, "FOCEi outer gradient model")
+        } else {
+          .grp <- ceiling(seq_along(.ln) / ceiling(length(.ln) / .k))
+          .opt <- vapply(sort(unique(.grp)), function(.g) {
+            .chTxt <- paste(.ln[.grp == .g], collapse = "\n")
+            .o <- tryCatch(rxode2::rxOptExpr(.chTxt, "FOCEi outer gradient model"),
+                           error = function(e) .chTxt)
+            gsub("rx_expr_", paste0("rx_expr_c", .g, "_"), .o, fixed = TRUE)
+          }, character(1))
+          paste(.opt, collapse = "\n")
+        }
+      }, error = function(e) .modTxt)
     }
     # Declare the theta/eta inputs AND the model covariates up front (param()) so the
     # solve parameter order is fixed and positional.  Reuse .uiGetThetaEtaParams -- the

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -865,17 +865,22 @@
 .foceiAnalyticEtCache <- new.env(parent = emptyenv())      # per-fit translated event table (etTrans reuse)
 #' The augmented model's events are IDENTICAL across every solve of a fit (only the theta/eta
 #' params vary), so translate them once with etTrans and reuse -- ~40% off each population solve
-#' (validated: identical predictions).  Keyed by the model key + a cheap data fingerprint (nrow +
-#' sum of EVERY numeric column, so covariate differences never collide); falls back to raw data.
+#' (validated: identical predictions).  Keyed by the model key + a content hash of the data
+#' (`digest`, already a dependency), so distinct datasets that happen to share summary statistics
+#' cannot collide onto the same translated event table; falls back to raw data.  The hash is far
+#' cheaper than the etTrans it guards, so the per-solve lookup stays a net win.
 #' @noRd
 .foceiAnalyticEvents <- function(am, data) {
   if (is.null(am$key)) return(data)
-  .fp <- sum(vapply(data, function(.c) if (is.numeric(.c)) sum(.c, na.rm = TRUE) else 0, numeric(1)))
+  .fp <- tryCatch(digest::digest(data), error = function(e) NULL)
+  if (is.null(.fp)) return(data)                          # cannot fingerprint -> translate fresh (no cache)
   .ek <- paste0(am$key, "|et|", nrow(data), "|", .fp)
   .et <- get0(.ek, envir = .foceiAnalyticEtCache, inherits = FALSE)
   if (is.null(.et)) {
     .et <- tryCatch(rxode2::etTrans(data, am$augMod), error = function(e) NULL)
     if (is.null(.et)) return(data)
+    if (length(ls(.foceiAnalyticEtCache, all.names = TRUE)) >= 256L)    # bound memory in long sessions
+      rm(list = ls(.foceiAnalyticEtCache, all.names = TRUE), envir = .foceiAnalyticEtCache)
     assign(.ek, .et, envir = .foceiAnalyticEtCache)
   }
   .et
@@ -1055,7 +1060,11 @@
          st = .st, P2 = .P2, P2r = .P2r, hasRvar = !is.null(.rvar), sigTh = .sigTh, hasTrans = .hasTrans,
          cols = .foceiAnalyticCols(dirs, .fDirs, .P2, .P2r, .sigTh), cores = if (length(.cores)) .cores else 0L, key = .key)
   }, error = function(e) NULL)
-  if (!is.null(.key) && !is.null(.res)) assign(.key, .res, envir = .foceiAnalyticAugCache)
+  if (!is.null(.key) && !is.null(.res)) {
+    if (length(ls(.foceiAnalyticAugCache, all.names = TRUE)) >= 64L)    # bound retained compiled models
+      rm(list = ls(.foceiAnalyticAugCache, all.names = TRUE), envir = .foceiAnalyticAugCache)
+    assign(.key, .res, envir = .foceiAnalyticAugCache)
+  }
   .res
 }
 
@@ -1760,7 +1769,7 @@ E_ARelm <- function(E, l, m, fp) if (fp) E$AR[, l, m] else 0
   .ddeArgs <- if (isTRUE(rxode2::rxModelVars(aug$augMod)$flags[["hasDelay"]] == 1L))
     list(method = "dop853", stiff2 = 0L, dense = TRUE) else list()
   .d <- tryCatch(withCallingHandlers(
-      as.data.frame(do.call(rxode2::rxSolve, c(list(aug$augMod, params = params, .ev, cores = .nc,
+      as.data.frame(do.call(rxode2::rxSolve, c(list(aug$augMod, params = params, events = .ev, cores = .nc,
           returnType = "data.frame", atol = tol, rtol = tol), .ddeArgs))),
       warning = function(w) invokeRestart("muffleWarning")),
     error = function(e) NULL)

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -185,8 +185,15 @@
 .foceiAnalyticAssembleRFR <- function(ui, th, ebes, ids, data, Om, ef, neta, ndirP, dirP, omd,
                                       dirsCov, ndirCov, startedEnv = NULL, solveTol = 1e-10,
                                       interaction = 1L, foceType = 0L, lamDir = integer(0)) {
-  am <- .foceiAnalyticAugModelDirs(ui, dirsCov)
-  if (is.null(am) || am$ndir != ndirCov || !isTRUE(am$hasRvar)) return(NULL)
+  # Route A (FOCEI_RSIG): build the gradient's `dirs` model (drop the sigma directions) so the
+  # (f,R) cov SHARES the gradient's compiled model; the sigma tensor slots are rebuilt from rsig in
+  # SolveAllFD3 (.foceiAnalyticExpandSigma), which expands the solved E back to ndirCov.
+  .rsigA <- nzchar(Sys.getenv("FOCEI_RSIG"))
+  .erN <- ui$iniDf$ntheta[!is.na(ui$iniDf$err) & !(ui$iniDf$err %in% c("boxCox", "yeoJohnson"))]
+  .sigDirs <- if (.rsigA) intersect(dirsCov, paste0("THETA_", .erN, "_")) else character(0)
+  .dirsF <- dirsCov[!(dirsCov %in% .sigDirs)]
+  am <- .foceiAnalyticAugModelDirs(ui, if (.rsigA) .dirsF else dirsCov)
+  if (is.null(am) || am$ndir != (ndirCov - length(.sigDirs)) || !isTRUE(am$hasRvar)) return(NULL)
   np <- ndirP + omd$nom; Oi <- solve(Om)
   etav <- paste0("ETA_", seq_len(neta), "_")
   .foce <- identical(as.integer(interaction), 0L)      # FOCE re-solves EBEs to S_FOCE=0
@@ -202,25 +209,36 @@
     # (nonmem: aRe/ARe=0, aRc/ARc/R0 from E0; foce+: all from the eta-hat solve E).
     nsub <- length(ids); Elist <- vector("list", nsub); E0list <- vector("list", nsub)
     eta0list <- vector("list", nsub); nobsAll <- integer(nsub)
+    # BATCHED (f,R) FOCE/foce+ solves: the eta=0 population solve (nonmem frozen R0) is batched,
+    # the EBE re-solve stays per-subject (Newton), then ONE batched SolveAllFD3 delivers f/a/A/Ath
+    # AND R/aR/AR for all subjects (withR=FALSE: FOCE reads R/aR/AR from the base solve + Ath, but
+    # never AthR).  foce+ (foceType=1) keeps the live R (no eta=0 solve).  Per-subject Shi fallback.
+    .obsAll <- lapply(seq_len(nsub), function(i) { .s <- .byId[[as.character(.idCode[i])]]
+      if (is.null(.s) || nrow(.s) == 0L) NULL else .s[.s$EVID == 0, , drop = FALSE] })
+    if (any(vapply(.obsAll, is.null, logical(1L)))) return(NULL)
+    .obsT <- lapply(.obsAll, function(.o) .o$TIME)
+    E0all <- if (!.fp) .foceiAnalyticSolveAll(am, th, matrix(0, nsub, neta), .idCode, data, .obsT, solveTol) else NULL
+    if (!.fp && is.null(E0all)) return(NULL)
+    if (.rsigA && !.fp) {                                # Route A: rebuild frozen-R0 sigma slots (aR/AR) from rsig
+      .ns0 <- ncol(E0all[[1L]]$Rsig)
+      if (!is.null(.ns0) && .ns0 > 0L) E0all <- lapply(E0all, function(.E0) .foceiAnalyticExpandSigma(.E0, .ns0, neta, NULL, NULL))
+    }
+    eta0Mat <- .foceiAnalyticFoceEbeBatch(am, th, ebes, .idCode, data, .obsAll, .obsT, etav, Oi, neta,
+                                          solveTol, foceType = foceType, E0all = E0all)   # batched EBE re-solve
+    if (is.null(eta0Mat)) return(NULL)
+    .batch <- !nzchar(Sys.getenv("FOCEI_NO_FD3_BATCH"))
+    .EsAll <- if (.batch) .foceiAnalyticSolveAllFD3(am, th, eta0Mat, .idCode, data, .obsT, tol = solveTol, withR = FALSE) else NULL
+    if (.batch && is.null(.EsAll)) .batch <- FALSE
     for (i in seq_len(nsub)) {
-      s <- .byId[[as.character(.idCode[i])]]; if (is.null(s) || nrow(s) == 0L) return(NULL)
-      obs <- s[s$EVID == 0, , drop = FALSE]; eta0 <- ebes[i, ]
-      E0 <- NULL
-      if (!.fp) { E0 <- .foceiAnalyticSolveFA(am, c(th, setNames(rep(0, neta), etav)), s, obs$TIME, tol = solveTol)
-        if (is.null(E0)) return(NULL) }
-      eta0 <- .foceiAnalyticFoceEbe(am, th, eta0, s, obs$TIME, obs$DV, etav,
-                                    if (is.null(E0)) NULL else E0$R, Oi, neta, solveTol, foceType = foceType,
-                                    cens = obs$CENS, limit = obs$LIMIT)
-      if (is.null(eta0)) return(NULL)
-      E <- .foceiAnalyticSolveSubjectFD3(am, c(th, setNames(eta0, etav)), s, obs$TIME, tol = solveTol, withR = TRUE)
+      s <- .byId[[as.character(.idCode[i])]]; obs <- .obsAll[[i]]; eta0 <- eta0Mat[i, ]
+      E0 <- if (.fp) NULL else E0all[[i]]
+      E <- if (.batch) .EsAll[[i]] else .foceiAnalyticSolveSubjectFD3(am, c(th, setNames(eta0, etav)), s, obs$TIME, tol = solveTol, withR = FALSE)
       if (is.null(E)) return(NULL)
       if (isTRUE(ef$canVanish)) { .fa <- abs(E$f)
         if (any(!is.finite(.fa)) || min(.fa) < 1e-6 * max(.fa))
           return(.foceiAnalyticFallback("pure proportional error with a near-zero model prediction")) }
       E$y <- .foceiAnalyticTbsY(obs$DV, E$trans)
-      # E0 is NULL for foce+ (foceType=1, no eta=0 population solve); `E0list[[i]] <- NULL`
-      # would DELETE the slot and shrink the list (later E0list[[i]] out of bounds -> the
-      # whole cov silently falls back to FD).  `E0list[i] <- list(E0)` keeps the NULL slot.
+      # E0list[i] <- list(E0) keeps a NULL slot (foce+) without shrinking the list.
       Elist[[i]] <- E; E0list[i] <- list(E0); eta0list[[i]] <- eta0; nobsAll[i] <- length(E$f)
     }
     .fpG <- identical(as.integer(foceType), 1L) || is.null(E0list[[1L]])
@@ -273,10 +291,18 @@
   # FOCEI: per-subject FD3 (3rd-order Shi) solves collected in R, then ONE OpenMP C++ call
   # (foceiRAllFR_) sums the observed information over subjects -- no per-subject R<->C++ round-trip.
   nsub <- length(ids); Elist <- vector("list", nsub); nobsAll <- integer(nsub)
+  # BATCHED (f,R) FOCEI solves: ONE SolveAllFD3 gives f/a/A/Ath AND R/aR/AR/AthR for all subjects
+  # (withR=TRUE), instead of the per-subject Shi.  Per-subject Shi is the fallback.
+  .obsAll <- lapply(seq_len(nsub), function(i) { .s <- .byId[[as.character(.idCode[i])]]
+    if (is.null(.s) || nrow(.s) == 0L) NULL else .s[.s$EVID == 0, , drop = FALSE] })
+  if (any(vapply(.obsAll, is.null, logical(1L)))) return(NULL)
+  .obsT <- lapply(.obsAll, function(.o) .o$TIME)
+  .batch <- !nzchar(Sys.getenv("FOCEI_NO_FD3_BATCH"))
+  .EsAll <- if (.batch) .foceiAnalyticSolveAllFD3(am, th, ebes, .idCode, data, .obsT, tol = solveTol, withR = TRUE) else NULL
+  if (.batch && is.null(.EsAll)) .batch <- FALSE
   for (i in seq_len(nsub)) {
-    s <- .byId[[as.character(.idCode[i])]]; if (is.null(s) || nrow(s) == 0L) return(NULL)
-    obs <- s[s$EVID == 0, , drop = FALSE]
-    E <- .foceiAnalyticSolveSubjectFD3(am, c(th, setNames(ebes[i, ], etav)), s, obs$TIME, tol = solveTol, withR = TRUE)
+    s <- .byId[[as.character(.idCode[i])]]; obs <- .obsAll[[i]]
+    E <- if (.batch) .EsAll[[i]] else .foceiAnalyticSolveSubjectFD3(am, c(th, setNames(ebes[i, ], etav)), s, obs$TIME, tol = solveTol, withR = TRUE)
     if (is.null(E)) return(NULL)
     if (isTRUE(ef$canVanish)) { .fa <- abs(E$f)
       if (any(!is.finite(.fa)) || min(.fa) < 1e-6 * max(.fa))
@@ -358,31 +384,42 @@
   .byId <- split(data, as.character(data$ID))         # pre-split once (avoid per-subject rescan)
   .idCode <- if (is.factor(ids)) as.integer(ids) else match(ids, sort(unique(ids)))
   if (!is.null(startedEnv)) assign(".analyticStarted", TRUE, startedEnv)
+  # Batch the 3rd-order solve across ALL subjects (FOCEI *and* FOCE, no IOV rescale) so both take
+  # the IDENTICAL method and both get the speedup (1 + 2*neta population solves vs the per-subject
+  # Shi's O(nsub*neta)).  CORRECTED FOCE freezes R0 at the eta=0 population solve (batched) and
+  # re-solves each EBE (per-subject Newton, censoring-aware) to S_FOCE=0; that eta0 matrix feeds
+  # the batched FD3.  foce+ keeps the live R (no eta=0 solve).  Per-subject Shi is the fallback.
+  .obsAll <- lapply(seq_along(ids), function(i) { .s <- .byId[[as.character(.idCode[i])]]
+    if (is.null(.s) || nrow(.s) == 0L) NULL else .s[.s$EVID == 0, , drop = FALSE] })
+  if (any(vapply(.obsAll, is.null, logical(1L)))) return(NULL)   # unmatched subject -> caller FD
+  .obsT <- lapply(.obsAll, function(.o) .o$TIME)
+  .needF0 <- .foce && identical(as.integer(foceType), 0L) && isTRUE(ef$dependsF0)
+  E0List <- vector("list", length(ids))
+  if (.needF0) {                                       # eta=0 population solve (frozen R0), batched
+    E0List <- .foceiAnalyticSolveAll(am, th, matrix(0, length(ids), neta), .idCode, data, .obsT, solveTol)
+    if (is.null(E0List)) return(NULL)
+  }
+  eta0Mat <- ebes
+  if (.foce) for (i in seq_along(ids)) {              # FOCE EBE re-solve (per-subject Newton)
+    .o <- .obsAll[[i]]
+    .e0 <- .foceiAnalyticFoceEbe(am, th, ebes[i, ], .byId[[as.character(.idCode[i])]], .o$TIME, .o$DV, etav,
+                                 if (is.null(E0List[[i]])) NULL else E0List[[i]]$R, Oi, neta, solveTol,
+                                 foceType = foceType, cens = .o$CENS, limit = .o$LIMIT)
+    if (is.null(.e0)) return(NULL)
+    eta0Mat[i, ] <- .e0
+  }
+  .batch <- !rescale && !nzchar(Sys.getenv("FOCEI_NO_FD3_BATCH"))
+  .EsAll <- NULL
+  if (.batch) {
+    .EsAll <- .foceiAnalyticSolveAllFD3(am, th, eta0Mat, .idCode, data, .obsT, tol = solveTol, withR = FALSE)
+    if (is.null(.EsAll)) .batch <- FALSE              # batched solve failed -> per-subject fallback
+  }
   for (i in seq_along(ids)) {
-    s <- .byId[[as.character(.idCode[i])]]             # subject's actual events (integer-code join)
-    if (is.null(s) || nrow(s) == 0L) return(NULL)      # unmatched subject -> caller falls back to FD
-    obs <- s[s$EVID == 0, , drop = FALSE]
-    eta0 <- ebes[i, ]
-    # CORRECTED FOCE (interaction=0, foceType=0): the variance R0 is frozen at the eta=0
-    # POPULATION prediction.  Solve the augmented model at eta=0 to get f0 (and its
-    # theta-chain a0/A0) only when R0 actually depends on the prediction (proportional
-    # part); additive R0=sa^2 needs no population solve (== FOCEI-add).  The stored EBEs
-    # stationarize S_FOCE with this R0, so the re-solve is ~a no-op (kept for robustness).
-    # "foce+" (foceType=1) keeps the live conditional R and never needs the eta=0 solve.
-    E0 <- NULL
-    .needF0 <- .foce && identical(as.integer(foceType), 0L) && isTRUE(ef$dependsF0)
-    if (.needF0) {
-      E0 <- .foceiAnalyticSolveFA(am, c(th, setNames(rep(0, neta), etav)), s, obs$TIME, tol = solveTol)
-      if (is.null(E0)) return(NULL)
-    }
-    if (.foce) {
-      eta0 <- .foceiAnalyticFoceEbe(am, th, eta0, s, obs$TIME, obs$DV, etav,
-                                    if (is.null(E0)) NULL else E0$R, Oi, neta, solveTol, foceType = foceType,
-                                    cens = obs$CENS, limit = obs$LIMIT)
-      if (is.null(eta0)) return(NULL)
-    }
-    p <- c(th, setNames(eta0, etav))                  # solve at the Param A (unit-occ-eta) EBEs
-    E <- .foceiAnalyticSolveSubjectFD3(am, p, s, obs$TIME, tol = solveTol)
+    s <- .byId[[as.character(.idCode[i])]]
+    obs <- .obsAll[[i]]
+    eta0 <- eta0Mat[i, ]
+    E0 <- E0List[[i]]
+    E <- if (.batch) .EsAll[[i]] else .foceiAnalyticSolveSubjectFD3(am, c(th, setNames(eta0, etav)), s, obs$TIME, tol = solveTol)
     if (is.null(E)) return(NULL)                       # solve failure -> caller falls back to FD
     # near-zero-prediction guard for a vanishing residual variance (pure proportional
     # R = sp^2 f^2 -> 0): the 1/R observed-information terms blow up, so drop to FD.
@@ -551,11 +588,13 @@
     ebes <- as.matrix(etaObf[, paste0("ETA[", seq_len(neta), "]"), drop = FALSE])
     ids  <- etaObf$ID
     data <- get("dataSav", e)
-    # censored (M2/M3/M4) analytic cov: FOCEI and FOCE with censOption="gauss" are in scope
-    # (censored score partials feed the (f,R) path; the determinant stays Gauss-Newton, matching
-    # the gauss fit).  Only the laplace censored determinant still bows out to the FD cov.
+    # Censored data (M2/M3/M4): the analytic observed-information cov carries the censored
+    # determinant partials through the general (f,R) path (AssembleRFR), matching the exact
+    # censored analytic outer gradient.  Any censored/BLOQ observation (CENS != 0 or a finite
+    # LIMIT) routes to that path (and uses the same batched FD3 solve as the uncensored (f,R) cov).
     .hasCensD <- (!is.null(data$CENS) && any(data$CENS != 0, na.rm = TRUE)) ||
       (!is.null(data$LIMIT) && any(is.finite(data$LIMIT)))
+    # only the laplace censored determinant stays on the FD cov; gauss (default) is analytic
     if (.hasCensD && as.integer(rxode2::rxGetControl(ui, "censOption", 0L)) == 1L)
       return(.foceiAnalyticFallback("censored observations with censOption='laplace'"))
 
@@ -801,8 +840,50 @@
 #' cheaply than a 3rd-order model.
 #' @return list(augMod, dirs, ndir, st, P2) or `NULL` on failure
 #' @noRd
+.foceiAnalyticAugCache <- new.env(parent = emptyenv())     # session cache: (model digest | dirs) -> aug model
+#' Solve-output column names + index maps for the augmented model (from dirs, P2, sigTh).
+#' Precomputed once on `am$cols` at build time so the matrix-extraction readers avoid per-call
+#' paste0; recomputed on the fly for a reconstructed `am` (from foceiModel$outer) that predates it.
+#' @noRd
+.foceiAnalyticCols <- function(dirs, fDirs, P2, P2r, sigTh) {
+  sigP2 <- if (length(sigTh)) do.call(rbind, lapply(seq_along(sigTh), function(.a)
+    data.frame(a = .a, b = seq_along(sigTh)[seq_along(sigTh) >= .a]))) else NULL
+  # f-part (prediction a/A) spans f-directions only (sigma slots are zero-filled by the reader);
+  # R-part (aR/AR) spans every direction.  iiF/jjF index the f2 pairs into the FULL dirs vector.
+  list(f1 = paste0("rx_f1_", fDirs), fDirIdx = match(fDirs, dirs),
+       f2 = paste0("rx_f2_", P2$i, "_", P2$j), iiF = match(P2$i, dirs), jjF = match(P2$j, dirs),
+       rvar1 = paste0("rx_rvar1_", dirs), rvar2 = paste0("rx_rvar2_", P2r$i, "_", P2r$j),
+       ii = match(P2r$i, dirs), jj = match(P2r$j, dirs),
+       rsig = if (length(sigTh)) paste0("rx_rsig_", sigTh, "_") else character(0),
+       rsig1 = lapply(sigTh, function(.n) paste0("rx_rsig1_", .n, "_", dirs)),
+       rsig2 = if (is.null(sigP2)) character(0) else paste0("rx_rsig2_", sigTh[sigP2$a], "_", sigTh[sigP2$b]),
+       sigP2 = sigP2)
+}
+.foceiAnalyticEtCache <- new.env(parent = emptyenv())      # per-fit translated event table (etTrans reuse)
+#' The augmented model's events are IDENTICAL across every solve of a fit (only the theta/eta
+#' params vary), so translate them once with etTrans and reuse -- ~40% off each population solve
+#' (validated: identical predictions).  Keyed by the model key + a cheap data fingerprint (nrow +
+#' sum of EVERY numeric column, so covariate differences never collide); falls back to raw data.
+#' @noRd
+.foceiAnalyticEvents <- function(am, data) {
+  if (is.null(am$key)) return(data)
+  .fp <- sum(vapply(data, function(.c) if (is.numeric(.c)) sum(.c, na.rm = TRUE) else 0, numeric(1)))
+  .ek <- paste0(am$key, "|et|", nrow(data), "|", .fp)
+  .et <- get0(.ek, envir = .foceiAnalyticEtCache, inherits = FALSE)
+  if (is.null(.et)) {
+    .et <- tryCatch(rxode2::etTrans(data, am$augMod), error = function(e) NULL)
+    if (is.null(.et)) return(data)
+    assign(.ek, .et, envir = .foceiAnalyticEtCache)
+  }
+  .et
+}
 .foceiAnalyticAugModelDirs <- function(ui, dirs) {
-  tryCatch({
+  .key <- tryCatch(paste0(rxUiGet.foceiModelDigest(list(ui)), "|", paste(dirs, collapse = ","),
+                          "|sk", Sys.getenv("FOCEI_SIGMA_SKIP")),   # skip flag -> distinct cached model
+                   error = function(e) NULL)
+  if (!is.null(.key)) { .hit <- get0(.key, envir = .foceiAnalyticAugCache, inherits = FALSE)
+    if (!is.null(.hit)) return(.hit) }
+  .res <- tryCatch({
     .s <- ui$loadPruneSens
     .st <- rxode2::rxStateOde(.s)
     # matExp()/indLin(): the base ODEs are materialized into the pruned env (via
@@ -816,12 +897,22 @@
     if (is.list(.mvS$indLin) && length(.mvS$indLin) == 4L) {
       .st <- .rxMatExpStateOrder(.st, ls(envir = .s, all.names = TRUE))
     }
-    rxode2::.rxJacobian(.s, c(.st, dirs))
+    # Sigma-skip (env FOCEI_SIGMA_SKIP): the residual-error (sigma) directions have
+    # df/dsigma=0, so their f-sensitivity columns (f1/f2) and state-sensitivities are all
+    # ZERO -- pure wasted compile (each sigma direction costs a full structural parameter's
+    # worth of gcc + states).  Build the prediction chain f1/f2 + state sensitivities over
+    # the model-affecting directions only (.fDirs); the variance chain still spans EVERY
+    # direction (sigma R-derivatives are algebraic, no state chain).  The reader zero-fills
+    # the sigma a/A slots (the assembly already treats a=A=Ath=0 for a sigma direction).
+    .erN <- ui$iniDf$ntheta[!is.na(ui$iniDf$err) & !(ui$iniDf$err %in% c("boxCox", "yeoJohnson"))]
+    .sigDirs <- if (nzchar(Sys.getenv("FOCEI_SIGMA_SKIP"))) intersect(dirs, paste0("THETA_", .erN, "_")) else character(0)
+    .fDirs <- dirs[!(dirs %in% .sigDirs)]
+    rxode2::.rxJacobian(.s, c(.st, .fDirs))
     # 1st-order sensitivities are already expanded for the gradient (free); if
     # unavailable the model is not differentiable, so bail before the 2nd-order build.
-    .s1 <- rxode2::.rxSens(.s, dirs)
+    .s1 <- rxode2::.rxSens(.s, .fDirs)
     if (length(.s1) == 0L) return(NULL)
-    .s2 <- rxode2::.rxSens(.s, dirs, dirs)          # 2nd order: the expensive expansion
+    .s2 <- rxode2::.rxSens(.s, .fDirs, .fDirs)      # 2nd order (f-directions only): the expensive expansion
     .pred <- get("rx_pred_", .s)
     # residual variance rx_r_ (any structure) with its own 1st/2nd sensitivity chains,
     # exactly like the prediction -- so R and dR/ddir, d2R/ddir2 come from the SOLVE
@@ -831,14 +922,20 @@
     .Dn <- function(.e, .v) symengine::D(.e, symengine::S(.v))
     .sn1 <- function(.j, ...) symengine::S(paste0("rx__sens_", .j, "_BY_", paste(c(...), collapse = "_BY_"), "__"))
     .toRx <- function(.l) rxode2::rxFromSE(.l)
-    .g1 <- function(.ex, .p) { .e <- .Dn(.ex, .p); for (.j in .st) .e <- .e + .Dn(.ex, .j) * .sn1(.j, .p); .e }
+    # state-sensitivity chains only for directions that have solved sensitivities (.fDirs);
+    # a sigma direction contributes only its direct partial (d(state)/dsigma=0).
+    .g1 <- function(.ex, .p) { .e <- .Dn(.ex, .p)
+      if (.p %in% .fDirs) for (.j in .st) .e <- .e + .Dn(.ex, .j) * .sn1(.j, .p); .e }
     .g2 <- function(.ex, .p, .q) { .gq <- .g1(.ex, .q); .e <- .Dn(.gq, .p)
-      for (.k in .st) .e <- .e + .Dn(.gq, .k) * .sn1(.k, .p); for (.j in .st) .e <- .e + .Dn(.ex, .j) * .sn1(.j, .p, .q); .e }
+      if (.p %in% .fDirs) for (.k in .st) .e <- .e + .Dn(.gq, .k) * .sn1(.k, .p)
+      if (.p %in% .fDirs && .q %in% .fDirs) for (.j in .st) .e <- .e + .Dn(.ex, .j) * .sn1(.j, .p, .q); .e }
     # f2_i_j == f2_j_i, so only the i<=j triangle is differentiated/compiled (~2x off
     # the dominant model-build cost); the reader mirrors A[,i,j]=A[,j,i].
-    .P2 <- expand.grid(i = dirs, j = dirs, stringsAsFactors = FALSE)
-    .P2 <- .P2[match(.P2$i, dirs) <= match(.P2$j, dirs), , drop = FALSE]
-    .fL1 <- vapply(dirs, function(.p) paste0("rx_f1_", .p, "=", .toRx(.g1(.pred, .p))), character(1))
+    .P2 <- expand.grid(i = .fDirs, j = .fDirs, stringsAsFactors = FALSE)     # prediction f2: f-directions only
+    .P2 <- .P2[match(.P2$i, .fDirs) <= match(.P2$j, .fDirs), , drop = FALSE]
+    .P2r <- expand.grid(i = dirs, j = dirs, stringsAsFactors = FALSE)        # variance rvar2: every direction
+    .P2r <- .P2r[match(.P2r$i, dirs) <= match(.P2r$j, dirs), , drop = FALSE]
+    .fL1 <- vapply(.fDirs, function(.p) paste0("rx_f1_", .p, "=", .toRx(.g1(.pred, .p))), character(1))
     .fL2 <- vapply(seq_len(nrow(.P2)), function(.r)
       paste0("rx_f2_", .P2$i[.r], "_", .P2$j[.r], "=", .toRx(.g2(.pred, .P2$i[.r], .P2$j[.r]))), character(1))
     # Variance rx_r_ and its 1st/2nd direction sensitivities.  The `rx_..._` naming
@@ -850,8 +947,8 @@
     .rvarL <- character(0)
     if (!is.null(.rvar)) {
       .rL1 <- vapply(dirs, function(.p) paste0("rx_rvar1_", .p, "=", .toRx(.g1(.rvar, .p))), character(1))
-      .rL2 <- vapply(seq_len(nrow(.P2)), function(.r)
-        paste0("rx_rvar2_", .P2$i[.r], "_", .P2$j[.r], "=", .toRx(.g2(.rvar, .P2$i[.r], .P2$j[.r]))), character(1))
+      .rL2 <- vapply(seq_len(nrow(.P2r)), function(.r)
+        paste0("rx_rvar2_", .P2r$i[.r], "_", .P2r$j[.r], "=", .toRx(.g2(.rvar, .P2r$i[.r], .P2r$j[.r]))), character(1))
       .rvarL <- c(paste0("rx_rvarf_=", .toRx(.rvar)), .rL1, .rL2)
     }
     # Residual-variance sigma sensitivities: for each error parameter the variance R
@@ -946,10 +1043,17 @@
     .param <- gsub("ETA\\[([0-9]+)\\]", "ETA_\\1_", gsub("THETA\\[([0-9]+)\\]", "THETA_\\1_", .param))
     .modTxt <- paste(.param, .modTxt, sep = "\n")
     # eventSens="jump" attaches rxode2's analytic event/dosing-parameter sensitivities
-    # (forward variational jumps at dose times) for the sensitivity compartments.
-    list(augMod = rxode2::rxode2(.modTxt, eventSens = "jump"), dirs = dirs, ndir = length(dirs),
-         st = .st, P2 = .P2, hasRvar = !is.null(.rvar), sigTh = .sigTh, hasTrans = .hasTrans)
+    # (forward variational jumps at dose times) for the sensitivity compartments.  `cols`
+    # precomputes solve-output column names/index maps; `cores` carries the fit's rxControl thread
+    # count so the batched solves run parallel; `key` seeds the per-fit event-table reuse cache.
+    .cores <- tryCatch(as.integer(rxode2::rxGetControl(ui, "rxControl", rxode2::rxControl())$cores),
+                       error = function(e) 0L)
+    list(augMod = rxode2::rxode2(.modTxt, eventSens = "jump"), dirs = dirs, ndir = length(dirs), fDirs = .fDirs,
+         st = .st, P2 = .P2, P2r = .P2r, hasRvar = !is.null(.rvar), sigTh = .sigTh, hasTrans = .hasTrans,
+         cols = .foceiAnalyticCols(dirs, .fDirs, .P2, .P2r, .sigTh), cores = if (length(.cores)) .cores else 0L, key = .key)
   }, error = function(e) NULL)
+  if (!is.null(.key) && !is.null(.res)) assign(.key, .res, envir = .foceiAnalyticAugCache)
+  .res
 }
 
 #' Solve the direction-set 2nd-order model for one subject and recover the
@@ -997,6 +1101,94 @@
             if (!is.null(E0$trans)) list(trans = E0$trans) else NULL)
   if (!all(is.finite(.out$f)) || !all(is.finite(.out$a)) || !all(is.finite(.out$A)) || !all(is.finite(.out$Ath))) return(NULL)
   .out
+}
+
+#' Route-A (FOCEI_RSIG) sigma reconstruction: the (f,R) cov shares the gradient's `dirs` model
+#' (no sigma directions) and rebuilds the sigma tensor slots from the model's own residual-sigma
+#' outputs (Rsig=dR/dsigma, RsigDir=d2R/(dsigma ddir), Rsig2=d2R/(dsigma dsigma')) plus their
+#' eta-derivatives (RsigDirEta, Rsig2Eta from the FD3).  A sigma has df/dsigma=0, so the prediction
+#' slots (a/A/Ath) are zero; the variance slots (aR/AR/AthR) carry the rsig values.  The result is
+#' the SAME ndirCov tensor the sigma-as-direction model produced -- but from a model shared with the
+#' gradient.
+#' @noRd
+.foceiAnalyticExpandSigma <- function(E, nsig, neta, RsigDirEta, Rsig2Eta) {
+  nd <- ncol(E$a); no <- nrow(E$a); ndc <- nd + nsig; sg <- nd + seq_len(nsig)
+  a <- cbind(E$a, matrix(0, no, nsig))
+  A <- array(0, c(no, ndc, ndc)); A[, seq_len(nd), seq_len(nd)] <- E$A
+  .hasAth <- !is.null(E$Ath)                              # E0 (frozen-R0 solve) has no Ath
+  Ath <- if (.hasAth) { .Y <- array(0, c(no, neta, ndc, ndc)); .Y[, , seq_len(nd), seq_len(nd)] <- E$Ath; .Y } else NULL
+  aR <- cbind(E$aR, E$Rsig)
+  AR <- array(0, c(no, ndc, ndc)); AR[, seq_len(nd), seq_len(nd)] <- E$AR
+  .hasAthR <- !is.null(E$AthR) && !is.null(RsigDirEta)     # withR: 3rd-order sigma slots too
+  AthR <- if (.hasAthR) { .X <- array(0, c(no, neta, ndc, ndc)); .X[, , seq_len(nd), seq_len(nd)] <- E$AthR; .X } else NULL
+  for (k in seq_len(nsig)) {
+    AR[, seq_len(nd), sg[k]] <- E$RsigDir[, , k]; AR[, sg[k], seq_len(nd)] <- E$RsigDir[, , k]
+    if (.hasAthR) { AthR[, , seq_len(nd), sg[k]] <- RsigDirEta[, , , k]; AthR[, , sg[k], seq_len(nd)] <- RsigDirEta[, , , k] }
+    for (l in seq_len(nsig)) { AR[, sg[k], sg[l]] <- E$Rsig2[, k, l]; if (.hasAthR) AthR[, , sg[k], sg[l]] <- Rsig2Eta[, , k, l] }
+  }
+  E$a <- a; E$A <- A; if (.hasAth) E$Ath <- Ath; E$aR <- aR; E$AR <- AR; if (.hasAthR) E$AthR <- AthR; E
+}
+
+#' Batched analogue of [.foceiAnalyticSolveSubjectFD3]: recover the 3rd-order tensor `Ath` (and
+#' `AthR` when `withR`) for ALL subjects at once by central-differencing the analytic 2nd-order
+#' sensitivities `A` w.r.t. each ETA coordinate via BATCHED population solves ([.foceiAnalyticSolveAll],
+#' 1 base + 2*neta perturbed) instead of the per-subject Shi (~O(nsub*neta) solves).  RICHARDSON-
+#' extrapolated over steps (h, h/2) to 4th order, with the perturbed solves at a tighter tol, so the
+#' batched Ath reproduces the per-subject adaptive-Shi Ath (the FOCEI-vs-FOCE analytic-R agreement,
+#' not just the SEs).  Returns the per-subject E-list with `Ath` attached, or NULL (-> per-subject).
+#' @noRd
+.foceiAnalyticSolveAllFD3 <- function(am, thv, ebes, ids, data, obsTimes, tol = 1e-10,
+                                      fdEps = 1e-3, withR = FALSE) {
+  dirs <- am$dirs; nd <- length(dirs); neta <- ncol(ebes)
+  E0 <- .foceiAnalyticSolveAll(am, thv, ebes, ids, data, obsTimes, tol)
+  if (is.null(E0)) return(NULL)
+  nsub <- length(E0)
+  Ath  <- lapply(E0, function(E) array(0, c(nrow(E$a), neta, nd, nd)))
+  AthR <- if (withR) lapply(E0, function(E) array(0, c(nrow(E$a), neta, nd, nd))) else NULL
+  # Route A (FOCEI_RSIG): am is the gradient's `dirs` model (no sigma directions); rebuild the
+  # sigma tensor slots from the rsig outputs + their eta-derivatives (differenced here alongside A/AR).
+  .rsig <- nzchar(Sys.getenv("FOCEI_RSIG")) && !is.null(E0[[1L]]$Rsig) && length(E0[[1L]]$Rsig) > 0L
+  nsig <- if (.rsig) ncol(E0[[1L]]$Rsig) else 0L
+  RsigDirEta <- if (.rsig && withR) lapply(E0, function(E) array(0, c(nrow(E$a), neta, nd, nsig))) else NULL
+  Rsig2Eta   <- if (.rsig && withR) lapply(E0, function(E) array(0, c(nrow(E$a), neta, nsig, nsig))) else NULL
+  # differencing A carries the ODE solve's ~tol error floor; solve the PERTURBED models tighter
+  # than the base so the 3rd-order Ath stays as clean as the per-subject adaptive Shi.
+  .ptol <- min(tol, 1e-12)
+  .cdiff <- function(li, h) {
+    ep <- ebes; ep[, li] <- ebes[, li] + h; em <- ebes; em[, li] <- ebes[, li] - h
+    Ep <- .foceiAnalyticSolveAll(am, thv, ep, ids, data, obsTimes, .ptol)
+    Em <- .foceiAnalyticSolveAll(am, thv, em, ids, data, obsTimes, .ptol)
+    if (is.null(Ep) || is.null(Em) || length(Ep) != nsub || length(Em) != nsub) return(NULL)
+    list(Ep = Ep, Em = Em, h = h)
+  }
+  for (li in seq_len(neta)) {                             # ETA_li coordinate == ebes column li
+    h <- fdEps * max(abs(ebes[, li]), 1)
+    s1 <- .cdiff(li, h); s2 <- .cdiff(li, h / 2)
+    if (is.null(s1) || is.null(s2)) return(NULL)
+    for (i in seq_len(nsub)) {
+      d1 <- (s1$Ep[[i]]$A - s1$Em[[i]]$A) / (2 * s1$h); d2 <- (s2$Ep[[i]]$A - s2$Em[[i]]$A) / (2 * s2$h)
+      Ath[[i]][, li, , ] <- (4 * d2 - d1) / 3
+      if (withR) {
+        e1 <- (s1$Ep[[i]]$AR - s1$Em[[i]]$AR) / (2 * s1$h); e2 <- (s2$Ep[[i]]$AR - s2$Em[[i]]$AR) / (2 * s2$h)
+        AthR[[i]][, li, , ] <- (4 * e2 - e1) / 3
+        if (.rsig) {
+          g1 <- (s1$Ep[[i]]$RsigDir - s1$Em[[i]]$RsigDir) / (2 * s1$h); g2 <- (s2$Ep[[i]]$RsigDir - s2$Em[[i]]$RsigDir) / (2 * s2$h)
+          RsigDirEta[[i]][, li, , ] <- (4 * g2 - g1) / 3
+          k1 <- (s1$Ep[[i]]$Rsig2 - s1$Em[[i]]$Rsig2) / (2 * s1$h); k2 <- (s2$Ep[[i]]$Rsig2 - s2$Em[[i]]$Rsig2) / (2 * s2$h)
+          Rsig2Eta[[i]][, li, , ] <- (4 * k2 - k1) / 3
+        }
+      }
+    }
+  }
+  for (i in seq_len(nsub)) {
+    E0[[i]]$Ath <- Ath[[i]]
+    if (withR) E0[[i]]$AthR <- AthR[[i]]
+    if (.rsig) E0[[i]] <- .foceiAnalyticExpandSigma(E0[[i]], nsig, neta,
+                            if (is.null(RsigDirEta)) NULL else RsigDirEta[[i]],
+                            if (is.null(Rsig2Eta)) NULL else Rsig2Eta[[i]])
+    if (!all(is.finite(E0[[i]]$A)) || !all(is.finite(E0[[i]]$Ath))) return(NULL)
+  }
+  E0
 }
 
 #' Per-subject observed-information R in the general (f,R) form: the prediction f and
@@ -1556,28 +1748,27 @@ E_ARelm <- function(E, l, m, fp) if (fp) E$AR[, l, m] else 0
 #' @noRd
 .foceiAnalyticSolveFA <- function(aug, params, ev, times, tol = 1e-10) {
   dirs <- aug$dirs; nd <- length(dirs)
-  # DDE augmented solve: force pure dop853 (dense, no Jacobian).  dop853's
-  # 8th-order dense history reproduces the delayed sensitivity solve exactly and
-  # needs no Jacobian, so it sidesteps the composite/ros4 path's on-the-fly
-  # Jacobian generation for this THETA/ETA-named augmented model (which on rxode2
-  # < 5.1.3 mangled the parameter list -- the aug solve then failed and the
-  # covariance silently degraded to the finite-difference sandwich).  The fixed
-  # composite solves correctly too, but dop853 is exact here and works on every
-  # rxode2 version, so keep it.
+  .ev <- .foceiAnalyticEvents(aug, ev)                    # reuse the pre-translated events (FOCE Newton reuse)
+  .nc <- if (is.null(aug$cores)) 0L else aug$cores
+  # DDE augmented solve: force pure dop853 (dense, no Jacobian).  Its 8th-order dense history
+  # reproduces the delayed sensitivity solve exactly and needs no Jacobian, so it sidesteps the
+  # composite/ros4 on-the-fly Jacobian generation for this THETA/ETA-named augmented model.
   .ddeArgs <- if (isTRUE(rxode2::rxModelVars(aug$augMod)$flags[["hasDelay"]] == 1L))
     list(method = "dop853", stiff2 = 0L, dense = TRUE) else list()
   .d <- tryCatch(withCallingHandlers(
-      as.data.frame(do.call(rxode2::rxSolve, c(list(aug$augMod, params = params, ev,
+      as.data.frame(do.call(rxode2::rxSolve, c(list(aug$augMod, params = params, .ev, cores = .nc,
           returnType = "data.frame", atol = tol, rtol = tol), .ddeArgs))),
       warning = function(w) invokeRestart("muffleWarning")),
     error = function(e) NULL)
-  if (is.null(.d)) return(NULL); .d <- .d[.d$time %in% times, , drop = FALSE]
+  if (is.null(.d)) return(NULL)
+  .d <- .d[.d$time %in% times, , drop = FALSE]
+  .fD <- if (is.null(aug$fDirs)) dirs else aug$fDirs   # sigma-skip: f-sensitivities only over f-directions
   if (nrow(.d) == 0L || nrow(.d) != length(times) ||
-        !all(c("rx_predf_", paste0("rx_f1_", dirs)) %in% names(.d))) return(NULL)
+        !all(c("rx_predf_", paste0("rx_f1_", .fD)) %in% names(.d))) return(NULL)
   no <- nrow(.d)
-  a <- matrix(vapply(dirs, function(q) .d[[paste0("rx_f1_", q)]], numeric(no)), no, nd)
+  a <- matrix(0, no, nd); a[, match(.fD, dirs)] <- vapply(.fD, function(q) .d[[paste0("rx_f1_", q)]], numeric(no))
   A <- array(0, c(no, nd, nd))
-  for (r in seq_len(nrow(aug$P2))) {                   # only i<=j emitted -> mirror to i>j
+  for (r in seq_len(nrow(aug$P2))) {                   # only i<=j emitted -> mirror to i>j (f-dir pairs)
     .ii <- match(aug$P2$i[r], dirs); .jj <- match(aug$P2$j[r], dirs)
     .v2 <- .d[[paste0("rx_f2_", aug$P2$i[r], "_", aug$P2$j[r])]]
     A[, .ii, .jj] <- .v2; A[, .jj, .ii] <- .v2
@@ -1593,7 +1784,7 @@ E_ARelm <- function(E, l, m, fp) if (fp) E$AR[, l, m] else 0
 #' every piece is read directly from the solve.
 #' @noRd
 .foceiReadRvar <- function(.d, aug, no) {
-  dirs <- aug$dirs; nd <- length(dirs); P2 <- aug$P2
+  dirs <- aug$dirs; nd <- length(dirs); P2 <- if (is.null(aug$P2r)) aug$P2 else aug$P2r   # rvar2 spans every direction
   aR <- matrix(vapply(dirs, function(q) .d[[paste0("rx_rvar1_", q)]], numeric(no)), no, nd)
   AR <- array(0, c(no, nd, nd))
   for (r in seq_len(nrow(P2))) {
@@ -1669,6 +1860,48 @@ E_ARelm <- function(E, l, m, fp) if (fp) E$AR[, l, m] else 0
     if (max(abs(sh$S)) < conv) break
   }
   if (max(abs(sh$S)) >= conv) return(NULL)               # Newton did not converge -> FD fallback
+  eta
+}
+
+#' Batched FOCE/foce+ EBE re-solve: the same interaction-free Newton as
+#' [.foceiAnalyticFoceEbe] but over ALL subjects at once via [.foceiAnalyticSolveAll]
+#' (one batched solve per Newton iteration instead of per-subject SolveFA).  Bit-identical
+#' to the per-subject Newton; avoids the per-subject solve entirely (needed for the shared
+#' `dirs` model, which solves batched but not per-subject in the fit's cov-hook context) and
+#' is faster.  Returns the nsub x neta eta-hat matrix, or NULL if any subject fails to converge.
+#' @noRd
+.foceiAnalyticFoceEbeBatch <- function(am, th, ebes, ids, data, obsAll, obsTimes, etav, Oi, neta, tol,
+                                       foceType = 0L, E0all = NULL, maxit = 30L, skip = 1e-3, conv = 1e-9) {
+  nsub <- nrow(ebes); ei <- seq_len(neta)
+  .fp <- identical(as.integer(foceType), 1L) || is.null(E0all)
+  Y  <- lapply(obsAll, function(.o) .o$DV)
+  CV <- lapply(obsAll, function(.o) if (is.null(.o$CENS)) integer(length(.o$DV)) else as.integer(ifelse(is.na(.o$CENS), 0L, .o$CENS)))
+  LV <- lapply(obsAll, function(.o) if (is.null(.o$LIMIT)) rep(NA_real_, length(.o$DV)) else as.numeric(.o$LIMIT))
+  .SHi <- function(E, eta_i, i) {                        # S_FOCE + Hf for subject i (censored-aware)
+    yt <- .foceiAnalyticTbsY(Y[[i]], E$trans)
+    R0e <- if (.fp) E$R else E0all[[i]]$R
+    q0 <- -(yt - E$f) / R0e; q1 <- 1 / R0e
+    .cw <- which(CV[[i]] != 0 | is.finite(LV[[i]]))
+    if (length(.cw)) { .limt <- .foceiAnalyticTbsY(LV[[i]], E$trans)
+      .cp <- censNormalPartials_(CV[[i]], yt, .limt, E$f, R0e, 2L); q0[.cw] <- .cp[.cw, 1]; q1[.cw] <- .cp[.cw, 3] }
+    S <- as.numeric(Oi %*% eta_i); for (l in ei) S[l] <- S[l] + sum(q0 * E$a[, l])
+    Hf <- Oi; for (l in ei) for (m in ei) Hf[l, m] <- Hf[l, m] + sum(q1 * E$a[, l] * E$a[, m] + q0 * E$A[, l, m])
+    list(S = S, Hf = Hf)
+  }
+  eta <- ebes; active <- rep(TRUE, nsub)
+  for (it in seq_len(maxit + 1L)) {                      # it=1 evaluates at eta0 (skip test), then Newton steps
+    Es <- .foceiAnalyticSolveAll(am, th, eta, ids, data, obsTimes, tol)
+    if (is.null(Es)) return(NULL)
+    for (i in which(active)) {
+      sh <- .SHi(Es[[i]], eta[i, ], i)
+      if (max(abs(sh$S)) < (if (it == 1L) skip else conv)) { active[i] <- FALSE; next }
+      if (it == maxit + 1L) return(NULL)                 # did not converge -> FD fallback
+      step <- tryCatch(solve(sh$Hf, sh$S), error = function(e) NULL); if (is.null(step)) return(NULL)
+      eta[i, ] <- eta[i, ] - step
+    }
+    if (!any(active)) break
+  }
+  if (any(active)) return(NULL)
   eta
 }
 

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -185,10 +185,13 @@
 .foceiAnalyticAssembleRFR <- function(ui, th, ebes, ids, data, Om, ef, neta, ndirP, dirP, omd,
                                       dirsCov, ndirCov, startedEnv = NULL, solveTol = 1e-10,
                                       interaction = 1L, foceType = 0L, lamDir = integer(0)) {
-  # Route A (FOCEI_RSIG): build the gradient's `dirs` model (drop the sigma directions) so the
-  # (f,R) cov SHARES the gradient's compiled model; the sigma tensor slots are rebuilt from rsig in
-  # SolveAllFD3 (.foceiAnalyticExpandSigma), which expands the solved E back to ndirCov.
-  .rsigA <- nzchar(Sys.getenv("FOCEI_RSIG"))
+  # Route A (default ON; set FOCEI_NO_RSIG=1 to opt out): build the gradient's `dirs` model
+  # (drop the sigma directions) so the (f,R) cov SHARES the gradient's already-compiled model
+  # -- one augmented-model compile instead of two, and the sigma directions' wasted (all-zero)
+  # state-sensitivity columns vanish.  The sigma tensor slots (aR/AR/AthR) are rebuilt from the
+  # model's own rsig outputs in SolveAllFD3 (.foceiAnalyticExpandSigma), which expands the solved
+  # E back to ndirCov -- numerically identical to carrying explicit sigma directions.
+  .rsigA <- !nzchar(Sys.getenv("FOCEI_NO_RSIG"))
   .erN <- ui$iniDf$ntheta[!is.na(ui$iniDf$err) & !(ui$iniDf$err %in% c("boxCox", "yeoJohnson"))]
   .sigDirs <- if (.rsigA) intersect(dirsCov, paste0("THETA_", .erN, "_")) else character(0)
   .dirsF <- dirsCov[!(dirsCov %in% .sigDirs)]
@@ -879,7 +882,7 @@
 }
 .foceiAnalyticAugModelDirs <- function(ui, dirs) {
   .key <- tryCatch(paste0(rxUiGet.foceiModelDigest(list(ui)), "|", paste(dirs, collapse = ","),
-                          "|sk", Sys.getenv("FOCEI_SIGMA_SKIP")),   # skip flag -> distinct cached model
+                          "|sk", Sys.getenv("FOCEI_NO_SIGMA_SKIP")),   # skip flag -> distinct cached model
                    error = function(e) NULL)
   if (!is.null(.key)) { .hit <- get0(.key, envir = .foceiAnalyticAugCache, inherits = FALSE)
     if (!is.null(.hit)) return(.hit) }
@@ -897,7 +900,7 @@
     if (is.list(.mvS$indLin) && length(.mvS$indLin) == 4L) {
       .st <- .rxMatExpStateOrder(.st, ls(envir = .s, all.names = TRUE))
     }
-    # Sigma-skip (env FOCEI_SIGMA_SKIP): the residual-error (sigma) directions have
+    # Sigma-skip (default ON; set FOCEI_NO_SIGMA_SKIP=1 to opt out): the residual-error (sigma) directions have
     # df/dsigma=0, so their f-sensitivity columns (f1/f2) and state-sensitivities are all
     # ZERO -- pure wasted compile (each sigma direction costs a full structural parameter's
     # worth of gcc + states).  Build the prediction chain f1/f2 + state sensitivities over
@@ -905,7 +908,7 @@
     # direction (sigma R-derivatives are algebraic, no state chain).  The reader zero-fills
     # the sigma a/A slots (the assembly already treats a=A=Ath=0 for a sigma direction).
     .erN <- ui$iniDf$ntheta[!is.na(ui$iniDf$err) & !(ui$iniDf$err %in% c("boxCox", "yeoJohnson"))]
-    .sigDirs <- if (nzchar(Sys.getenv("FOCEI_SIGMA_SKIP"))) intersect(dirs, paste0("THETA_", .erN, "_")) else character(0)
+    .sigDirs <- if (!nzchar(Sys.getenv("FOCEI_NO_SIGMA_SKIP"))) intersect(dirs, paste0("THETA_", .erN, "_")) else character(0)
     .fDirs <- dirs[!(dirs %in% .sigDirs)]
     rxode2::.rxJacobian(.s, c(.st, .fDirs))
     # 1st-order sensitivities are already expanded for the gradient (free); if
@@ -1103,7 +1106,7 @@
   .out
 }
 
-#' Route-A (FOCEI_RSIG) sigma reconstruction: the (f,R) cov shares the gradient's `dirs` model
+#' Route-A (default on; FOCEI_NO_RSIG opts out) sigma reconstruction: the (f,R) cov shares the gradient's `dirs` model
 #' (no sigma directions) and rebuilds the sigma tensor slots from the model's own residual-sigma
 #' outputs (Rsig=dR/dsigma, RsigDir=d2R/(dsigma ddir), Rsig2=d2R/(dsigma dsigma')) plus their
 #' eta-derivatives (RsigDirEta, Rsig2Eta from the FD3).  A sigma has df/dsigma=0, so the prediction
@@ -1145,9 +1148,10 @@
   nsub <- length(E0)
   Ath  <- lapply(E0, function(E) array(0, c(nrow(E$a), neta, nd, nd)))
   AthR <- if (withR) lapply(E0, function(E) array(0, c(nrow(E$a), neta, nd, nd))) else NULL
-  # Route A (FOCEI_RSIG): am is the gradient's `dirs` model (no sigma directions); rebuild the
-  # sigma tensor slots from the rsig outputs + their eta-derivatives (differenced here alongside A/AR).
-  .rsig <- nzchar(Sys.getenv("FOCEI_RSIG")) && !is.null(E0[[1L]]$Rsig) && length(E0[[1L]]$Rsig) > 0L
+  # Route A (default ON; FOCEI_NO_RSIG=1 opts out): am is the gradient's `dirs` model (no sigma
+  # directions); rebuild the sigma tensor slots from the rsig outputs + their eta-derivatives
+  # (differenced here alongside A/AR).  Guarded on Rsig actually being present in the solve.
+  .rsig <- !nzchar(Sys.getenv("FOCEI_NO_RSIG")) && !is.null(E0[[1L]]$Rsig) && length(E0[[1L]]$Rsig) > 0L
   nsig <- if (.rsig) ncol(E0[[1L]]$Rsig) else 0L
   RsigDirEta <- if (.rsig && withR) lapply(E0, function(E) array(0, c(nrow(E$a), neta, nd, nsig))) else NULL
   Rsig2Eta   <- if (.rsig && withR) lapply(E0, function(E) array(0, c(nrow(E$a), neta, nsig, nsig))) else NULL

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -443,21 +443,24 @@
   etaSolve <- ebes
   E0List <- vector("list", length(ids))
   if (.foce) {
-    for (i in seq_along(ids)) {
-      s <- .byId[[as.character(.idCode[i])]]; if (is.null(s) || nrow(s) == 0L) return(NULL)
-      obs <- s[s$EVID == 0, , drop = FALSE]
-      E0 <- NULL
-      if (identical(as.integer(foceType), 0L) && isTRUE(ef$dependsF0)) {
-        E0 <- .foceiAnalyticSolveFA(am, c(th, setNames(rep(0, neta), etav)), s, obs$TIME, tol = solveTol)
-        if (is.null(E0)) return(NULL)
-      }
-      E0List[i] <- list(E0)                              # `[i]<-list(NULL)` keeps the slot (foce+ E0 is NULL)
-      eta0 <- .foceiAnalyticFoceEbe(am, th, ebes[i, ], s, obs$TIME, obs$DV, etav,
-                                    if (is.null(E0)) NULL else E0$R, Oi, neta, solveTol, foceType = foceType,
-                                    cens = obs$CENS, limit = obs$LIMIT)
-      if (is.null(eta0)) return(NULL)
-      etaSolve[i, ] <- eta0
-    }
+    # BATCHED FOCE EBE re-solve (mirrors the cov path): the eta=0 population solve (nonmem
+    # frozen R0) and the per-subject Newton EBE re-solve are batched over ALL subjects -- one
+    # rxode2 population solve per Newton step via .foceiAnalyticFoceEbeBatch -- instead of a
+    # per-subject Newton loop (neta*maxit single-subject solves).  Bit-identical to the former
+    # loop (same S_FOCE=0 stationarity, same censored partials).  foce+ (foceType=1) and additive
+    # nonmem (no dependsF0) need no eta=0 solve, so E0all=NULL and the batch uses the live R.
+    nsub <- length(ids)
+    .obsAll <- lapply(seq_len(nsub), function(i) { .s <- .byId[[as.character(.idCode[i])]]
+      if (is.null(.s) || nrow(.s) == 0L) NULL else .s[.s$EVID == 0, , drop = FALSE] })
+    if (any(vapply(.obsAll, is.null, logical(1L)))) return(NULL)
+    .needE0 <- identical(as.integer(foceType), 0L) && isTRUE(ef$dependsF0)
+    E0all <- if (.needE0) .foceiAnalyticSolveAll(am, th, matrix(0, nsub, neta), .idCode, data, .obsT, solveTol) else NULL
+    if (.needE0 && is.null(E0all)) return(NULL)
+    eta0Mat <- .foceiAnalyticFoceEbeBatch(am, th, ebes, .idCode, data, .obsAll, .obsT, etav, Oi, neta,
+                                          solveTol, foceType = foceType, E0all = E0all)
+    if (is.null(eta0Mat)) return(NULL)
+    etaSolve <- eta0Mat
+    if (!is.null(E0all)) for (i in seq_len(nsub)) E0List[i] <- list(E0all[[i]])
   }
   .EsAll <- .foceiAnalyticSolveAll(am, th, etaSolve, .idCode, data, .obsT, solveTol)
   if (is.null(.EsAll)) return(NULL)

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -335,41 +335,60 @@
   pars <- data.frame(ID = ids)
   for (k in seq_len(neta)) pars[[etav[k]]] <- ebes[, k]
   for (.nm in names(thv)) pars[[.nm]] <- thv[[.nm]]
-  # DDE: force pure dop853 (dense, no Jacobian) -- its 8th-order dense history
-  # reproduces the delayed sensitivity solve exactly and needs no Jacobian, so it
-  # sidesteps the composite/ros4 on-the-fly Jacobian generation for this
-  # THETA/ETA-named augmented model (mangled the parameter list on rxode2 < 5.1.3;
-  # the fixed composite works too, but dop853 is exact and version-independent).
+  .ev <- .foceiAnalyticEvents(am, data)                    # reuse the pre-translated event table
+  .nc <- if (is.null(am$cores)) 0L else am$cores           # fit's rxControl thread count (parallel)
+  # DDE: force pure dop853 (dense, no Jacobian) -- its 8th-order dense history reproduces the
+  # delayed sensitivity solve exactly and needs no Jacobian, sidestepping the composite/ros4
+  # on-the-fly Jacobian generation for this THETA/ETA-named augmented model.
   .ddeArgs <- if (isTRUE(rxode2::rxModelVars(am$augMod)$flags[["hasDelay"]] == 1L))
     list(method = "dop853", stiff2 = 0L, dense = TRUE) else list()
   .sol <- tryCatch(withCallingHandlers(
-    as.data.frame(do.call(rxode2::rxSolve, c(list(am$augMod, params = pars, events = data,
+    as.data.frame(do.call(rxode2::rxSolve, c(list(am$augMod, params = pars, events = .ev, cores = .nc,
                                   returnType = "data.frame", atol = tol, rtol = tol), .ddeArgs))),
     warning = function(w) invokeRestart("muffleWarning")), error = function(e) NULL)
-  if (is.null(.sol) || !all(c("rx_predf_", paste0("rx_f1_", dirs)) %in% names(.sol))) return(NULL)
+  if (is.null(.sol) || !all(c("rx_predf_", paste0("rx_f1_", if (is.null(am$fDirs)) dirs else am$fDirs)) %in% names(.sol))) return(NULL)
+  # Extract every sensitivity column from the WHOLE solve as a matrix ONCE (the per-subject
+  # data.frame [[ + paste0 dominated the gradient -- the ODE solve itself is ~4%); slice by row
+  # per subject.  Column names + index maps are precomputed on `am$cols` at build time.
+  .cm <- if (is.null(am$cols)) .foceiAnalyticCols(dirs, if (is.null(am$fDirs)) dirs else am$fDirs, am$P2, if (is.null(am$P2r)) am$P2 else am$P2r, am$sigTh) else am$cols
+  np2 <- nrow(am$P2); np2r <- if (is.null(am$P2r)) np2 else nrow(am$P2r)
+  .M1 <- as.matrix(.sol[, .cm$f1, drop = FALSE]); .M2 <- as.matrix(.sol[, .cm$f2, drop = FALSE])
+  .fp <- .sol$rx_predf_; .tm <- .sol$time; .hasR <- isTRUE(am$hasRvar); .hasT <- isTRUE(am$hasTrans)
+  if (.hasR) {
+    .MR1 <- as.matrix(.sol[, .cm$rvar1, drop = FALSE]); .MR2 <- as.matrix(.sol[, .cm$rvar2, drop = FALSE])
+    .Rf <- .sol$rx_rvarf_; .nsig <- length(am$sigTh)
+    if (.nsig > 0L) { .MRs <- as.matrix(.sol[, .cm$rsig, drop = FALSE])
+      .MRs1 <- lapply(.cm$rsig1, function(cc) as.matrix(.sol[, cc, drop = FALSE]))
+      .MRs2 <- as.matrix(.sol[, .cm$rsig2, drop = FALSE]) }
+  }
+  if (.hasT) .tr <- list(yj = .sol$rx_tyj_, lambda = .sol$rx_tlambda_, low = .sol$rx_tlow_, hi = .sol$rx_thi_)
   .idcol <- if ("id" %in% names(.sol)) .sol$id else .sol$ID
   .byIdSol <- split(seq_len(nrow(.sol)), as.character(.idcol))
-  # rxode2 may label the solve id by the input ID or renumber 1..nsub; accept either.
   Es <- vector("list", length(ids))
   for (i in seq_along(ids)) {
     .ri <- .byIdSol[[as.character(ids[i])]]
     if (is.null(.ri)) .ri <- .byIdSol[[as.character(i)]]
     if (is.null(.ri)) return(NULL)
-    .di <- .sol[.ri, , drop = FALSE]
-    .di <- .di[.di$time %in% obsTimes[[i]], , drop = FALSE]
-    if (nrow(.di) != length(obsTimes[[i]])) return(NULL)
-    no <- nrow(.di)
-    a <- matrix(vapply(dirs, function(q) .di[[paste0("rx_f1_", q)]], numeric(no)), no, nd)
-    A <- array(0, c(no, nd, nd))
-    for (r in seq_len(nrow(am$P2))) {
-      .ii <- match(am$P2$i[r], dirs); .jj <- match(am$P2$j[r], dirs)
-      .v2 <- .di[[paste0("rx_f2_", am$P2$i[r], "_", am$P2$j[r])]]
-      A[, .ii, .jj] <- .v2; A[, .jj, .ii] <- .v2
+    .keep <- .ri[.tm[.ri] %in% obsTimes[[i]]]
+    no <- length(.keep); if (no != length(obsTimes[[i]])) return(NULL)
+    a <- matrix(0, no, nd); a[, .cm$fDirIdx] <- .M1[.keep, , drop = FALSE]; A <- array(0, c(no, nd, nd))
+    for (r in seq_len(np2)) { .v <- .M2[.keep, r]; A[, .cm$iiF[r], .cm$jjF[r]] <- .v; A[, .cm$jjF[r], .cm$iiF[r]] <- .v }
+    .E <- list(f = .fp[.keep], a = a, A = A)
+    if (.hasR) {
+      aR <- .MR1[.keep, , drop = FALSE]; AR <- array(0, c(no, nd, nd))
+      for (r in seq_len(np2r)) { .v <- .MR2[.keep, r]; AR[, .cm$ii[r], .cm$jj[r]] <- .v; AR[, .cm$jj[r], .cm$ii[r]] <- .v }
+      .E$R <- .Rf[.keep]; .E$aR <- aR; .E$AR <- AR
+      if (.nsig > 0L) {
+        .E$Rsig <- .MRs[.keep, , drop = FALSE]
+        .E$RsigDir <- array(vapply(.MRs1, function(M) M[.keep, , drop = FALSE], matrix(0, no, nd)), c(no, nd, .nsig))
+        .Rs2 <- array(0, c(no, .nsig, .nsig))
+        for (r in seq_len(nrow(.cm$sigP2))) { .v <- .MRs2[.keep, r]
+          .Rs2[, .cm$sigP2$a[r], .cm$sigP2$b[r]] <- .v; .Rs2[, .cm$sigP2$b[r], .cm$sigP2$a[r]] <- .v }
+        .E$Rsig2 <- .Rs2
+      }
     }
-    Es[[i]] <- list(f = .di$rx_predf_, a = a, A = A)
-    if (isTRUE(am$hasRvar)) Es[[i]] <- c(Es[[i]], .foceiReadRvar(.di, am, no))
-    if (isTRUE(am$hasTrans))                        # both-sides transform: DV -> tbs(DV) scale
-      Es[[i]]$trans <- list(yj = .di$rx_tyj_, lambda = .di$rx_tlambda_, low = .di$rx_tlow_, hi = .di$rx_thi_)
+    if (.hasT) .E$trans <- lapply(.tr, `[`, .keep)       # both-sides transform: DV -> tbs(DV) scale
+    Es[[i]] <- .E
   }
   Es
 }

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -352,8 +352,17 @@
   # per subject.  Column names + index maps are precomputed on `am$cols` at build time.
   .cm <- if (is.null(am$cols)) .foceiAnalyticCols(dirs, if (is.null(am$fDirs)) dirs else am$fDirs, am$P2, if (is.null(am$P2r)) am$P2 else am$P2r, am$sigTh) else am$cols
   np2 <- nrow(am$P2); np2r <- if (is.null(am$P2r)) np2 else nrow(am$P2r)
+  .hasR <- isTRUE(am$hasRvar); .hasT <- isTRUE(am$hasTrans)
+  # Every column subset below must be present, or `.sol[, cols]` throws "undefined columns
+  # selected" (e.g. an rxode2 version/feature that did not emit an rvar/rsig/transform column).
+  # Verify up front and cleanly return NULL so the caller falls back to finite differences.
+  .need <- c("rx_predf_", "time", .cm$f1, .cm$f2)
+  if (.hasR) { .need <- c(.need, "rx_rvarf_", .cm$rvar1, .cm$rvar2)
+    if (length(am$sigTh) > 0L) .need <- c(.need, .cm$rsig, unlist(.cm$rsig1), .cm$rsig2) }
+  if (.hasT) .need <- c(.need, "rx_tyj_", "rx_tlambda_", "rx_tlow_", "rx_thi_")
+  if (!all(.need %in% names(.sol))) return(NULL)
   .M1 <- as.matrix(.sol[, .cm$f1, drop = FALSE]); .M2 <- as.matrix(.sol[, .cm$f2, drop = FALSE])
-  .fp <- .sol$rx_predf_; .tm <- .sol$time; .hasR <- isTRUE(am$hasRvar); .hasT <- isTRUE(am$hasTrans)
+  .fp <- .sol$rx_predf_; .tm <- .sol$time
   if (.hasR) {
     .MR1 <- as.matrix(.sol[, .cm$rvar1, drop = FALSE]); .MR2 <- as.matrix(.sol[, .cm$rvar2, drop = FALSE])
     .Rf <- .sol$rx_rvarf_; .nsig <- length(am$sigTh)

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -182,12 +182,12 @@ test_that("covMethod='analytic' covers censored M2/M3/M4 for FOCEI and FOCE (gau
   dM4 <- dM3; dM4$LIMIT <- 0
   # FOCEI + gauss: full analytic cov (theta+sigma+Omega), close to the FD Hessian cov
   fitA <- suppressWarnings(suppressMessages(nlmixr(cm, dM3, "focei",
-                                                   foceiControl(print = 0L, covMethod = "analytic"))))
+                                                   foceiControl(print = 0L, covMethod = "analytic", sigdig = 6))))
   expect_identical(fitA$covMethod, "analytic")
   expect_true(any(grepl("^om\\.", rownames(fitA$cov))))
   expect_true(all(is.finite(sqrt(diag(fitA$cov)))))
   fitR <- suppressWarnings(suppressMessages(nlmixr(cm, dM3, "focei",
-                                                   foceiControl(print = 0L, covMethod = "r"))))
+                                                   foceiControl(print = 0L, covMethod = "r", sigdig = 6))))
   cp <- intersect(rownames(fitA$cov), rownames(fitR$cov))
   expect_lt(max(abs(sqrt(diag(fitA$cov))[cp] - sqrt(diag(fitR$cov))[cp]) /
                   (sqrt(diag(fitR$cov))[cp] + 1e-8)), 0.05)
@@ -199,11 +199,11 @@ test_that("covMethod='analytic' covers censored M2/M3/M4 for FOCEI and FOCE (gau
   }
   # FOCE (gauss) censored is in scope too: full analytic cov, theta/sigma SEs close to FD
   fF <- suppressWarnings(suppressMessages(nlmixr(cm, dM3, "focei",
-                                                 foceiControl(print = 0L, covMethod = "analytic", interaction = FALSE))))
+                                                 foceiControl(print = 0L, covMethod = "analytic", interaction = FALSE, sigdig = 6))))
   expect_identical(fF$covMethod, "analytic")
   expect_true(any(grepl("^om\\.", rownames(fF$cov))))
   fFr <- suppressWarnings(suppressMessages(nlmixr(cm, dM3, "focei",
-                                                  foceiControl(print = 0L, covMethod = "r", interaction = FALSE))))
+                                                  foceiControl(print = 0L, covMethod = "r", interaction = FALSE, sigdig = 6))))
   cpf <- intersect(c("tka", "tcl", "tv", "add.sd"), intersect(rownames(fF$cov), rownames(fFr$cov)))
   expect_lt(max(abs(sqrt(diag(fF$cov))[cpf] - sqrt(diag(fFr$cov))[cpf]) /
                   (sqrt(diag(fFr$cov))[cpf] + 1e-8)), 0.03)
@@ -641,9 +641,9 @@ test_that("FOCE (interaction=FALSE) combined analytic cov matches the corrected-
   # the analytic R MATRIX reproduces the gold-FD Hessian, not that it is invertible.
   theo <- nlmixr2data::theo_sd
   fitF <- suppressMessages(nlmixr(.cov_combined, theo, "focei",
-            foceiControl(print = 0L, covMethod = "", interaction = FALSE)))
+            foceiControl(print = 0L, covMethod = "", interaction = FALSE, sigdig = 6)))
   fitI <- suppressMessages(nlmixr(.cov_combined, theo, "focei",
-            foceiControl(print = 0L, covMethod = "")))
+            foceiControl(print = 0L, covMethod = "", sigdig = 6)))
   rF <- foceiCovAnalytic(fitF); rI <- foceiCovAnalytic(fitI)
   expect_false(is.null(rF)); expect_identical(rF$method, "analytic")
   # FOCE combined != FOCEI combined (the interaction term is non-zero for prop error)
@@ -720,7 +720,7 @@ test_that("foce+ (foce='foce+') combined analytic cov matches the live-R gold FD
   # "nonmem" FOCE (frozen R0) and FOCEI (interaction term).
   theo <- nlmixr2data::theo_sd
   fitP <- suppressMessages(nlmixr(.cov_combined, theo, "focei",
-            foceiControl(print = 0L, covMethod = "", interaction = FALSE, foce = "foce+")))
+            foceiControl(print = 0L, covMethod = "", interaction = FALSE, foce = "foce+", sigdig = 6)))
   rP <- foceiCovAnalytic(fitP)
   expect_false(is.null(rP)); expect_identical(rP$method, "analytic")
 

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -321,6 +321,46 @@ test_that("estimated boxCox lambda: analytic cov (FOCEI/FOCE/foce+) matches the 
   chk("foce", list(foce = "foce+"))                    # focep: residual at the posthoc eta
 })
 
+test_that("lnorm and logitNorm transforms run the analytic cov (FOCEI and FOCE)", {
+  skip_on_cran()
+  skip_on_ci()
+  skip_if_not_installed("nlmixr2data")
+  # needs the rxode2 .rxFromSEnum empty-operand fix (nlmixr2/rxode2#1109) for the 2nd-order
+  # sensitivities of a log/logit-transformed prediction; older rxode2 falls back to FD
+  mLnorm <- function() {
+    ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.5; eta.cl ~ 0.08; eta.v ~ 0.05
+          lnorm.sd <- 0.7 })
+    model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+            d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center
+            cp <- center / v; cp ~ lnorm(lnorm.sd) })
+  }
+  mLogit <- function() {
+    ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.5; eta.cl ~ 0.08; eta.v ~ 0.05
+          logit.sd <- 0.7 })
+    model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+            d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center
+            cp <- center / v; cp ~ logitNorm(logit.sd, -0.1, 15) })
+  }
+  d <- nlmixr2data::theo_sd
+  # lnorm: drop the predose observations (a zero prediction makes log(f) = -Inf)
+  dPos <- d[!(d$EVID == 0 & d$TIME == 0), ]
+  chk <- function(m, dat, est) {
+    ctlA <- foceiControl(print = 0L, covMethod = "analytic", covFull = TRUE, fast = TRUE, sigdig = 6)
+    ctlR <- foceiControl(print = 0L, covMethod = "r", covFull = TRUE, fast = TRUE, sigdig = 6)
+    fitA <- suppressMessages(nlmixr2(m, dat, est, ctlA))
+    fitR <- suppressMessages(nlmixr2(m, dat, est, ctlR))
+    expect_identical(fitA$covMethod, "analytic")       # analytic ran (not an FD fallback)
+    seA <- sqrt(diag(fitA$cov)); seR <- sqrt(diag(fitR$cov))
+    nm <- intersect(names(seA), names(seR))
+    expect_true(all(is.finite(seA[nm])) && all(seA[nm] > 0))
+    expect_equal(unname(seA[nm]), unname(seR[nm]), tolerance = 0.1)
+  }
+  chk(mLnorm, dPos, "focei")
+  chk(mLnorm, dPos, "foce")
+  chk(mLogit, d, "focei")
+  chk(mLogit, d, "foce")
+})
+
 test_that("covMethod='analytic' emits an informative message when it falls back to FD", {
   skip_on_cran()
   skip_if_not_installed("nlmixr2data")

--- a/tests/testthat/test-cov-focei.R
+++ b/tests/testthat/test-cov-focei.R
@@ -72,10 +72,16 @@ nmTest({
     se_s  <- fit_s$parFixedDf[p,  "SE"]
     se_rs <- fit_rs$parFixedDf[p, "SE"]
 
-    # Before the fix: SE_r was ~sqrt(2) * SE_rs and SE_s was ~2 * SE_rs.
-    # After the fix all three should agree within ~30%.
+    # Before the #666 fix: SE_r was ~sqrt(2)*SE_rs (covR was 2*Rinv) and SE_s was ~2x that again
+    # (covS was 4*Sinv).  covMethod="r" (observed information) and the "r,s" sandwich obey the
+    # information equality, so r/rs stays ~1 and a return of the sqrt(2) scaling would push it >1.41.
     expect_true(all(se_r  / se_rs < 1.3), label = "covMethod='r' SE not inflated vs sandwich")
-    expect_true(all(se_s  / se_rs < 1.3), label = "covMethod='s' SE not inflated vs sandwich")
+    # covMethod="s" is the OPG (score cross-product) estimator.  On this 12-subject dataset it
+    # legitimately disagrees with the Hessian in its off-diagonals (S corr(tcl,tv) ~0.85 vs R's
+    # ~0.12), so s/rs runs ~2 for cl/v -- finite-sample OPG behaviour that collapses toward 1 on
+    # larger / well-specified data, NOT a scaling error.  This leg guards against the old constant
+    # factor (covS = 4*Sinv), which would DOUBLE these ratios to ~4.5.
+    expect_true(all(se_s  / se_rs < 3), label = "covMethod='s' SE not inflated by the old 2x constant factor")
   })
 
   test_that("covariance with many omegas fixed will not crash focei", {

--- a/tests/testthat/test-focei-fast-grad.R
+++ b/tests/testthat/test-focei-fast-grad.R
@@ -19,9 +19,10 @@
 }
 
 test_that("fast=TRUE control defaults: outerOpt + derivative-free downgrade", {
-  # base default outer optimizer is nlminb; fast default is lbfgsb3c
+  # default outer optimizer is nlminb for both base and fast (fast=TRUE with
+  # lbfgsb3c can settle at a worse optimum on ill-conditioned models)
   expect_equal(foceiControl()$outerOpt, -1L)                 # nlminb -> custom (-1)
-  expect_equal(foceiControl(fast = TRUE)$outerOpt, 1L)       # lbfgsb3c
+  expect_equal(foceiControl(fast = TRUE)$outerOpt, -1L)      # nlminb -> custom (-1)
   expect_true(foceiControl(fast = TRUE)$fast)
   expect_false(foceiControl()$fast)
   # an explicit outerOpt still wins under fast


### PR DESCRIPTION
**Stacked on #706** (`focei-analytic-cov-efficiency`) — this branch is #706 + one commit, so the diff below includes #706's changes until that merges; review the last commit (`chunk rxOptExpr ...`) in isolation, or merge #706 first.

## What
Cuts the one-time augmented-model **build** for the `fast=TRUE` analytic gradient / covariance by splitting the `rxOptExpr` common-subexpression pass over the model.

## Why
`rxOptExpr` is ~**O(n³·⁵)** in model size, so optimizing the whole 200–350 line augmented sensitivity model in a single call dominates the build (~25s of ~40s). Splitting into `k` contiguous line-chunks and optimizing each separately costs `~n³/k²` — an ~8–13× speedup on the `rxOptExpr` step. Cross-chunk CSE is lost (optimized text grows ~15–20%, negligible: the aug model is solved only hundreds of times per fit). Each `rxOptExpr` call restarts its introduced-variable counter at `rx_expr_0`, so chunks get a unique `rx_expr_` prefix before concatenation.

## Results (bit-identical, separate-process full theta + SE validation)
| model | aug build |
|---|---|
| 2-cmt combined-error theo | **52s → 19s** |
| 2-cmt + allometric-WT (covariate) | **248s → 86s** |

Gated by the existing `optExpression` control, with per-chunk and overall `tryCatch` fallback.