### PR TITLE
Issue #515: surface a clear focei error instead of "Aborted calculation"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -473,6 +473,13 @@
 
 ### Estimation
 
+- A focei model whose predictions do not depend on any random effect (for
+  example `y ~ dpois(rate)` where `rate` is a fixed population parameter rather
+  than a model-predicted value) no longer reports the generic "Aborted
+  calculation" message.  The underlying cause is raised directly with guidance on
+  linking each endpoint's distribution parameter to an eta-varying model quantity
+  (#515).
+
 - `est="advi"` now rejects a mixture (`mix()`) model up front with a clear
   message (`rxode2::assertRxUiNoMix`) instead of running a wrong fit that ignored
   the mixture structure and then failed late in the output tables with a cryptic

--- a/R/focei.R
+++ b/R/focei.R
@@ -777,8 +777,12 @@ rxUiGet.foceiHdEta <- function(x, ...) {
     .arCorr <- .rxFoceiArEtaCorrect(.s, .grd)
   }
   rxode2::rxProgress(dim(.grd)[1])
+  # Guard the abort so a clean rxProgressStop() below prevents the generic
+  # "Aborted calculation" from masking the informative error we raise here
+  # (issue #515).
+  .progressStopped <- FALSE
   on.exit({
-    rxode2::rxProgressAbort()
+    if (!.progressStopped) rxode2::rxProgressAbort()
   })
   .any.zero <- FALSE
   .all.zero <- TRUE
@@ -796,7 +800,13 @@ rxUiGet.foceiHdEta <- function(x, ...) {
     .ret
   })
   if (.all.zero) {
-    stop("none of the predictions depend on 'ETA'", call. = FALSE)
+    rxode2::rxProgressStop()
+    .progressStopped <- TRUE
+    stop("none of the model predictions depend on a random effect ('ETA'); ",
+         "check that each endpoint's distribution parameter is linked to an ",
+         "eta-varying model quantity (for example 'y ~ dpois(rate)' needs ",
+         "'rate' to be a model-predicted value, not a fixed population parameter)",
+         call. = FALSE)
   }
   if (.any.zero) {
     warning("some of the predictions do not depend on 'ETA'", call. = FALSE)
@@ -809,6 +819,7 @@ rxUiGet.foceiHdEta <- function(x, ...) {
   .s$..HdEta <- .ret
   .s$..pred.minus.dv <- .predMinusDv
   rxode2::rxProgressStop()
+  .progressStopped <- TRUE
   .s
 }
 attr(rxUiGet.foceiHdEta, "desc") <- "Generate the d(err)/d(eta) values for FO related methods"

--- a/tests/testthat/test-issue-515.R
+++ b/tests/testthat/test-issue-515.R
@@ -1,0 +1,30 @@
+nmTest({
+  test_that("Issue nlmixr2est#515: a constant likelihood rate gives a clear error, not 'Aborted calculation'", {
+    # 'lamba' is a fixed population parameter, so the poisson likelihood does
+    # not depend on any random effect; focei used to mask the real cause with
+    # the generic "Aborted calculation" message.
+    mod <- function() {
+      ini({
+        te0 <- log(10)
+        eta.e0 ~ 0.9
+        lamba <- 0.1
+      })
+      model({
+        e0 = exp(te0 + eta.e0)
+        kout = 1.1
+        effect(0) = e0
+        kin = e0 * kout
+        d/dt(effect) = kin - kout * effect
+        effect ~ dpois(lamba)
+      })
+    }
+    d <- data.frame(ID = c(1, 1, 2, 2), TIME = c(0, 1, 0, 1),
+                    DV = c(1, 2, 1, 3), EVID = 0)
+    .e <- expect_error(
+      .nlmixr(mod, d, est = "focei", control = foceiControl(print = 0)),
+      "none of the model predictions depend on a random effect"
+    )
+    # the informative error is no longer masked by the generic abort message
+    expect_false(any(grepl("Aborted calculation", conditionMessage(.e))))
+  })
+})


### PR DESCRIPTION
Fixes #515.

### Problem

Running a focei model whose predictions do not depend on any random effect -- the reprex in #515 uses `effect ~ dpois(lamba)` where `lamba` is a fixed population parameter -- produced the cryptic:

```
Error: Aborted calculation
```

Two things were wrong:

1. **The real error was masked.** In `rxUiGet.foceiHdEta()` the `.all.zero` branch raises `stop("none of the predictions depend on 'ETA'")`, but the surrounding `on.exit({ rxode2::rxProgressAbort() })` then raised `"Aborted calculation"`, which replaced the informative message.
2. **The message itself was cryptic.** `llikPois(DV, lamba)` genuinely does not depend on any ETA because `lamba` is a fixed theta -- but "none of the predictions depend on 'ETA'" doesn't tell the user *why* or *how to fix it*.

### Fix

In `rxUiGet.foceiHdEta()`:

- Stop the progress bar cleanly (`rxProgressStop()`) and guard the `on.exit` abort with a `.progressStopped` flag before raising, so the generic "Aborted calculation" no longer masks (or precedes) the real cause.
- Reword the error to name the likely cause and how to fix it:

  > none of the model predictions depend on a random effect ('ETA'); check that each endpoint's distribution parameter is linked to an eta-varying model quantity (for example 'y ~ dpois(rate)' needs 'rate' to be a model-predicted value, not a fixed population parameter)

### Testing

- New `tests/testthat/test-issue-515.R` asserts the informative message is raised and that "Aborted calculation" is not in it. Fails fast during symbolic prep (no ODE compile), so it stays in the essential push/PR subset.
- Verified a normal `linCmt()` focei fit is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)