### PR TITLE
Reuse the fit's persistent rxInv for the analytic Omega derivatives

### DIFF
--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -586,7 +586,7 @@
 #' post-fit gradient paths.  Returns a list of the assembled pieces, or `NULL`
 #' (out of scope).  `thVals` is the named converged theta vector.
 #' @noRd
-.foceiAnalyticGradSetup <- function(ui, thVals, Om) {
+.foceiAnalyticGradSetup <- function(ui, thVals, Om, e = NULL) {
   if (!isTRUE(rxode2::rxGetControl(ui, "fast", FALSE))) return(NULL)
   if (!.hasRxSens()) return(NULL)
   if (isTRUE(any(ui$predDf$linCmt))) return(NULL)   # linCmt(): no symbolic state sensitivities
@@ -620,7 +620,7 @@
   # multiple estimated lambdas (per-endpoint) need an endpoint->lambda DV mapping not yet
   # wired; keep those on FD.  A single estimated lambda is the ported case.
   if (length(.dir$lamNames) > 1L) return(NULL)
-  .oe <- .foceiEstOmegaDeriv(ui, Om); if (is.null(.oe)) return(NULL)
+  .oe <- .foceiEstOmegaDeriv(ui, Om, e); if (is.null(.oe)) return(NULL)
   list(ef = ef, dir = .dir, dOiEst = .oe$dOi, tr28 = .oe$tr28, omNames = .oe$names,
        neta = neta, etaNames = etaNames, interaction = interaction, foceType = foceType)
 }
@@ -667,7 +667,7 @@
       get("theta", e)$theta
     }
     names(thVals) <- thNames
-    st <- .foceiAnalyticGradSetup(ui, thVals, Om)
+    st <- .foceiAnalyticGradSetup(ui, thVals, Om, e)
     if (is.null(st)) return(NULL)
     th <- setNames(as.numeric(thVals[thNames]), paste0("THETA_", seq_along(thNames), "_"))
     etaObf <- get("etaObf", e)
@@ -739,13 +739,29 @@ attr(rxUiGet.foceiOuter, "rstudio") <- emptyenv()
 #' tr.28).  Returns `list(dOi = list(dOmega^{-1}/d theta_omega_k), tr28 = 0.5 *
 #' tr(dOmega^{-1}_k Omega), names = <omega parameter names>)`, or `NULL`.
 #' @noRd
