### PR TITLE
Drop blank BSV/Shrink columns from $parFixed for models without etas (#355)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -645,6 +645,10 @@
 
 ### Output, tables, and printing
 
+- For models without etas, the `BSV(SD)` and `Shrink(SD)%` columns are no longer
+  added to `$parFixed` and `$parFixedDf`; they were always blank for these models
+  (#355).
+
 - Model-defined variables (e.g. `ka`, `cl`, `v`, `tad`, `dosenum`, and any
   user-added line such as `WT.OUT <- WT`) are now included in the output table
   whether or not `cwres` is requested.  Previously `tableControl(cwres=FALSE)`

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -393,13 +393,17 @@
       btEnv = nlmixr2global$nlmixrEvalEnv$envir
     )
   popDf <- .updateParFixedAddParameterLabel(popDf, iniDf = .ui$iniDf)
-  .bsv <- .updateParFixedAddBsv(
-    popDf, iniDf = .ui$iniDf, omega = .ret$omega,
-    .sigdig = .parFixedDigits,
-    .muRefDataFrame = .ui$muRefDataFrame, .muRefCurEval = .ui$muRefCurEval
-  )
-  popDf <- .bsv$popDf
-  popDf <- .updateParFixedAddShrinkage(popDf, shrink = .ret$shrink, ui = .ui)
+  # without etas both columns would be entirely blank, so drop them (#355)
+  .bsv <- list(popDf = popDf, bsvFixedNames = character())
+  if (!is.null(.ret$omega)) {
+    .bsv <- .updateParFixedAddBsv(
+      popDf, iniDf = .ui$iniDf, omega = .ret$omega,
+      .sigdig = .parFixedDigits,
+      .muRefDataFrame = .ui$muRefDataFrame, .muRefCurEval = .ui$muRefCurEval
+    )
+    popDf <- .bsv$popDf
+    popDf <- .updateParFixedAddShrinkage(popDf, shrink = .ret$shrink, ui = .ui)
+  }
   .ret$popDf <- popDf
   # $popDfSig may still exist from the C++ side but is no longer used
   .ret$parFixed <-

--- a/tests/testthat/test-nlmixr2output.R
+++ b/tests/testthat/test-nlmixr2output.R
@@ -161,9 +161,7 @@ test_that("formatMinWidth in parFixed", {
             formatMinWidth(fitFixed$parFixedDf$`CI Lower`, digits = 4),
             formatMinWidth(fitFixed$parFixedDf$`CI Upper`, digits = 4)
           )[2:4]
-        ),
-        `BSV(SD)` = c("", "", "", ""),
-        `Shrink(SD)%` = c("", "", "", "")
+        )
       ),
       class = c("nlmixr2ParFixed", "data.frame"),
       row.names = c("tka", "tcl", "tv", "add.sd")
@@ -207,9 +205,7 @@ test_that("formatMinWidth in parFixed", {
             formatMinWidth(fitFixedLabel$parFixedDf$`CI Lower`, digits = 4),
             formatMinWidth(fitFixedLabel$parFixedDf$`CI Upper`, digits = 4)
           )[2:4]
-        ),
-        `BSV(SD)` = c("", "", "", ""),
-        `Shrink(SD)%` = c("", "", "", "")
+        )
       ),
       class = c("nlmixr2ParFixed", "data.frame"),
       row.names = c("tka", "tcl", "tv", "add.sd")
@@ -234,9 +230,7 @@ test_that("formatMinWidth in parFixed", {
               formatMinWidth(fitFixedLabelCI$parFixedDf$`Back-transformed`, digits = 4),
               formatMinWidth(fitFixedLabelCI$parFixedDf$`CI Lower`, digits = 4),
               formatMinWidth(fitFixedLabelCI$parFixedDf$`CI Upper`, digits = 4)
-            )[2:4]),
-        `BSV(SD)` = c("", "", "", ""),
-        `Shrink(SD)%` = c("", "", "", "")
+            )[2:4])
       ),
       class = c("nlmixr2ParFixed", "data.frame"),
       row.names = c("tka", "tcl", "tv", "add.sd")
