### PR TITLE
FO/FOI: carry control on the intermediate fit object (#517)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -473,6 +473,13 @@
 
 ### Estimation
 
+- The `est="fo"`/`est="foi"` linearization pass returned an intermediate fit
+  object with an empty `control`, so `.updateParFixed()` silently fell back to
+  default table settings (`ci`/`sigdigTable`) instead of the fit's control
+  (#517).  The FO/FOI fit now carries its control, and an intermediate fit
+  without a method-specific `nmObjGetControl` surfaces its stored control rather
+  than returning `NULL`.
+
 - `est="advi"` now rejects a mixture (`mix()`) model up front with a clear
   message (`rxode2::assertRxUiNoMix`) instead of running a wrong fit that ignored
   the mixture structure and then failed late in the output tables with a cryptic

--- a/R/focei.R
+++ b/R/focei.R
@@ -2725,6 +2725,15 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       .ret$shrink <- .Call(`_nlmixr2est_calcShrinkOnly`, .ret$omega, .pars$eta.lst, length(.etas$ID))
     }
     assign("est", est, envir=.ret)
+    # The FO/FOI estimation path (fo=TRUE, maxOuterIterations>0) returns the fit
+    # env with an empty `control` binding, so downstream consumers such as
+    # .updateParFixed() would see a NULL control and fall back to defaults
+    # (issue #517).  Populate the raw binding from the fit's control so the
+    # object carries its control (nmObjGetControl.default then surfaces it).
+    if (is.environment(.ret) && !is.null(.control) &&
+          is.null(get0("control", envir=.ret, inherits=FALSE))) {
+      assign("control", .control, envir=.ret)
+    }
     .foceiInstallAnalyticCov(.ret)
     .foceiInstallFdFullCov(.ret)
     .updateParFixed(.ret)

--- a/R/nmObjHandle.R
+++ b/R/nmObjHandle.R
@@ -155,5 +155,13 @@ nmObjGetControl.saem <- function(x, ...) {
 nmObjGetControl.default <- function(x, ...) {
   ## stop("cannot figure out get the control, add method for `nmObjHandleControlObject.", class(x)[1], "`",
   ##      call.=FALSE)
+  # Intermediate fits without a method-specific getter (e.g. the est="none"
+  # FO/FOI linearization pass, issue #517) still carry their control in the
+  # raw `control` binding -- surface it so $control is not silently NULL.
+  .env <- x[[1]]
+  if (is.environment(.env) && exists("control", envir=.env, inherits=FALSE)) {
+    .control <- get("control", envir=.env)
+    if (is.list(.control)) return(.control)
+  }
   NULL
 }

--- a/tests/testthat/test-fo-control.R
+++ b/tests/testthat/test-fo-control.R
@@ -1,0 +1,55 @@
+nmTest({
+
+  # Regression tests for issue #517: the FO/FOI estimation path returned the
+  # intermediate (est="none") linearization fit env with an empty control, so
+  # .updateParFixed() saw a NULL $control and silently fell back to defaults.
+
+  test_that("nmObjGetControl.default surfaces a raw control binding (issue #517)", {
+    # An intermediate fit whose est has no method-specific nmObjGetControl
+    # should still return its stored control instead of NULL.
+    .e <- new.env(parent = emptyenv())
+    assign("est", "none", envir = .e)
+    assign("control", foceiControl(), envir = .e)
+    .obj <- list(.e)
+    class(.obj) <- "none"
+    expect_true(inherits(nlmixr2est:::nmObjGetControl(.obj), "foceiControl"))
+
+    # With no control binding at all it must still return NULL.
+    .e2 <- new.env(parent = emptyenv())
+    assign("est", "none", envir = .e2)
+    .obj2 <- list(.e2)
+    class(.obj2) <- "none"
+    expect_null(nlmixr2est:::nmObjGetControl(.obj2))
+  })
+
+  test_that("FO/FOI fits never see a NULL control in .updateParFixed (issue #517)", {
+    .seen <- new.env(parent = emptyenv())
+    .seen$nullControl <- logical(0)
+    trace(
+      nlmixr2est:::.updateParFixed,
+      tracer = bquote({
+        .env517 <- .(.seen)
+        .env517$nullControl <- c(.env517$nullControl, is.null(.ret$control))
+      }),
+      print = FALSE
+    )
+    on.exit(suppressMessages(untrace(nlmixr2est:::.updateParFixed)), add = TRUE)
+
+    fitFo <- .nlmixr(one.compartment, theo_sd, est = "fo",
+                     control = foControl(print = 0))
+    fitFoi <- .nlmixr(one.compartment, theo_sd, est = "foi",
+                      control = foiControl(print = 0))
+
+    # .updateParFixed ran on both the intermediate est="none" objects and the
+    # final fits; none should have carried a NULL control.
+    expect_gt(length(.seen$nullControl), 0L)
+    expect_false(any(.seen$nullControl))
+
+    # The final fits resolve their method control and produce a parFixed table.
+    expect_true(inherits(fitFo$control, "foControl"))
+    expect_true(inherits(fitFoi$control, "foiControl"))
+    expect_s3_class(fitFo$parFixed, "data.frame")
+    expect_s3_class(fitFoi$parFixed, "data.frame")
+  })
+
+})


### PR DESCRIPTION
Fixes #517.

## Problem

The `est="fo"` / `est="foi"` estimation runs a two-pass sequence: a linearization
fit (the actual FO estimation) followed by a posthoc/table pass. The first pass
comes back from `foceiFitCpp_` with an **empty `control` binding** (the C++ FO
path, `fo=TRUE` with `maxOuterIterations>0`, leaves it unset). Because the fit
env is a `nlmixr2FitCore` object, `$control` dispatches through
`nmObjGetControl`; for that intermediate `est="none"` object there is no
method-specific getter, so `nmObjGetControl.default` returned `NULL`.

As a result `.updateParFixed()` saw a `NULL` `$control` and silently fell back to
default table settings (`ci` = 0.95, `sigdigTable` = 3) instead of the values on
the fit's control. This was the root cause noted in #509.

## Fix

- `.foceiFamilyReturn()` restores the raw `control` binding from the fit's
  control when it is empty, so the returned object carries its control.
- `nmObjGetControl.default()` surfaces a stored `control` binding (instead of
  returning `NULL`) for an intermediate fit whose `est` has no method-specific
  getter.

Both are no-ops for methods that already populate their control.

## Test

`tests/testthat/test-fo-control.R`:
- unit: `nmObjGetControl.default` surfaces a raw `control` binding (and still
  returns `NULL` when there is none);
- end-to-end: `.updateParFixed` never sees a `NULL` control during an FO or FOI
  fit (the intermediate `est="none"` object included), and the final fits resolve
  their `foControl`/`foiControl` and produce a `parFixed` table.

The end-to-end assertion fails on `main` (the intermediate object trips
`any(nullControl)`) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)