### PR TITLE
Remove unreachable duplicate missingTable default in nlmixr2Est0 (#385)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -684,6 +684,10 @@
 
 ### Internal
 
+- Removed an unreachable duplicate `missingTable` default assignment in
+  `nlmixr2Est0()` (issue #385); the earlier default already fixes the value, so
+  the second block could never run.  No change to fit results.
+
 - Consolidated data preparation and the nlm-family control/fit functions, and
   the analytic-covariance augmented model now uses rxode2's chunked
   `rxOptExpr()`; no change to fit results.  The test suite runs a single

--- a/R/nlmixr2Est.R
+++ b/R/nlmixr2Est.R
@@ -183,9 +183,6 @@ nlmixr2Est0 <- function(env, ...) {
   if (!exists("missingEst", envir=env)) {
     assign("missingEst", FALSE, envir=env)
   }
-  if (!exists("missingTable", envir=env)) {
-    assign("missingTable", TRUE, envir=env)
-  }
   if (inherits(env$ui, "rxUi")) {
     .modelName <- env$ui$modelName
     assign("ui",


### PR DESCRIPTION
Fixes #385.

## Problem

In `nlmixr2Est0()` (`R/nlmixr2Est.R`) the `!exists("missingTable", envir=env)` check appeared twice:

```r
if (!exists("missingTable", envir=env)) {
  assign("missingTable", FALSE, envir=env)
}
...
if (!exists("missingTable", envir=env)) {   # can never be TRUE
  assign("missingTable", TRUE, envir=env)
}
```

The first block already assigns a default when `missingTable` is absent, so by the time control reaches the second block `missingTable` always exists. The second `assign(..., TRUE)` branch is therefore dead code (which is why coverage reported it as untested).

## Fix

Removed the unreachable second block. The retained default (`FALSE`) is the effective behavior today, so fit results are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)