### PR TITLE
Consistent output columns regardless of cwres= (#497)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -559,6 +559,13 @@
 
 ### Output, tables, and printing
 
+- Model-defined variables (e.g. `ka`, `cl`, `v`, `tad`, `dosenum`, and any
+  user-added line such as `WT.OUT <- WT`) are now included in the output table
+  whether or not `cwres` is requested.  Previously `tableControl(cwres=FALSE)`
+  dropped these columns while `cwres=TRUE` (the default) kept them, so the same
+  model produced different output columns depending on the residual request
+  (#497).
+
 - A zero-fixed eta (e.g. `bsva ~ 0`) is again restored into the fitted model's
   `ini()`/`model()` blocks when the estimation makes a nested `nlmixr2()` call
   (e.g. adding the focei objective or CWRES), so `fit |> ini(bsva ~ 0.1)`

--- a/R/resid.R
+++ b/R/resid.R
@@ -235,7 +235,11 @@ nmObjGet.foceiThetaEtaParameters <- function(x, ...) {
     predOnly <- TRUE
   }
   if (predOnly) {
-    .ipredModel <- fit$ipredModel
+    # Use predOnlyModel (which outputs the user-defined lhs like ka/cl/v and
+    # tad/dosenum) instead of ipredModel (only rx_pred_/rx_r_ + sensitivities).
+    # This keeps the output columns consistent with the cwres=TRUE path, which
+    # solves predOnlyModel for these display columns; see nlmixr2/nlmixr2est#497.
+    .ipredModel <- fit$predOnlyModel
   }
   .ret <- list(ipred = .residAdjustIpredNames(
     .foceiSolvePars(fit, .ipredModel, thetaEtaParameters$ipred,

--- a/tests/testthat/test-table-cmt.R
+++ b/tests/testthat/test-table-cmt.R
@@ -102,6 +102,14 @@ nmTest({
     expect_true(all(!is.na(tab2$CMT)))
     expect_s3_class(tab2$CMT, "factor")
 
+    # nlmixr2/nlmixr2est#497: model-defined variables (V, Cl, K, cp, ...) must
+    # appear in the cwres=FALSE output just as they do with cwres=TRUE.  Only the
+    # cwres-specific residual columns should differ between the two tables.
+    expect_true(all(c("V", "Cl", "K", "cp") %in% names(tab1)))
+    expect_setequal(setdiff(names(tab2), names(tab1)),
+                    c("WRES", "CPRED", "CRES", "CWRES"))
+    expect_equal(setdiff(names(tab1), names(tab2)), character(0))
+
     tab3 <- .addTable(fit.s, table=tableControl(cwres=FALSE, npde=TRUE))
     expect_true(all(c("CMT", "CRPZERO","WT", "PCA") %in% names(tab3)))
     expect_true(all(!is.na(tab3$CMT)))


### PR DESCRIPTION
Fixes #497.

## Problem

For a model with etas, the set of output columns depended on whether
`cwres` was requested in `tableControl()`:

```r
fit1 <- nlmixr2(one.compartment, theo_sd, est="focei",
                table=tableControl(cwres=FALSE, npde=TRUE))
fit2 <- nlmixr2(one.compartment, theo_sd, est="focei",
                table=tableControl(cwres=TRUE,  npde=TRUE))
```

`fit2` (and the default fit, which is effectively `cwres=TRUE`) included the
model-defined variables `ka`, `cl`, `v`, `tad`, `dosenum` and any user line
such as `WT.OUT <- WT`, while `fit1` (`cwres=FALSE`) dropped all of them --
keeping only the residual columns.

## Cause

`.foceiPredIpredList()` (`R/resid.R`) solves `fit$ipredModel` in the
`cwres=FALSE` (`res.cpp`) path. That model only outputs `rx_pred_`/`rx_r_`
plus the FOCEi sensitivity states -- it does **not** compute the user model
variables, so `getDfSubsetVars(ipredL, relevantLHS)` in `res.cpp` finds none
of them. The `cwres=TRUE` path additionally solves `fit$predOnlyModel` (which
does output those lhs), so they appear only there.

## Fix

Solve `fit$predOnlyModel` in the `predOnly` (`cwres=FALSE`) branch. It
computes the same `rx_pred_`/`rx_r_` as `ipredModel` but also emits the
user lhs, and drops the unused sensitivity states (so it is also slightly
cheaper). Output columns are now identical between `cwres=FALSE` and
`cwres=TRUE` except for the cwres-specific residuals (`WRES`, `CPRED`,
`CRES`, `CWRES`).

## Verification

- Reproduced the issue, confirmed the fix: `cwres=FALSE` now includes
  `ka`/`cl`/`v`/`tad`/`dosenum`/`WT.OUT`; `setdiff(names(fit2), names(fit1))`
  is exactly `{WRES, CPRED, CRES, CWRES}`.
- `PRED`/`IPRED`/`IWRES` agree with the `cwres=TRUE` fit to solver tolerance
  (~1e-6, from the non-augmented vs augmented ODE solve); `NPDE` and the lhs
  columns match exactly.
- No-eta models (the separate `.calcIres` path) were already correct and are
  unaffected.
- Added a regression assertion in `test-table-cmt.R`.
- Passing: `test-addCwres`, `test-cwres`, `test-focei-1`, `test-table-cmt`,
  `test-focei-cens`, `test-focei-char`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)