### PR TITLE
rpem: fix centered (non-mu-referenced) etas in the C++ E-M loop

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^design$
 ^plans$
 ^tools$
 ^.augment$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,7 +84,8 @@ Suggests:
     fastGHQuad,
     rmarkdown,
     rlang,
-    numDeriv
+    numDeriv,
+    rstan
 LinkingTo:
     BH,
     n1qn1 (>= 6.0.1-12),

--- a/NEWS.md
+++ b/NEWS.md
@@ -760,6 +760,11 @@
   underflowing/collapsing mixture probabilities, and a fix for the
   SAEM omega-diagonal floor being raised outside mixture fits
 
+- Fixed `est = "rpem"` failing with `muIdx / mu0 / omDiag0 must have nEta
+  entries` for models with a centered (non-mu-referenced) random effect,
+  e.g. a bounded typical value like `tcl <- log(c(0, 2.7, 100))` with an
+  eta (the bounded transform demotes the eta to centered)
+
 - Fix segfault in `nlmSetup` on the first estimator call of a fresh R
   session for pooled estimators
 

--- a/R/rpem.R
+++ b/R/rpem.R
@@ -569,9 +569,14 @@
     .resIdx <- c(.naI(.cl$propSdIdx), .naI(.cl$powIdx), .naI(.cl$lambdaIdx))
     .resPar0 <- c(.naN(.cl$propSd0), .naN(.cl$pow0), .naN(.cl$lambda0))
     .designC <- if (.useReg) .design else matrix(0.0, 0L, 0L)
+    # muIdx for the C++ loop is per-eta (nEta entries): -1 marks a centered
+    # (non-mu-referenced) eta, e.g. an IOV occasion eta or a bounded-transformed
+    # typical value whose theta moved into the structural set.
+    .muIdxC <- rep(-1L, .cl$nEta)
+    .muIdxC[.cl$muRef] <- .cl$muIdx
     # config List for the C++ E-M loop (rpemEMLoopK1 takes one cfg, not a positional list)
     .cfg <- list(
-      base = base, etaIdx = .cl$etaIdx, muIdx = .cl$muIdx, addSdIdx = .naI(.cl$addSdIdx),
+      base = base, etaIdx = .cl$etaIdx, muIdx = .muIdxC, addSdIdx = .naI(.cl$addSdIdx),
       errType = .cl$errType, mu0 = .cl$mu0, omDiag0 = diag(as.matrix(.cl$omega0)),
       addSd0 = .naN(.cl$addSd0), resIdx = .resIdx, resPar0 = .resPar0,
       structIdx = as.integer(.cl$structIdx), struct0 = as.numeric(.cl$struct0),

--- a/src/rpem.cpp
+++ b/src/rpem.cpp
@@ -882,7 +882,8 @@ List rpemEMLoopK1(Environment e, List cfg) {
       mu[0] = coefs[0];
       for (int k = 0; k < (int)covIdxBuf.size(); ++k) baseBuf[covIdxBuf[k]] = coefs[k + 1];
     }
-    for (int a = 0; a < nEta; ++a) baseBuf[muIdxBuf[a]] = mu[a];
+    // centered (non-mu-referenced) etas have muIdx -1: no theta carries their typical value
+    for (int a = 0; a < nEta; ++a) if (muIdxBuf[a] >= 0) baseBuf[muIdxBuf[a]] = mu[a];
     if (addSdIdx >= 0) baseBuf[addSdIdx] = addSd;   // LL (doLik): no residual parameter
     if (doComb) baseBuf[propSdIdx] = propSd;
     if (doPow) baseBuf[powIdx] = power;
@@ -1319,7 +1320,7 @@ List rpemEMLoopK1(Environment e, List cfg) {
         prow[muIdxBuf[0]] = coefs[0];
         for (int k = 0; k < (int)covIdxBuf.size(); ++k) prow[covIdxBuf[k]] = coefs[k + 1];
       } else {
-        for (int a = 0; a < nEta; ++a) prow[muIdxBuf[a]] = mu[a];
+        for (int a = 0; a < nEta; ++a) if (muIdxBuf[a] >= 0) prow[muIdxBuf[a]] = mu[a];
       }
       if (addSdIdx >= 0) prow[addSdIdx] = addSd;
       if (doComb) prow[propSdIdx] = propSd;

--- a/tests/testthat/test-rpem-boundfix.R
+++ b/tests/testthat/test-rpem-boundfix.R
@@ -83,3 +83,45 @@ test_that("RPEM fits a bounded structural (likelihood) parameter within its boun
   # recovers in the right ballpark (true 1.5) within its declared bounds.
   expect_gt(.shape, 0.9); expect_lt(.shape, 2.3)
 })
