### PR TITLE
Make saem endpoint mis-match error actionable (#579)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -460,6 +460,13 @@
 
 ### Estimation
 
+- `est="saem"`'s "mis-match in nbr endpoints in model & in data" error is now
+  actionable: it reports the number of endpoints in the model versus the data,
+  lists the observation compartments found in the data, and points the user to
+  check that the `CMT`/`DVID` values match the number of model endpoints (error
+  terms).  This is the common case of a dataset with extra `DVID` levels that
+  the model has no matching endpoint for (issue #579).
+
 - `est="advi"` now rejects a mixture (`mix()`) model up front with a clear
   message (`rxode2::assertRxUiNoMix`) instead of running a wrong fit that ignored
   the mixture structure and then failed late in the output tables with a cryptic

--- a/R/saem_fit.R
+++ b/R/saem_fit.R
@@ -638,8 +638,14 @@
   cfg$opt$cmt_endpnt <- cfg$optM$cmt_endpnt <- sort(unique(s))
   cfg$nendpnt <- length(unique(s))
   if (model$nendpnt != cfg$nendpnt) {
-    msg <- sprintf("mis-match in nbr endpoints in model & in data")
-    stop(msg)
+    msg <- paste0(
+      sprintf("mis-match in number of endpoints between the model (%d) and the data (%d)",
+              model$nendpnt, cfg$nendpnt),
+      sprintf("\nthe data has observations (EVID=0) in %d compartment(s): %s",
+              cfg$nendpnt, paste(cfg$opt$cmt_endpnt, collapse=", ")),
+      "\ncheck that the 'CMT'/'DVID' values in your dataset match the number of",
+      "\nendpoints (model error terms like 'cp ~ add(add.sd)') defined in your model")
+    stop(msg, call.=FALSE)
   }
   t <- unlist(split(1L:length(s), s))
   cfg$ys <- cfg$y[t]

--- a/tests/testthat/test-issue-579.R
+++ b/tests/testthat/test-issue-579.R
@@ -1,0 +1,41 @@
+nmTest({
+  test_that("Issue nlmixr2est#579: saem endpoint mis-match error is actionable", {
+    one.compartment <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        d/dt(depot) = -ka * depot
+        d/dt(center) = ka * depot - cl / v * center
+        cp = center / v
+        cp ~ add(add.sd)
+      })
+    }
+
+    # A single-endpoint model but data with two DVID levels -> the data has more
+    # observation compartments than the model has endpoints.
+    d_fit <- nlmixr2data::theo_sd
+    d_fit$DVID <- 1
+    d_fit$DVID[d_fit$ID <= 6] <- 2
+
+    # The error should now name the model/data endpoint counts and point the user
+    # at the CMT/DVID columns instead of the old opaque message.
+    expect_error(
+      .nlmixr(one.compartment, d_fit, est = "saem", control = saemControlFast),
+      "endpoints between the model \\(1\\) and the data \\(2\\)"
+    )
+    expect_error(
+      .nlmixr(one.compartment, d_fit, est = "saem", control = saemControlFast),
+      "CMT'/'DVID"
+    )
+  })
+})


### PR DESCRIPTION
Closes #579.

## Problem

With a single-endpoint model but data carrying two `DVID` levels, `est="saem"`
fails with an opaque message:

```
Error in .configsaem(...): mis-match in nbr endpoints in model & in data
```

while `est="focei"` runs (FOCEI ignores `DVID` when the model has a single
endpoint). The reporter asked that the SAEM error guide the user toward the
`CMT`/`DVID` mismatch.

## Change

Rather than change FOCEI's intentional single-endpoint `DVID`-ignoring behavior
(or touch the SAEM C interface), this makes the SAEM error actionable. It now
reports the model-vs-data endpoint counts, lists the observation compartments
found in the data, and points at the `CMT`/`DVID` columns:

```
mis-match in number of endpoints between the model (1) and the data (2)
the data has observations (EVID=0) in 2 compartment(s): 2, 3
check that the 'CMT'/'DVID' values in your dataset match the number of
endpoints (model error terms like 'cp ~ add(add.sd)') defined in your model
```

## Testing

- New `tests/testthat/test-issue-579.R` reproduces the reprex and asserts the
  new message content (endpoint counts + `CMT`/`DVID` guidance). Passes.
- `NEWS.md` bug-fix entry added under Estimation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)