### PR TITLE
Accept 'print' control alias for est="nlme"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -473,6 +473,12 @@
 
 ### Estimation
 
+- `est="nlme"` now accepts the common `print` control alias, so
+  `nlmixr2(..., "nlme", list(print=0))` no longer errors with
+  `unused argument: 'print'`.  `nlme` prints through its own `verbose` option, so
+  `print` maps to it (`print=0` runs quietly, any positive value is verbose);
+  an explicit `verbose` is still honored when `print` is not supplied.
+
 - `est="advi"` now rejects a mixture (`mix()`) model up front with a clear
   message (`rxode2::assertRxUiNoMix`) instead of running a wrong fit that ignored
   the mixture structure and then failed late in the output tables with a cryptic

--- a/R/nlme.R
+++ b/R/nlme.R
@@ -11,6 +11,11 @@
 #'   of `random`, `fixed`, `sens`, the nlme object is returned
 #' @inheritParams foceiControl
 #' @inheritParams saemControl
+#' @param print Convenience alias for the shared nlmixr `print` control.
+#'   `nlme` prints progress through its own `verbose` option, so `print`
+#'   maps to it: `print=0` runs quietly (`verbose=FALSE`) and any positive
+#'   value is verbose (`verbose=TRUE`).  When `print` is not supplied an
+#'   explicit `verbose` is used as given.
 #' @return a nlmixr-nlme list
 #' @examples
 #' nlmeControl()
@@ -28,7 +33,7 @@ nlmixr2NlmeControl <- function(maxIter = 100, pnlsMaxIter = 100, msMaxIter = 100
     random=NULL, fixed=NULL, weights=NULL, verbose=TRUE, returnNlme=FALSE,
     addProp = c("combined2", "combined1"), calcTables=TRUE, compress=TRUE,
     adjObf=TRUE, ci=0.95, sigdig=4, sigdigTable=NULL, muRefCovAlg=TRUE,
-    eventSens=c("jump", "fd"), ...) {
+    eventSens=c("jump", "fd"), print=NULL, ...) {
 
   checkmate::assertLogical(optExpression, len=1, any.missing=FALSE)
   checkmate::assertLogical(literalFix, len=1, any.missing=FALSE)
@@ -60,6 +65,14 @@ nlmixr2NlmeControl <- function(maxIter = 100, pnlsMaxIter = 100, msMaxIter = 100
   method <- match.arg(method)
   addProp <- match.arg(addProp)
   eventSens <- match.arg(eventSens)
+
+  # 'print' is the common nlmixr control alias; nlme prints through 'verbose',
+  # so map it (print=0 means quiet) and let an explicit 'verbose' stand when
+  # 'print' is not supplied.
+  if (!is.null(print)) {
+    checkmate::assertIntegerish(print, len=1, lower=0, any.missing=FALSE)
+    verbose <- print > 0
+  }
 
   .xtra <- list(...)
   .bad <- names(.xtra)

--- a/man/nlmixr2NlmeControl.Rd
+++ b/man/nlmixr2NlmeControl.Rd
@@ -43,6 +43,7 @@ nlmixr2NlmeControl(
   sigdigTable = NULL,
   muRefCovAlg = TRUE,
   eventSens = c("jump", "fd"),
+  print = NULL,
   ...
 )
 
@@ -84,6 +85,7 @@ nlmeControl(
   sigdigTable = NULL,
   muRefCovAlg = TRUE,
   eventSens = c("jump", "fd"),
+  print = NULL,
   ...
 )
 }
@@ -278,6 +280,12 @@ for \code{foceiControl()} only takes effect when
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
 uses the legacy finite-difference behavior.}
+
+\item{print}{Convenience alias for the shared nlmixr `print` control.
+`nlme` prints progress through its own `verbose` option, so `print`
+maps to it: `print=0` runs quietly (`verbose=FALSE`) and any positive
+value is verbose (`verbose=TRUE`).  When `print` is not supplied an
+explicit `verbose` is used as given.}
 
 \item{...}{Further, named control arguments to be passed to
    \code{\link{nlminb}} (apart from \code{trace} and \code{iter.max}

--- a/tests/testthat/test-nlme-control.R
+++ b/tests/testthat/test-nlme-control.R
@@ -1,0 +1,21 @@
+test_that("nlmeControl() accepts the common 'print' alias (issue: list(print=) with est='nlme')", {
+  # nlme prints through 'verbose'; 'print' is the shared nlmixr control alias, so
+  # a generic list(print=0) must not error but map to quiet output.
+  expect_false(nlmeControl(print=0)$verbose)
+  expect_true(nlmeControl(print=1)$verbose)
+  expect_true(nlmeControl(print=5)$verbose)
+
+  # default and an explicit 'verbose' (without 'print') are unchanged
+  expect_true(nlmeControl()$verbose)
+  expect_false(nlmeControl(verbose=FALSE)$verbose)
+
+  # 'print' is validated and genuinely unknown args are still rejected
+  expect_error(nlmeControl(print=-1))
+  expect_error(nlmeControl(bogus=1), "unused argument")
+
+  # the shared control validator (what nlmixr2(..., 'nlme', list(...)) uses) now
+  # builds a valid nlmeControl from a bare list(print=)
+  .ctl <- getValidNlmixrControl(list(print=0), "nlme")
+  expect_s3_class(.ctl, "nlmeControl")
+  expect_false(.ctl$verbose)
+})


### PR DESCRIPTION
## Problem

`nlmixr2(model, data, "nlme", list(print=0))` errored with:

```
Error: unused argument: 'print'
```

`print` is the common, cross-method control option (it's a real argument of
`foceiControl()`, `saemControl()`, `nlmControl()`, ...), but `nlmeControl()`
had no `print` argument and explicitly rejects unknown `...` args, so the bare
`list(print=0)` idiom blew up in `getValidNlmixrCtl.nlme()` -> `do.call("nlmeControl", .ctl)`.
`nlme` prints progress through its own `verbose` option, which had no alias.

(Spun off from the single-subject fix in #759, where this surfaced.)

## Fix

Add a `print` argument to `nlmeControl()` that maps onto `verbose`:

- `print=0` -> `verbose=FALSE` (quiet)
- `print` > 0 -> `verbose=TRUE`
- `print` not supplied -> an explicit `verbose` is honored as-is (default `verbose=TRUE` unchanged)

So `list(print=0)` now both works and does what the user intends (quiet). Default
behavior and existing `verbose`/`msVerbose` usage are unchanged, and genuinely
unknown arguments (e.g. `nlmeControl(bogus=1)`) still error.

## Tests

`tests/testthat/test-nlme-control.R` (essential, no fit): asserts the
`print` -> `verbose` mapping, that default/explicit `verbose` are untouched,
that invalid/unknown args still error, and that the shared control validator
(`getValidNlmixrControl(list(print=0), "nlme")`) builds a valid `nlmeControl`.
Existing `test-nlme.R` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)