### PR TITLE
Mu-referenced thetas as standard iteration-print/parHist columns; family-gated bound clamping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # nlmixr2est (development version)
 
+- In the mu-referenced estimation family (`mfocei`/`ifocei`, `mfoce`/`ifoce`,
+  `mfocep`/`ifocep`, `magq`/`iagq`, `mlaplace`/`ilaplace`), the
+  regression-updated mu thetas (population and covariate coefficients) now
+  appear as standard columns, in natural theta order, in the live iteration
+  print and in `fit$parHist`/`parHistData`; gradient rows record `NaN` for them
+  (shown as blank console cells) and the previous appended `|   mu|` row was
+  removed.
+
 - Fixed the `foceiControl(fast=TRUE)` analytic outer gradient for FOCEI models
   whose residual variance depends on the prediction (`prop()`, `add()+prop()`,
   `combined1`, `pow()`, `add()+pow()`).  The `(f,R)` determinant chain rule

--- a/NEWS.md
+++ b/NEWS.md
@@ -238,11 +238,18 @@
   general (f,R) assembler now runs with no free residual direction, reading the (fixed)
   variance from the solved `rx_r_`.
 - Bounded mu-referenced parameters (population thetas and covariate coefficients) are
-  now also profiled by the mu/irls regression, with the update clamped to the bounds
-  (box-constrained least squares, `foceiControl(muModelClampRetries=)`); parameters
-  that were clamped during the fit are reported once as a fit note.  Previously a
-  bounded population theta dropped its whole group (with a warning) and a bounded
-  covariate coefficient stayed outer-optimized.
+  now also profiled by the mu/irls regression in the clamped `m*`/`i*` family
+  (`mfocei`/`ifocei` and variants, `muModel != "none"`), with the update clamped to
+  the bounds (box-constrained least squares, `foceiControl(muModelClampRetries=)`);
+  parameters that were clamped during the fit are reported once as a fit note.  Every
+  other (non-clamped) method keeps the previous style: a bounded population theta
+  rejects its whole mu group (with a warning) and a bounded covariate coefficient
+  stays an ordinary outer-optimized parameter.
+- Fixed the mu-family regression's handling of a user-fixed covariate coefficient:
+  its (fixed) contribution was added into the regression target but never taken back
+  out, so each regression pass shifted the group's linear predictor by the fixed
+  term (biasing the population theta and inflating the eta variance).  The fixed
+  contribution is now left out of the regression entirely.
 - `fast=TRUE` now defaults the outer optimizer to `lbfgsb3c` (FD methods keep
   `nlminb`); an explicit `outerOpt` is honored.
 - The iteration print and `$parHistData` track analytic gradients as their own type

