### PR TITLE
Remove unused hi/low in npde CDF imputation (#382)

### DIFF
--- a/src/npde.cpp
+++ b/src/npde.cpp
@@ -127,8 +127,8 @@ static inline void handleCensNpdeCdf(calcNpdeInfoId &ret, arma::Col<int> &cens, 
   // pd already holds the below-limit probability (left cens) or 1-pd (right cens);
   // replace with runif over that range, then back-calculate EPRED from sorted tcomp.
   arma::vec curRow;
-  unsigned int j, j2;
-  double low, hi, low2, hi2;
+  unsigned int j2;
+  double low2, hi2;
   switch (cens[i]) {
   case 1:
     curRow = sort(trans(ret.matsim.row(i)));
@@ -143,16 +143,14 @@ static inline void handleCensNpdeCdf(calcNpdeInfoId &ret, arma::Col<int> &cens, 
   default:
     return;
   }
-  // Now back-calculate the EPRED
-  j = trunc(ret.pd[i]*K);
+  // Back-calculate the imputed transformed observation from the marginal (npd)
+  // percentile pd2; yobst is a single value shared by both the npde and npd
+  // tracks, so only the marginal percentile (which indexes the sorted simulated
+  // row curRow) is meaningful here.
   j2 = trunc(ret.pd2[i]*K);
-  // pd can round to 1.0; clamp to keep curRow indices in bounds
-  if (j >= K) j = K - 1;
+  // pd2 can round to 1.0; clamp to keep curRow indices in bounds
   if (j2 >= K) j2 = K - 1;
-  low = curRow[j];
   low2 = curRow[j2];
-  if (j+1 >= K) hi = (j > 0) ? (2*low - curRow[j-1]) : low;
-  else hi = curRow[j+1];
   if (j2+1 >= K) hi2 = (j2 > 0) ? (2*low2 - curRow[j2-1]) : low2;
   else hi2 = curRow[j2+1];
   // Use npd instead of npde as suggested by Nguyen2017; toggled by npdeControl()


### PR DESCRIPTION
## Summary

Fixes #382, which flagged that `hi` is assigned but never used in `handleCensNpdeCdf` (`src/npde.cpp`). On investigation, `low` (and the index `j` with its bounds clamp) are dead alongside `hi`.

## Analysis

`handleCensNpdeCdf` imputes the transformed observation `ret.yobst[i]` for a `CENS_CDF`-censored point. It computed two parallel percentile tracks:

- `pd` -> `j` -> `low`/`hi` -- the **decorrelated** (npde) track
- `pd2` -> `j2` -> `low2`/`hi2` -- the **marginal** (npd) track

`ret.yobst[i]` is written **only** from `low2`/`hi2`, so the entire `pd`-track computation was never read.

This is **not a latent bug**: `yobst` is a single imputed value obtained by inverting against the sorted *marginal* simulated row `curRow`, so the marginal percentile `pd2` is the correct index. The decorrelated `pd` has no position in `curRow`, so `low`/`hi` were genuinely meaningless. Removing them is behavior-preserving.

## Change

- Remove the dead `j`, `low`, `hi` variables and their bounds clamp.
- Clarify the comment to note why only the marginal (`pd2`) percentile is used.

Syntax-checks cleanly against the package include set; no exported-symbol or argument-count change, so `init.c`/`RcppExports` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)