### PR TITLE
augPred: keep the fit's original (factor/character) subject ids (#450)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -581,6 +581,10 @@
   (`exp`/`expit`/`probitInv`) in the `Back-transformed` column instead of the
   raw log/logit-scale estimate.
 
+- `augPred()` now keeps the fit's original subject ids: the returned `id`
+  factor carries the actual (character/factor) ids from the fit instead of the
+  internal integer re-numbering (#450).
+
 - `fit$time` again attributes model build/compile to `setup`/`configure` (and
   the nlm family times setup/optimize) instead of `other`.
 

--- a/R/augPred.R
+++ b/R/augPred.R
@@ -168,6 +168,12 @@ nlmixr2AugPredSolve <- function(fit, covsInterpolation = c("locf", "nocb", "line
   }
 
   .stk$id <- .sim$id
+  # rxSolve returns integer-coded ids; restore the fit's original ID labels
+  # (e.g. character/factor subject ids) so augPred identifies the actual subject
+  .idLvl <- fit$idLvl
+  if (!is.null(.idLvl) && is.factor(.stk$id)) {
+    levels(.stk$id) <- .idLvl[as.integer(levels(.stk$id))]
+  }
   .stk$time <- .sim$time
   .stk$cmt <- as.integer(.sim$CMT)
   .ipredModel <- .augPredIpredModel(fit)

--- a/tests/testthat/test-augpred.R
+++ b/tests/testthat/test-augpred.R
@@ -175,6 +175,40 @@ nmTest({
     expect_error(augPred(fit), NA)
   })
 
+  test_that("augPred keeps the fit's original (factor/character) IDs (issue #450)", {
+
+    one.cmt <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- log(c(0, 2.7, 100))
+        tv <- 3.45
+        add.sd <- 0.7
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+
+    dat <- nlmixr2data::theo_sd
+    dat$ID <- paste0("SUBJ-", dat$ID)
+
+    fit <- .nlmixr(one.cmt, dat, est="focei", control=foceiControlFast)
+
+    ap <- augPred(fit)
+
+    # the augPred id column must carry the actual subject ids from the fit,
+    # not the internal integer re-numbering
+    expect_true(is.factor(ap$id))
+    expect_equal(levels(ap$id), fit$idLvl)
+    expect_true(all(grepl("^SUBJ-", levels(ap$id))))
+  })
+
   test_that("augPred with zero etas", {
 
     # Use centralized model from helper-models.R


### PR DESCRIPTION
Fixes #450.

## Problem

`augPred()` did not retain the factor that maps the internal integer id back to the actual subject id from the fit. When a fit was built from data whose `ID` was character/factor (e.g. `"SUBJ-1"`, `"SUBJ-2"`, ...), the augmented-prediction output `id` column came back as a factor with integer levels (`1..N`) instead of the real ids, so callers could not tell which subject a curve belonged to.

## Fix

`rxode2::rxSolve()` returns the internal integer-coded ids. In `nlmixr2AugPredSolve()`, after assigning `.stk$id <- .sim$id`, relabel that factor's levels from `fit$idLvl` (which holds the fit's original id labels, in integer-id order). Integer-id fits are unaffected (`fit$idLvl` is `"1".."N"`, so the relabel is a no-op).

```r
.stk$id <- .sim$id
.idLvl <- fit$idLvl
if (!is.null(.idLvl) && is.factor(.stk$id)) {
  levels(.stk$id) <- .idLvl[as.integer(levels(.stk$id))]
}
```

## Tests

Added a regression test in `test-augpred.R` that fits with character ids (`SUBJ-<n>`) and asserts `augPred(fit)$id` is a factor whose `levels` equal `fit$idLvl`. Full `test-augpred.R` passes (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)