### PR TITLE
Address issue #632: remove bare Rf_error calls in C++

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -684,6 +684,13 @@
 
 ### Internal
 
+- Removed the last bare `Rf_error` call from the C++ sources (issue #632):
+  the `Rcpp::compileAttributes()` output now emits the parenthesized
+  `(Rf_error)` form, and the internal `rxError` macro was switched to
+  `(Rf_error)` as well, so the package no longer trips Rcpp's upcoming
+  `Rf_error` deprecation warning (RcppCore/Rcpp#1247).  The C `.Call`
+  entry-point validators keep their justified `Rf_errorcall` uses.
+
 - Consolidated data preparation and the nlm-family control/fit functions, and
   the analytic-covariance augmented model now uses rxode2's chunked
   `rxOptExpr()`; no change to fit results.  The test suite runs a single

--- a/src/rxProtect.h
+++ b/src/rxProtect.h
@@ -27,8 +27,10 @@ public:
     }
 };
 
-// Map rxError to Rf_error for C++ exceptions to easily jump out
-#define rxError Rf_error
+// Map rxError to the parenthesized (Rf_error) form so the call bypasses
+// Rcpp's Rf_error deprecation macro (RcppCore/Rcpp#1247).  C++ code that
+// needs proper stack unwinding should call Rcpp::stop instead.
+#define rxError (Rf_error)
 
 #else /* C */
 /* C equivalent of rxProtect: RAII guard using __attribute__((cleanup)).


### PR DESCRIPTION
Closes #632.

## Context

Rcpp will soon warn (then error) on unprotected `Rf_error` calls in C++,
because `Rf_error` `longjmp`s past C++ destructors instead of unwinding the
stack (RcppCore/Rcpp#1247). The recommended fixes are to substitute
`Rcpp::stop` (which unwinds), or to parenthesize the call as `(Rf_error)(...)`
where the bare use is justified.

## Findings

Auditing all native sources for the bare `Rf_error` token:

- **`src/RcppExports.cpp`** -- the original trigger (`Rf_error("%s", ...)`) is
  already resolved on `main`: the current `Rcpp::compileAttributes()` generator
  emits the parenthesized `(Rf_error)` form.
- **`src/rxProtect.h`** -- the only remaining bare `Rf_error` token our sources
  own, in the (currently unused) `rxError` macro. Switched to `(Rf_error)` so
  any future use bypasses the deprecation macro, with a comment pointing C++
  callers that need real unwinding to `Rcpp::stop`.
- **`src/utilc.c`** -- the `Rf_errorcall` validators in the `.Call` entry points
  are left as-is: they are pure C (no destructors to unwind), a different
  function, and the justified case the upstream issue calls out.

After this change no bare `Rf_error` call remains in the C++ translation units.

## Testing

- Confirmed `grep -rnE '\bRf_error\b'` finds no unparenthesized `Rf_error` in
  the C++ sources.
- `g++ -std=c++17` and `gcc -std=c11` syntax-check of `src/rxProtect.h` (with R
  headers) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)