### PR TITLE
Fix est="fo"/est="foi" broken by freezeResidGrad residThetaIdx

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -488,6 +488,11 @@
   (#517).  The FO/FOI fit now carries its control, and an intermediate fit
   without a method-specific `nmObjGetControl` surfaces its stored control rather
   than returning `NULL`.
+- `est="fo"`/`est="foi"` fits no longer error with "cannot find fo/foi related
+  control object".  The `freezeResidGrad` work added an internal `residThetaIdx`
+  field to the fitted control, which was not on the accepted-internal
+  (`.foceiControlInternal`) list, so the post-fit table step failed when it
+  re-validated the control by round-tripping it through `foceiControl()`.
 - `est="nlme"` now accepts the common `print` control alias, so
   `nlmixr2(..., "nlme", list(print=0))` no longer errors with
   `unused argument: 'print'`.  `nlme` prints through its own `verbose` option, so

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -19,7 +19,12 @@
                            "foceiConstCovs",
                            # TRUE when the outer optimizer was defaulted (not user
                            # specified); lets *f wrappers re-default under fast=TRUE
-                           "outerOptDefault")
+                           "outerOptDefault",
+                           # residual-theta index vector stashed on the control by
+                           # .foceiFamilyReturn (ui$foceiResidTheta); internal so a
+                           # built control round-trips (e.g. fo/foi post-fit
+                           # nmObjGetControl re-validation)
+                           "residThetaIdx")
 
 #' Control Options for FOCEi
 #'

--- a/tests/testthat/test-fo-control.R
+++ b/tests/testthat/test-fo-control.R
@@ -52,4 +52,22 @@ nmTest({
     expect_s3_class(fitFoi$parFixed, "data.frame")
   })
 
+  test_that("a built control with internal residThetaIdx round-trips for fo/foi", {
+    # .foceiFamilyReturn stashes ui$foceiResidTheta on the control as
+    # $residThetaIdx.  The fo/foi post-fit table step re-validates the stored
+    # control by round-tripping it through foceiControl() (nmObjGetControl.fo /
+    # .foi), so residThetaIdx must be an accepted internal dot-argument.  When it
+    # was not, the round-trip errored with "unused argument: 'residThetaIdx'" and
+    # the fit died with "cannot find fo/foi related control object".
+    expect_true("residThetaIdx" %in% nlmixr2est:::.foceiControlInternal)
+
+    .ctl <- foceiControl()
+    .ctl$residThetaIdx <- c(1L, 2L, 3L)
+    # foceiControl() accepts the round-tripped internal field
+    expect_silent(do.call(foceiControl, .ctl))
+    # and the fo/foi validators return the method control rather than erroring
+    expect_true(inherits(nlmixr2est:::getValidNlmixrCtl.fo(list(.ctl)), "foControl"))
+    expect_true(inherits(nlmixr2est:::getValidNlmixrCtl.foi(list(.ctl)), "foiControl"))
+  })
+
 })


### PR DESCRIPTION
## Problem

`est="fo"` and `est="foi"` currently error out at the end of the fit:

```
Error : cannot find fo related control object
Error : cannot find foi related control object
```

## Root cause

The `freezeResidGrad` work (`R/focei.R`, `.foceiFamilyReturn`) stashes an
internal `residThetaIdx` field on the fitted control:

```r
env$control$residThetaIdx <- ui$foceiResidTheta
```

but `residThetaIdx` was never added to the `.foceiControlInternal`
accepted-internal dot-argument whitelist in `R/foceiControl.R`.

The FO/FOI post-fit table step re-validates the stored control by
round-tripping it through `foceiControl()` (via `nmObjGetControl.fo` /
`nmObjGetControl.foi` -> `getValidNlmixrCtl.*`).  `foceiControl()` rejects any
unrecognized dot argument, so the round-trip failed with `unused argument:
'residThetaIdx'`; `nmObjGetControl` then exhausted its candidate names and
raised "cannot find fo/foi related control object".

## Fix

Add `residThetaIdx` to `.foceiControlInternal` so a built control round-trips
cleanly, matching how the other internal derived fields (`nF`, `foceiMuRef`,
`covType`, `foceiConstCovs`, ...) are handled.

## Test

Added a focused regression test to `tests/testthat/test-fo-control.R` that pins
the mechanism directly: a `foceiControl()` carrying an internal `residThetaIdx`
must be accepted by `foceiControl()` and round-trip through
`getValidNlmixrCtl.fo`/`.foi` to the method control.  The file's existing
end-to-end fo/foi fit tests (issue #517) also exercise the full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)