@@ -255,4 +249,13 @@ test_that("formatMinWidth in parFixed", {
   expect_equal(unname(fitNoLiteralFix$parFixed["tka", "%RSE"]), "FIXED")
   expect_equal(unname(fitNoLiteralFix$parFixed["tcl", "SE"]),
                formatMinWidth(fitNoLiteralFix$parFixedDf["tcl", "SE"], digits = 4))
+
+  # nlmixr2est#355: without etas the BSV/shrinkage columns are always blank
+  expect_false(any(startsWith(names(fitFixed$parFixed), "BSV(")))
+  expect_false("Shrink(SD)%" %in% names(fitFixed$parFixed))
+  expect_false(any(startsWith(names(fitFixed$parFixedDf), "BSV(")))
+  expect_false("Shrink(SD)%" %in% names(fitFixed$parFixedDf))
+  # ...but a model with etas keeps them
+  expect_true(any(startsWith(names(fit$parFixed), "BSV(")))
+  expect_true("Shrink(SD)%" %in% names(fit$parFixed))
 })


### PR DESCRIPTION
Fixes #355.

For models without etas, `$parFixed` and `$parFixedDf` carried a `BSV(SD)` and a `Shrink(SD)%` column that were always entirely blank -- `$omega` and `$shrink` are both `NULL` for these models, so every row resolved to `NA`:

```
         Est.      SE  %RSE Back-transformed(95%CI) BSV(SD) Shrink(SD)%
tka    0.4403  0.2125 48.26    1.553 (1.024, 2.355)
tcl    0.9615  0.1387 14.43    2.616 (1.993, 3.433)
tv      3.492 0.08807 2.522    32.86 (27.65, 39.05)
add.sd  1.375  0.1693 12.31    1.375 (1.044, 1.707)
```

## Change

`.updateParFixed()` (`R/nlmixr2output.R`) now only calls `.updateParFixedAddBsv()` / `.updateParFixedAddShrinkage()` when `.ret$omega` is non-NULL. `is.null(omega)` is the existing "no etas" idiom in this package (`R/augPred.R`, `R/resid.R`, `R/nlmixr2output.R`).

Both `$parFixed` and `$parFixedDf` derive from the same `popDf`, so the columns drop from both -- which matches the preference stated in the issue.

The guard is deliberately tied to `omega` rather than a generic "drop the column if it is all blank": for models *with* etas the `Shrink(SD)%` column also carries IWRES shrinkage on the residual-error rows, and that must keep working.

## Verification

- The no-eta fit above now ends cleanly at `Back-transformed(95%CI)`, in both `$parFixed` and `$parFixedDf`.
- An eta model is unchanged: `BSV(CV%)` and `Shrink(SD)%` are still populated, including the `<`/`>` shrinkage suffixes.
- `test-nlmixr2output.R` 23/23; `test-parFixedDf.R`, `test-manual-back-transform.R`, `test-cov-focei.R`, `test-mu-plain-fit.R` all pass.

## Tests

Three eta-free cases in `test-nlmixr2output.R` asserted the blank columns (``  `BSV(SD)` = c("", "", "", "")  ``) -- exactly the blanks the issue asks to remove -- so those expectations are updated. Added assertions that the columns are absent for a no-eta fit and present for an eta fit, so this cannot silently regress in either direction.

## Note on unrelated failures

Two tests fail on this branch, but they fail identically on a clean `origin/main` (verified by stashing) and neither touches `parFixed`:

- `test-bounded-transform.R:153` -- SAEM fixed-bounded-param assertion on `fit$theta`.
- `test-issue-641.R` -- fit errors with "Maximum number of theta resets (10) exceeded; fit is unstable" (ETA drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)