### PR TITLE
Fix IOV with a zero-IIV eta on another parameter (#627)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -459,6 +459,15 @@
 
 ### Estimation
 
+- A model that combines an inter-occasion variability (IOV) term with a zero
+  inter-individual variability eta on another parameter (for example
+  `eta.ka ~ 0` alongside `iov.cl ~ 0.1 | occ`) no longer fails with "initial
+  'omega' matrix inverse is non-positive definite".  With IOV present the omega
+  is a per-condition list, so the zero-eta detector could not read the eta names
+  and left the zero eta in the matrix, making it singular; the zero eta is now
+  detected and removed as usual.  Restoring the original model after such a fit
+  also no longer errors for `est="saem"` (including `table=list(cwres=TRUE)`),
+  where the IOV eta is re-expressed as per-occasion id-level etas (#627).
 - `est="saem"` no longer collapses subjects that combine two dosing episodes with
   overlapping clock times separated by an `evid=4` reset -- for example a crossover
   where an IV arm and a depot (`f(depot)`) arm share the same times.  SAEM solves

--- a/R/nlmixr2Est.R
+++ b/R/nlmixr2Est.R
@@ -122,6 +122,12 @@ nlmixr2Est.default <- function(env, ...) {
       .etas <- .iniDf[!is.na(.iniDf$neta1),, drop = FALSE]
       if (length(.etas$name) > 0) {
         .etaNames <- .etas[.etas$neta1 == .etas$neta2, "name"]
+        ## Only map etas that also exist in the pure input model.  A fit
+        ## may re-express etas that are absent from the input model (e.g.
+        ## SAEM expands an IOV eta into per-occasion id-level etas plus a
+        ## variance theta); those cannot be mapped back by name and their
+        ## variance is restored via the theta loop above.
+        .etaNames <- .etaNames[.etaNames %in% .finalIni$name]
         .etaFinal <- vapply(.etaNames, function(n) {
           .finalIni[which(.finalIni$name == n), "neta1"]
         }, double(1), USE.NAMES=TRUE)

--- a/R/preProcessZeroOmega.R
+++ b/R/preProcessZeroOmega.R
@@ -9,7 +9,12 @@
   if (length(.iniDf$neta1) == 0) return(character(0))
   .r <- range(.iniDf$neta1)
   .r <- seq(.r[1], .r[2])
-  .etaNames <- dimnames(ui$omega)[[1]]
+  ## Derive the eta name for each index from iniDf directly.  With IOV
+  ## present ui$omega is a list (per condition), so dimnames(ui$omega)[[1]]
+  ## is NULL and the zero etas would never be detected.
+  .etaNames <- vapply(.r, function(i) {
+    .iniDf[.iniDf$neta1 == i & .iniDf$neta2 == i, "name"]
+  }, character(1), USE.NAMES=FALSE)
   .zeroEta <- vapply(.r, function(i) {
     all(.iniDf[(.iniDf$neta1 == i) | (.iniDf$neta2 == i), "est"] == 0)
   }, logical(1), USE.NAMES=FALSE)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -67,7 +67,7 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   c("impmap", "matexp", "mfocei", "focei-wang2007-yeojohnson",
     "focei-wang2007-boxcox-lnorm", "nlme", "focei-fast-grad"),
   # batch 5
-  c("focei-llik", "iov", "nlm-adjoint", "saem-mix", "saem-mix-regress", "posthoc", "ar-est",
+  c("focei-llik", "iov", "iov-zero-eta", "nlm-adjoint", "saem-mix", "saem-mix-regress", "posthoc", "ar-est",
     "mu-family", "mu-plain-fit", "vae-fit", "focei-wang2007-basic",
     "vae-neonatal", "vae-errmodel", "table-cmt", "vae-covariate"),
   # batch 6 -- heaviest remaining files on the single-worker CI runner

--- a/tests/testthat/test-iov-zero-eta.R
+++ b/tests/testthat/test-iov-zero-eta.R
@@ -1,0 +1,43 @@
+test_that("IOV model with a zero iiv eta fits with focei and saem (#627)", {
+  skip_on_cran()
+
+  one.cmt <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      iov.cl ~ 0.1 | occ
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  theo_iov <- nlmixr2data::theo_md
+  theo_iov$occ <- 1
+  theo_iov$occ[theo_iov$TIME >= 144] <- 2
+
+  # focei: previously errored with "initial 'omega' matrix inverse is
+  # non-positive definite"; the removed zero eta is restored in the final ui
+  fitF <- suppressMessages(suppressWarnings(
+    nlmixr2(one.cmt, theo_iov, est = "focei",
+            control = foceiControl(print = 0, maxOuterIterations = 0))))
+  expect_s3_class(fitF, "nlmixr2FitData")
+  expect_true("eta.ka" %in% fitF$ui$iniDf$name)
+
+  # saem + cwres: previously errored while restoring the original model
+  # because SAEM re-expresses the IOV eta into per-occasion id etas
+  fitS <- suppressMessages(suppressWarnings(
+    nlmixr2(one.cmt, theo_iov, est = "saem",
+            control = saemControl(print = 0, nBurn = 5, nEm = 5),
+            table = list(cwres = TRUE))))
+  expect_s3_class(fitS, "nlmixr2FitData")
+  expect_true("CWRES" %in% names(fitS))
+})

--- a/tests/testthat/test-zero-omega-restore.R
+++ b/tests/testthat/test-zero-omega-restore.R
@@ -37,3 +37,39 @@ test_that("zero etas are restored in the final ui even with nested nlmixr2 calls
   newUi <- suppressMessages(rxode2::ini(fit, bsva ~ 0.1))
   expect_equal(newUi$iniDf$est[newUi$iniDf$name == "bsva"], 0.1)
 })
+
+test_that("zero iiv eta is detected alongside an IOV eta (#627)", {
+  # With IOV present ui$omega is a per-condition list, so the zero-eta
+  # detector used to read dimnames() off a list, return NULL and leave the
+  # zero eta in the omega -- producing a singular initial 'omega' matrix.
+  one.cmt <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      iov.cl ~ 0.1 | occ
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(one.cmt))
+
+  expect_equal(.getZeroEtasFromModel(ui), "eta.ka")
+
+  # downgrading drops the zero eta and leaves a non-singular id omega plus
+  # the untouched occ (IOV) omega
+  ui2 <- .downgradeEtas(ui, "eta.ka")
+  expect_false("eta.ka" %in% ui2$iniDf$name)
+  expect_true("iov.cl" %in% ui2$iniDf$name)
+  expect_true(is.list(ui2$omega))
+  expect_false("eta.ka" %in% dimnames(ui2$omega$id)[[1]])
+  expect_true(all(eigen(ui2$omega$id, only.values = TRUE)$values > 0))
+})


### PR DESCRIPTION
Fixes #627.

## Problem

A model that combines an IOV term with a zero-IIV eta on another parameter -- e.g. `eta.ka ~ 0` alongside `iov.cl ~ 0.1 | occ` -- failed:

- `est="focei"`: `initial 'omega' matrix inverse is non-positive definite`
- `est="saem"` with `table=list(cwres=TRUE)`: errored while restoring the original model

Removing the zero `eta.ka` entirely was the only workaround.

## Root cause

Both symptoms come from the same situation. When IOV is present, `ui$omega` is a **per-condition list** (`$id`, `$occ`), not a matrix:

1. **focei** -- The zero-eta detector `.getZeroEtasFromModel()` read `dimnames(ui$omega)[[1]]`, which is `NULL` for a list, so it returned `NULL` and never removed the zero eta. The zero variance stayed in the `id` omega, making it singular.

2. **saem** -- A *latent* bug the first fix exposes: once the zero eta is detected, the post-fit model-restore (`.nlmixrEstUpdatesOrigModel`) runs. SAEM re-expresses the IOV eta as per-occasion id-level etas (`rx.iov.cl.1/2`) plus a variance theta; those expanded names are absent from the pure input model, so the name->index map hit a length-0 lookup and crashed.

## Fix

- `R/preProcessZeroOmega.R` -- derive eta names from `iniDf` diagonals instead of `dimnames(omega)`.
- `R/nlmixr2Est.R` -- only map etas that also exist in the input model; the IOV variance is restored via the theta loop.

Both changes are backward-compatible (verified identical output for non-IOV and correlated-block cases).

## Tests

- Fast unit regression added to `test-zero-omega-restore.R` (essential CI).
- End-to-end focei + saem(cwres) fit in new `test-iov-zero-eta.R` (weekly slow batch 5).
- `NEWS.md` entry under Bug fixes / Estimation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)