-.foceiEstOmegaDeriv <- function(ui, Om) {
+.foceiEstOmegaDeriv <- function(ui, Om, e = NULL) {
   tryCatch({
     # Build the rxSymInvChol env from the current Omega with the SAME diagonal
     # transform the optimizer uses, so the Cholesky parameter order/scale matches
     # op_focei's Omega slots (rxUiGet.focei builds env$rxInv the same way).
     .diagXform <- rxode2::rxGetControl(ui, "diagXform", "sqrt")
-    .rxInv <- rxode2::rxSymInvCholCreate(mat = Om, diag.xform = .diagXform)
+    # A fresh env pays ~60ms of one-time symbolic setup on its first `$d.omegaInv` (a
+    # repeat read is free), which made this ~40% of each analytic gradient.  Reuse the
+    # fit's persistent `env$rxInv` (C++ keeps it current via setOmegaTheta) -- but only
+    # when it is already at this Omega, so a stale env falls back instead of silently
+    # returning derivatives at the wrong one.
+    .rxInv <- NULL
+    if (!is.null(e)) {
+      .cand <- tryCatch(get("rxInv", e), error = function(.) NULL)
+      if (!is.null(.cand) && rxode2::rxIs(.cand, "rxSymInvCholEnv")) {
+        .omChk <- tryCatch(as.matrix(.cand$omega), error = function(.) NULL)
+        if (!is.null(.omChk) && identical(dim(.omChk), dim(as.matrix(Om))) &&
+              isTRUE(all.equal(unname(.omChk), unname(as.matrix(Om)), tolerance = 1e-10))) {
+          .rxInv <- .cand
+        }
+      }
+    }
+    if (is.null(.rxInv)) .rxInv <- rxode2::rxSymInvCholCreate(mat = Om, diag.xform = .diagXform)
     # `$.rxSymInvCholEnv` dispatches to the C rxSymInvCholEnvCalculate; d.omegaInv
     # is the list of dOmega^-1/d(chol theta_k), tr.28 = 0.5*tr(dOmega^-1_k Omega).
     .dOi <- .rxInv$d.omegaInv

--- a/tests/testthat/test-focei-fast-grad.R
+++ b/tests/testthat/test-focei-fast-grad.R
@@ -375,4 +375,25 @@ nmTest({
     }, numeric(1))
     expect_equal(unname(g[names(base)]), unname(fd), tolerance = 0.02)
   })
+  test_that("Omega derivatives reuse the fit's rxInv only when it is at the same Omega", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    .ui <- rxode2::rxUiDecompress(nlmixr2(.fast_one_cmt))
+    rxode2::rxAssignControlValue(.ui, "fast", TRUE)
+    .om <- lotri::lotri(eta.ka ~ 0.6, eta.cl ~ 0.3, eta.v ~ 0.1)
+    .ref <- .foceiEstOmegaDeriv(.ui, .om)                       # fresh env (no `e`)
+    expect_false(is.null(.ref))
+    # an env whose rxInv is already at this Omega: reused, and EXACTLY equal
+    .e <- new.env()
+    .e$rxInv <- rxode2::rxSymInvCholCreate(mat = .om, diag.xform = "sqrt")
+    expect_equal(.foceiEstOmegaDeriv(.ui, .om, .e), .ref, tolerance = 0)
+    # a STALE env (different Omega) must fall back, not return the wrong derivatives
+    .s <- new.env()
+    .s$rxInv <- rxode2::rxSymInvCholCreate(mat = .om * 1.5, diag.xform = "sqrt")
+    expect_equal(.foceiEstOmegaDeriv(.ui, .om, .s), .ref, tolerance = 0)
+    # a junk / absent rxInv falls back too
+    .j <- new.env(); .j$rxInv <- "not an rxSymInvCholEnv"
+    expect_equal(.foceiEstOmegaDeriv(.ui, .om, .j), .ref, tolerance = 0)
+    expect_equal(.foceiEstOmegaDeriv(.ui, .om, new.env()), .ref, tolerance = 0)
+  })
 })


### PR DESCRIPTION
`.foceiEstOmegaDeriv()` builds a fresh `rxSymInvChol` env on every analytic outer-gradient call (`foceiControl(fast = TRUE)`). A fresh env pays a one-time symbolic setup on its first `$d.omegaInv`; a repeat read on the same env is free, and a 3x3 diagonal Omega has no 60ms of arithmetic in it. Measured, that setup was **~40% of each analytic gradient**.

The fit env already holds a persistent `rxInv` that C++ keeps current — `foceiSetup` takes it as `_rxInv`, `updateTheta` pushes each new Omega in via `setOmegaTheta`, and `analyticOuterGrad` runs `foceiOfv0` before calling back into R. This passes the live env down and reuses it, paying the symbolic setup once per fit instead of once per gradient.

| | before | after |
|---|---|---|
| `.foceiEstOmegaDeriv` per call | 45ms | **0.2ms** |

Benefits the whole FOCEI fast family, not one estimator.

### Correctness

Reused-env and fresh-env derivatives are **bit-identical** (`max|d.omegaInv diff| = 0`, `max|tr.28 diff| = 0`).

The reuse is **guarded**: the env is used only when its own omega is the Omega being asked about, otherwise it falls back to a fresh build. In a live fit the check always passes (measured 15/15 gradient calls, guard never fired), so it is deliberate insurance rather than load-bearing — `rxSymInvCholEnv` is a `list`, not an environment, and C++ takes `as<List>(rxInv)`, so the two only stay in sync because the list references an inner environment (`create.env = TRUE`). If that invariant ever broke, this degrades to a no-op instead of to a silently wrong gradient.

### Tests

New test in `test-focei-fast-grad.R` asserting the reuse is exact and that a stale env (wrong Omega), a junk `rxInv`, and an absent `rxInv` all fall back to the fresh result.

Existing suite: `test-focei-fast-grad.R` passes 47 assertions, 0 failed, 0 skipped.