### PR TITLE
saem: make saemDopred* diagnostics use the reset-offset event table (#455 follow-up)

### DIFF
--- a/R/nmObjGet.R
+++ b/R/nmObjGet.R
@@ -753,7 +753,11 @@ nmObjGet.saemEvtDf <- function(x, ...) {
   .obj <- x[[1]]
   .evt <- nmObjGet.dataSav(x, ...)
   .evt$ID <- .evt$ID - 1
-  .evt
+  # Reproduce the fit's kernel event table: reset episodes are offset so
+  # within-subject solve times increase (issue #455).  Without this the
+  # saemDopred* diagnostics would solve a merged trajectory and disagree with
+  # the fit; a no-op unless the subject has overlapping-time reset episodes.
+  .saemMonotonicResetTime(.evt)
 }
 #attr(nmObjGet.saemEvtDf, "desc") <- "event data frame as seen by saem"
 

--- a/R/saem_fit.R
+++ b/R/saem_fit.R
@@ -35,14 +35,21 @@
 #' no-op.
 #'
 #' `dat` is the post-`etTrans` event table (columns ID, TIME, EVID, ...); `evid==3`
-#' marks the reset that starts a new episode.
-#' @param dat post-etTrans event data.frame (ID=col 1, TIME=col 2, EVID=col 3)
-#' @return `dat` with column 2 (TIME) offset so each subject's times increase monotonically
+#' marks the reset that starts a new episode.  Columns are resolved by name
+#' (case-insensitive) so this works both on the kernel event table built in
+#' `.configsaem` and on the `dataSav`-derived table used by the `saemDopred*`
+#' diagnostics; positions 1/2/3 are the fallback.
+#' @param dat post-etTrans event data.frame with ID, TIME and EVID columns
+#' @return `dat` with its TIME column offset so each subject's times increase monotonically
 #' @noRd
 .saemMonotonicResetTime <- function(dat) {
-  .id <- dat[[1L]]
-  .time <- dat[[2L]]
-  .evid <- dat[[3L]]
+  .nm <- toupper(names(dat))
+  .idCol <- which(.nm == "ID")[1L]; if (is.na(.idCol)) .idCol <- 1L
+  .timeCol <- which(.nm == "TIME")[1L]; if (is.na(.timeCol)) .timeCol <- 2L
+  .evidCol <- which(.nm == "EVID")[1L]; if (is.na(.evidCol)) .evidCol <- 3L
+  .id <- dat[[.idCol]]
+  .time <- dat[[.timeCol]]
+  .evid <- dat[[.evidCol]]
   .n <- length(.time)
   if (.n < 2L) return(dat)
   # gap added past the running maximum when a reset would otherwise overlap; its
@@ -70,7 +77,7 @@
     if (.adj > .runMax) .runMax <- .adj
     .time[.i] <- .adj
   }
-  if (.changed) dat[[2L]] <- .time
+  if (.changed) dat[[.timeCol]] <- .time
   dat
 }
 

--- a/tests/testthat/test-issue-455.R
+++ b/tests/testthat/test-issue-455.R
@@ -106,5 +106,14 @@ nmTest({
     expect_true(.f > 0.6 && .f < 0.9)
     # PRED is no longer collapsed to a single value
     expect_true(stats::sd(fit$PRED) > 0.3)
+
+    # The low-level saemDopred* diagnostics rebuild the event table from the saved
+    # data; they must apply the same reset offset as the fit, otherwise they solve a
+    # merged trajectory.  With the offset the individual predictions track the
+    # observations (cor ~0.97); a merged solve collapses this to ~0.5.
+    .ip <- fit$saemDopredIpred
+    .dvObs <- dat$DV[!is.na(dat$DV)]
+    expect_equal(length(.ip), length(.dvObs))
+    expect_true(stats::cor(.dvObs, .ip) > 0.85)
   })
 })


### PR DESCRIPTION
Follow-up to #767 (merged).

## Background

#767 fixed `est="saem"` collapsing overlapping-time `evid=4` reset episodes (combined IV + depot crossover) by offsetting each reset episode in the kernel event table (`.saemMonotonicResetTime()` in `.configsaem`). The **fit** is correct.

The low-level diagnostic accessors `fit$saemDopredIpred` / `fit$saemDopredPred` were left inconsistent: `nmObjGet.saem` rebuilds `saem.cfg$evt` from the saved data via `nmObjGet.saemEvtDf` (the raw C++ event matrix is compressed away), and that rebuild did **not** carry the reset offset. So the diagnostics solved a merged trajectory and disagreed with the fit -- the individual predictions collapsed (correlation with the observations ~0.5 instead of ~0.97).

## Change

- Apply `.saemMonotonicResetTime()` in `nmObjGet.saemEvtDf` so the `saemDopred*` diagnostics use the same reset-offset event table as the fit. `dataSav` is already the `etTrans`-expanded layout (`evid==3` resets), so the same helper applies. No-op unless a subject has overlapping-time reset episodes.
- `.saemMonotonicResetTime()` now resolves `ID`/`TIME`/`EVID` **by name** (case-insensitive, positional 1/2/3 fallback) since it now runs on two tables: the `.configsaem` kernel table and the `dataSav`-derived diagnostic table.
- `test-issue-455.R` gains an assertion that `cor(DV, saemDopredIpred) > 0.85` (it is ~0.97 with the offset, ~0.5 when merged).

## Verification

On the combined IV + depot reproducer (12 subjects): `add.sd`=0.206, `f`=0.792, and `cor(DV, saemDopredIpred)`=0.97 (was ~0.5 before this change). `saemDopredPred` predictions are no longer duplicated pairs across the two arms.

Diff is R-only (3 files); NAMESPACE unchanged; no C++.

Note: running the full `test_file` locally via `devtools::load_all` is currently blocked by an unrelated `foi` fixture-prefit failure on `main` ("cannot find foi related control object", a `load_all`-time artifact independent of this change); the new test's assertions were verified with a standalone fit.