### PR TITLE
augPred() with focei and a zero-fixed eta in the prediction (#514)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -564,6 +564,12 @@
   (e.g. adding the focei objective or CWRES), so `fit |> ini(bsva ~ 0.1)`
   works; the nested call used to wipe the restore info held in a global (#741).
 
+- `augPred()` now works on a `focei` fit whose model has a zero-fixed eta that
+  appears in the prediction (e.g. `eta.v ~ 0` used in both the ODE and the
+  residual), instead of erroring with `parameter(s) are required for solving:
+  eta.v`; the simulation model drops the zero eta consistently with `saem`
+  (#514).
+
 - `laplace`/`agq` family fits label their `$objDf` row `Laplace`/`AGQ<n>`
   (matching `$ofvType`) instead of `FOCEi`; previously the default
   `interaction=TRUE` made the interaction label win over the quadrature one.

--- a/tests/testthat/test-augpred.R
+++ b/tests/testthat/test-augpred.R
@@ -187,4 +187,34 @@ nmTest({
     expect_error(augPred(fit1), NA)
 
   })
+
+  test_that("augPred with a zero eta used in the prediction (focei, #514)", {
+
+    # #514: the zeroed eta (eta.v) appears in both the ODE and the
+    # residual/prediction (cp = A1/v).  This exercised a code path that
+    # failed for focei with "parameter(s) are required for solving: eta.v".
+    pheno <- function() {
+      ini({
+        tcl <- log(0.008)
+        tv <-  log(0.6)
+        eta.v ~ 0
+        eta.cl ~ 1
+        add.err <- 0.1
+      })
+      model({
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        ke <- cl / v
+        d/dt(A1) = - ke * A1
+        cp = A1 / v
+        cp ~ add(add.err)
+      })
+    }
+
+    fit514 <- .nlmixr(pheno, nlmixr2data::pheno_sd, est = "focei",
+                      foceiControlFast)
+
+    expect_error(augPred(fit514), NA)
+
+  })
 })


### PR DESCRIPTION
Closes #514.

## Problem

`augPred()` worked on a `saem` fit but errored on the equivalent `focei` fit
when the model had a zero-fixed eta that appears in the prediction:

```r
eta.v ~ 0        # fixed to zero
...
v  <- exp(tv + eta.v)   # used in the ODE and in cp = A1/v
cp <- A1 / v
cp ~ add(add.err)
```

```
Error in rxSolveSEXP(...): The following parameter(s) are required for solving: eta.v
```

The simulation model kept `eta.v` as a solve parameter but no value was
supplied for it.

## Fix status

The underlying fix -- running nlmixr2est's pre-processing hooks (including the
zero-omega drop) when building the simulation model for `augPred()`, `vpcSim()`
and `$simInfo` -- already landed in 4.1.1 under the duplicate issue #587
(commit `bd743818`). On current `main` the exact #514 report already works.

This PR closes the loop on #514 specifically:

- Adds a regression test replicating the exact #514 report (an ODE `pheno`
  model with `eta.v ~ 0` used in **both** the ODE and the residual/prediction,
  fit with `focei`, then `augPred()`). The existing "augPred with zero etas"
  test only zeroed an eta used in a single non-prediction term, so this covers
  the distinguishing code path.
- Adds a `NEWS.md` bullet crediting #514.

## Testing

`test-augpred.R` passes (7/7, including the new test):

```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 7 ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)