### PR TITLE
saemControl: allow covMethod="" (skip covariance)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -802,6 +802,11 @@
   collapsed the eta finite-difference sensitivity on later inner iterations (the
   eta could get stuck near 0).  The step is now clamped both above and below.
 
+- `saemControl(covMethod = "")` no longer errors.  `""` is a documented choice
+  that skips the covariance step, but `saemControl()` rejected it because
+  `match.arg()` selects choices with `pmatch()`, and `pmatch("")` matches
+  nothing; it is now handled explicitly.
+
 # nlmixr2est 6.1.0
 
 - Added focei, foce, foi, fo mixture support in `nlmixr2est`

--- a/R/saemControl.R
+++ b/R/saemControl.R
@@ -488,7 +488,11 @@ saemControl <- function(seed = 99,
     stop("solving options 'rxControl' needs to be generated from 'rxode2::rxControl'", call=FALSE)
   }
 
-  if (checkmate::testIntegerish(covMethod, lower=0, len=1, any.missing=FALSE)) {
+  if (identical(covMethod, "")) {
+    ## "" requests no covariance; match.arg() cannot select it because
+    ## pmatch("") matches nothing, so handle it explicitly.
+    .covMethod <- ""
+  } else if (checkmate::testIntegerish(covMethod, lower=0, len=1, any.missing=FALSE)) {
     .covMethod <- covMethod
   } else {
     .covMethod <- match.arg(covMethod)

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -60,6 +60,15 @@ nmTest({
     .ctl2 <- do.call(saemControl, .ctl)
     expect_equal(.ctl, .ctl2)
 
+    ## covMethod="" requests no covariance; it is a documented choice but
+    ## match.arg() cannot select it (pmatch("") matches nothing), so it must be
+    ## handled explicitly rather than erroring.
+    expect_error(saemControl(covMethod=""), NA)
+    expect_equal(saemControl(covMethod="")$covMethod, "")
+    .ctl <- saemControl(covMethod="")
+    .ctl2 <- do.call(saemControl, .ctl)
+    expect_equal(.ctl, .ctl2)
+
     expect_error(saemControl(foceiControl="matt"))
   })
 


### PR DESCRIPTION
Fixes `saemControl(covMethod = "")` erroring out.

`""` is a documented `saemControl()` choice that skips the covariance step (handled in `.saemCalcCov`, `saem.R`), but constructing the control errored:

```r
saemControl(covMethod = "")
#> Error in match.arg(covMethod) :
#>   'arg' should be one of "linFim", "fim", "sa", "r,s", "r", "s"
```

`match.arg()` selects choices with `pmatch()`, and `pmatch("")` matches nothing, so the empty string can never be selected even though it is listed in the formals. This handles `covMethod = ""` explicitly before `match.arg()`.

This lets callers (e.g. an iterative outer loop that only needs the estimates each round) disable the SAEM covariance/FIM step cleanly.

- `R/saemControl.R`: explicit `covMethod == ""` branch.
- `tests/testthat/test-control.R`: sanity checks (`saemControl(covMethod="")` constructs, round-trips, `$covMethod == ""`).
- `NEWS.md`: bug-fix entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmVREEBZmrR1nfv3cFUd39