### PR TITLE
Fix vpcSim(pred=TRUE) for IOV models (#629)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -675,6 +675,12 @@
   factor carries the actual (character/factor) ids from the fit instead of the
   internal integer re-numbering (#450).
 
+- `vpcSim(fit, pred=TRUE)` (and hence VPC plots with a `pred` line) now works
+  for models with IOV.  With IOV the fit's `omega` is a list of matrices (`id`
+  plus one per occasion level), which the `pred` path treated as a single
+  matrix and errored with `invalid 'times' argument`; the population prediction
+  now zeros every random effect across all omega levels (#629).
+
 - `fit$time` again attributes model build/compile to `setup`/`configure` (and
   the nlm family times setup/optimize) instead of `other`.
 

--- a/R/vpc.R
+++ b/R/vpc.R
@@ -1,3 +1,15 @@
+# Named vector of zeros for every random effect in an omega/sigma.  Accepts a
+# single matrix or, for IOV, a list of matrices (id + per-occasion levels).
+.vpcZeroRanef <- function(mat) {
+  if (is.null(mat)) return(NULL)
+  if (is.list(mat) && !is.matrix(mat)) {
+    # unname() so the list names (id, occ) are not prefixed onto eta names
+    return(do.call(c, unname(lapply(mat, .vpcZeroRanef))))
+  }
+  .n <- dimnames(mat)[[2]]
+  setNames(rep(0, length(.n)), .n)
+}
+
 #' VPC simulation
 #'
 #' @param object This is the nlmixr2 fit object
@@ -152,9 +164,10 @@ vpcSim <- function(object, ..., keep=NULL, n=300,
   if (pred) {
     .si$nsim <- n # restore for pred
     .si2 <- .si
+    # For pred, zero out every random effect.  With IOV the omega is a
+    # list of matrices (e.g. id + occ), so collect names across all of them.
     .si2$params <- c(
-      .si$params, setNames(rep(0, dim(.si$omega)[1]), dimnames(.si$omega)[[2]]),
-      setNames(rep(0, dim(.si$sigma)[1]), dimnames(.si$sigma)[[2]]))
+      .si$params, .vpcZeroRanef(.si$omega), .vpcZeroRanef(.si$sigma))
     .si2$omega <- NULL
     .si2$sigma <- NULL
     .si2$returnType <- "data.frame"

--- a/tests/testthat/test-vpcSim.R
+++ b/tests/testthat/test-vpcSim.R
@@ -98,4 +98,46 @@ nmTest({
     fit <- .nlmixr(one.cmt, theo_sd, est="focei", control = foceiControl(print = 0, eval.max = 1))
     expect_s3_class(vpcSim(fit, pred=TRUE), "data.frame")
   })
+
+  test_that("vpcSim works with IOV, including pred=TRUE (#629)", {
+    one.cmt <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- log(c(0, 2.7, 100))
+        tv <- 3.45
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        iov.cl ~ 0.1 | occ
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl + iov.cl)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+
+    theo_iov <- nlmixr2data::theo_md
+    theo_iov$occ <- 1
+    theo_iov$occ[theo_iov$TIME >= 144] <- 2
+
+    fit <- .nlmixr(one.cmt, theo_iov, est="focei",
+                   control=foceiControl(print=0, maxOuterIterations=0L,
+                                        maxInnerIterations=5L, covMethod=""))
+
+    # IOV omega is a list of matrices (id + occ); the sim must vary iov.cl by
+    # occasion within a subject
+    f <- vpcSim(fit, n=3)
+    expect_s3_class(f, "data.frame")
+    .byId <- tapply(f$iov.cl, paste(f$sim.id, f$id), function(x) length(unique(x)))
+    expect_true(all(.byId == 2))
+
+    # pred=TRUE previously errored ("invalid 'times' argument") because the
+    # list omega was treated as a single matrix
+    fp <- vpcSim(fit, n=3, pred=TRUE)
+    expect_s3_class(fp, "data.frame")
+    expect_true("pred" %in% names(fp))
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #629 -- VPC did not work for models with IOV.

`vpcSim()` worked in the default (`pred=FALSE`) path, but the `pred=TRUE` branch -- which VPC plots use to draw the population-prediction line -- errored with `invalid 'times' argument`.

**Root cause:** for an IOV fit the fit's `omega` is no longer a single matrix but a *list of matrices* (an `id` block plus one block per occasion level, e.g. `occ`). The `pred` branch assumed a single matrix and did `setNames(rep(0, dim(.si$omega)[1]), dimnames(.si$omega)[[2]])`; `dim()`/`dimnames()` of a list return `NULL`, so `rep(0, NA)` cascaded into the cryptic `rxSolve` error.

## Fix

Add a `.vpcZeroRanef()` helper that collects the names of every random effect whether `omega`/`sigma` is a single matrix or a list of matrices, then zeros them all for the population prediction. The `unname()` step matters -- otherwise the list names (`id`, `occ`) get prefixed onto the eta names (`id.eta.ka`, `occ.iov.cl`) and the zeros no longer match the model's actual parameters, so the solve reports the etas as still required.

## Verification

- Reproduced the original `invalid 'times' argument` error, then confirmed `vpcSim(fit, pred=TRUE)` works after the fix and yields a `pred` column distinct from `ipred`.
- Confirmed IOV varies by occasion within each simulated subject (2 distinct `iov.cl` values per subject, one per occasion).
- Regression-checked the non-IOV (single-matrix) `pred=TRUE` path still works.
- Added a test to `tests/testthat/test-vpcSim.R` covering both per-occasion variation and the `pred=TRUE` path; the full file passes.
- Added a NEWS.md bug-fix entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)