### PR TITLE
saem: project non-PD Omega to nearest PD instead of erroring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # nlmixr2est (development version)
 
+- SAEM no longer errors when the between-subject-variability covariance
+  (`Omega`) collapses to a non-positive-definite matrix mid-run.  It is now
+  projected to the nearest positive-definite matrix (with a one-time user-visible
+  warning recorded in `fit$runInfo`) instead of stopping with `inv_sympd():
+  matrix is singular or not positive definite`.
+
 - Fixed the `foceiControl(fast=TRUE)` analytic outer gradient for FOCEI models
   whose residual variance depends on the prediction (`prop()`, `add()+prop()`,
   `combined1`, `pow()`, `add()+pow()`).  The `(f,R)` determinant chain rule

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -1306,14 +1306,14 @@ public:
         _savLres = lres; _savVcsig2 = vcsig2; _savPhiM = phiM; _savHa = Ha;
         if (nMix > 1) { _savMixProb = mixProb; _savMixWeights = mixWeights; }
       }
+      IGamma2_phi1=invSympdNearPd(Gamma2_phi1, "Gamma2_phi1 (Omega)");
       gamma2_phi1=Gamma2_phi1.diag();
-      IGamma2_phi1=inv_sympd(Gamma2_phi1);
       D1Gamma21=LCOV1*IGamma2_phi1;
       D2Gamma21=D1Gamma21*LCOV1.t();
       CGamma21=COV21%D2Gamma21;
 
+      IGamma2_phi0=invSympdNearPd(Gamma2_phi0, "Gamma2_phi0 (Omega)");
       gamma2_phi0=Gamma2_phi0.diag();
-      IGamma2_phi0=inv_sympd(Gamma2_phi0);
       D1Gamma20=LCOV0*IGamma2_phi0;
       D2Gamma20=D1Gamma20*LCOV0.t();
       CGamma20=COV20%D2Gamma20;
@@ -3240,6 +3240,28 @@ private:
     }
     fsb = fsM(fsb_idx);
     ysb = arma::repmat(ys(idx), (arma::uword)nmc, 1);
+  }
+
+  // Invert a symmetric covariance (omega) matrix.  If it is not positive
+  // definite, project it to the nearest positive-definite matrix (in place, so
+  // downstream chol()/set_mcmcphi() see the corrected matrix), warn the user
+  // once, and return the inverse of the corrected matrix.
+  bool _nearPdWarned = false;
+  mat invSympdNearPd(mat &G, const char *what) {
+    mat out;
+    if (inv_sympd(out, G)) return out;
+    mat pd;
+    if (nmNearPD(pd, G)) {
+      G = pd;
+      if (!_nearPdWarned) {
+        Rcpp::warning(std::string("SAEM: ") + what +
+                      " was not positive definite; projected to the nearest positive-definite matrix (results may be affected)");
+        _nearPdWarned = true;
+      }
+      if (inv_sympd(out, G)) return out;
+    }
+    // last resort: general inverse of the symmetrized matrix
+    return inv(0.5 * (G + G.t()));
   }
 
   void set_mcmcphi(mcmcphi &mphi1,

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -60,7 +60,7 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
     "fsaem"),
   # batch 3
   c("focei-wang2007-boxcox-half", "nlm-cens", "issue-429",
-    "focei-wang2007-bounded", "saem-loglik", "mu-timevarying"),
+    "focei-wang2007-bounded", "saem-loglik", "mu-timevarying", "saem-nearpd"),
   # batch 4
   c("impmap", "matexp", "mfocei", "focei-wang2007-yeojohnson",
     "focei-wang2007-boxcox-lnorm", "nlme", "focei-fast-grad"),