+test_that("RPEM recovers a bounded mu-referenced typical value (centered-eta demotion)", {
+  skip_on_cran()
+
+  # The bounded transform rewrites tcl (bounded, mu-referenced by eta.cl) into a
+  # structural theta rxBoundedTr.tcl + a model-computed tcl, so eta.cl becomes a
+  # centered eta whose omega is still estimated by the conjugate M-step.
+  one.cmt <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- log(c(0, 2.7, 100))
+      tv <- 3.45
+      eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  # classification after the transform: eta.cl is centered, its theta is structural
+  ui <- rxode2::rxUiDecompress(rxode2::rxode2(one.cmt))
+  res <- .preProcessBoundedTransform(ui, "rpem", nlmixr2data::theo_sd, rpemControl())
+  cl <- .rpemClassify(res$ui)
+  expect_equal(cl$muRef, c(TRUE, FALSE, TRUE))
+  expect_true("rxBoundedTr.tcl" %in% cl$thetaNames[cl$structIdx + 1L])
+
+  f <- suppressMessages(suppressWarnings(nlmixr2est::nlmixr2(one.cmt, nlmixr2data::theo_sd,
+    est = "rpem",
+    control = rpemControl(nGauss = 300L, nMH = 50000L, mhBurn = 5000L, niter = 30L,
+                          collect = 12L, seed = 7L, cores = 4L))))
+  expect_s3_class(f, "nlmixr2FitData")
+  .pf <- f$parFixedDf
+  # tcl reported back-transformed inside its declared box; theo_sd reference ~ 1.01
+  expect_lte(.pf["tcl", "Estimate"], log(100))
+  expect_equal(unname(.pf["tcl", "Estimate"]), 1.01, tolerance = 0.15)
+  expect_equal(unname(.pf["tka", "Estimate"]), 0.45, tolerance = 0.35)
+  expect_equal(unname(.pf["tv", "Estimate"]), 3.45, tolerance = 0.1)
+  .om <- diag(f$omega)
+  expect_true(all(is.finite(.om) & .om > 0))       # centered eta.cl omega estimated
+})

--- a/tests/testthat/test-rpem-est.R
+++ b/tests/testthat/test-rpem-est.R
@@ -41,3 +41,39 @@ test_that("est='rpem' dispatch runs end-to-end (K=1)", {
   expect_true(is.finite(.pf["tka", "SE"]) && .pf["tka", "SE"] > 0)
   expect_true(is.finite(.pf["add.sd", "SE"]) && .pf["add.sd", "SE"] > 0)
 })
+
+test_that("est='rpem' runs with a bounded mu-referenced typical value (centered-eta demotion)", {
+  skip_on_cran()
+
+  # A bounded typical value with an eta (tcl <- log(c(0, 2.7, 100))) is rewritten by the
+  # bounded transform into a structural theta (rxBoundedTr.tcl) + model-computed tcl,
+  # demoting eta.cl to a centered (non-mu-referenced) eta.  The C++ loop takes a per-eta
+  # muIdx with -1 for centered etas; this used to fail with
+  # 'muIdx / mu0 / omDiag0 must have nEta entries'.
+  one.cmt <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- log(c(0, 2.7, 100))
+      tv <- 3.45
+      eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  fit <- suppressMessages(suppressWarnings(nlmixr2(one.cmt, nlmixr2data::theo_sd, est = "rpem",
+    control = rpemControl(nGauss = 100L, nMH = 20000L, mhBurn = 2000L,
+                          niter = 10L, collect = 4L, seed = 42L, print = 0L))))
+  expect_s3_class(fit, "nlmixr2FitData")
+  .pf <- fit$parFixedDf
+  # tcl is reported back-transformed on the natural scale, inside its declared box
+  expect_gt(.pf["tcl", "Estimate"], log(1e-8)); expect_lt(.pf["tcl", "Estimate"], log(100))
+  # all three omegas (including the centered eta.cl) are estimated, finite and positive
+  .om <- diag(fit$omega)
+  expect_equal(length(.om), 3L)
+  expect_true(all(is.finite(.om) & .om > 0))
+})


### PR DESCRIPTION
## Summary

The simplest bounded model failed with `est = "rpem"`:

```r
tcl <- log(c(0, 2.7, 100))   # bounded typical value with eta.cl
...
Error: muIdx / mu0 / omDiag0 must have nEta entries
```

**Root cause:** the bounded-parameter transform rewrites a bounded mu-referenced theta (`tcl`) into a structural theta (`rxBoundedTr.tcl`) plus a model-computed variable, which demotes its eta (`eta.cl`) to a centered (non-mu-referenced) eta. The C++ E-M loop (`rpemEMLoopK1`) expects `muIdx` with one entry per eta, but the R side passed the compact mu-ref-only vector, so any model with a centered eta hit the `nEta` guard. (The centered-eta clamps themselves were already in the C++ loop -- only the index contract was broken.)

## Fix

- `R/rpem.R`: pass a per-eta `muIdx` to the C++ loop with `-1` marking centered etas (bounded-transformed typical values, IOV occasion etas).
- `src/rpem.cpp`: skip the theta write-back (`baseBuf` / live-print row) for `muIdx == -1`.

For fully mu-referenced models the passed vector is unchanged, so existing fits are bit-for-bit identical.

## Tests

- Quick-core (`test-rpem-est.R`): the reported `one.cmt` + `theo_sd` model now runs end-to-end; checks the back-transformed `tcl` respects its box and all three omegas (including centered `eta.cl`) are estimated.
- Weekly (`test-rpem-boundfix.R`): classification assertions (`muRef = c(TRUE, FALSE, TRUE)`, `rxBoundedTr.tcl` in the structural set) plus recovery of the theo_sd reference estimates.
- `test-rpem-iov.R` (centered occasion etas, same code path) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)