### PR TITLE
Actionable error for single-subject (N of 1) fits (#493)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -473,6 +473,14 @@
 
 ### Estimation
 
+- A single-subject / fixed-effect ("N of 1") model -- one whose only random
+  effects are fixed to zero, which are dropped before estimation -- now gives an
+  actionable error when a method that requires random effects (`fo`, `foi`,
+  `saem`, `fsaem`, `nlme`) is used, pointing to methods that can fit it (`focei`,
+  `foce`, or a population method such as `nlminb`, `bobyqa` or `nls`).  The error
+  also keeps the user's original model name instead of reporting the internal
+  `.mod` (issue #493).
+
 - `est="advi"` now rejects a mixture (`mix()`) model up front with a clear
   message (`rxode2::assertRxUiNoMix`) instead of running a wrong fit that ignored
   the mixture structure and then failed late in the output tables with a cryptic

--- a/R/fo.R
+++ b/R/fo.R
@@ -108,7 +108,7 @@ nlmixr2Est.fo <- function(env, ...) {
   rxode2::assertRxUiNoAutoregressive(.ui, " for the estimation routine 'fo'", .var.name=.ui$modelName)
   rxode2::assertRxUiTransformNormal(.ui, " for the estimation routine 'fo'", .var.name=.ui$modelName)
   rxode2::assertRxUiRandomOnIdOnly(.ui, " for the estimation routine 'fo'", .var.name=.ui$modelName)
-  rxode2::assertRxUiMixedOnly(.ui, " for the estimation routine 'fo'", .var.name=.ui$modelName)
+  rxode2::assertRxUiMixedOnly(.ui, .noRandomEffectMsg("fo"), .var.name=.ui$modelName)
   .foceiFamilyControl(env, ..., type="foControl")
   .control <- .ui$control
   .posthoc <- .control$posthoc

--- a/R/foi.R
+++ b/R/foi.R
@@ -109,7 +109,7 @@ nlmixr2Est.foi <- function(env, ...) {
   rxode2::assertRxUiNoAutoregressive(.ui, " for the estimation routine 'foi'", .var.name=.ui$modelName)
   rxode2::assertRxUiTransformNormal(.ui, " for the estimation routine 'foi'", .var.name=.ui$modelName)
   rxode2::assertRxUiRandomOnIdOnly(.ui, " for the estimation routine 'foi'", .var.name=.ui$modelName)
-  rxode2::assertRxUiMixedOnly(.ui, " for the estimation routine 'foi'", .var.name=.ui$modelName)
+  rxode2::assertRxUiMixedOnly(.ui, .noRandomEffectMsg("foi"), .var.name=.ui$modelName)
   .foceiFamilyControl(env, ..., type="foiControl")
   .control <- .ui$control
   .posthoc <- .control$posthoc

--- a/R/fsaem.R
+++ b/R/fsaem.R
@@ -66,7 +66,7 @@ nlmixr2Est.fsaem <- function(env, ...) {
   }
   rxode2::assertRxUiIovNoCor(.ui, " for the estimation routine 'fsaem'",
                              .var.name=.ui$modelName)
-  rxode2::assertRxUiMixedOnly(.ui, " for the estimation routine 'fsaem'", .var.name=.ui$modelName)
+  rxode2::assertRxUiMixedOnly(.ui, .noRandomEffectMsg("fsaem"), .var.name=.ui$modelName)
   rxode2::warnRxBounded(.ui, " which are ignored in 'fsaem'", .var.name=.ui$modelName)
   if (length(.ui$mixProbs) > 0) {
     message("mixture SAEM computation scales with the number of sub-populations")

--- a/R/nlme.R
+++ b/R/nlme.R
@@ -510,7 +510,7 @@ nlmixr2Est.nlme <- function(env, ...) {
          call. = FALSE)
   }
   rxode2::assertRxUiNoAutoregressive(.ui, " for the estimation routine 'nlme', try 'focei'", .var.name=.ui$modelName)
-  rxode2::assertRxUiMixedOnly(.ui, " for the estimation routine 'nlme', try 'focei'", .var.name=.ui$modelName)
+  rxode2::assertRxUiMixedOnly(.ui, .noRandomEffectMsg("nlme"), .var.name=.ui$modelName)
   rxode2::assertRxUiNormal(.ui, " for the estimation routine 'nlme'", .var.name=.ui$modelName)
   rxode2::assertRxUiSingleEndpoint(.ui, " for the estimation routine 'nlme'", .var.name=.ui$modelName)
   rxode2::assertRxUiRandomOnIdOnly(.ui, " for the estimation routine 'nlme'", .var.name=.ui$modelName)

--- a/R/preProcessZeroOmega.R
+++ b/R/preProcessZeroOmega.R
@@ -107,7 +107,11 @@
   .ini <- as.expression(lotri::as.lotri(.iniDf))
   .ini[[1]] <- quote(`ini`)
   .mod <- .getUiFunFromIniAndModel(ui, .ini, .model)
-  .mod()
+  .newUi <- rxode2::rxUiDecompress(.mod())
+  ## keep the user's original model name (rebuilding via .mod() would otherwise
+  ## report it as '.mod')
+  assign("modelName", ui$modelName, envir=.newUi)
+  .newUi
 }
 #' Remove an eta from the model
 #'

--- a/R/saem.R
+++ b/R/saem.R
@@ -1204,7 +1204,7 @@ nlmixr2Est.saem <- function(env, ...) {
   }
   rxode2::assertRxUiIovNoCor(.ui, " for the estimation routine 'saem'",
                              .var.name=.ui$modelName)
-  rxode2::assertRxUiMixedOnly(.ui, " for the estimation routine 'saem'", .var.name=.ui$modelName)
+  rxode2::assertRxUiMixedOnly(.ui, .noRandomEffectMsg("saem"), .var.name=.ui$modelName)
   rxode2::warnRxBounded(.ui, " which are ignored in 'saem'", .var.name=.ui$modelName)
   if (length(.ui$mixProbs) > 0) {
     message("mixture SAEM computation scales with the number of sub-populations")

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,6 +21,22 @@
 
 # Utilities for nlmixr2 ####################################################
 
+#' Message suffix for a method that requires random effects
+#'
+#' Used as the `extra` argument to `rxode2::assertRxUiMixedOnly()` so a
+#' single-subject / fixed-effect ("N of 1") model gets an actionable error
+#' pointing to the methods that can fit models with no random effects.
+#'
+#' @param est estimation method name
+#' @return character message suffix
+#' @author Matthew L. Fidler
+#' @noRd
+.noRandomEffectMsg <- function(est) {
+  paste0(" for the estimation routine '", est,
+         "'; a model with no random effects (for example single-subject or 'N of 1' data) can be ",
+         "fit with 'focei', 'foce', or a population method such as 'nlminb', 'bobyqa' or 'nls'")
+}
+
 #' Cox Box, Yeo Johnson and inverse transformation
 #'
 #' @param x data to transform

--- a/tests/testthat/test-single-subject.R
+++ b/tests/testthat/test-single-subject.R
@@ -1,0 +1,49 @@
+nmTest({
+
+  # A model whose only random effect is fixed to zero collapses to a
+  # fixed-effect / single-subject ("N of 1") model once the zero eta is dropped
+  # (see issue #493).
+  one.cmt <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ fix(0)
+      add.err <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      linCmt() ~ add(add.err)
+    })
+  }
+
+  test_that("methods that require random effects give an actionable error", {
+    for (.est in c("fo", "foi", "saem", "fsaem")) {
+      .err <- tryCatch(.nlmixr(one.cmt, nlmixr2data::theo_sd, .est, list(print = 0)),
+                       error = function(e) conditionMessage(e))
+      # keeps the original model name (not the internal '.mod') ...
+      expect_true(grepl("'one.cmt'", .err, fixed = TRUE))
+      # ... and points to methods that can fit a no-random-effect model
+      expect_true(grepl("focei", .err, fixed = TRUE))
+      expect_true(grepl("nlminb", .err, fixed = TRUE))
+    }
+  })
+
+  test_that("focei / foce fit a single-subject model", {
+    for (.est in c("focei", "foce")) {
+      .fit <- .nlmixr(one.cmt, nlmixr2data::theo_sd, .est,
+                      list(print = 0, calcTables = FALSE, maxOuterIterations = 0))
+      expect_s3_class(.fit, "nlmixr2FitCore")
+    }
+  })
+
+  test_that("nlm-family fits a single-subject model", {
+    for (.est in c("nlminb", "bobyqa")) {
+      .fit <- .nlmixr(one.cmt, nlmixr2data::theo_sd, .est, list(print = 0))
+      expect_s3_class(.fit, "nlmixr2FitCore")
+    }
+  })
+
+})


### PR DESCRIPTION
Fixes #493.

## Problem

Fitting single-subject / "N of 1" data means fitting a model with no random
effects. Users express this by fixing the only random effect to zero
(`eta.ka ~ fix(0)`), and the zero-omega preprocessing then drops that eta,
collapsing the model to a fixed-effect model.

For methods that fundamentally require random effects (`fo`, `foi`, `saem`,
`fsaem`, `nlme`) this produced a generic, unhelpful error that (a) gave no
guidance on how to actually fit N-of-1 data and (b) reported the internal
`.mod` name instead of the user's model name:

```
'.mod' needs to be a mixed effect model for the estimation routine 'fo'
```

## Fix

- Give an **actionable** error that points to the methods which *can* fit a
  no-random-effect model -- `focei`, `foce`, or a population method such as
  `nlminb`, `bobyqa` or `nls` -- via a shared `.noRandomEffectMsg()` suffix used
  by `fo`, `foi`, `saem`, `fsaem` and `nlme`.
- Preserve the user's original model name in `.downgradeEtas()` so the message
  (and `rmEta()` output) reports `'one.cmt'` rather than `'.mod'`.

`focei`, `foce` and the nlm-family already fit single-subject data correctly, so
no estimator behavior changes -- this only improves the diagnostics for the
methods that cannot.

New error:

```
'one.cmt' needs to be a mixed effect model for the estimation routine 'fo';
a model with no random effects (for example single-subject or 'N of 1' data)
can be fit with 'focei', 'foce', or a population method such as 'nlminb',
'bobyqa' or 'nls'
```

## Tests

`tests/testthat/test-single-subject.R`: asserts the actionable message (and
preserved model name) for `fo`/`foi`/`saem`/`fsaem`, and that `focei`/`foce`
and the nlm-family (`nlminb`/`bobyqa`) fit the collapsed model. Existing
`test-np.R` (which asserts the `saem` message substring) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)