--- a/tests/testthat/test-saem-nearpd.R
+++ b/tests/testthat/test-saem-nearpd.R
@@ -1,0 +1,54 @@
+nmTest({
+  # A dense BLOCK(4) BSV spread across a PK endpoint and two covariate endpoints
+  # drives Omega (Gamma2_phi1) to a non-positive-definite matrix mid-run.  SAEM
+  # used to abort with "inv_sympd(): matrix is singular or not positive
+  # definite"; it now projects Omega to the nearest positive-definite matrix
+  # (nmNearPD), warns once, and finishes.
+
+  .mkDat <- function() {
+    set.seed(42)
+    nid <- 30
+    cov1 <- rnorm(nid, 70, 10)
+    cov2 <- 0.5 * cov1 + rnorm(nid, 0, 5)
+    pk <- do.call(rbind, lapply(seq_len(nid), function(i) data.frame(
+      ID = i, TIME = c(0, 0.5, 1, 2, 4, 8), EVID = c(1, 0, 0, 0, 0, 0),
+      AMT = c(100, 0, 0, 0, 0, 0), CMT = 1,
+      DV = c(0, 5, 7, 6, 4, 2) * exp(rnorm(1, 0, 0.2)) + rnorm(6, 0, 0.2))))
+    pk$CMT[pk$EVID == 0] <- 2
+    c1 <- data.frame(ID = seq_len(nid), TIME = 0, EVID = 0, AMT = 0, CMT = 3, DV = cov1)
+    c2 <- data.frame(ID = seq_len(nid), TIME = 0, EVID = 0, AMT = 0, CMT = 4, DV = cov2)
+    dat <- rbind(pk, c1, c2)
+    dat[order(dat$ID, dat$TIME, dat$CMT), ]
+  }
+
+  mod <- function() {
+    ini({
+      tcl <- 1; tv <- 3.5; tc1 <- 70; tc2 <- 40
+      eta.cl + eta.v + eta.c1 + eta.c2 ~
+        c(0.1,
+          0.03, 0.1,
+          0.03, 0.03, 100,
+          0.02, 0.02, 0.5, 30)          # dense BLOCK(4) across endpoints
+      add.sd <- 0.5
+      c.sd1 <- fixed(0.01); c.sd2 <- fixed(0.01)
+    })
+    model({
+      cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+      c1p <- tc1 + eta.c1;  c1p ~ add(c.sd1) | cov1
+      c2p <- tc2 + eta.c2;  c2p ~ add(c.sd2) | cov2
+    })
+  }
+
+  test_that("saem recovers from a non-positive-definite Omega via nearPD", {
+    .d <- .mkDat()
+    .f <- suppressWarnings(suppressMessages(
+      nlmixr2(mod, .d, est = "saem",
+              control = saemControl(nBurn = 50, nEm = 80, seed = 42, print = 0L))))
+    # the fit completes instead of erroring ...
+    expect_true(inherits(.f, "nlmixr2FitData"))
+    # ... and the nearPD projection is actually exercised (mechanism-used check):
+    # the one-time warning is recorded in the fit's runInfo.
+    expect_true(any(grepl("positive definite", .f$runInfo, ignore.case = TRUE)))
+  })
+})


### PR DESCRIPTION
## Summary

SAEM aborts the whole fit with `inv_sympd(): matrix is singular or not positive definite` when the between-subject-variability covariance (`Omega`, i.e. `Gamma2_phi1` / `Gamma2_phi0`) collapses to a non-positive-definite matrix mid-run. This happens, for example, with a dense `BLOCK(4)`-across-endpoints model where covariate-endpoint etas shrink toward zero.

This routes those two omega inversions at the top of the SAEM iteration loop (`src/saem.cpp`) through a new helper `invSympdNearPd()`, which:

1. tries `inv_sympd()` as before (fast path, no behavior change when the matrix is PD);
2. on failure, projects the matrix to the nearest positive-definite one via the existing `nmNearPD()`, updates it **in place** so the downstream `chol()` in `set_mcmcphi()` stays consistent with the inverse, emits a **one-time user-visible warning**, and returns the inverse of the corrected matrix;
3. falls back to a general inverse of the symmetrized matrix only as a last resort.

## Reproduction

The model in the linked issue (dense `BLOCK(4)` across PK + two covariate endpoints) previously errored at ~iteration 40. It now completes, with the warning recorded in `fit$runInfo`:

> SAEM: Gamma2_phi1 (Omega) was not positive definite; projected to the nearest positive-definite matrix (results may be affected)

The warning wording notes results may be affected, since projecting `Omega` to PD is a numerical rescue, not a guarantee the underlying model/data is well-identified.

## Verification

- The reported reproduction now completes instead of erroring; warning surfaces in `fit$runInfo`.
- A normal PD SAEM fit (`theo_sd`) still completes with `fit$runInfo == NULL` -- no spurious warning, fast path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)