### PR TITLE
Fix muModel lin/irls with >=2 mu-ref covariate expressions (#711)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # nlmixr2est (development version)
 
+- Fixed `muModel = "lin"`/`"irls"` erroring with "undefined columns selected" when a
+  model has two or more mu-referenced covariates that are expressions (e.g.
+  `log(WT/70)`) rather than bare data columns (#711).
 - `est = "vae"` now assembles its fit with `nlmixr2CreateOutputFromUi()` and computes
   its covariance directly in the focei covariance step; `vaeControl(covMethod=)` now
   takes the focei choices (`"analytic"` (default), `"r,s"`, `"r"`, `"s"`, `""`)

--- a/R/muRefClassify.R
+++ b/R/muRefClassify.R
@@ -235,5 +235,12 @@
   if (length(covNames) == 0L) return(matrix(numeric(0), nrow = 0, ncol = 0))
   .byId <- dataSav[!duplicated(dataSav$ID), , drop = FALSE]
   .byId <- .byId[order(.byId$ID), , drop = FALSE]
-  as.matrix(.byId[, covNames, drop = FALSE])
+  # a name can be a covariate expression (e.g. log(WT/70)) rather than a
+  # bare column; evaluate those against the baseline rows
+  .cols <- lapply(covNames, function(.cn) {
+    if (.cn %in% names(.byId)) return(as.numeric(.byId[[.cn]]))
+    as.numeric(eval(parse(text = .cn), envir = .byId))
+  })
+  matrix(unlist(.cols, use.names = FALSE),
+         nrow = nrow(.byId), ncol = length(covNames))
 }

--- a/tests/testthat/test-muRefClassify.R
+++ b/tests/testthat/test-muRefClassify.R
@@ -234,3 +234,23 @@ test_that(".muRefGroups only marks the bounded covariate when a group has severa
   expect_false(.cv$bounded[.cv$covariateParameter == "allo.cl"])
   expect_true(.cv$bounded[.cv$covariateParameter == "allo.cl2"])
 })
+
+test_that(".muRefCppCovData evaluates covariate expressions that are not data columns (#711)", {
+  dataSav <- data.frame(
+    ID = c(2L, 2L, 1L, 1L),
+    WT = c(80, 80, 60, 60),
+    logWT = log(c(80, 80, 60, 60) / 70)
+  )
+  # bare columns still subset directly
+  .m <- .muRefCppCovData(c("logWT", "WT"), dataSav)
+  expect_equal(dim(.m), c(2L, 2L))
+  expect_equal(.m[, 1], log(c(60, 80) / 70))
+  expect_equal(.m[, 2], c(60, 80))
+  # expression names (e.g. from >=2 mu-ref covariate expressions) are
+  # evaluated against the baseline rows instead of erroring
+  .m2 <- .muRefCppCovData(c("log(WT/70)", "log(WT/70)", "WT"), dataSav)
+  expect_equal(dim(.m2), c(2L, 3L))
+  expect_equal(.m2[, 1], log(c(60, 80) / 70))
+  expect_equal(.m2[, 2], .m2[, 1])
+  expect_equal(.m2[, 3], c(60, 80))
+})

--- a/tests/testthat/test-mufocei.R
+++ b/tests/testthat/test-mufocei.R
@@ -331,3 +331,33 @@ nmTest({
     expect_true(any(grepl("[-0-9]\\.[0-9]", gradRows)))
   })
 })
+
+nmTest({
+  test_that("mufocei handles >=2 mu-ref covariate expressions (#711)", {
+    # two mu-referenced covariates that are expressions (log(WT/70)), not
+    # bare data columns, used to error with "undefined columns selected"
+    mod <- function() {
+      ini({
+        tka <- log(1.5); tcl <- log(2.7); tv <- log(31.5)
+        wtcl <- 0.75; wtv <- 1
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl + wtcl * log(WT/70))
+        v <- exp(tv + eta.v + wtv * log(WT/70))
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl/v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+    .f <- .nlmixr(mod, nlmixr2data::theo_sd, "focei",
+                  foceiControl(muModel = "lin", print = 0,
+                               maxOuterIterations = 0L, covMethod = "",
+                               calcTables = FALSE))
+    expect_true(inherits(.f, "nlmixr2FitCore"))
+    expect_true(all(is.finite(.f$theta)))
+  })
+})


### PR DESCRIPTION
Closes #711

## Bug

With `muModel = "lin"`/`"irls"` (`mufocei`/`irlsfocei`/...), a model with two or more mu-referenced covariates that are algebraic expressions (e.g. `log(WT/70)` on both CL and V) errored with `undefined columns selected`, under both `fast = TRUE` and `fast = FALSE`.

`.muRefCppCovData()` (`R/muRefClassify.R`) built the C++ regression's per-subject covariate matrix by subsetting `dataSav` with the flattened covariate names from `.muRefCppGroupSetup()`. Those names can be covariate expression strings, which are never materialized as columns in `dataSav`, so the `[.data.frame` subset failed. Single-expression and raw-column models never hit the failing path.

## Fix

Resolve each covariate name individually: bare column names subset directly as before; anything else is evaluated as an expression against the per-subject baseline rows.

## Verification

- The issue reprex runs to completion under both `fast = FALSE` (OBJF 113.05) and `fast = TRUE` (113.01) with sensible estimates.
- Unit test in `test-muRefClassify.R`: bare columns, duplicated expression names, and a mix of both.
- End-to-end regression test in `test-mufocei.R` (kept cheap with `maxOuterIterations = 0`; the crash happened during setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)