### PR TITLE
Fix focei names-length error when a subject's rows are all dropped (#606)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -676,6 +676,13 @@
   the output with a population `PRED` and `NA` individual columns, like FOCEi
   (#687).
 
+- FOCEi no longer errors with `'names' attribute [n] must be the same length as
+  the vector [m]` when a subject's records are all removed during data
+  translation (e.g. every `TIME` is `NA`).  Such a subject vanishes from the
+  processed data entirely rather than losing only its observations, so it is now
+  detected and dropped from the subject index alongside observation-less
+  subjects (#606).
+
 - Fixed `nlmControl()` listing `eventSens`/`sensMethod` twice.  The "initial
   ETAs were nudged" warning fires only when a nudge actually happened, and a
   non-default `mceta` on a fully mu-referenced model falls back to the default

--- a/R/focei.R
+++ b/R/focei.R
@@ -2145,15 +2145,21 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   .keepL <- .lst$keepL[[1]]
   .idLvl <- .lst$idLvl
   .dat <- cbind(as.data.frame(.et), .keepL)
-  # Drop subjects with no EVID==0 rows (DV=NA observations become EVID==2 in
-  # etTrans and would otherwise slip through); re-inserted later in addTable().
-  .obsId <- unique(.dat$ID[.dat$EVID == 0])
-  .noObsId <- setdiff(unique(.dat$ID), .obsId)
-  if (length(.noObsId) > 0L) {
+  # Drop subjects without an EVID==0 observation; re-inserted later in
+  # addTable().  Two ways a subject loses all observations: (1) DV=NA rows
+  # become EVID==2 in etTrans (rows still present, just no EVID==0), and (2)
+  # every row is removed outright (e.g. all-NA TIME), so the subject is absent
+  # from .dat but still listed in .idLvl.  Comparing the kept observation IDs
+  # against the full .idLvl index catches both -- comparing only against IDs
+  # present in .dat misses case (2) and leaves .idLvl longer than the solved
+  # subject count (issue #606).
+  .obsId <- sort(unique(.dat$ID[.dat$EVID == 0]))
+  .dropId <- setdiff(seq_along(.idLvl), .obsId)
+  if (length(.dropId) > 0L) {
     warning("IDs without observations dropped: ",
-            paste(.idLvl[.noObsId], collapse = " "), call. = FALSE)
-    .dat <- .dat[!(.dat$ID %in% .noObsId), , drop = FALSE]
-    .keepLvl <- .idLvl[sort(.obsId)]
+            paste(.idLvl[.dropId], collapse = " "), call. = FALSE)
+    .dat <- .dat[.dat$ID %in% .obsId, , drop = FALSE]
+    .keepLvl <- .idLvl[.obsId]
     .dat$ID <- match(.idLvl[.dat$ID], .keepLvl)
     .idLvl <- .keepLvl
   }

--- a/tests/testthat/test-saem-no-obs-subject.R
+++ b/tests/testthat/test-saem-no-obs-subject.R
@@ -62,6 +62,36 @@ nmTest({
     expect_true(all(is.na(.f3$IPRED)))        # individual columns NA
   })
 
+  test_that("FOCEI tolerates a subject whose rows are all removed (all-NA TIME) (#606)", {
+    # #606: unlike #687 (dose row present, DV all NA), here every row of the
+    # subject is dropped outright by etTrans (all TIME NA), so the subject is
+    # absent from dataSav but still listed in idLvl.  The old drop logic only
+    # caught subjects that still had rows, leaving idLvl one longer than the
+    # solved subject count -> foceiPhiOne named a length-N list with N+1 names
+    # ("'names' attribute [N+1] must be the same length as the vector [N]").
+    d <- nlmixr2data::theo_sd[nlmixr2data::theo_sd$ID %in% 1:3, ]
+    d$TIME[d$ID == 3] <- NA_real_
+    # maxOuterIterations=0 keeps this fast and lands directly on the phi step
+    # where the length mismatch surfaced.
+    fitFocei <- suppressWarnings(suppressMessages(
+      .nlmixr(one.compartment, d, est = "focei",
+              control = foceiControl(print = 0, maxOuterIterations = 0))))
+    expect_true(inherits(fitFocei, "nlmixr2FitData"))
+    expect_equal(
+      sum(grepl("IDs without observations dropped: 3", fitFocei$runInfo, fixed = TRUE)),
+      1L)
+    # estimation used only the two subjects that have data
+    expect_setequal(as.integer(as.character(fitFocei$eta$ID)), c(1L, 2L))
+    # dropped subject re-inserted in the output; its TIME (hence PRED/IPRED) is
+    # NA so nothing can be solved, but the rows are preserved
+    .dfF <- as.data.frame(fitFocei)
+    .f3 <- .dfF[as.integer(as.character(.dfF$ID)) == 3, ]
+    expect_equal(nrow(.f3), 11L)
+    expect_true(all(is.na(.f3$TIME)))
+    expect_true(all(is.na(.f3$PRED)))
+    expect_true(all(is.na(.f3$IPRED)))
+  })
+
   test_that("multiple no-observation subjects are each dropped and re-inserted (#687)", {
     d <- nlmixr2data::theo_sd[nlmixr2data::theo_sd$ID %in% 1:4, ]
     # subjects 3 and 4: a dose but no measurement


### PR DESCRIPTION
Fixes #606.

## Problem

FOCEi errored with `'names' attribute [3923] must be the same length as the vector [3848]` (from `foceiFitCpp_()`) whenever a subject's records were all removed during data translation -- e.g. every `TIME` is `NA`.

## Root cause

`.foceiPreProcessData()` (`R/focei.R`) drops subjects that have no `EVID==0` observation and remaps `idLvl`. It detected such subjects by comparing against IDs **still present** in the translated data, which only catches subjects that kept their rows (DV=NA -> EVID==2). When `etTrans` removes *every* row of a subject (all-NA `TIME`), the subject is absent from the data entirely but is still listed in `idLvl`, so `idLvl` ends up one longer than the solved subject count. `foceiPhiOne()` (`src/inner.cpp`) then names a length-N list (`getRxNsub`) with the N+1 `idLvl`, throwing the mismatch.

## Fix

Detect dropped subjects by comparing the kept `EVID==0` IDs against the full `idLvl` index (`setdiff(seq_along(.idLvl), .obsId)`) rather than against IDs present in the data. This covers both the pre-existing observation-less case (#687) and the fully-absent-subject case (#606), and remaps `idLvl`/`dataSav` IDs consistently.

## Verification

- The issue reprex now fits cleanly instead of erroring.
- New regression test in `test-saem-no-obs-subject.R` reproduces the exact error without the fix and passes with it.
- Existing #687 no-obs FOCEi/SAEM cases and the no-drop baseline are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)