### PR TITLE
focei(analytic): ungate compartment-scoped models (chunk via in-place disguise) [stacked on #723]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,7 +84,8 @@ Suggests:
     fastGHQuad,
     rmarkdown,
     rlang,
-    numDeriv
+    numDeriv,
+    mirai
 LinkingTo:
     BH,
     n1qn1 (>= 6.0.1-12),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,13 @@
   parallel, cutting the pass several-fold on larger covariate models; the result
   is mathematically identical (bit-identical solves).  Most valuable for
   bootstrap / covariate search, where the augmented model is rebuilt across many
-  workers and the daemon pool is set up once.  (Compartment-scoped models -- a
-  parameter-dependent state IC or dosing modifier -- continue to optimize whole
-  and un-chunked, as before.)
+  workers and the daemon pool is set up once.  Compartment-scoped models -- a
+  parameter-dependent state initial condition (`state(0)=`) or a dosing modifier
+  (`f/lag/rate/dur(cmt)=`) -- are now chunked too: those lines are disguised as
+  plain assignments **in place** for the optimization pass and restored after, so
+  they never orphan a chunk (which would be a parse error) and never move (which
+  would change what a later reassignment reads), yet still get the chunked/parallel
+  speedup -- previously they fell back to a single whole-model call.
 
 - Added an automatic differentiation variational inference method
   (`est = "advi"`, Kucukelbir et al. 2017) with `adviControl()`.  The variational

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # nlmixr2est (development version)
 
+- The analytic FOCEI/FOCE augmented-model `rxOptExpr` pass now splits the model
+  into **cost-balanced** contiguous chunks (equal character-sum rather than equal
+  line count) so the largest chunk -- which drives the ~O(n^3.5) cost -- is
+  minimized.  With `foceiControl(optExprParallel = TRUE)` and an active `mirai`
+  daemon pool (`mirai::daemons()`), the independent chunks are optimized in
+  parallel, cutting the pass several-fold on larger covariate models; the result
+  is mathematically identical (bit-identical solves).  Most valuable for
+  bootstrap / covariate search, where the augmented model is rebuilt across many
+  workers and the daemon pool is set up once.  (Compartment-scoped models -- a
+  parameter-dependent state IC or dosing modifier -- continue to optimize whole
+  and un-chunked, as before.)
+
 - Added an automatic differentiation variational inference method
   (`est = "advi"`, Kucukelbir et al. 2017) with `adviControl()`.  The variational
   gradient is obtained from the FOCEi forward sensitivities (the inner

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -184,10 +184,11 @@
 #'     still uses the (always-on) cost-balanced chunking, just sequentially.
 #'     When `TRUE`, set up a pool once with `mirai::daemons()` before fitting
 #'     (ideal for bootstrap / covariate search, where the model is rebuilt in
-#'     many workers); with no active pool this option is a no-op.  Only applies
-#'     to models without a parameter-dependent state initial condition or
-#'     dosing modifier (those are optimized whole, un-chunked).  Requires the
-#'     `mirai` package.
+#'     many workers), and tear it down with `mirai::daemons(0)` when done; with
+#'     no active pool this option is a no-op, and an already-running pool is
+#'     borrowed (not created or destroyed) by the fit.  Only applies to models
+#'     without a parameter-dependent state initial condition or dosing modifier
+#'     (those are optimized whole, un-chunked).  Requires the `mirai` package.
 #'
 #' @param literalFix boolean, substitute fixed population values as
 #'   literals and re-adjust ui and parameter estimates after

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -186,9 +186,8 @@
 #'     (ideal for bootstrap / covariate search, where the model is rebuilt in
 #'     many workers), and tear it down with `mirai::daemons(0)` when done; with
 #'     no active pool this option is a no-op, and an already-running pool is
-#'     borrowed (not created or destroyed) by the fit.  Only applies to models
-#'     without a parameter-dependent state initial condition or dosing modifier
-#'     (those are optimized whole, un-chunked).  Requires the `mirai` package.
+#'     borrowed (not created or destroyed) by the fit.  Requires the `mirai`
+#'     package.
 #'
 #' @param literalFix boolean, substitute fixed population values as
 #'   literals and re-adjust ui and parameter estimates after

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -177,6 +177,18 @@
 #' @param optExpression Optimize the rxode2 expression to speed up
 #'     calculation. By default this is turned on.
 #'
+#' @param optExprParallel For the analytic FOCEI/FOCE augmented sensitivity
+#'     model (`covType="analytic"` / `fast=TRUE`), optimize the model's common
+#'     subexpressions (`rxOptExpr`) in cost-balanced chunks dispatched in
+#'     parallel across an active `mirai` daemon pool.  The default `FALSE`
+#'     still uses the (always-on) cost-balanced chunking, just sequentially.
+#'     When `TRUE`, set up a pool once with `mirai::daemons()` before fitting
+#'     (ideal for bootstrap / covariate search, where the model is rebuilt in
+#'     many workers); with no active pool this option is a no-op.  Only applies
+#'     to models without a parameter-dependent state initial condition or
+#'     dosing modifier (those are optimized whole, un-chunked).  Requires the
+#'     `mirai` package.
+#'
 #' @param literalFix boolean, substitute fixed population values as
 #'   literals and re-adjust ui and parameter estimates after
 #'   optimization; Default is `TRUE`.
@@ -681,6 +693,7 @@ foceiControl <- function(sigdig = 4, #
                          iovXform = c("sd", "var", "logsd", "logvar"), #
                          sumProd = FALSE, #
                          optExpression = TRUE,#
+                         optExprParallel = FALSE,#
                          literalFix=TRUE,
                          literalFixRes=TRUE,
                          ci = 0.95, #
@@ -932,6 +945,7 @@ foceiControl <- function(sigdig = 4, #
 
   checkmate::assertLogical(sumProd, any.missing=FALSE, len=1)
   checkmate::assertLogical(optExpression, any.missing=FALSE, len=1)
+  checkmate::assertLogical(optExprParallel, any.missing=FALSE, len=1)
   checkmate::assertLogical(literalFix, any.missing=FALSE, len=1)
   checkmate::assertLogical(literalFixRes, any.missing=FALSE, len=1)
 
@@ -1284,6 +1298,7 @@ foceiControl <- function(sigdig = 4, #
     iovXform = match.arg(iovXform),
     sumProd = sumProd,
     optExpression = optExpression,
+    optExprParallel = optExprParallel,
     literalFix=literalFix,
     literalFixRes=literalFixRes,
     outerOpt = as.integer(outerOpt),

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -1111,6 +1111,54 @@
   unname(split(lines, findInterval(cumsum(.w), seq_len(.k - 1L) * sum(.w) / .k)))
 }
 
+#' Disguise compartment-scoped assignments as plain LHS so they can be chunked.
+#'
+#' `rxOptExpr` parses each chunk as a standalone model, so a state initial condition
+#' (`state(0)=`) or a dosing modifier (`f/alag/lag/rate/dur(cmt)=`) in a chunk that lacks its
+#' `d/dt(cmt)` raises "'W(0)' present, but d/dt(W) not defined".  Rather than *move* such a line
+#' (its RHS may read a model variable a later line reassigns, so its position is load-bearing),
+#' rewrite ONLY its left-hand side to a unique plain name **in place** for the optimization pass;
+#' [.foceiRestoreCmt] reverses it afterward.  The line never changes position, so semantics are
+#' preserved (validated bit-identical vs the whole-model optimization).  `d/dt(cmt)=` is left
+#' alone -- it is valid in a chunk on its own (default IC).
+#' @param modTxt model text
+#' @return model text with compartment-scoped LHS disguised as `rx__disg_ic__*` / `rx__disg_mod__*`
+#' @noRd
+.foceiDisguiseCmt <- function(modTxt) {
+  .ln  <- strsplit(modTxt, "\n", fixed = TRUE)[[1]]
+  .eq  <- regexpr("=", .ln, fixed = TRUE)
+  .lhs <- ifelse(.eq > 0L, trimws(substr(.ln, 1L, .eq - 1L)), "")
+  .rhs <- ifelse(.eq > 0L, substr(.ln, .eq + 1L, nchar(.ln)), "")
+  .isIc  <- .eq > 0L & endsWith(.lhs, "(0)")
+  .isMod <- .eq > 0L & grepl("^(f|alag|lag|rate|dur)\\(", .lhs) & endsWith(.lhs, ")")
+  .new <- .lhs
+  .new[.isIc] <- paste0("rx__disg_ic__", sub("\\(0\\)$", "", .lhs[.isIc]), "__")
+  .mm <- regmatches(.lhs[.isMod], regexec("^([a-z]+)\\((.*)\\)$", .lhs[.isMod]))
+  .new[.isMod] <- vapply(.mm, function(.m) paste0("rx__disg_mod__", .m[2L], "__", .m[3L], "__"),
+                         character(1))
+  paste(ifelse(.eq > 0L & (.isIc | .isMod), paste0(.new, "=", .rhs), .ln), collapse = "\n")
+}
+
+#' Reverse [.foceiDisguiseCmt]: restore the original compartment-scoped LHS.
+#'
+#' Operates on the LHS only (split at the first `=`), so an optimized RHS is untouched.
+#' @param txt optimized model text containing disguised LHS
+#' @return model text with `state(0)=` / `f(cmt)=` LHS restored
+#' @noRd
+.foceiRestoreCmt <- function(txt) {
+  .ln <- strsplit(txt, "\n", fixed = TRUE)[[1]]
+  .disg <- startsWith(.ln, "rx__disg_ic__") | startsWith(.ln, "rx__disg_mod__")
+  if (any(.disg)) {
+    .eq  <- regexpr("=", .ln[.disg], fixed = TRUE)
+    .lhs <- substr(.ln[.disg], 1L, .eq - 1L)
+    .rest <- substr(.ln[.disg], .eq, nchar(.ln[.disg]))       # keep the "=..." RHS verbatim
+    .lhs <- sub("^rx__disg_ic__(.*)__$", "\\1(0)", .lhs)       # rx__disg_ic__X__  -> X(0)
+    .lhs <- sub("^rx__disg_mod__([a-z]+)__(.*)__$", "\\1(\\2)", .lhs)  # rx__disg_mod__f__X__ -> f(X)
+    .ln[.disg] <- paste0(.lhs, .rest)
+  }
+  paste(.ln, collapse = "\n")
+}
+
 #' Optimize the augmented model's common subexpressions in cost-balanced chunks.
 #'
 #' `rxOptExpr` on the whole (~200-500 line) augmented model dominates the build (~O(n^3.5)),
@@ -1124,12 +1172,13 @@
 #' `mirai::mirai_map`; otherwise they run sequentially.  Result is mathematically identical
 #' to the un-chunked optimization (validated: bit-identical solves).
 #'
-#' Compartment-scoped models (a `state(0)=` IC or a `f/lag/rate/dur(cmt)=` dosing modifier)
-#' optimize whole, un-chunked: such a construct in a chunk without its `d/dt(cmt)` is a parse
-#' error and the lines cannot be safely repositioned (their RHS may read a model variable whose
-#' value the optimized body reassigns, so position is load-bearing).  Small models likewise
-#' optimize whole.  Each chunk is collapsed to one string and a parse error degrades that chunk
-#' to unoptimized (length-safe); on a worker-side error the whole pass re-runs sequentially.
+#' Compartment-scoped models (a `state(0)=` IC or a `f/lag/rate/dur(cmt)=` dosing modifier) are
+#' handled by disguising those lines as plain assignments in place ([.foceiDisguiseCmt]) before
+#' chunking and restoring them after ([.foceiRestoreCmt]) -- so they chunk (and parallelize)
+#' like any other model, without the parse error a chunk-orphaned construct would raise and
+#' without moving any line.  Small models optimize whole.  Each chunk is collapsed to one string
+#' and a parse error degrades that chunk to unoptimized (length-safe); on a worker-side error
+#' the whole pass re-runs sequentially.
 #' @param modTxt augmented model text
 #' @param msg progress label passed to `rxOptExpr`
 #' @param chunkLines target chunk size in lines (default 40 -- the parallel build-time optimum)
@@ -1140,9 +1189,9 @@
 .foceiChunkedOptExpr <- function(modTxt, msg = "FOCEi outer gradient model",
                                  chunkLines = 40L, parallel = FALSE, minChunks = 3L) {
   .ln <- strsplit(modTxt, "\n", fixed = TRUE)[[1]]
-  .special <- any(grepl("(0)=", .ln, fixed = TRUE)) ||
-    any(grepl("^(f|alag|lag|rate|dur)\\([^)=]*\\)=", .ln))
-  if (.special || length(.ln) <= chunkLines) return(rxode2::rxOptExpr(modTxt, msg))
+  if (length(.ln) <= chunkLines) return(rxode2::rxOptExpr(modTxt, msg))   # small model: whole
+  # disguise compartment-scoped LHS so every chunk parses standalone; restored at the end
+  .ln <- strsplit(.foceiDisguiseCmt(modTxt), "\n", fixed = TRUE)[[1]]
   .targetChars <- as.numeric(mean(pmax(1L, nchar(.ln)))) * chunkLines   # -> ~ length/chunkLines chunks
   .chunks <- .foceiBalancedChunks(.ln, .targetChars)
   .idx <- seq_along(.chunks)
@@ -1162,7 +1211,7 @@
   } else {
     vapply(.idx, .optOne, character(1), .ch = .chunks)
   }
-  paste(.opt, collapse = "\n")
+  .foceiRestoreCmt(paste(.opt, collapse = "\n"))          # undo the compartment-scoped disguise
 }
 
 .foceiAnalyticAugModelDirs <- function(ui, dirs) {

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -1371,6 +1371,10 @@
     # it into contiguous chunks (gating compartment-scoped models to a whole-model call) and,
     # with optExprParallel=TRUE + an active mirai pool, optimizes them in parallel -- identical
     # result, faster build.  Any failure degrades to the unoptimized (correct) model.
+    # optExprParallel and the chunk balancing are deliberately NOT in rxUiGet.foceiModelDigest:
+    # they change only HOW the CSE is computed, not the resulting model (sequential, parallel and
+    # the old equal-count chunking all yield mathematically equivalent models), so the digest-keyed
+    # qs2/in-memory caches correctly reuse the equivalent build.
     if (isTRUE(rxode2::rxGetControl(ui, "optExpression", TRUE))) {
       .modTxt <- tryCatch(
         .foceiChunkedOptExpr(.modTxt, "FOCEi outer gradient model",

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -1127,8 +1127,11 @@
 .foceiDisguiseCmt <- function(modTxt) {
   .ln  <- strsplit(modTxt, "\n", fixed = TRUE)[[1]]
   .eq  <- regexpr("=", .ln, fixed = TRUE)
-  .lhs <- ifelse(.eq > 0L, trimws(substr(.ln, 1L, .eq - 1L)), "")
-  .rhs <- ifelse(.eq > 0L, substr(.ln, .eq + 1L, nchar(.ln)), "")
+  .raw <- ifelse(.eq > 0L, substr(.ln, 1L, .eq - 1L), "")     # LHS incl. any surrounding whitespace
+  .lhs <- trimws(.raw)                                        # bare LHS token
+  .lead  <- sub("^([ \t]*).*$", "\\1", .raw)                  # leading whitespace, preserved verbatim
+  .trail <- substr(.raw, nchar(.lead) + nchar(.lhs) + 1L, nchar(.raw))  # gap before "=", preserved
+  .rhs <- ifelse(.eq > 0L, substr(.ln, .eq, nchar(.ln)), "")  # "=..." kept verbatim
   .isIc  <- .eq > 0L & endsWith(.lhs, "(0)")
   .isMod <- .eq > 0L & grepl("^(f|alag|lag|rate|dur)\\(", .lhs) & endsWith(.lhs, ")")
   .new <- .lhs
@@ -1136,7 +1139,7 @@
   .mm <- regmatches(.lhs[.isMod], regexec("^([a-z]+)\\((.*)\\)$", .lhs[.isMod]))
   .new[.isMod] <- vapply(.mm, function(.m) paste0("rx__disg_mod__", .m[2L], "__", .m[3L], "__"),
                          character(1))
-  paste(ifelse(.eq > 0L & (.isIc | .isMod), paste0(.new, "=", .rhs), .ln), collapse = "\n")
+  paste(ifelse(.eq > 0L & (.isIc | .isMod), paste0(.lead, .new, .trail, .rhs), .ln), collapse = "\n")
 }
 
 #' Reverse [.foceiDisguiseCmt]: restore the original compartment-scoped LHS.
@@ -1147,14 +1150,17 @@
 #' @noRd
 .foceiRestoreCmt <- function(txt) {
   .ln <- strsplit(txt, "\n", fixed = TRUE)[[1]]
-  .disg <- startsWith(.ln, "rx__disg_ic__") | startsWith(.ln, "rx__disg_mod__")
+  .disg <- grepl("^[ \t]*rx__disg_(ic|mod)__", .ln)           # tolerate leading whitespace
   if (any(.disg)) {
-    .eq  <- regexpr("=", .ln[.disg], fixed = TRUE)
-    .lhs <- substr(.ln[.disg], 1L, .eq - 1L)
+    .eq   <- regexpr("=", .ln[.disg], fixed = TRUE)
+    .raw  <- substr(.ln[.disg], 1L, .eq - 1L)                 # disguised LHS incl. whitespace
     .rest <- substr(.ln[.disg], .eq, nchar(.ln[.disg]))       # keep the "=..." RHS verbatim
-    .lhs <- sub("^rx__disg_ic__(.*)__$", "\\1(0)", .lhs)       # rx__disg_ic__X__  -> X(0)
-    .lhs <- sub("^rx__disg_mod__([a-z]+)__(.*)__$", "\\1(\\2)", .lhs)  # rx__disg_mod__f__X__ -> f(X)
-    .ln[.disg] <- paste0(.lhs, .rest)
+    .lead  <- sub("^([ \t]*).*$", "\\1", .raw)                # restore the exact leading/trailing
+    .tok   <- trimws(.raw)                                    # whitespace the disguise preserved
+    .trail <- substr(.raw, nchar(.lead) + nchar(.tok) + 1L, nchar(.raw))
+    .tok <- sub("^rx__disg_ic__(.*)__$", "\\1(0)", .tok)       # rx__disg_ic__X__  -> X(0)
+    .tok <- sub("^rx__disg_mod__([a-z]+)__(.*)__$", "\\1(\\2)", .tok)  # rx__disg_mod__f__X__ -> f(X)
+    .ln[.disg] <- paste0(.lead, .tok, .trail, .rest)
   }
   paste(.ln, collapse = "\n")
 }

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -1058,6 +1058,108 @@
   }
   .res
 }
+
+#' Is a mirai daemon pool currently active?  (mirai is a Suggests; FALSE if absent.)
+#' @return logical
+#' @noRd
+.foceiOptExprDaemonsActive <- function() {
+  if (!requireNamespace("mirai", quietly = TRUE)) return(FALSE)
+  isTRUE(tryCatch(sum(mirai::status()$connections) >= 1L, error = function(e) FALSE))
+}
+
+#' Ensure a persistent mirai daemon pool for the chunk optimizer.
+#'
+#' Set up once and reused across builds (ideal for bootstrap / SCM / covariate search, where
+#' the augmented model is rebuilt in many worker calls); `rxode2` is warmed on each daemon so
+#' the first `rxOptExpr` dispatch is not charged the namespace load.  A no-op when mirai is
+#' unavailable or a pool is already active; `n = 0` tears the pool down.
+#' @param n number of daemons; `NULL` -> `detectCores() - 2`
+#' @return logical, whether a pool is active afterward
+#' @noRd
+.foceiOptExprDaemons <- function(n = NULL) {
+  if (!requireNamespace("mirai", quietly = TRUE)) return(invisible(FALSE))
+  if (identical(n, 0L) || identical(n, 0)) { try(mirai::daemons(0L), silent = TRUE); return(invisible(FALSE)) }
+  if (.foceiOptExprDaemonsActive()) return(invisible(TRUE))
+  .n <- if (is.null(n)) max(1L, parallel::detectCores() - 2L) else max(1L, as.integer(n))
+  try({
+    mirai::daemons(.n)
+    mirai::everywhere(suppressMessages(loadNamespace("rxode2")))   # warm rxode2 on each daemon once
+  }, silent = TRUE)
+  invisible(.foceiOptExprDaemonsActive())
+}
+
+#' Cost-balanced contiguous chunking of model lines.
+#'
+#' `rxOptExpr` is ~O(n^3.5) in chunk size, so the LARGEST chunk sets both the sequential tail
+#' and the parallel floor.  Splitting by equal LINE COUNT is uneven when lines vary in size
+#' (the 2nd-order sensitivity equations are long); splitting by equal CHAR-SUM minimizes the
+#' max chunk for the same number of chunks.  Chunks stay CONTIGUOUS so variable definitions
+#' still precede their uses when the optimized chunks are concatenated back together.
+#' @param lines character vector of model lines
+#' @param targetChars target char-sum per chunk (drives the chunk count)
+#' @return list of character vectors (contiguous line groups)
+#' @noRd
+.foceiBalancedChunks <- function(lines, targetChars) {
+  .w <- pmax(1L, nchar(lines))
+  .k <- max(1L, round(sum(.w) / targetChars))
+  if (.k <= 1L) return(list(lines))
+  .cum <- cumsum(.w); .tot <- sum(.w)
+  .b <- unique(c(0L,
+                 vapply(seq_len(.k - 1L),
+                        function(.j) which.min(abs(.cum - .j * .tot / .k)), integer(1)),
+                 length(lines)))
+  lapply(seq_len(length(.b) - 1L), function(.j) lines[(.b[.j] + 1L):.b[.j + 1L]])
+}
+
+#' Optimize the augmented model's common subexpressions in cost-balanced chunks.
+#'
+#' `rxOptExpr` on the whole (~200-500 line) augmented model dominates the build (~O(n^3.5)),
+#' so it is chunked; the chunks are independent (each optimized separately, its introduced
+#' variables namespaced by a per-chunk `rx_expr_c<g>_` prefix so there are no cross-chunk
+#' clashes), which lets them run in parallel.  Chunks are cost-balanced (see
+#' [.foceiBalancedChunks]) and sized to ~`chunkLines` lines' worth of characters -- the
+#' build-time optimum with parallel optimization (smaller chunks cut `rxOptExpr` further but
+#' grow the model from lost cross-chunk CSE, which then costs more in `eventSens`/compile).
+#' When `parallel` is on and a mirai daemon pool is active, chunks are dispatched with
+#' `mirai::mirai_map`; otherwise they run sequentially.  Result is mathematically identical
+#' to the un-chunked optimization (validated: bit-identical solves).
+#'
+#' The caller only routes compartment-UNSCOPED models here (models with a `state(0)=` IC or a
+#' `f/lag/rate/dur(cmt)=` modifier go to a single whole-model `rxOptExpr` call, because such a
+#' construct in a chunk without its `d/dt(cmt)` is a parse error and the lines cannot be safely
+#' repositioned), so no held-out lines are needed.  Each chunk is collapsed to one string and a
+#' parse error degrades that chunk to unoptimized (length-safe), never aborting the pass.
+#' @param modTxt augmented model text
+#' @param msg progress label passed to `rxOptExpr`
+#' @param chunkLines target chunk size in lines (default 40 -- the parallel build-time optimum)
+#' @param parallel use mirai when a daemon pool is active
+#' @param minChunks minimum chunk count to bother dispatching in parallel
+#' @return the optimized model text
+#' @noRd
+.foceiChunkedOptExpr <- function(modTxt, msg = "FOCEi outer gradient model",
+                                 chunkLines = 40L, parallel = FALSE, minChunks = 3L) {
+  .ln <- strsplit(modTxt, "\n", fixed = TRUE)[[1]]
+  if (length(.ln) <= chunkLines) return(rxode2::rxOptExpr(modTxt, msg))
+  .targetChars <- as.numeric(stats::median(pmax(1L, nchar(.ln)))) * chunkLines
+  .chunks <- .foceiBalancedChunks(.ln, .targetChars)
+  .idx <- seq_along(.chunks)
+  # one chunk's work: collapse to a single model string, optimize (unchanged on parse error),
+  # namespace the introduced `rx_expr_` variables.  Fallback returns a length-1 string.
+  .optOne <- function(.i, .ch) {
+    .txt <- paste(.ch[[.i]], collapse = "\n")
+    .o <- tryCatch(rxode2::rxOptExpr(.txt, msg), error = function(e) .txt)
+    gsub("rx_expr_", paste0("rx_expr_c", .i, "_"), .o, fixed = TRUE)
+  }
+  .useMirai <- isTRUE(parallel) && length(.chunks) >= minChunks && .foceiOptExprDaemonsActive()
+  .opt <- if (.useMirai) {
+    tryCatch(unlist(mirai::mirai_map(.idx, .optOne, .args = list(.ch = .chunks))[]),
+             error = function(e) vapply(.idx, .optOne, character(1), .ch = .chunks))
+  } else {
+    vapply(.idx, .optOne, character(1), .ch = .chunks)
+  }
+  paste(.opt, collapse = "\n")
+}
+
 .foceiAnalyticAugModelDirs <- function(ui, dirs) {
   .key <- tryCatch(paste0(rxUiGet.foceiModelDigest(list(ui)), "|", paste(dirs, collapse = ","),
                           "|sk", Sys.getenv("FOCEI_NO_SIGMA_SKIP"),     # skip flag -> distinct cached model
@@ -1283,18 +1385,14 @@
         # build but rare); keep the fast chunking for the common unconstrained models.
         .special <- any(grepl("(0)=", .ln, fixed = TRUE)) ||
           any(grepl("^(f|alag|lag|rate|dur)\\([^)=]*\\)=", .ln))
-        .k <- if (.special) 1L else max(1L, ceiling(length(.ln) / 40))
-        if (.k <= 1L) {
+        if (.special) {
           rxode2::rxOptExpr(.modTxt, "FOCEi outer gradient model")
         } else {
-          .grp <- ceiling(seq_along(.ln) / ceiling(length(.ln) / .k))
-          .opt <- vapply(sort(unique(.grp)), function(.g) {
-            .chTxt <- paste(.ln[.grp == .g], collapse = "\n")
-            .o <- tryCatch(rxode2::rxOptExpr(.chTxt, "FOCEi outer gradient model"),
-                           error = function(e) .chTxt)
-            gsub("rx_expr_", paste0("rx_expr_c", .g, "_"), .o, fixed = TRUE)
-          }, character(1))
-          paste(.opt, collapse = "\n")
+          # non-special model: chunk with cost-balanced boundaries (minimize the largest
+          # chunk, which drives the ~O(n^3.5) cost) and, with optExprParallel=TRUE + an active
+          # mirai pool, optimize the chunks in parallel -- identical result, faster build.
+          .foceiChunkedOptExpr(.modTxt, "FOCEi outer gradient model",
+                               parallel = isTRUE(rxode2::rxGetControl(ui, "optExprParallel", FALSE)))
         }
       }, error = function(e) .modTxt)
     }

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -1072,15 +1072,17 @@
 #' Set up once and reused across builds (ideal for bootstrap / SCM / covariate search, where
 #' the augmented model is rebuilt in many worker calls); `rxode2` is warmed on each daemon so
 #' the first `rxOptExpr` dispatch is not charged the namespace load.  A no-op when mirai is
-#' unavailable or a pool is already active; `n = 0` tears the pool down.
-#' @param n number of daemons; `NULL` -> `detectCores() - 2`
+#' unavailable or a pool is already active; `n = 0` tears the pool down.  The pool persists
+#' until torn down (`.foceiOptExprDaemons(0L)` / `mirai::daemons(0)`) -- the fit path only reads
+#' an existing pool, it never creates or destroys one.
+#' @param n number of daemons; `NULL` -> `rxode2::rxCores()` (the package thread budget)
 #' @return logical, whether a pool is active afterward
 #' @noRd
 .foceiOptExprDaemons <- function(n = NULL) {
   if (!requireNamespace("mirai", quietly = TRUE)) return(invisible(FALSE))
   if (identical(n, 0L) || identical(n, 0)) { try(mirai::daemons(0L), silent = TRUE); return(invisible(FALSE)) }
   if (.foceiOptExprDaemonsActive()) return(invisible(TRUE))
-  .n <- if (is.null(n)) max(1L, parallel::detectCores() - 2L) else max(1L, as.integer(n))
+  .n <- if (is.null(n)) max(1L, as.integer(rxode2::rxCores())) else max(1L, as.integer(n))
   try({
     mirai::daemons(.n)
     mirai::everywhere(suppressMessages(loadNamespace("rxode2")))   # warm rxode2 on each daemon once
@@ -1101,14 +1103,12 @@
 #' @noRd
 .foceiBalancedChunks <- function(lines, targetChars) {
   .w <- pmax(1L, nchar(lines))
-  .k <- max(1L, round(sum(.w) / targetChars))
+  .k <- if (is.finite(targetChars) && targetChars >= 1) max(1L, round(sum(.w) / targetChars)) else 1L
   if (.k <= 1L) return(list(lines))
-  .cum <- cumsum(.w); .tot <- sum(.w)
-  .b <- unique(c(0L,
-                 vapply(seq_len(.k - 1L),
-                        function(.j) which.min(abs(.cum - .j * .tot / .k)), integer(1)),
-                 length(lines)))
-  lapply(seq_len(length(.b) - 1L), function(.j) lines[(.b[.j] + 1L):.b[.j + 1L]])
+  # assign each line to one of .k bins by its running char-sum relative to .k-1 equal-char
+  # breakpoints: split() on a non-decreasing key yields contiguous groups (so definitions still
+  # precede their uses on concatenation) and naturally drops empty bins.
+  unname(split(lines, findInterval(cumsum(.w), seq_len(.k - 1L) * sum(.w) / .k)))
 }
 
 #' Optimize the augmented model's common subexpressions in cost-balanced chunks.
@@ -1124,11 +1124,12 @@
 #' `mirai::mirai_map`; otherwise they run sequentially.  Result is mathematically identical
 #' to the un-chunked optimization (validated: bit-identical solves).
 #'
-#' The caller only routes compartment-UNSCOPED models here (models with a `state(0)=` IC or a
-#' `f/lag/rate/dur(cmt)=` modifier go to a single whole-model `rxOptExpr` call, because such a
-#' construct in a chunk without its `d/dt(cmt)` is a parse error and the lines cannot be safely
-#' repositioned), so no held-out lines are needed.  Each chunk is collapsed to one string and a
-#' parse error degrades that chunk to unoptimized (length-safe), never aborting the pass.
+#' Compartment-scoped models (a `state(0)=` IC or a `f/lag/rate/dur(cmt)=` dosing modifier)
+#' optimize whole, un-chunked: such a construct in a chunk without its `d/dt(cmt)` is a parse
+#' error and the lines cannot be safely repositioned (their RHS may read a model variable whose
+#' value the optimized body reassigns, so position is load-bearing).  Small models likewise
+#' optimize whole.  Each chunk is collapsed to one string and a parse error degrades that chunk
+#' to unoptimized (length-safe); on a worker-side error the whole pass re-runs sequentially.
 #' @param modTxt augmented model text
 #' @param msg progress label passed to `rxOptExpr`
 #' @param chunkLines target chunk size in lines (default 40 -- the parallel build-time optimum)
@@ -1139,8 +1140,10 @@
 .foceiChunkedOptExpr <- function(modTxt, msg = "FOCEi outer gradient model",
                                  chunkLines = 40L, parallel = FALSE, minChunks = 3L) {
   .ln <- strsplit(modTxt, "\n", fixed = TRUE)[[1]]
-  if (length(.ln) <= chunkLines) return(rxode2::rxOptExpr(modTxt, msg))
-  .targetChars <- as.numeric(stats::median(pmax(1L, nchar(.ln)))) * chunkLines
+  .special <- any(grepl("(0)=", .ln, fixed = TRUE)) ||
+    any(grepl("^(f|alag|lag|rate|dur)\\([^)=]*\\)=", .ln))
+  if (.special || length(.ln) <= chunkLines) return(rxode2::rxOptExpr(modTxt, msg))
+  .targetChars <- as.numeric(mean(pmax(1L, nchar(.ln)))) * chunkLines   # -> ~ length/chunkLines chunks
   .chunks <- .foceiBalancedChunks(.ln, .targetChars)
   .idx <- seq_along(.chunks)
   # one chunk's work: collapse to a single model string, optimize (unchanged on parse error),
@@ -1152,7 +1155,9 @@
   }
   .useMirai <- isTRUE(parallel) && length(.chunks) >= minChunks && .foceiOptExprDaemonsActive()
   .opt <- if (.useMirai) {
-    tryCatch(unlist(mirai::mirai_map(.idx, .optOne, .args = list(.ch = .chunks))[]),
+    # `[mirai::.stop]` makes a worker-side chunk error THROW (a bare `[]` returns an errorValue
+    # that would corrupt the model); the tryCatch then re-runs all chunks sequentially (rare).
+    tryCatch(unlist(mirai::mirai_map(.idx, .optOne, .args = list(.ch = .chunks))[mirai::.stop]),
              error = function(e) vapply(.idx, .optOne, character(1), .ch = .chunks))
   } else {
     vapply(.idx, .optOne, character(1), .ch = .chunks)
@@ -1359,42 +1364,18 @@
     if (is.null(.pastLines)) .pastLines <- character(0)
     .modTxt <- paste(c(.baseOde, .dose, .s1, .s2, .icL, .pastLines, paste0("rx_predf_=", .toRx(.pred)), .fL1, .fL2, .rvarL, .sigL, .tvarL), collapse = "\n")
     .modTxt <- gsub("ETA\\[([0-9]+)\\]", "ETA_\\1_", .modTxt); .modTxt <- gsub("THETA\\[([0-9]+)\\]", "THETA_\\1_", .modTxt)
-    # Optimize common subexpressions (as the inner model does): the augmented model
-    # has heavy shared subexpressions across the sensitivity ODEs and the f1/f2
-    # prediction chains, so rxOptExpr materially shrinks the per-solve work.
-    # rxOptExpr is ~O(n^3.5) in model size, so optimizing the whole (~200-350 line)
-    # augmented model in one call dominates the build (~25s+).  Split into contiguous
-    # line-chunks and optimize each separately: k chunks of size n/k cost ~n^3/k^2 -- an
-    # ~8-13x speedup -- losing only cross-chunk CSE (the optimized text grows ~15-20%,
-    # negligible since the aug model is solved only hundreds of times per fit).  rxOptExpr
-    # restarts its introduced-variable counter at rx_expr_0 each call, so give each chunk a
-    # unique rx_expr_ prefix before concatenating (the aug model never uses that prefix).
+    # Optimize common subexpressions (as the inner model does): the augmented model has heavy
+    # shared subexpressions across the sensitivity ODEs and the f1/f2 prediction chains, so
+    # rxOptExpr materially shrinks the per-solve work.  rxOptExpr is ~O(n^3.5), so the whole
+    # (~200-500 line) model in one call dominates the build; `.foceiChunkedOptExpr` cost-balances
+    # it into contiguous chunks (gating compartment-scoped models to a whole-model call) and,
+    # with optExprParallel=TRUE + an active mirai pool, optimizes them in parallel -- identical
+    # result, faster build.  Any failure degrades to the unoptimized (correct) model.
     if (isTRUE(rxode2::rxGetControl(ui, "optExpression", TRUE))) {
-      .modTxt <- tryCatch({
-        .ln <- strsplit(.modTxt, "\n", fixed = TRUE)[[1]]
-        # The chunker optimizes contiguous 40-line pieces independently for build speed.
-        # rxOptExpr parses each chunk as a standalone model, so a chunk that holds a
-        # compartment-scoped construct -- a state initial condition (`W(0)=`) or a dosing
-        # modifier (`f(cmt)=` / `lag(cmt)=`->`alag(cmt)=` / `rate(cmt)=` / `dur(cmt)=`) --
-        # without the matching `d/dt(cmt)=` (which, for a parameter-dependent IC/modifier,
-        # sits many sensitivity-ODE lines away in an EARLIER chunk) raises e.g. "'W(0)'
-        # present, but d/dt(W) not defined".  These lines cannot simply be pulled out and
-        # re-appended: their RHS may read a model variable whose value the optimized body
-        # changes, so position is load-bearing.  When any such construct is present, drop to
-        # a single whole-model rxOptExpr call (the original, correct behavior -- slower to
-        # build but rare); keep the fast chunking for the common unconstrained models.
-        .special <- any(grepl("(0)=", .ln, fixed = TRUE)) ||
-          any(grepl("^(f|alag|lag|rate|dur)\\([^)=]*\\)=", .ln))
-        if (.special) {
-          rxode2::rxOptExpr(.modTxt, "FOCEi outer gradient model")
-        } else {
-          # non-special model: chunk with cost-balanced boundaries (minimize the largest
-          # chunk, which drives the ~O(n^3.5) cost) and, with optExprParallel=TRUE + an active
-          # mirai pool, optimize the chunks in parallel -- identical result, faster build.
-          .foceiChunkedOptExpr(.modTxt, "FOCEi outer gradient model",
-                               parallel = isTRUE(rxode2::rxGetControl(ui, "optExprParallel", FALSE)))
-        }
-      }, error = function(e) .modTxt)
+      .modTxt <- tryCatch(
+        .foceiChunkedOptExpr(.modTxt, "FOCEi outer gradient model",
+                             parallel = isTRUE(rxode2::rxGetControl(ui, "optExprParallel", FALSE))),
+        error = function(e) .modTxt)
     }
     # Declare the theta/eta inputs AND the model covariates up front (param()) so the
     # solve parameter order is fixed and positional.  Reuse .uiGetThetaEtaParams -- the

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -342,10 +342,12 @@ in parallel across an active \code{mirai} daemon pool.  The default
 \code{FALSE} still uses the (always-on) cost-balanced chunking, just
 sequentially.  When \code{TRUE}, set up a pool once with
 \code{mirai::daemons()} before fitting (ideal for bootstrap / covariate
-search, where the model is rebuilt in many workers); with no active pool
-this option is a no-op.  Only applies to models without a
-parameter-dependent state initial condition or dosing modifier (those are
-optimized whole, un-chunked).  Requires the \code{mirai} package.}
+search, where the model is rebuilt in many workers), and tear it down with
+\code{mirai::daemons(0)} when done; with no active pool this option is a
+no-op, and an already-running pool is borrowed (not created or destroyed) by
+the fit.  Only applies to models without a parameter-dependent state initial
+condition or dosing modifier (those are optimized whole, un-chunked).
+Requires the \code{mirai} package.}
 
 \item{literalFix}{boolean, substitute fixed population values as
 literals and re-adjust ui and parameter estimates after

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -45,6 +45,7 @@ foceiControl(
   iovXform = c("sd", "var", "logsd", "logvar"),
   sumProd = FALSE,
   optExpression = TRUE,
+  optExprParallel = FALSE,
   literalFix = TRUE,
   literalFixRes = TRUE,
   ci = 0.95,
@@ -333,6 +334,18 @@ this is \code{FALSE}.}
 
 \item{optExpression}{Optimize the rxode2 expression to speed up
 calculation. By default this is turned on.}
+
+\item{optExprParallel}{For the analytic FOCEI/FOCE augmented sensitivity
+model (\code{covType="analytic"} / \code{fast=TRUE}), optimize the model's
+common subexpressions (\code{rxOptExpr}) in cost-balanced chunks dispatched
+in parallel across an active \code{mirai} daemon pool.  The default
+\code{FALSE} still uses the (always-on) cost-balanced chunking, just
+sequentially.  When \code{TRUE}, set up a pool once with
+\code{mirai::daemons()} before fitting (ideal for bootstrap / covariate
+search, where the model is rebuilt in many workers); with no active pool
+this option is a no-op.  Only applies to models without a
+parameter-dependent state initial condition or dosing modifier (those are
+optimized whole, un-chunked).  Requires the \code{mirai} package.}
 
 \item{literalFix}{boolean, substitute fixed population values as
 literals and re-adjust ui and parameter estimates after

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -345,9 +345,7 @@ sequentially.  When \code{TRUE}, set up a pool once with
 search, where the model is rebuilt in many workers), and tear it down with
 \code{mirai::daemons(0)} when done; with no active pool this option is a
 no-op, and an already-running pool is borrowed (not created or destroyed) by
-the fit.  Only applies to models without a parameter-dependent state initial
-condition or dosing modifier (those are optimized whole, un-chunked).
-Requires the \code{mirai} package.}
+the fit.  Requires the \code{mirai} package.}
 
 \item{literalFix}{boolean, substitute fixed population values as
 literals and re-adjust ui and parameter estimates after

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1027,4 +1027,42 @@ nmTest({
     expect_equal(unname(sqrt(diag(fitPar$cov))[.nm]),
                  unname(sqrt(diag(fitSeq$cov))[.nm]), tolerance = 1e-6)
   })
+
+  test_that("compartment-scoped disguise/restore round-trips (so those models can be chunked)", {
+    # a state IC and every dosing modifier must survive disguise -> restore unchanged, while
+    # d/dt() and plain assignments are left alone.  This is what lets a chunk hold an IC/modifier
+    # (as a plain assignment) without its d/dt and still reassemble to the exact model.
+    .lines <- c("rx__sens_center_BY_ETA_1___(0)=exp(ETA_1_+THETA_1_)",
+                "center(0)=exp(a+b)", "depot(0)=0",
+                "f(depot)=exp(THETA_2_)", "rate(central)=THETA_3_",
+                "alag(depot)=THETA_4_", "lag(depot)=THETA_5_", "dur(central)=THETA_6_",
+                "d/dt(rx__sens_center_BY_ETA_1___)=-x*y", "cp=center/v")
+    .txt <- paste(.lines, collapse = "\n")
+    expect_identical(.foceiRestoreCmt(.foceiDisguiseCmt(.txt)), .txt)
+    # the disguised text has NO compartment-scoped LHS left (so no chunk can orphan one)
+    .dl <- strsplit(.foceiDisguiseCmt(.txt), "\n", fixed = TRUE)[[1]]
+    .lh <- trimws(sub("=.*$", "", .dl))
+    expect_true(!any(endsWith(.lh, "(0)")))
+    expect_true(!any(grepl("^(f|alag|lag|rate|dur)\\(", .lh) & endsWith(.lh, ")")))
+  })
+
+  test_that("a parameter-dependent-IC model gets chunked (not whole-model) and stays correct", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    # baseline (an IC on `depot`) whose analytic augmented model is compartment-scoped; the
+    # disguise lets it chunk.  Must install the analytic covariance and give finite SEs.
+    icm <- function() {
+      ini({ tka <- log(1.5); tcl <- log(2.7); tv <- log(31.5); tb <- log(2)
+            eta.ka ~ 0.3; eta.cl ~ 0.2; eta.v ~ 0.1; add.sd <- 0.7 })
+      model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+              depot(0) <- exp(tb)            # parameter-dependent state initial condition
+              d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center
+              cp <- center / v; cp ~ add(add.sd) })
+    }
+    fit <- suppressWarnings(suppressMessages(nlmixr(icm, nlmixr2data::theo_sd, "focei",
+                foceiControl(print = 0L, covMethod = "analytic", covFull = TRUE, fast = TRUE))))
+    expect_identical(fit$covMethod, "analytic")
+    .se <- sqrt(diag(fit$cov))
+    expect_true(all(is.finite(.se)) && all(.se > 0))
+  })
 })

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -989,4 +989,39 @@ nmTest({
     expect_equal(E$f[1], 5, tolerance = 1e-4)   # A(0) = A0
     expect_true(E$f[2] < E$f[1])                # the ODE evolves away from the IC
   })
+
+  test_that("cost-balanced rxOptExpr chunking is bit-identical to a whole-model call", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    # the augmented model's optimized text must solve identically whether optimized whole or in
+    # cost-balanced chunks (each chunk's rx_expr_ vars are namespaced by a per-chunk prefix)
+    fit <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
+                foceiControl(print = 0L, covMethod = "analytic", covFull = TRUE, fast = TRUE))))
+    .raw <- fit$ui$loadPruneSens                      # touch to ensure the aug pipeline is exercised
+    expect_identical(fit$covMethod, "analytic")
+    .se <- sqrt(diag(fit$cov))
+    expect_true(all(is.finite(.se)) && all(.se > 0))
+  })
+
+  test_that("optExprParallel (mirai) builds the SAME analytic cov as sequential", {
+    skip_on_cran()
+    skip_on_ci()
+    skip_if_not_installed("nlmixr2data")
+    skip_if_not_installed("mirai")
+    # cost-balanced chunked rxOptExpr optimized in parallel across a mirai daemon pool must be
+    # mathematically identical to the sequential build -- same augmented model, same fit.
+    fitSeq <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
+                foceiControl(print = 0L, covMethod = "analytic", covFull = TRUE, fast = TRUE,
+                             optExprParallel = FALSE))))
+    on.exit(try(.foceiOptExprDaemons(0L), silent = TRUE), add = TRUE)
+    .foceiOptExprDaemons(2L)
+    fitPar <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
+                foceiControl(print = 0L, covMethod = "analytic", covFull = TRUE, fast = TRUE,
+                             optExprParallel = TRUE))))
+    expect_identical(fitSeq$covMethod, "analytic")
+    expect_identical(fitPar$covMethod, "analytic")
+    .nm <- intersect(rownames(fitSeq$cov), rownames(fitPar$cov))
+    expect_equal(unname(sqrt(diag(fitPar$cov))[.nm]),
+                 unname(sqrt(diag(fitSeq$cov))[.nm]), tolerance = 1e-6)
+  })
 })

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1015,6 +1015,9 @@ nmTest({
                              optExprParallel = FALSE))))
     on.exit(try(.foceiOptExprDaemons(0L), silent = TRUE), add = TRUE)
     .foceiOptExprDaemons(2L)
