### PR TITLE
fix(focei): bound the shi21 finite-difference step size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -809,6 +809,14 @@
 
 - Use OpenMP threading wile calculating NPDEs
 
+- Bounded the adaptive finite-difference step size (Shi et al. 2021) used for the
+  FOCEi eta gradient to a reasonable region.  When the finite differences carried
+  no detectable curvature the step-size search could grow the step without bound
+  and probe a parameter far outside the region where the local model holds,
+  producing a degenerate ODE solve that corrupted the shared solver state and
+  collapsed the eta finite-difference sensitivity on later inner iterations (the
+  eta could get stuck near 0).  The step is now clamped both above and below.
+
 # nlmixr2est 6.1.0
 
 - Added focei, foce, foi, fo mixture support in `nlmixr2est`

--- a/src/shi21.cpp
+++ b/src/shi21.cpp
@@ -65,6 +65,9 @@ double shi21Forward(shi21fn_type f, arma::vec &t, double &h,
   } else {
     h = fabs(h);
   }
+  // Bound the FD step both ways -- see shi21Central; an unbounded step corrupts the
+  // shared solver state via a degenerate probe, and a vanishing step is roundoff.
+  const double hMax = 0.5, hMin = 1e-4;
   double l = 0, u = R_PosInf, rcur = NA_REAL;
   arma::vec f1(f0.size());
   gr.zeros(f0.n_elem); // avoid uninitialized read if no finite forward step is found
@@ -103,9 +106,13 @@ double shi21Forward(shi21fn_type f, arma::vec &t, double &h,
       break;
     }
     if (!R_finite(u)) {
+      if (h >= hMax) break;
       h = 4.0*h;
+      if (h > hMax) h = hMax;
     } else if (l == 0) {
+      if (h <= hMin) break;
       h = h/4.0;
+      if (h < hMin) h = hMin;
     } else {
       h = (l + u)/2.0;
     }
@@ -189,6 +196,14 @@ double shi21Central(shi21fn_type f, arma::vec &t, double &h,
   } else {
     h = fabs(h);
   }
+  // Bound the finite-difference step to a reasonable region.  Too big: a flat
+  // objective makes the ratio test keep growing h until it probes the parameter
+  // far outside the region where the local model holds (e.g. an eta perturbed by
+  // several units), producing a degenerate/failed solve that corrupts the shared
+  // solver state for every later finite difference.  Too small: repeated shrinking
+  // drives h into the roundoff-dominated regime (central optimum ~ eps^(1/3)).
+  // Clamp both ends so the step stays sane.
+  const double hMax = 0.5, hMin = 1e-4;
   double l = 0, u = R_PosInf, rcur = NA_REAL;
   double hlast = h;
 
@@ -244,9 +259,13 @@ double shi21Central(shi21fn_type f, arma::vec &t, double &h,
       break;
     }
     if (!R_finite(u)) {
+      if (h >= hMax) break; // already at the cap and still growing: stop here
       h = nu*h;
+      if (h > hMax) h = hMax; // clamp; probe once at hMax, then break if still growing
     } else if (l == 0) {
+      if (h <= hMin) break; // already at the floor and still shrinking: stop here
       h = h/nu;
+      if (h < hMin) h = hMin; // clamp; probe once at hMin, then break if still shrinking
     } else {
       h = (l + u)/2.0;
     }

--- a/tests/testthat/test-shi21-hbound.R
+++ b/tests/testthat/test-shi21-hbound.R
@@ -1,0 +1,59 @@
+## Regression guard for the shi21 finite-difference step-size bound
+## (src/shi21.cpp shi21Central / shi21Forward).
+##
+## The adaptive Shi (2021) step-size search grows h when it cannot detect
+## curvature in the finite differences.  For a FOCEi eta whose finite-difference
+## information is (numerically) degenerate the search could grow h without bound,
+## perturbing the eta so far that the ODE solve degenerates -- which corrupts the
+## shared solver state and collapses the eta finite-difference sensitivity for
+## every subsequent inner iteration (the inner problem then leaves the eta stuck
+## near 0).  shi21Central/shi21Forward now clamp h to a reasonable region
+## (hMin <= h <= hMax) so the probe stays sane.
+##
+## This exercises the FOCEi FD eta-sensitivity path via a dosing-parameter (lag
+## time) eta -- the etas that are always finite-differenced -- and checks the eta
+## is genuinely estimated (a collapsed FD sensitivity would leave the lag eta
+## unmoved and its EBEs at ~0).
+
+test_that("FOCEi finite-differenced (lag-time) eta is estimated -- shi21 step stays bounded", {
+  skip_on_cran()
+  skip_if_not_installed("nlmixr2data")
+  .old <- rxode2::getRxThreads(); on.exit(rxode2::setRxThreads(.old), add = TRUE)
+  rxode2::setRxThreads(1L)
+
+  d <- nlmixr2data::theo_sd
+  mod <- function() {
+    ini({
+      tka <- 0.45; tcl <- 1; tv <- 3.45
+      tlag <- log(0.15)
+      add.sd <- 0.7
+      eta.cl ~ 0.1
+      eta.lag ~ 0.05
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      tlg <- exp(tlag + eta.lag)      # lag-time IIV -> finite-differenced eta
+      lag(depot) <- tlg
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  fit <- suppressWarnings(suppressMessages(
+    nlmixr2(mod, d, "focei",
+            foceiControl(print = 0L, maxOuterIterations = 20L,
+                         maxInnerIterations = 30L, calcTables = FALSE))))
+
+  ## the fit converges to a finite, sane objective
+  expect_true(is.finite(fit$objf))
+  expect_lt(fit$objf, 260)
+
+  ## the finite-differenced lag eta is genuinely estimated (not collapsed): its
+  ## variance is a sane positive value and its EBEs are non-degenerate.
+  expect_gt(unname(fit$omega["eta.lag", "eta.lag"]), 0.05)
+  expect_gt(diff(range(fit$eta$eta.lag)), 0.5)
+})


### PR DESCRIPTION
## Problem

The adaptive Shi et al. (2021) finite-difference step-size search
(`src/shi21.cpp`, `shi21Central` / `shi21Forward`) grows the step `h` when it
cannot detect curvature in the finite differences. For a FOCEi eta whose
finite-difference information is (numerically) degenerate, `h` could grow
**without bound** and probe the parameter far outside the region where the local
model holds -- perturbing an eta by several units. That produces a degenerate ODE
solve which corrupts the **shared** solver state, collapsing the eta
finite-difference sensitivity for every subsequent inner iteration (the inner
problem then leaves the eta stuck near 0, and the step-size search itself returns
an absurd `h` such as ~4 for an eta of SD ~0.3).

## Fix

Clamp `h` to a reasonable region in both `shi21Central` and `shi21Forward`:

- **Upper bound** (`hMax = 0.5`): stop the step-size search from probing into the
  degenerate/failed-solve regime.
- **Lower bound** (`hMin = 1e-4`): stop repeated contraction from driving `h`
  into the roundoff-dominated regime (central optimum ~ `eps^(1/3)`).

Once `h` reaches a bound and the search still wants to move further in the same
direction, it stops.

## Test

`tests/testthat/test-shi21-hbound.R` exercises the FOCEi finite-differenced
eta path via a dosing-parameter (lag-time) eta -- the etas that are always
finite-differenced -- and asserts the eta is genuinely estimated (a collapsed FD
sensitivity would leave the lag eta unmoved with EBEs at ~0).

## Notes

`src/shi21.cpp` here is byte-identical to the same fix on `feat/nn-sens-contrib`,
so it merges cleanly with that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmVREEBZmrR1nfv3cFUd39