### PR TITLE
Regression test for sine over a compound argument (#513)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -473,6 +473,13 @@
 
 ### Estimation
 
+- FOCEi/FOCE models with a trigonometric term whose argument is a compound
+  expression divided by something (for example a sinusoidal enterohepatic-cycle
+  release `sin(2 * 3.14 * (time - mtime1) / period)`) no longer fail to build
+  with "too few arguments to function 'sin'".  The fix is in `rxode2`'s
+  `rxFromSE()` (which was dropping the whole argument, emitting `sin()`); a
+  regression test is added here (nlmixr2/nlmixr2est#513).
+
 - `est="advi"` now rejects a mixture (`mix()`) model up front with a clear
   message (`rxode2::assertRxUiNoMix`) instead of running a wrong fit that ignored
   the mixture structure and then failed late in the output tables with a cryptic

--- a/tests/testthat/test-focei-inner.R
+++ b/tests/testthat/test-focei-inner.R
@@ -114,5 +114,46 @@ nmTest({
     expect_equal(c("tka", "tcl", "tv", "add.sd"), row.names(fit$parFixedDf))
   })
 
+  test_that("focei model with sine over a compound argument builds (#513)", {
+    # A trig function whose argument is a compound expression divided by
+    # something (here 2*3.14*(time-mtime1)/period) used to lose its argument in
+    # the symengine round-trip, emitting sin()/cos() with no argument and
+    # failing to compile ("too few arguments to function 'sin'").  Requires the
+    # rxFromSE fix in rxode2; skip on an rxode2 that still drops the argument.
+    skip_if(rxode2::rxFromSE("sin((a-b)/c)") == "sin()",
+            "installed rxode2 predates the rxFromSE compound-argument fix")
+
+    ehc <- function() {
+      ini({
+        tKa <- log(10)
+        tCl <- log(93794.73)
+        tV <- log(973551.9)
+        tKemp <- log(30)
+        tmtime1 <- log(1)
+        tperiod <- 6
+        add.err <- c(0, 0.01)
+        prop.err <- c(0, 0.2)
+        eta.Ka ~ 0.1
+        eta.mtime1 ~ 0.1
+      })
+      model({
+        Ka <- exp(tKa + eta.Ka)
+        Cl <- exp(tCl)
+        V <- exp(tV)
+        Kemp <- exp(tKemp)
+        mtime1 <- exp(tmtime1 + eta.mtime1)
+        period <- tperiod
+        SINE <- sin(2 * 3.14 * (time - mtime1) / period)
+        EHC <- ifelse(SINE > 0, SINE, 0)
+        d/dt(depot) = -Ka * depot + Kemp * GB * EHC
+        d/dt(center) = Ka * depot - Cl / V * center
+        d/dt(GB) = -Kemp * GB * EHC
+        Cp <- center / V
+        Cp ~ add(add.err) + prop(prop.err)
+      })
+    }
+    f <- suppressMessages(ehc())
+    expect_error(f$foceiModel, NA)
+  })
 
 })


### PR DESCRIPTION
## Summary

Fixes the build failure reported in #513: a FOCEi model of an enterohepatic cycle with a sinusoidal release,

```r
SINE = sin(2 * 3.14 * (time - mtime1) / period)
```

failed to compile with:

```
error: too few arguments to function 'sin'
  879 |   rx_expr_0 =sin();
```

## Root cause (in rxode2)

The empty `sin()`/`cos()` are produced by `rxode2::rxFromSE()`, not by nlmixr2est. Its `.rxM1rmF()` helper (used to fold `sin(pi*x)` -> `sinpi(x)`) only handled an **atomic** numerator in its `/` branch; a compound numerator such as `2*3.14*(time-mtime1)` fell through with no return, so the reconstructed argument became `NULL` and the emitted C was `sin()`.

The actual code fix lives in **rxode2**: nlmixr2/rxode2#1136.

## This PR

Adds a regression test in `tests/testthat/test-focei-inner.R` that builds such a `foceiModel` and asserts it compiles (`expect_error(f$foceiModel, NA)`). The test is gated with `skip_if(rxode2::rxFromSE("sin((a-b)/c)") == "sin()", ...)` so it **skips** on an rxode2 that predates the fix (keeping CI green until rxode2 releases) and **runs** once the fixed rxode2 is installed.

Verified locally:
- with the rxode2 fix applied: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 5 ]`
- with the current (unpatched) rxode2: `[ FAIL 0 | WARN 0 | SKIP 1 | PASS 4 ]`

Depends on nlmixr2/rxode2#1136.
Refs #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)