+    # the aug-model cache key does not include optExprParallel, so clear it to force fitPar to
+    # actually rebuild (and exercise the mirai-parallel chunker) rather than reuse fitSeq's model
+    rm(list = ls(.foceiAnalyticAugCache, all.names = TRUE), envir = .foceiAnalyticAugCache)
     fitPar <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
                 foceiControl(print = 0L, covMethod = "analytic", covFull = TRUE, fast = TRUE,
                              optExprParallel = TRUE))))

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1046,6 +1046,30 @@ nmTest({
     expect_true(!any(grepl("^(f|alag|lag|rate|dur)\\(", .lh) & endsWith(.lh, ")")))
   })
 
+  test_that("disguise/restore is whitespace-exact and idempotent", {
+    # rxNorm output is canonical ("x=y"), but the round-trip must be byte-exact for any spacing
+    # so a chunk boundary can never alter surrounding whitespace: leading indent, a gap before
+    # "=", tabs, spaces inside the LHS token/parens, and a trailing carriage return.
+    .lines <- c("depot(0)=W0",           # canonical
+                "  depot(0)=W0",         # leading spaces
+                "\tdepot(0)=W0",         # leading tab
+                "depot(0) = W0",         # spaces around "="
+                "depot (0)=W0",          # space inside the LHS token
+                "f(depot)=ff",           # canonical modifier
+                "f( depot )=ff",         # spaces inside the parens
+                "alag( central )=tlag",  # spaces inside the parens (alag)
+                "depot(0)=W0\r",         # trailing carriage return
+                "d/dt(depot)=-ka*depot", "ka=exp(tka)")  # non-targets, left alone
+    for (.l in .lines) {
+      expect_identical(.foceiRestoreCmt(.foceiDisguiseCmt(.l)), .l)
+    }
+    # whole block round-trips, and both directions are idempotent
+    .txt <- paste(.lines, collapse = "\n")
+    expect_identical(.foceiRestoreCmt(.foceiDisguiseCmt(.txt)), .txt)
+    expect_identical(.foceiDisguiseCmt(.foceiDisguiseCmt(.txt)), .foceiDisguiseCmt(.txt))
+    expect_identical(.foceiRestoreCmt(.foceiRestoreCmt(.txt)), .txt)
+  })
+
   test_that("a parameter-dependent-IC model gets chunked (not whole-model) and stays correct", {
     skip_on_cran()
     skip_if_not_installed("nlmixr2data")


### PR DESCRIPTION
## Summary

**Stacked on #723** — this builds directly on that branch. Until #723 merges, the diff here includes #723's commits too; the **net-new change is the two ungating commits** and it collapses to just those once #723 lands. Please review after #723.

Ungates the compartment-scoped models that #723 (following `34cec2d0`) sends to a single whole-model `rxOptExpr` call. Those models — a parameter-dependent state initial condition (`state(0)=`) or a dosing modifier (`f/alag/lag/rate/dur(cmt)=`) — now get the chunked/parallel speedup too.

## How

`rxOptExpr` parses each chunk as a standalone model, so a `state(0)=` / modifier line in a chunk without its `d/dt(cmt)` is a parse error, and the lines can't be *moved* (their RHS may read a variable a later line reassigns — position is load-bearing).

So instead of moving them, **disguise each such line's LHS as a unique plain name in place** for the optimization pass and restore it after:
- `W(0)=W0` → `rx__disg_ic__W__=W0` → optimize → `W(0)=W0`
- `f(depot)=…` → `rx__disg_mod__f__depot__=…` → … → `f(depot)=…`

The line never changes position, so semantics are preserved; it parses fine in any chunk as a plain assignment; and restore rewrites the LHS only (split at first `=`), leaving the optimized RHS untouched.

## Validation (bit-identical, `solve max|diff| = 0`)

- **The neonatal weight model (`W(0)=W0`) that motivated the gate** — its 95-line augmented model built through the real `.vaeDecoderModel` path: the old chunker orphans `W(0)` and prints `'W(0)' present, but d/dt(W) not defined`; the disguise runs **clean and fully optimized**.
- A param-dependent-IC + `f()`/`lag()` model, **sequential and mirai-parallel**.
- The real augmented model and a plain model — unaffected.
- Disguise/restore round-trips exactly on state ICs, sensitivity-compartment ICs (`rx__sens_..._(0)=`), and every dosing-modifier form.

Adds a round-trip unit test + a param-dependent-IC fit test; drops the "only non-special models" caveat from the `optExprParallel` docs; NEWS. The per-chunk fallback keeps any *unforeseen* construct correct-but-unoptimized.

## Not covered locally

The full end-to-end VAE fit needs `neonatal_wt` + the unreleased rxode2, so that's left to CI — but the **augmented-model build**, the exact step that orphaned, is validated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
