### PR TITLE
FOCEi: estimate a theta initialized at exactly 0 (fix scaleC 1/0)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -473,6 +473,13 @@
 
 ### Estimation
 
+- FOCEi now estimates a population parameter that is initialized at exactly `0`
+  (e.g. a covariate effect or an additive term) instead of leaving it frozen at
+  its starting value.  The default scaling constant is `1/|initPar|`, which is
+  `Inf` when `initPar` is `0`; it clamped to `scaleCmax` and made the parameter
+  effectively unoptimizable.  `getScaleC()` now falls back to unit scaling when
+  the initial estimate is `0`.
+
 - `est="advi"` now rejects a mixture (`mix()`) model up front with a clear
   message (`rxode2::assertRxUiNoMix`) instead of running a wrong fit that ignored
   the mixture structure and then failed late in the output tables with a cryptic

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -798,22 +798,30 @@ void updateZm(focei_ind *indF){
 
 static inline double getScaleC(int i){
   if (ISNA(op_focei.scaleC[i])) {
+    // The default scaling constant is 1/|initPar|.  When a parameter is
+    // initialized at exactly 0 (e.g. a covariate effect or an additive term)
+    // this is 1/0 = Inf, which clamps to scaleCmax and makes the parameter
+    // effectively unoptimizable: a tiny step in scaled space becomes a huge
+    // step in the parameter, so the line search freezes it at its starting
+    // value.  Fall back to unit scaling when initPar is 0 so a zero-initialized
+    // parameter is still estimated.
+    double aInit = fabs(op_focei.initPar[i]);
     switch (op_focei.xPar[i]){
     case 1: // log
       op_focei.scaleC[i]=1.0;
       break;
     case 2: // diag^2
-      op_focei.scaleC[i]=1.0/fabs(op_focei.initPar[i]);
+      op_focei.scaleC[i]= (aInit == 0.0) ? 1.0 : 1.0/aInit;
       break;
     case 3: // exp(diag)
       op_focei.scaleC[i] = 1.0/2.0;
       break;
     case 4: // Identity diagonal chol(Omega ^-1)
     case 5: // off diagonal chol(Omega^-1)
-      op_focei.scaleC[i] = 1.0/(2.0*fabs(op_focei.initPar[i]));
+      op_focei.scaleC[i] = (aInit == 0.0) ? 1.0 : 1.0/(2.0*aInit);
       break;
     default:
-      op_focei.scaleC[i]= 1.0/(fabs(op_focei.initPar[i]));
+      op_focei.scaleC[i]= (aInit == 0.0) ? 1.0 : 1.0/aInit;
       break;
     }
   }

--- a/tests/testthat/test-focei-zero-init-scale.R
+++ b/tests/testthat/test-focei-zero-init-scale.R
@@ -1,0 +1,73 @@
+# Regression: a population parameter (theta) initialized at exactly 0 must still
+# be estimated by FOCEi.
+#
+# The default nlmixr2 scaling constant is 1/|initPar|.  For a parameter
+# initialized at 0 this is 1/0 = Inf, which clamps to scaleCmax and makes the
+# parameter effectively unoptimizable -- a tiny step in the scaled space becomes
+# an enormous step in the parameter, the line search rejects it, and the value
+# stays frozen at ~0.  getScaleC() now falls back to unit scaling when initPar
+# is 0 so the parameter is estimated normally.
+
+nmTest({
+  test_that("a theta initialized at exactly 0 is estimated, not frozen", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+
+    # simulate a 1-cmt oral model with a strong linear body-weight effect on CL
+    .sim <- function() {
+      ini({
+        tka <- 0.45; tcl <- -1.0; tv <- 3.45; b.cl <- 0.03
+        eta.ka ~ 0.3; eta.cl ~ 0.02; eta.v ~ 0.05; add.sd <- 0.15
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + b.cl * WT + eta.cl)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    set.seed(11)
+    .obsT <- seq(0.5, 60, length.out = 12)
+    .ev <- do.call(rbind, lapply(seq_len(60), function(id) {
+      wt <- round(runif(1, 50, 110))
+      e <- as.data.frame(rxode2::et(amt = 320) |> rxode2::et(.obsT))
+      e$ID <- id
+      e$WT <- wt
+      e
+    }))
+    .s <- rxode2::rxSolve(.sim(), .ev, returnType = "data.frame")
+    .dose <- do.call(rbind, lapply(seq_len(60), function(id) {
+      data.frame(ID = id, time = 0, DV = NA, amt = 320, evid = 1,
+                 WT = .ev$WT[.ev$ID == id][1])
+    }))
+    .obs <- data.frame(ID = .s$id, time = .s$time, DV = .s$sim, amt = NA,
+                       evid = 0, WT = .s$WT)
+    .d <- rbind(.dose, .obs)
+    .d <- .d[order(.d$ID, .d$time, -.d$evid), ]
+
+    # candidate model: covariate coefficient `b` initialized at exactly 0
+    .cand <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1.0; tv <- 3.45; b <- 0
+        eta.ka ~ 0.3; eta.cl ~ 0.1; eta.v ~ 0.1; add.sd <- 0.3
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl + b * WT)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+
+    fit <- suppressWarnings(
+      nlmixr2(.cand, .d, "focei", foceiControl(print = 0L, covMethod = ""))
+    )
+
+    b <- unname(fit$parFixedDf["b", "Estimate"])
+    # before the fix `b` stayed pinned at ~ -2e-4 (the finite-difference step);
+    # it should now move well away from 0 toward the true value (0.03)
+    expect_true(abs(b) > 0.01)
+    # and land in a sensible neighborhood of the simulated effect (0.03)
+    expect_true(b > 0.015 && b < 0.05)
+  })
+})


### PR DESCRIPTION
## Summary

FOCEi leaves a population parameter that is initialized at **exactly `0`** frozen at its starting value — it is never estimated. This affects any `theta` a user (or an automated routine) starts at 0, such as a covariate effect (`cl <- exp(tcl + eta.cl + b*WT)` with `b <- 0`) or an additive term.

## Root cause

The default scaling constant in `getScaleC()` (`src/inner.cpp`) is `1/|initPar|`:

```c
default:
  op_focei.scaleC[i]= 1.0/(fabs(op_focei.initPar[i]));   // 1/0 = Inf when initPar == 0
```

When `initPar == 0` this is `Inf`, which clamps to `scaleCmax` (default `1e5`). With the default `scaleType="nlmixr2"`, `unscalePar()` then maps a step in the scaled space to `(x - scaleTo)*1e5`, so any reasonable optimizer step becomes an enormous step in the actual parameter — `exp()` blows up, the line search rejects every step, and the parameter stays pinned at ~0 (it moves only by the finite-difference gradient step, ≈ `-2e-4`).

## Fix

`getScaleC()` falls back to **unit scaling** when the initial estimate is `0`. Parameters with a non-zero initial estimate are unaffected — the `1/|initPar|` path is bit-identical — so only previously-broken zero-initialized parameters change behavior.

## Reproduction

Minimal reprex: 1-cmt oral model, strong linear body-weight effect on CL (true `b = 0.03`), coefficient initialized at `0`:

```
                 before fix          after fix
b.init = 0    objf=-572.5 b=-0.00019   objf=-1343.6 b=0.03115   (was frozen; now estimated)
b.init = 0.01 objf=-1343.6 b=0.03109   objf=-1343.6 b=0.03109   (unchanged)
```

A standard `theo_sd` FOCEi fit is unchanged (objf `116.810`, `tcl` `1.012`).

## Test

Adds `tests/testthat/test-focei-zero-init-scale.R`: simulates a clear covariate effect, fits with the coefficient initialized at `0`, and asserts it is estimated away from 0 and lands near the simulated value (rather than staying frozen).

## Context

Found while debugging nlmixr2/nlmixr2extra#103 (`covarSearchAuto()`): the covariate-search harness adds candidate effects initialized at 0, so under FOCEi the effects came back ~0 and nothing was selected. The nlmixr2extra-side crash/logic fixes are in nlmixr2/nlmixr2extra#104; this PR fixes the underlying estimator behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