--- a/R/focei.R
+++ b/R/focei.R
@@ -1938,7 +1938,9 @@ rxUiGet.foceiOptEnv <- function(x, ...) {
     .muPlain <- !(rxode2::rxGetControl(.x, "est", "") %in%
                     c("impmap", "imp", "qrpem", "advi")) &&
       !(.ctlClass %in% c("impmapControl", "impControl", "qrpemControl", "adviControl"))
-    .muGroupSetup <- .muRefCppGroupSetup(.x, plain = .muPlain)
+    # muModel != "none" is the clamped family: bounded mu parameters stay
+    # grouped and updateMuGroups() clamps their regression update
+    .muGroupSetup <- .muRefCppGroupSetup(.x, plain = .muPlain, clamp = TRUE)
   } else {
     .muGroupSetup <- list(muGroupTheta = integer(0), muGroupEta = integer(0),
                           muGroupCovStart = integer(0), muGroupCovCount = integer(0),

--- a/R/muRefClassify.R
+++ b/R/muRefClassify.R
@@ -117,35 +117,51 @@
 #'
 #' A user-fixed (`fix()`, `literalFix=FALSE`) population theta excludes the
 #' group (the regression would move the fixed value); a user-fixed covariate
-#' coefficient stays out of the design matrix as a live offset. Bounded
-#' population thetas and covariate coefficients ARE grouped: the regression
-#' update is clamped to the bounds (box-constrained least squares,
-#' `updateMuGroups()`), and each group carries `thetaLower`/`thetaUpper` plus
-#' per-covariate `lower`/`upper` columns for the clamp. Only affects this
-#' family (`mfocei`/`ifocei`/`mfoce`/`ifoce`/`magq`/`iagq`/
-#' `mlaplace`/`ilaplace`).
+#' coefficient stays out of the regression (outer-supplied, not estimated by
+#' it). Bounded parameters follow one of two styles, selected by `clamp`:
+#'
+#' - `clamp=TRUE` (the clamped mu-referenced FOCEI family: `mfocei`/
+#'   `ifocei`/`mfoce`/`ifoce`/`magq`/`iagq`/`mlaplace`/`ilaplace`, i.e.
+#'   `muModel != "none"`): bounded population thetas and covariate
+#'   coefficients ARE grouped; the regression update is clamped to the
+#'   bounds (box-constrained least squares, `updateMuGroups()`), and each
+#'   group carries `thetaLower`/`thetaUpper` plus per-covariate
+#'   `lower`/`upper` columns for the clamp.
+#' - `clamp=FALSE` (the default for every other method): bounded parameters
+#'   are rejected from the mu-referencing, since a plain (unclamped)
+#'   regression cannot respect a box constraint. A finite bound on the
+#'   group's population theta excludes the whole group (warns); a bound on
+#'   a covariate coefficient excludes only that covariate (warns, marked
+#'   `bounded=TRUE`, estimated as an ordinary bounded parameter by the
+#'   outer optimizer) while the rest of the group keeps the speed-up.
 #'
 #' With `plain=TRUE`, plain (covariate-free) mu-ref pairs
 #' (`muPlainThetas`, see `.muRefClassify`) are appended as intercept-only
-#' groups (empty `covariates`); fixed plain thetas are excluded quietly. If
+#' groups (empty `covariates`); fixed plain thetas are excluded quietly, and
+#' with `clamp=FALSE` bounded plain thetas are too (with an `.minfo`). If
 #' profiling the plain groups would leave the outer optimizer with no free
 #' parameter at all, the plain groups are dropped (covariate groups kept).
 #'
 #' @param ui rxode2 ui object (post mu2-hook, if applicable)
 #' @param plain also form intercept-only groups for plain mu-ref pairs
+#' @param clamp accept bounded parameters and carry their bounds for the
+#'   clamped regression; defaults from the ui's `muModel` control so the
+#'   clamped family clamps and everything else rejects
 #' @return list of `list(theta=, eta=, thetaLower=, thetaUpper=,
 #'   covariates=data.frame(covariate=, covariateParameter=, lower=,
-#'   upper=))`, one element per group whose population theta is not
-#'   user-fixed
+#'   upper=, bounded=))`, one element per group whose population theta is
+#'   not user-fixed
 #' @author Matthew L. Fidler
 #' @noRd
-.muRefGroups <- function(ui, plain = FALSE) {
+.muRefGroups <- function(ui, plain = FALSE,
+                         clamp = !identical(rxode2::rxGetControl(ui, "muModel", "none"), "none")) {
   .cls <- .muRefClassify(ui)
   .muRefDf <- ui$muRefDataFrame
   .muRefCovDf <- ui$muRefCovariateDataFrame
   .iniDf <- ui$iniDf
   .thetaRows <- .iniDf[!is.na(.iniDf$ntheta), , drop = FALSE]
   .fixedThetas <- .thetaRows$name[which(.thetaRows$fix)]
+  .boundedThetas <- .thetaRows$name[.thetaRows$lower > -Inf | .thetaRows$upper < Inf]
   .lowerOf <- setNames(.thetaRows$lower, .thetaRows$name)
   .upperOf <- setNames(.thetaRows$upper, .thetaRows$name)
   lapply(.cls$muCovThetas, function(.theta) {
@@ -153,6 +169,17 @@
     if (length(.w) != 1L) return(NULL)
     .eta <- as.character(.muRefDf$eta[.w])
     if (!(.eta %in% .cls$muCovEtas)) return(NULL)
+    if (!clamp && .theta %in% .boundedThetas) {
+      warning(
+        "mu-referenced theta '", .theta, "' has boundaries and cannot ",
+        "benefit from the mu-referenced speed gains (this method's ",
+        "regression cannot respect a boundary on its population theta); ",
+        "estimated as an ordinary (bounded) parameter by the outer ",
+        "optimizer instead",
+        call. = FALSE
+      )
+      return(NULL)
+    }
     if (.theta %in% .fixedThetas) {
       .minfo(paste0("mu-referenced theta '", .theta,
                     "' is fixed; kept out of the mu-referenced regression"))
@@ -161,6 +188,20 @@
     .wc <- which(as.character(.muRefCovDf$theta) == .theta)
     .covParams <- as.character(.muRefCovDf$covariateParameter[.wc])
     .covNames <- as.character(.muRefCovDf$covariate[.wc])
+    .boundedCov <- !clamp & (.covParams %in% .boundedThetas)
+    if (any(.boundedCov)) {
+      warning(
+        "mu-referenced covariate coefficient(s) ",
+        paste0("'", .covParams[.boundedCov], "'", collapse = ", "),
+        " have boundaries and cannot benefit from the mu-referenced ",
+        "speed gains (this method's regression cannot respect a ",
+        "boundary); treated as if time-varying and excluded from the ",
+        "mu-referencing -- estimated as ordinary (bounded) parameters ",
+        "by the outer optimizer instead, while '", .theta,
+        "' and any other covariate(s) on it still benefit",
+        call. = FALSE
+      )
+    }
     list(
       theta = .theta,
       eta = .eta,
@@ -171,6 +212,7 @@
         covariateParameter = .covParams,
         lower = unname(.lowerOf[.covParams]),
         upper = unname(.upperOf[.covParams]),
+        bounded = .boundedCov,
         stringsAsFactors = FALSE
       )
     )
@@ -180,23 +222,35 @@
   .emptyCov <- data.frame(covariate = character(0),
                           covariateParameter = character(0),
                           lower = numeric(0), upper = numeric(0),
+                          bounded = logical(0),
                           stringsAsFactors = FALSE)
+  .boundedPlain <- character(0)
   .plainLst <- list()
   for (.k in seq_along(.cls$muPlainThetas)) {
     .th <- .cls$muPlainThetas[.k]
     if (.th %in% .fixedThetas) next
+    if (!clamp && .th %in% .boundedThetas) {
+      .boundedPlain <- c(.boundedPlain, .th)
+      next
+    }
     .plainLst[[length(.plainLst) + 1L]] <-
       list(theta = .th, eta = .cls$muPlainEtas[.k],
            thetaLower = unname(.lowerOf[.th]),
            thetaUpper = unname(.upperOf[.th]),
            covariates = .emptyCov)
   }
+  if (length(.boundedPlain) > 0L) {
+    .minfo(paste0("mu-referenced theta(s) ",
+                  paste0("'", .boundedPlain, "'", collapse = ", "),
+                  " have boundaries; estimated by the outer optimizer ",
+                  "instead of the mu-referenced regression"))
+  }
   if (length(.plainLst) == 0L) return(.lst)
   # Guard: profiling every theta out with nothing left free (no non-grouped
   # estimated theta, no estimated omega) would give the outer optimizer an
   # empty problem; drop the plain groups (covariate groups kept) instead.
   .grouped <- unlist(lapply(c(.lst, .plainLst), function(g) {
-    c(g$theta, g$covariates$covariateParameter)
+    c(g$theta, g$covariates$covariateParameter[!g$covariates$bounded])
   }))
   .freeTh <- .thetaRows$name[!.thetaRows$fix & !(.thetaRows$name %in% .grouped)]
   .omRows <- .iniDf[is.na(.iniDf$ntheta), , drop = FALSE]
@@ -215,8 +269,15 @@
 #' UI-derived only; `.muRefCppCovData()` builds the covariate matrix
 #' separately once the dataset is available.
 #'
+#' With `clamp=FALSE` (see `.muRefGroups`), covariates carved out for their
+#' boundaries (`bounded=TRUE`) are left out of the flattened arrays
+#' entirely, so they stay ordinary outer-optimized parameters (not skipped,
+#' not regressed).
+#'
 #' @param ui rxode2 ui object (post mu2-hook, if applicable)
 #' @param plain also include plain mu-ref pairs (see `.muRefGroups`)
+#' @param clamp accept bounded parameters for the clamped regression (see
+#'   `.muRefGroups`)
 #' @return list with `muGroupTheta`, `muGroupEta`, `muGroupCovStart`,
 #'   `muGroupCovCount`, `muGroupCovTheta`, `muGroupCovUserFixed` (integer
 #'   vectors), `muGroupThetaLower`/`muGroupThetaUpper` (numeric, per group),
@@ -226,8 +287,9 @@
 #'   dataset columns)
 #' @author Matthew L. Fidler
 #' @noRd
-.muRefCppGroupSetup <- function(ui, plain = FALSE) {
-  .groups <- .muRefGroups(ui, plain = plain)
+.muRefCppGroupSetup <- function(ui, plain = FALSE,
+                                clamp = !identical(rxode2::rxGetControl(ui, "muModel", "none"), "none")) {
+  .groups <- .muRefGroups(ui, plain = plain, clamp = clamp)
   if (length(.groups) == 0L) {
     return(list(
       muGroupTheta = integer(0), muGroupEta = integer(0),
@@ -264,20 +326,21 @@
   .muGroupCovNames <- character(0)
 
   for (g in .groups) {
+    .cov <- g$covariates[!g$covariates$bounded, , drop = FALSE]
     .muGroupTheta <- c(.muGroupTheta, .thetaIdxOf(g$theta))
     .muGroupEta <- c(.muGroupEta, .etaIdxOf(g$eta))
     .muGroupThetaLower <- c(.muGroupThetaLower, as.numeric(g$thetaLower))
     .muGroupThetaUpper <- c(.muGroupThetaUpper, as.numeric(g$thetaUpper))
     .muGroupCovStart <- c(.muGroupCovStart, length(.muGroupCovTheta))
-    .muGroupCovCount <- c(.muGroupCovCount, nrow(g$covariates))
-    for (.k in seq_len(nrow(g$covariates))) {
-      .cp <- g$covariates$covariateParameter[.k]
+    .muGroupCovCount <- c(.muGroupCovCount, nrow(.cov))
+    for (.k in seq_len(nrow(.cov))) {
+      .cp <- .cov$covariateParameter[.k]
       .muGroupCovTheta <- c(.muGroupCovTheta, .thetaIdxOf(.cp))
       .muGroupCovUserFixed <- c(.muGroupCovUserFixed,
                                  as.integer(isTRUE(.userFixed[[.cp]])))
-      .muGroupCovLower <- c(.muGroupCovLower, as.numeric(g$covariates$lower[.k]))
-      .muGroupCovUpper <- c(.muGroupCovUpper, as.numeric(g$covariates$upper[.k]))
-      .muGroupCovNames <- c(.muGroupCovNames, g$covariates$covariate[.k])
+      .muGroupCovLower <- c(.muGroupCovLower, as.numeric(.cov$lower[.k]))
+      .muGroupCovUpper <- c(.muGroupCovUpper, as.numeric(.cov$upper[.k]))
+      .muGroupCovNames <- c(.muGroupCovNames, .cov$covariate[.k])
     }
   }
 

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -5715,52 +5715,14 @@ static inline void foceiPrintLine(int ncol){
 extern "C" double foceiOfvOptim(int n, double *x, void *ex){
   double ret = foceiOfv0(x);
   niter.push_back(op_focei.nF2+(++op_focei.nF));
-  // Scaled
-  vPar.push_back(ret);
-  iterType.push_back(5);
-  int finalize = 0, i = 0;
-  for (i = 0; i < n; i++){
-    vPar.push_back(x[i]);
-  }
-  // Unscaled
-  iterType.push_back(6);
-  niter.push_back(niter.back());
-  if (op_focei.scaleObjective){
-    vPar.push_back(op_focei.initObjective * ret / op_focei.scaleObjectiveTo);
-  } else {
-    vPar.push_back(ret);
-  }
-  for (i = 0; i < n; i++){
-    vPar.push_back(unscalePar(x, i));
-  }
-  // Back-transformed (7)
-  iterType.push_back(7);
-  niter.push_back(niter.back());
-  if (op_focei.scaleObjective){
-    vPar.push_back(op_focei.initObjective * ret / op_focei.scaleObjectiveTo);
-  } else {
-    vPar.push_back(ret);
-  }
-  for (i = 0; i < n; i++){
-    // op_focei.probitIdxArr (not scale.probitIdx) -- the scale pointer is in
-    // print-map order for the mu family, this loop runs over optimizer indices
-    int probitCode = (op_focei.probitIdxArr != NULL) ? op_focei.probitIdxArr[i] : 0;
-    vPar.push_back(scaleBackTransform(unscalePar(x, i),
-                                      op_focei.xPar[i], probitCode,
-                                      op_focei.scale.logitThetaLow,
-                                      op_focei.scale.logitThetaHi,
-                                      op_focei.scale.probitThetaLow,
-                                      op_focei.scale.probitThetaHi));
-  }
-  // Emit the per-iteration #/U/X rows via scale.h; when scaleObjective is on,
-  // rescale back to the unscaled OFV so all rows show the number the user expects.
-  double displayedOfv = op_focei.scaleObjective
-    ? op_focei.initObjective * ret / op_focei.scaleObjectiveTo
-    : ret;
-  // The mu-family prints nparsPrint columns: optimizer values interleaved
-  // with the current regression-updated mu thetas (raw estimation scale).
+  // The mu-family records/prints nparsPrint columns: optimizer values
+  // interleaved with the current regression-updated mu thetas (raw estimation
+  // scale, fresh from the foceiOfv0 inner/updateMuGroups cycle above);
+  // identity over the optimizer set when muModel is off.
   double *xp = x;
+  int np = n;
   if (muPrintActive()) {
+    np = (int)op_focei.nparsPrint;
     _printX.resize(op_focei.nparsPrint);
     for (unsigned int p = 0; p < op_focei.nparsPrint; p++) {
       int ko = _printOptIdx[p];
@@ -5775,6 +5737,58 @@ extern "C" double foceiOfvOptim(int n, double *x, void *ex){
     }
     xp = _printX.data();
   }
+  // Scaled
+  vPar.push_back(ret);
+  iterType.push_back(5);
+  int finalize = 0, i = 0;
+  for (i = 0; i < np; i++){
+    vPar.push_back(xp[i]);
+  }
+  // Unscaled
+  iterType.push_back(6);
+  niter.push_back(niter.back());
+  if (op_focei.scaleObjective){
+    vPar.push_back(op_focei.initObjective * ret / op_focei.scaleObjectiveTo);
+  } else {
+    vPar.push_back(ret);
+  }
+  for (i = 0; i < np; i++){
+    int ko = muPrintActive() ? _printOptIdx[i] : i;
+    vPar.push_back(ko >= 0 ? unscalePar(x, ko) : xp[i]);
+  }
+  // Back-transformed (7)
+  iterType.push_back(7);
+  niter.push_back(niter.back());
+  if (op_focei.scaleObjective){
+    vPar.push_back(op_focei.initObjective * ret / op_focei.scaleObjectiveTo);
+  } else {
+    vPar.push_back(ret);
+  }
+  for (i = 0; i < np; i++){
+    int ko = muPrintActive() ? _printOptIdx[i] : i;
+    double u; int xc, pc;
+    if (ko >= 0) {
+      u = unscalePar(x, ko);
+      xc = op_focei.xPar[ko];
+      // op_focei.probitIdxArr (not scale.probitIdx) -- the scale pointer is
+      // in print-map order for the mu family, ko is an optimizer index
+      pc = (op_focei.probitIdxArr != NULL) ? op_focei.probitIdxArr[ko] : 0;
+    } else {
+      u = xp[i];
+      xc = _printXPar[i];
+      pc = _printProbitIdx[i];
+    }
+    vPar.push_back(scaleBackTransform(u, xc, pc,
+                                      op_focei.scale.logitThetaLow,
+                                      op_focei.scale.logitThetaHi,
+                                      op_focei.scale.probitThetaLow,
+                                      op_focei.scale.probitThetaHi));
+  }
+  // Emit the per-iteration #/U/X rows via scale.h; when scaleObjective is on,
+  // rescale back to the unscaled OFV so all rows show the number the user expects.
+  double displayedOfv = op_focei.scaleObjective
+    ? op_focei.initObjective * ret / op_focei.scaleObjectiveTo
+    : ret;
   scalePrintFun(&op_focei.scale, xp, displayedOfv);
   // One summary line per printed iteration for any ODE-solve warnings (e.g.
   // intdy window-misses) accumulated since the last flush; without this a
@@ -5822,7 +5836,6 @@ extern "C" void outerGradNumOptim(int n, double *par, double *gr, void *ex){
     grp = _printGr.data();
   }
   scalePrintGrad(&op_focei.scale, grp, gradType.back());
-  vGrad.push_back(NA_REAL); // Gradient doesn't record objf
   for (i = 0; i < n; i++){
     if (gr[i] == 0){
       if (op_focei.nF+op_focei.nF2 == 1) {
@@ -5849,7 +5862,19 @@ extern "C" void outerGradNumOptim(int n, double *par, double *gr, void *ex){
         }
       }
     }
-    vGrad.push_back(gr[i]);
+  }
+  // Record after the zero-gradient fix-ups so the history holds the values the
+  // optimizer sees; mu columns record NaN (regression-updated, no gradient).
+  vGrad.push_back(NA_REAL); // Gradient doesn't record objf
+  if (muPrintActive()) {
+    for (unsigned int p = 0; p < op_focei.nparsPrint; p++) {
+      int ko = _printOptIdx[p];
+      vGrad.push_back(ko >= 0 ? gr[ko] : R_NaN);
+    }
+  } else {
+    for (i = 0; i < n; i++){
+      vGrad.push_back(gr[i]);
+    }
   }
 }
 
@@ -7846,7 +7871,7 @@ void parHistData(Environment e, bool focei){
     CharacterVector thetaNames=as<CharacterVector>(e["thetaNames"]);
     CharacterVector dfNames;
     if (focei){
-      CharacterVector dfNames2(3+op_focei.npars);
+      CharacterVector dfNames2(3+op_focei.nparsPrint);
       dfNames = dfNames2;
     } else {
       CharacterVector dfNames2(3+thetaNames.size());
@@ -7857,8 +7882,10 @@ void parHistData(Environment e, bool focei){
     dfNames[2] = "objf";
     int i, j, k=1;
     if (focei){
-      for (i = 0; i < op_focei.npars; i++){
-        j=op_focei.fixedTrans[i];
+      // print-map order: optimizer columns plus regression-updated mu thetas
+      // at their natural positions (identity over fixedTrans when muModel off)
+      for (i = 0; i < (int)op_focei.nparsPrint; i++){
+        j=_printFullIdx[i];
         if (j < thetaNames.size()){
           dfNames[i+3] = thetaNames[j];
         } else {
@@ -7873,7 +7900,7 @@ void parHistData(Environment e, bool focei){
     // iter type parameters
     List ret;
     if (focei){
-      ret = List(3+op_focei.npars);
+      ret = List(3+op_focei.nparsPrint);
     } else {
       ret = List(3+thetaNames.size());
     }
@@ -7910,7 +7937,7 @@ void parHistData(Environment e, bool focei){
       vals = cPar;
     }
     if (focei){
-      for (i = 0; i < min2(op_focei.npars+1, vals.n_cols); i++){
+      for (i = 0; i < min2(op_focei.nparsPrint+1, vals.n_cols); i++){
         ret[i+2]= vals.col(i);
       }
     } else {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -169,6 +169,9 @@ struct focei_options {
   unsigned int neta;
   unsigned int ntheta;
   unsigned int npars;
+  // Printed/history column count: npars plus the regression-updated mu-group
+  // thetas (== npars when muModel is off); see _printOptIdx/_printFullIdx.
+  unsigned int nparsPrint;
   unsigned int thetan;
   unsigned int omegan;
 
@@ -615,6 +618,18 @@ std::vector<double> vPar;
 std::vector<double> vGrad;
 std::vector<int> niterGrad;
 std::vector<int> gradType;
+
+// Printed-column layout for the mu-referenced focei family: printed column p
+// maps to optimizer index _printOptIdx[p] (-1 for regression-updated mu
+// columns, which have no optimizer slot) and fullTheta index _printFullIdx[p];
+// identity over fixedTrans when muModel is off. Rebuilt by foceiSetupTheta_.
+static std::vector<int> _printOptIdx, _printFullIdx, _printNoGrad;
+static std::vector<double> _printX, _printGr, _printInitPar, _printScaleC;
+static std::vector<int> _printXPar, _printProbitIdx;
+
+static inline bool muPrintActive() {
+  return op_focei.muModel != 0 && op_focei.muGroupN > 0;
+}
 
 static void releaseCovSolveArgs_(); // defined with covSolveArgs_ below; teardown backstop
 
@@ -4448,6 +4463,25 @@ static inline void foceiSetupTheta_(List mvi,
       }
     }
   }
+  // Printed-column map: optimizer columns in fixedTrans order interleaved with
+  // the regression-updated mu thetas at their natural fullTheta positions
+  // (user-fixed thetas get no column either way, matching plain focei).
+  _printOptIdx.clear(); _printFullIdx.clear(); _printNoGrad.clear();
+  int k2 = 0;
+  for (j = 0; j < thetan+omegan; j++){
+    if (isMuGroupSkip(j)) {
+      if (!(j < thetaFixed2.size() && thetaFixed2[j])) {
+        _printOptIdx.push_back(-1);
+        _printFullIdx.push_back(j);
+        _printNoGrad.push_back(1);
+      }
+    } else if (k2 < npars && op_focei.fixedTrans[k2] == j) {
+      _printOptIdx.push_back(k2++);
+      _printFullIdx.push_back(j);
+      _printNoGrad.push_back(0);
+    }
+  }
+  op_focei.nparsPrint = (unsigned int)_printOptIdx.size();
   op_focei.npars  = (unsigned int)npars;
 }
 

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -344,8 +344,7 @@ struct focei_options {
   // coefficients. Reported once by R at finalize, never per iteration.
   int *muGroupClamped = NULL;       // [muGroupN + muGroupCovN]
   int muGroupClampRetries = 10;
-  // Display names for mu-group thetas, used only by printMuGroupThetaRow() to
-  // label the extra print row; excluded from op_focei.scale's own column names.
+  // Display names for mu-group thetas, used by the finalize-time clamp report.
   CharacterVector muGroupThetaNames;    // [muGroupN]
   CharacterVector muGroupCovThetaNames; // [muGroupCovN]
   // A single updateMuGroups() step per outer iteration isn't always enough:
@@ -5711,41 +5710,6 @@ static inline void foceiPrintLine(int ncol){
   RSprintf("\n");
 }
 
-// Mu-group thetas are excluded from op_focei.scale's parameter vector, so
-// scalePrintFun/scalePrintGrad's table never shows them; this adds one extra
-// self-labeled row after each call (current regression value, or NA for the
-// gradient print since these thetas have no FD gradient). Kept out of the
-// shared scale.h to avoid touching its column layout; uses the same
-// scale->every/cn throttle so it no-ops when printing is off or muModel="none".
-static inline void printMuGroupThetaRow(bool isGrad) {
-  if (op_focei.muModel == 0 || op_focei.muGroupN == 0) return;
-  scaling *scale = &op_focei.scale;
-  if (scale->every == 0 || scale->cn % scale->every != 0) return;
-  RSprintf(isGrad ? "|   mu|   (no gradient - regression update)  |" :
-                     "|   mu|                                     |");
-  for (unsigned int g = 0; g < op_focei.muGroupN; g++) {
-    std::string nm = (g < (unsigned int)op_focei.muGroupThetaNames.size() &&
-                       op_focei.muGroupThetaNames[g] != NA_STRING) ?
-      as<std::string>(op_focei.muGroupThetaNames[g]) : "?";
-    if (isGrad) {
-      RSprintf(" %8s:         NA |", nm.c_str());
-    } else {
-      RSprintf(" %8s: %#10.4g |", nm.c_str(), op_focei.fullTheta[op_focei.muGroupTheta[g]]);
-    }
-  }
-  for (unsigned int c = 0; c < op_focei.muGroupCovN; c++) {
-    std::string nm = (c < (unsigned int)op_focei.muGroupCovThetaNames.size() &&
-                       op_focei.muGroupCovThetaNames[c] != NA_STRING) ?
-      as<std::string>(op_focei.muGroupCovThetaNames[c]) : "?";
-    if (isGrad) {
-      RSprintf(" %8s:         NA |", nm.c_str());
-    } else {
-      RSprintf(" %8s: %#10.4g |", nm.c_str(), op_focei.fullTheta[op_focei.muGroupCovTheta[c]]);
-    }
-  }
-  RSprintf("\n");
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Outer l-BFGS-b from R
 extern "C" double foceiOfvOptim(int n, double *x, void *ex){
@@ -5778,7 +5742,9 @@ extern "C" double foceiOfvOptim(int n, double *x, void *ex){
     vPar.push_back(ret);
   }
   for (i = 0; i < n; i++){
-    int probitCode = (op_focei.scale.probitIdx != NULL) ? op_focei.scale.probitIdx[i] : 0;
+    // op_focei.probitIdxArr (not scale.probitIdx) -- the scale pointer is in
+    // print-map order for the mu family, this loop runs over optimizer indices
+    int probitCode = (op_focei.probitIdxArr != NULL) ? op_focei.probitIdxArr[i] : 0;
     vPar.push_back(scaleBackTransform(unscalePar(x, i),
                                       op_focei.xPar[i], probitCode,
                                       op_focei.scale.logitThetaLow,
@@ -5791,8 +5757,25 @@ extern "C" double foceiOfvOptim(int n, double *x, void *ex){
   double displayedOfv = op_focei.scaleObjective
     ? op_focei.initObjective * ret / op_focei.scaleObjectiveTo
     : ret;
-  scalePrintFun(&op_focei.scale, x, displayedOfv);
-  printMuGroupThetaRow(false);
+  // The mu-family prints nparsPrint columns: optimizer values interleaved
+  // with the current regression-updated mu thetas (raw estimation scale).
+  double *xp = x;
+  if (muPrintActive()) {
+    _printX.resize(op_focei.nparsPrint);
+    for (unsigned int p = 0; p < op_focei.nparsPrint; p++) {
+      int ko = _printOptIdx[p];
+      if (ko >= 0) {
+        _printX[p] = x[ko];
+        getScaleC(ko); // resolve any lazily-cached scaleC before copying
+        _printScaleC[p]  = op_focei.scaleC[ko];
+        _printInitPar[p] = op_focei.initPar[ko];
+      } else {
+        _printX[p] = op_focei.fullTheta[_printFullIdx[p]];
+      }
+    }
+    xp = _printX.data();
+  }
+  scalePrintFun(&op_focei.scale, xp, displayedOfv);
   // One summary line per printed iteration for any ODE-solve warnings (e.g.
   // intdy window-misses) accumulated since the last flush; without this a
   // difficult model floods the console with identical lines each iteration.
@@ -5829,8 +5812,16 @@ extern "C" void outerGradNumOptim(int n, double *par, double *gr, void *ex){
   }
   // gradType convention: 1=Gill, 2=Mixed, 3=Forward, 4=Central, 5=Shi21,
   // 8=nlm forward sensitivity, 9=analytic outer gradient (fast=TRUE).
-  scalePrintGrad(&op_focei.scale, gr, gradType.back());
-  printMuGroupThetaRow(true);
+  double *grp = gr;
+  if (muPrintActive()) {
+    _printGr.resize(op_focei.nparsPrint);
+    for (unsigned int p = 0; p < op_focei.nparsPrint; p++) {
+      int ko = _printOptIdx[p];
+      _printGr[p] = (ko >= 0) ? gr[ko] : R_NaN;
+    }
+    grp = _printGr.data();
+  }
+  scalePrintGrad(&op_focei.scale, grp, gradType.back());
   vGrad.push_back(NA_REAL); // Gradient doesn't record objf
   for (i = 0; i < n; i++){
     if (gr[i] == 0){
@@ -9289,8 +9280,7 @@ Environment foceiFitCpp_(Environment e){
   wallT0 = focei_wall_clock::now();
   CharacterVector thetaNames=as<CharacterVector>(e["thetaNames"]);
   // Capture mu-group theta display names here while the full thetaNames is
-  // available (op_focei.scale's own is npars-sized and excludes them); used
-  // only by printMuGroupThetaRow() below.
+  // available; used by the finalize-time clamp report.
   if (op_focei.muModel != 0 && op_focei.muGroupN > 0) {
     CharacterVector muThetaNm(op_focei.muGroupN);
     for (unsigned int g = 0; g < op_focei.muGroupN; g++) {
@@ -9349,24 +9339,55 @@ Environment foceiFitCpp_(Environment e){
   // since focei keeps its own iteration history in module-level globals.
   {
     // Build a CharacterVector with the printed column names in the same
-    // order scalePrintFun emits them (fixedTrans-indexed).
-    CharacterVector scaleNames(op_focei.npars);
+    // order scalePrintFun emits them (print-map order; identity over
+    // fixedTrans when muModel is off).
+    CharacterVector scaleNames(op_focei.nparsPrint);
     int k = 1;
-    for (unsigned int i = 0; i < op_focei.npars; i++) {
-      int jj = op_focei.fixedTrans[i];
+    for (unsigned int i = 0; i < op_focei.nparsPrint; i++) {
+      int jj = _printFullIdx[i];
       if (jj < thetaNames.size()) {
         scaleNames[i] = thetaNames[jj];
       } else {
         scaleNames[i] = "o" + std::to_string(k++);
       }
     }
-    op_focei.scale.npars         = op_focei.npars;
-    op_focei.scale.initPar       = op_focei.initPar;
-    op_focei.scale.scaleC        = op_focei.scaleC;
-    op_focei.scale.xPar          = op_focei.xPar;
+    if (muPrintActive()) {
+      // Padded per-column buffers: optimizer columns copy the live values;
+      // regression-updated mu columns get identity scaling (their noGrad mask
+      // skips the unscale) plus the model's own back-transform codes so the
+      // X row shows them like any other theta.
+      unsigned int npp = op_focei.nparsPrint;
+      _printXPar.resize(npp); _printProbitIdx.resize(npp);
+      _printInitPar.resize(npp); _printScaleC.resize(npp);
+      for (unsigned int p = 0; p < npp; p++) {
+        int ko = _printOptIdx[p], jj = _printFullIdx[p];
+        if (ko >= 0) {
+          _printXPar[p]      = op_focei.xPar[ko];
+          _printProbitIdx[p] = op_focei.probitIdxArr[ko];
+          _printInitPar[p]   = op_focei.initPar[ko];
+          _printScaleC[p]    = op_focei.scaleC[ko];
+        } else {
+          _printXPar[p]      = (jj < thetaXPar.size()) ? thetaXPar[jj] : 0;
+          _printProbitIdx[p] = (jj < thetaProbitIdx.size()) ? thetaProbitIdx[jj] : 0;
+          _printInitPar[p]   = op_focei.fullTheta[jj];
+          _printScaleC[p]    = 1.0;
+        }
+      }
+      op_focei.scale.npars   = (int)npp;
+      op_focei.scale.initPar = _printInitPar.data();
+      op_focei.scale.scaleC  = _printScaleC.data();
+      op_focei.scale.xPar    = _printXPar.data();
+      op_focei.scale.noGrad  = _printNoGrad.data();
+    } else {
+      op_focei.scale.npars   = op_focei.npars;
+      op_focei.scale.initPar = op_focei.initPar;
+      op_focei.scale.scaleC  = op_focei.scaleC;
+      op_focei.scale.xPar    = op_focei.xPar;
+      op_focei.scale.noGrad  = NULL; // op_focei.scale persists across fits
+    }
     op_focei.scale.logitThetaLow = op_focei.logitThetaLow.size() ? &op_focei.logitThetaLow[0] : NULL;
     op_focei.scale.logitThetaHi  = op_focei.logitThetaHi.size()  ? &op_focei.logitThetaHi[0]  : NULL;
-    op_focei.scale.probitIdx       = op_focei.probitIdxArr;
+    op_focei.scale.probitIdx       = muPrintActive() ? _printProbitIdx.data() : op_focei.probitIdxArr;
     op_focei.scale.probitThetaLow  = op_focei.probitThetaLow.size() ? &op_focei.probitThetaLow[0] : NULL;
     op_focei.scale.probitThetaHi   = op_focei.probitThetaHi.size()  ? &op_focei.probitThetaHi[0]  : NULL;
     op_focei.scale.thetaNames    = scaleNames;
@@ -9388,7 +9409,15 @@ Environment foceiFitCpp_(Environment e){
     op_focei.scale.showOfv       = 1;
     // focei's richer Key suffix — gradient-method legend and omega note.
     // Appended after "X: Back-transformed parameters; " by scalePrintHeader.
-    op_focei.scale.keyExtra =
+    op_focei.scale.keyExtra = muPrintActive() ?
+      "G: Gill difference gradient approximation\n"
+      "F: Forward difference gradient approximation\n"
+      "C: Central difference gradient approximation\n"
+      "M: Mixed forward and central difference gradient approximation\n"
+      "A: Analytic (forward sensitivity) gradient (fast=TRUE)\n"
+      "Unscaled parameters for Omegas=chol(solve(omega));\n"
+      "Diagonals are transformed, as specified by foceiControl(diagXform=)\n"
+      "mu-referenced thetas are regression-updated each iteration (blank gradient)\n" :
       "G: Gill difference gradient approximation\n"
       "F: Forward difference gradient approximation\n"
       "C: Central difference gradient approximation\n"

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -2903,24 +2903,18 @@ static inline double updateMuGroups() {
     unsigned int covStart = (unsigned int)op_focei.muGroupCovStart[g];
     unsigned int covCount = (unsigned int)op_focei.muGroupCovCount[g];
 
-    // Split covariates into known-offset (user-fixed, not estimated here) vs
-    // free (estimated by the clamped regression). The fixed offset reads
-    // fullTheta[covTheta] fresh each call.
+    // A user-fixed coefficient is not estimated here; its contribution is
+    // left out of the regression target y and the design matrix entirely
+    // (the model itself still applies it), so the regression re-partitions
+    // only the free part: y = pop + free-cov terms + eta.
     std::vector<unsigned int> freeCovCols;
     std::vector<int> freeCovTheta;
-    arma::vec offset(nsubAll, arma::fill::zeros);
     for (unsigned int c = 0; c < covCount; c++) {
       unsigned int flatIdx = covStart + c;
       int covTheta = op_focei.muGroupCovTheta[flatIdx];
       bool userFixed = op_focei.muGroupCovUserFixed != NULL &&
         op_focei.muGroupCovUserFixed[flatIdx] != 0;
-      if (userFixed) {
-        double coefVal = op_focei.fullTheta[covTheta];
-        for (int id = 0; id < nsubAll; id++) {
-          int rid = getRxId(id);
-          offset(id) += coefVal * op_focei.muGroupCovData(rid, flatIdx);
-        }
-      } else {
+      if (!userFixed) {
         freeCovCols.push_back(flatIdx);
         freeCovTheta.push_back(covTheta);
       }
@@ -2933,7 +2927,7 @@ static inline double updateMuGroups() {
     for (int id = 0; id < nsubAll; id++) {
       focei_ind *fInd = &(inds_focei[id]);
       int rid = getRxId(id);
-      double phi = op_focei.fullTheta[popIdx] + offset(id) + fInd->eta[etaIdx];
+      double phi = op_focei.fullTheta[popIdx] + fInd->eta[etaIdx];
       for (int c = 0; c < nFree; c++) {
         double covVal = op_focei.muGroupCovData(rid, freeCovCols[c]);
         phi += covVal * op_focei.fullTheta[freeCovTheta[c]];

--- a/src/scale.h
+++ b/src/scale.h
@@ -65,6 +65,12 @@ struct scaling {
   int *probitIdx;
   double *probitThetaLow;
   double *probitThetaHi;
+  // Optional per-column mask (NULL = no mask): a masked column's value is
+  // regression/externally updated rather than optimizer-owned -- unscaling is
+  // skipped (the value passes through as-is in the #/U rows), the X row still
+  // back-transforms, the gradient cell prints blank, and NaN is recorded for
+  // its gradient when save is on.
+  int *noGrad = NULL;
   // Backing storage for the six transform pointers, populated by
   // scaleAttachXform(); estimators owning their own buffers (e.g. focei)
   // leave these empty and assign raw pointers directly.
@@ -126,6 +132,7 @@ static inline void scaleSetup(scaling *scale,
   scale->probitIdx = NULL;
   scale->probitThetaLow = NULL;
   scale->probitThetaHi = NULL;
+  scale->noGrad = NULL;
   scale->thetaNames = thetaNames;
 
   scale->useColor = useColor;
@@ -616,6 +623,10 @@ static inline double scaleBackTransform(double est, int xParCode, int probitCode
   return est;
 }
 
+static inline int scaleNoGrad(scaling *scale, int i) {
+  return scale->noGrad != NULL && scale->noGrad[i];
+}
+
 static inline void scalePrintFun(scaling *scale, double *x, double f) {
   // Scaled
   int finalize = 0, i = 0;
@@ -644,7 +655,7 @@ static inline void scalePrintFun(scaling *scale, double *x, double f) {
       scale->niter.push_back(scale->niter.back());
       scale->vPar.push_back(f);
       for (i = 0; i < scale->npars; i++){
-        scale->vPar.push_back(scaleUnscalePar(scale, x, i));
+        scale->vPar.push_back(scaleNoGrad(scale, i) ? x[i] : scaleUnscalePar(scale, x, i));
       }
     }
     if (!scale->simple && !skipX) {
@@ -654,7 +665,7 @@ static inline void scalePrintFun(scaling *scale, double *x, double f) {
       scale->vPar.push_back(f);
       for (i = 0; i < scale->npars; i++){
         int probitCode = (scale->probitIdx != NULL) ? scale->probitIdx[i] : 0;
-        scale->vPar.push_back(scaleBackTransform(scaleUnscalePar(scale, x, i),
+        scale->vPar.push_back(scaleBackTransform(scaleNoGrad(scale, i) ? x[i] : scaleUnscalePar(scale, x, i),
                                                  scale->xPar[i], probitCode,
                                                  scale->logitThetaLow, scale->logitThetaHi,
                                                  scale->probitThetaLow, scale->probitThetaHi));
@@ -710,7 +721,7 @@ static inline void scalePrintFun(scaling *scale, double *x, double f) {
       if (scale->showOfv) RSprintf("|    U|               |");
       else                RSprintf("|    U|");
       for (i = 0; i < scale->npars; i++){
-        RSprintf("%#10.4g |", scaleUnscalePar(scale, x, i));
+        RSprintf("%#10.4g |", scaleNoGrad(scale, i) ? x[i] : scaleUnscalePar(scale, x, i));
         if ((i + 1) != scale->npars && (i + 1) % scale->ncol == 0){
           if (scale->useColor && scale->ncol + i  > scale->npars){
             RSprintf("%s", scaleWrapMarker(scale, 1));
@@ -759,7 +770,7 @@ static inline void scalePrintFun(scaling *scale, double *x, double f) {
       for (i = 0; i < scale->npars; i++){
         int probitCode = (scale->probitIdx != NULL) ? scale->probitIdx[i] : 0;
         RSprintf("%#10.4g |",
-                 scaleBackTransform(scaleUnscalePar(scale, x, i),
+                 scaleBackTransform(scaleNoGrad(scale, i) ? x[i] : scaleUnscalePar(scale, x, i),
                                     scale->xPar[i], probitCode,
                                     scale->logitThetaLow, scale->logitThetaHi,
                                     scale->probitThetaLow, scale->probitThetaHi));
@@ -835,7 +846,8 @@ static inline void scalePrintGrad(scaling *scale, double *gr, int type) {
       RSprintf("|%s", label);
     }
     for (i = 0; i < scale->npars; i++){
-      RSprintf("%#10.4g ", gr[i]);
+      if (scaleNoGrad(scale, i)) RSprintf("%10s ", "");
+      else RSprintf("%#10.4g ", gr[i]);
       if (scale->useColor && gradNcol >= scale->npars && i == scale->npars-1){
         RSprintf("\033[0m");
       }
@@ -869,7 +881,7 @@ static inline void scalePrintGrad(scaling *scale, double *gr, int type) {
   if (scale->save) {
     scale->vGrad.push_back(NA_REAL); // Gradient doesn't record objf
     for (i = 0; i < scale->npars; i++){
-      scale->vGrad.push_back(gr[i]);
+      scale->vGrad.push_back(scaleNoGrad(scale, i) ? R_NaN : gr[i]);
     }
   }
 }

--- a/tests/testthat/test-mfocei.R
+++ b/tests/testthat/test-mfocei.R
@@ -270,20 +270,15 @@ nmTest({
     expect_false(is.na(suppressWarnings(as.numeric(.pf["allo.cl2", "SE"]))))
   })
 
-  test_that("mfocei's live iteration print shows mu-group theta values, blank on gradient rows", {
-    # Phase 5: the mu-group population/covariate thetas are excluded from
-    # the outer optimizer's own parameter vector, so the shared
-    # scale.h-based per-iteration table never shows them. printMuGroupThetaRow()
-    # (src/inner.cpp) adds one extra "|   mu|..." row after each real
-    # parameter print (current regression-updated value) and after each
-    # gradient print (blank/NA, since these thetas are never part of the
-    # gradient finite-difference -- there is no restart-loop involved,
-    # the value comes from updateMuGroups() running inside innerOpt()).
+  test_that("mfocei's live iteration print shows mu-group thetas as standard columns", {
+    # The mu-group population/covariate thetas are regression-updated (no
+    # outer-optimizer slot) but print as normal scale.h columns at their
+    # natural theta positions; gradient rows show blank cells for them.
     #
     # capture.output() must wrap the *un-suppressed* nlmixr() call directly
     # (not the .nlmixr()/suppressMessages() test helper) -- this console
-    # output is otherwise swallowed by suppressMessages() in this R
-    # session, unrelated to whether printMuGroupThetaRow() itself ran.
+    # output is otherwise swallowed by suppressMessages() in this R session.
+    # width=200 keeps all 8 columns on one print row (no wrap).
     theo_sd2 <- nlmixr2data::theo_sd
     theo_sd2$logWT <- log(theo_sd2$WT / 70)
 
@@ -306,34 +301,32 @@ nmTest({
       })
     }
 
-    out <- capture.output({
+    out <- withr::with_options(list(width = 200), capture.output({
       nlmixr2est::nlmixr(mod, theo_sd2, "mfocei",
                           mfoceiControl(print = 1, maxOuterIterations = 2))
-    })
+    }))
 
-    muValueRows <- grep("^\\|   mu\\|.*tcl:\\s*[-0-9]", out, value = TRUE)
-    muNaRows <- grep("^\\|   mu\\|.*tcl:\\s*NA", out, value = TRUE)
-    gradRows <- grep("^\\|    [GFCMS]\\|", out, value = TRUE)
-
-    expect_true(length(muValueRows) > 0)
-    expect_true(length(muNaRows) > 0)
-    # every mu-group value row also shows allo.cl (the covariate
-    # coefficient), and every blank row shows NA for it too
-    expect_true(all(grepl("allo\\.cl:\\s*[-0-9]", muValueRows)))
-    expect_true(all(grepl("allo\\.cl:\\s*NA", muNaRows)))
-    # plain (covariate-free) mu-ref thetas are profiled out too and appear
-    # in the same mu rows
-    expect_true(all(grepl("tka:\\s*[-0-9]", muValueRows)))
-    expect_true(all(grepl("tv:\\s*[-0-9]", muValueRows)))
-    expect_true(all(grepl("tka:\\s*NA", muNaRows)))
-    # ... and are gone from the scale table's own parameter columns
-    headerRows <- grep("^\\|    #\\|", out, value = TRUE)
-    expect_true(length(headerRows) > 0)
-    expect_false(any(grepl("\\btka\\b|\\btcl\\b|\\btv\\b", headerRows)))
-    expect_true(any(grepl("add\\.sd", headerRows)))
-    # a standard (non-mu-group) theta still shows a real numeric gradient
-    # on the same gradient-print events
+    # the old bolt-on "|   mu|" row is gone
+    expect_false(any(grepl("^\\|   mu\\|", out)))
+    # Key legend notes the regression-updated thetas
+    expect_true(any(grepl("mu-referenced thetas are regression-updated", out)))
+    # mu-group thetas (pop + covariate coefficient) are header columns at
+    # their natural positions among the other parameters
+    hdr <- grep("^\\|    #\\|", out, value = TRUE)[1]
+    expect_false(is.na(hdr))
+    .pos <- vapply(c("tka", "tcl", "tv", "allo\\.cl", "add\\.sd"),
+                   function(nm) as.numeric(regexpr(paste0("\\b", nm, "\\b"), hdr)),
+                   numeric(1))
+    expect_true(all(.pos > 0))
+    expect_true(all(diff(.pos) > 0))
+    # gradient rows: one blank cell per regression-updated theta
+    # (tka/tcl/tv/allo.cl), real numbers for the optimizer-owned columns
+    gradRows <- grep("^\\|    [GFCMSA]\\|", out, value = TRUE)
     expect_true(length(gradRows) > 0)
+    .blanks <- vapply(gradRows,
+                      function(r) sum(gregexpr(" {11}\\|", r)[[1]] > 0),
+                      numeric(1))
+    expect_true(all(.blanks == 4))
     expect_true(any(grepl("[-0-9]\\.[0-9]", gradRows)))
   })
 })

--- a/tests/testthat/test-mfocei.R
+++ b/tests/testthat/test-mfocei.R
@@ -151,6 +151,16 @@ nmTest({
     # objective function values should be in the same ballpark (not an
     # exact match -- different optimization paths)
     expect_equal(fitMu$objf, fitFocei$objf, tolerance = 0.1)
+
+    # mu thetas are recorded in the parameter history like plain focei
+    expect_identical(names(fitMu$parHist), names(fitFocei$parHist))
+    .u <- fitMu$parHistData[fitMu$parHistData$type == "Unscaled", ]
+    expect_true(nrow(.u) > 0)
+    expect_true(all(is.finite(.u$tcl)))
+    expect_true(all(is.finite(.u$allo.cl)))
+    expect_equal(unname(.u$tcl[nrow(.u)]), unname(.thMu["tcl"]), tolerance = 0.05)
+    expect_equal(unname(.u$allo.cl[nrow(.u)]), unname(.thMu["allo.cl"]),
+                 tolerance = 0.05)
   })
 
   test_that("mfocei respects a user-fixed covariate coefficient", {

--- a/tests/testthat/test-mu-parhist.R
+++ b/tests/testthat/test-mu-parhist.R
@@ -1,0 +1,130 @@
+nmTest({
+  # Mu-referenced thetas (pop + covariate coefficients) are regression-updated
+  # (no outer-optimizer slot) but appear as standard scale.h columns at their
+  # natural theta positions and in parHist/parHistData; gradient rows record
+  # NaN (blank console cells). Console layout details are covered in
+  # test-mfocei.R (weekly batch); this is the always-run core check.
+
+  .ocmt <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  test_that("ifocei parHist has mu-theta columns in natural order with NaN gradients", {
+    skip_on_cran()
+
+    d <- nlmixr2data::theo_sd
+    out <- withr::with_options(list(width = 200), capture.output({
+      fitM <- nlmixr2est::nlmixr(.ocmt, d, "ifocei",
+                                 ifoceiControl(print = 1, maxOuterIterations = 2L,
+                                               covMethod = "", calcTables = FALSE))
+    }))
+    fitP <- .nlmixr(.ocmt, d, "focei",
+                    foceiControl(print = 0, maxOuterIterations = 2L,
+                                 covMethod = "", calcTables = FALSE))
+
+    # same columns as plain focei on the same model, natural theta order
+    expect_identical(names(fitM$parHist), names(fitP$parHist))
+
+    ph <- fitM$parHistData
+    g <- ph[grepl("Gradient|Difference|Sensitivity", ph$type), ]
+    expect_true(nrow(g) > 0)
+    # mu columns: NaN gradients; optimizer columns: finite
+    expect_true(all(is.nan(g$tka)))
+    expect_true(all(is.nan(g$tcl)))
+    expect_true(all(is.nan(g$tv)))
+    expect_true(all(is.finite(g$add.sd)))
+    expect_true(all(is.finite(g$o1)))
+
+    s <- ph[ph$type == "Scaled", ]
+    u <- ph[ph$type == "Unscaled", ]
+    b <- ph[ph$type == "Back-Transformed", ]
+    expect_true(nrow(u) > 0 && nrow(b) > 0)
+    # mu columns pass through unscaled (# == U) and back-transform in X
+    expect_identical(s$tka, u$tka)
+    expect_equal(exp(u$tka), b$tka)
+    expect_true(all(is.finite(u$tka)))
+    # final recorded mu values are the fitted thetas
+    expect_equal(unname(u$tcl[nrow(u)]), unname(fitM$theta[["tcl"]]),
+                 tolerance = 1e-6)
+
+    # console: standard columns, no bolt-on |mu| row, key note, blank grad cells
+    expect_false(any(grepl("^\\|   mu\\|", out)))
+    expect_true(any(grepl("mu-referenced thetas are regression-updated", out)))
+    hdr <- grep("^\\|    #\\|", out, value = TRUE)[1]
+    expect_false(is.na(hdr))
+    .pos <- vapply(c("tka", "tcl", "tv", "add\\.sd"),
+                   function(nm) as.numeric(regexpr(paste0("\\b", nm, "\\b"), hdr)),
+                   numeric(1))
+    expect_true(all(.pos > 0))
+    expect_true(all(diff(.pos) > 0))
+    gradRows <- grep("^\\|    [GFCMSA]\\|", out, value = TRUE)
+    expect_true(length(gradRows) > 0)
+    .blanks <- vapply(gradRows,
+                      function(r) sum(gregexpr(" {11}\\|", r)[[1]] > 0),
+                      numeric(1))
+    expect_true(all(.blanks == 3))
+
+    # plain focei is untouched: full-width columns, no NaN gradient entries
+    phP <- fitP$parHistData
+    expect_identical(ncol(phP), ncol(ph))
+    gP <- phP[grepl("Gradient|Difference|Sensitivity", phP$type), ]
+    expect_true(nrow(gP) > 0)
+    expect_false(any(is.nan(gP$tka)))
+  })
+
+  test_that("mfocei parHist includes the mu covariate coefficient at its natural position", {
+    skip_on_cran()
+
+    theo_sd2 <- nlmixr2data::theo_sd
+    theo_sd2$logWT <- log(theo_sd2$WT / 70)
+    mod <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        allo.cl <- 0.75
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl + allo.cl * logWT)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    fit <- .nlmixr(mod, theo_sd2, "mfocei",
+                   mfoceiControl(print = 0, maxOuterIterations = 2L,
+                                 covMethod = "", calcTables = FALSE))
+    nm <- names(fit$parHist)
+    expect_true(all(c("tka", "tcl", "tv", "allo.cl", "add.sd") %in% nm))
+    # natural ini order: coefficient between tv and add.sd
+    expect_true(which(nm == "allo.cl") > which(nm == "tv"))
+    expect_true(which(nm == "allo.cl") < which(nm == "add.sd"))
+    g <- fit$parHistData[grepl("Gradient|Difference|Sensitivity",
+                               fit$parHistData$type), ]
+    expect_true(nrow(g) > 0)
+    expect_true(all(is.nan(g$allo.cl)))
+    expect_true(all(is.nan(g$tcl)))
+    expect_true(all(is.finite(g$add.sd)))
+  })
+})

--- a/tests/testthat/test-mu-plain.R
+++ b/tests/testthat/test-mu-plain.R
@@ -108,14 +108,20 @@ nmTest({
       })
     }
     ui <- rxode2::rxode2(bnd)
-    expect_no_warning(g <- suppressMessages(nlmixr2est:::.muRefGroups(ui, plain = TRUE)))
-    # bounded tka is regression-updated too (update clamped to [-2, 2])
+    # clamp=TRUE (the mfocei/ifocei family style): bounded tka is
+    # regression-updated too (update clamped to [-2, 2])
+    expect_no_warning(g <- suppressMessages(nlmixr2est:::.muRefGroups(ui, plain = TRUE, clamp = TRUE)))
     expect_equal(vapply(g, function(x) x$theta, character(1)),
                  c("tka", "tcl", "tv"))
-    s <- nlmixr2est:::.muRefCppGroupSetup(ui, plain = TRUE)
+    s <- nlmixr2est:::.muRefCppGroupSetup(ui, plain = TRUE, clamp = TRUE)
     expect_equal(s$muGroupThetaLower, c(-2, -Inf, -Inf))
     expect_equal(s$muGroupThetaUpper, c(2, Inf, Inf))
     expect_null(s$muGroupCovBounded)
+    # clamp=FALSE (every other method, the default for a bare ui): the
+    # bounded plain theta is rejected from the mu-referencing instead
+    expect_no_warning(g0 <- suppressMessages(nlmixr2est:::.muRefGroups(ui, plain = TRUE)))
+    expect_equal(vapply(g0, function(x) x$theta, character(1)),
+                 c("tcl", "tv"))
 
     fx <- function() {
       ini({
@@ -199,7 +205,7 @@ nmTest({
     }
     ui <- rxode2::rxode2(mixedBnd)
     expect_no_warning(s <- suppressMessages(
-      nlmixr2est:::.muRefCppGroupSetup(ui, plain = TRUE)))
+      nlmixr2est:::.muRefCppGroupSetup(ui, plain = TRUE, clamp = TRUE)))
     thNames <- ui$iniDf$name[!is.na(ui$iniDf$ntheta)]
     expect_equal(thNames[s$muGroupTheta + 1L], c("tcl", "tka", "tv"))
     # bounded tcl group carries its clamp bounds; plain groups are infinite

--- a/tests/testthat/test-muRefClassify.R
+++ b/tests/testthat/test-muRefClassify.R
@@ -236,6 +236,75 @@ nmTest({
     expect_true(.cv$bounded[.cv$covariateParameter == "allo.cl2"])
   })
 
+  test_that(".muRefGroups with clamp=TRUE accepts bounded parameters and carries their bounds", {
+    # the clamped mu-family (mfocei/ifocei/...) style: bounded population
+    # thetas and coefficients stay grouped; the regression update is clamped
+    mod <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- c(0, 1, 5) # bounded population theta
+        tv <- 3.45
+        allo.cl <- c(-1, 0.75, 2) # bounded covariate coefficient
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl + allo.cl * logWT)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    ui <- rxode2::rxode2(mod)
+    expect_warning(.groups <- .muRefGroups(ui, clamp = TRUE), NA)
+    expect_length(.groups, 1L)
+    expect_equal(.groups[[1]]$theta, "tcl")
+    expect_equal(.groups[[1]]$thetaLower, 0)
+    expect_equal(.groups[[1]]$thetaUpper, 5)
+    .cv <- .groups[[1]]$covariates
+    expect_false(any(.cv$bounded))
+    expect_equal(.cv$lower[.cv$covariateParameter == "allo.cl"], -1)
+    expect_equal(.cv$upper[.cv$covariateParameter == "allo.cl"], 2)
+    # the flattened setup keeps the bounded coefficient in the arrays
+    .s <- .muRefCppGroupSetup(ui, clamp = TRUE)
+    .thNames <- ui$iniDf$name[!is.na(ui$iniDf$ntheta)]
+    expect_equal(.thNames[.s$muGroupCovTheta + 1L], "allo.cl")
+    expect_equal(.s$muGroupCovLower, -1)
+    expect_equal(.s$muGroupCovUpper, 2)
+  })
+
+  test_that(".muRefCppGroupSetup with clamp=FALSE keeps a carved-out bounded coefficient out of the arrays", {
+    mod <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        allo.cl <- 0.75 # unbounded
+        allo.cl2 <- c(0, 0.1, 1) # bounded
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl + allo.cl * logWT + allo.cl2 * sexf)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    ui <- rxode2::rxode2(mod)
+    suppressWarnings(.s <- .muRefCppGroupSetup(ui))
+    .thNames <- ui$iniDf$name[!is.na(ui$iniDf$ntheta)]
+    # allo.cl2 stays an ordinary bounded outer parameter: not flattened,
+    # so the C++ regression neither skips nor updates it
+    expect_equal(.thNames[.s$muGroupCovTheta + 1L], "allo.cl")
+    expect_equal(.s$muGroupCovNames, "logWT")
+    expect_equal(.s$muGroupCovCount, 1L)
+  })
+
   test_that(".muRefCppCovData evaluates covariate expressions that are not data columns (#711)", {
     dataSav <- data.frame(
       ID = c(2L, 2L, 1L, 1L),


### PR DESCRIPTION
## Summary

- **Mu thetas as first-class output columns** (whole `m*`/`i*` family: `mfocei`/`ifocei`, `mfoce`/`ifoce`, `mfocep`/`ifocep`, `magq`/`iagq`, `mlaplace`/`ilaplace`): the regression-updated mu population thetas and covariate coefficients now appear as normal `scale.h` columns at their natural theta positions in the live iteration print (raw estimation-scale value in the `#`/`U` rows, model back-transform in the `X` row, blank gradient cells) and in `fit$parHist`/`parHistData` (gradient rows record `NaN`). The bolt-on `|   mu|` console row is removed; the Key gains a one-line note.
- **Mechanism**: a new optional per-column `noGrad` mask on the shared `scale.h` scaling struct plus a natural-order printed-column map in `foceiSetupTheta_`; estimators that set no mask (focei/saem/nlm/vae/impmap) are unchanged.
- **Family-gated bound clamping** (integrated from local work): bounded mu-referenced thetas/coefficients stay regression-profiled with clamped updates only in the `m*`/`i*` family; other methods keep the previous reject/outer-optimize behavior. Also fixes the mu regression's handling of a user-fixed covariate coefficient (its fixed contribution is now excluded from the regression target/design instead of biasing the linear predictor each pass); this fixes the 7 `test-muRefClassify.R` failures present on `main`.

## Verification

- Plain focei, saem, and nlm console output and `parHistData` verified **byte-identical** to `origin/main` builds after each commit.
- ifocei/mfocei (with covariate), ilaplace: parHist columns match plain focei on the same model; mu gradient entries `NaN`; `#`==`U` and `X`==back-transform for mu columns; final history values match `fixef`.
- impmap run immediately after a mu fit in one session (stale-mask reset check).
- New always-run `test-mu-parhist.R` (29 assertions); `test-mu-plain.R` 46/46 and `test-muRefClassify.R` 63/63 with the clamp fix; the weekly `test-mfocei.R` print test rewritten for the integrated layout plus parHist parity assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)