### PR TITLE
Fix two pre-existing test failures: SAEM fix()ed thetas and freezeResidGrad theta resets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -489,6 +489,17 @@
 
 ### Estimation
 
+- `est="saem"` no longer estimates a `fix()`ed theta that has no eta attached to
+  it; such a parameter now stays at its initial estimate, as it already did for
+  the FOCEi family.  The direct phi0 optimization (`nonMuTheta="regress"`, and
+  general-likelihood models) takes over phi0 partway through the fit and skips
+  the update that restores fixed values, so a fixed non-mu-referenced theta drifted
+  off its initial estimate.  Estimates of non-fixed parameters are unchanged.
+- `foceiControl(freezeResidGrad=TRUE)` (the default) no longer makes a fit die with
+  "maximum number of theta resets (10) exceeded".  The base solve that caches the
+  states/EBEs for the frozen gradient ran without the gradient flag set, so an
+  ETA-drift theta reset raised inside a gradient restarted the whole fit -- on every
+  gradient, until the reset limit tripped (#641).
 - A model that combines an inter-occasion variability (IOV) term with a zero
   inter-individual variability eta on another parameter (for example
   `eta.ka ~ 0` alongside `iov.cl ~ 0.1 | occ`) no longer fails with "initial

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -1275,7 +1275,15 @@ static inline double foceiOfv0(double *theta); // fwd
 // then snapshot.  freezeOde is left off; numericGrad enables it per residual cpar.
 static void foceiResidFreezeBuildAt(double *theta) {
   op_focei.freezeOde = false;
+  // This base solve happens inside numericGrad, so it must not mutate outer
+  // state: with calcGrad off it reaches the theta-reset / mu-group / objective-
+  // recalc sites, and an ETA-drift reset raised here restarts the fit on every
+  // gradient (issue #641 fits then die on "maximum number of theta resets").
+  // calcGrad also matches how the perturbed evaluations below are solved.
+  int calcGrad0 = op_focei.calcGrad;
+  op_focei.calcGrad = 1;
   foceiOfv0(theta);
+  op_focei.calcGrad = calcGrad0;
   foceiResidFreezeSnapshot();
 }
 

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -572,6 +572,10 @@ static double gPhi0ObjR(Rcpp::NumericVector p);
 // gPhi0Work is the full phi0 vector, gPhi0Coord the coordinate optimize() varies.
 static arma::vec gPhi0Work;
 static int gPhi0Coord = 0;
+// Free (non-FIXED) phi0 coordinates the bounded optimizer varies; gPhi0Full holds
+// the full phi0 vector so FIXED coordinates keep their ini value in the objective.
+static arma::vec gPhi0Full;
+static std::vector<int> gPhi0FreeIx;
 static double gPhi0Obj1DR(double x);
 
 // Fill an armadillo mat/vec from rxode2's threefry engine (the current seeded
@@ -711,6 +715,25 @@ public:
 
   void refinePhi0Lik(unsigned int kiter, const vec &pas) {
     if (nphi0 <= 0) return;
+    // A user-FIXED phi0 theta must not be touched here.  Once this refinement
+    // owns phi0 the stochastic update that restores MCOV0(fixedIx0) is skipped
+    // (skipStochPhi0), so anything this function writes to a fixed entry is
+    // never put back and the theta drifts off its ini value.  fixedIx0 indexes
+    // phi0 columns (refinePhi0Lik only handles the intercept-only phi0 case).
+    std::vector<bool> phi0Fix((size_t)nphi0, false);
+    for (unsigned int j = 0; j < fixedIx0.n_elem; ++j) {
+      if (fixedIx0(j) < (unsigned int)nphi0) phi0Fix[(size_t)fixedIx0(j)] = true;
+    }
+    gPhi0FreeIx.clear();
+    for (int c = 0; c < nphi0; ++c) {
+      if (!phi0Fix[(size_t)c]) gPhi0FreeIx.push_back(c);
+    }
+    if (gPhi0FreeIx.empty()) return;
+    // Snapshot the fixed MCOV0 entries: the closing least-squares update rewrites
+    // all of MCOV0 from mprior_phi0, which redistributes a fixed theta's value
+    // across the design even when its coordinate never moved.
+    vec mcov0Fixed;
+    if (fixedIx0.n_elem > 0) mcov0Fixed = vec(MCOV0(jcov0(fixedIx0)));
     // If the fast kernel re-pointed the global solve to the FOCEi inner, restore
     // the SAEM (N*nmc) solve before the direct-optim user_fn calls.
     if (!Rf_isNull(fsaemStepFn)) {
@@ -779,6 +802,7 @@ public:
       Rcpp::InternalFunction fn1d(&gPhi0Obj1DR);
       for (int sweep = 0; sweep < 2; sweep++) {
         for (int c = 0; c < nphi0; c++) {
+          if (phi0Fix[(size_t)c]) continue;
           if (!(hi[c] > lo[c])) continue;
           gPhi0Coord = c;
           Rcpp::List o = optimize(Rcpp::_["f"] = fn1d,
@@ -793,10 +817,23 @@ public:
       Rcpp::Environment nlmixr2 = Rcpp::Environment::namespace_env("nlmixr2est");
       Rcpp::Function boundedOpt = nlmixr2[".boundedResidOpt"];
       Rcpp::InternalFunction fn(&gPhi0ObjR);
-      Rcpp::List ret = boundedOpt(Rcpp::_["par"] = par0, Rcpp::_["fn"] = fn,
-                                  Rcpp::_["lower"] = lo, Rcpp::_["upper"] = hi);
+      // Optimize only the free coordinates: gPhi0ObjR expands them back into
+      // gPhi0Full, which holds the FIXED coordinates at their ini values.
+      gPhi0Full.set_size(nphi0);
+      for (int c = 0; c < nphi0; c++) gPhi0Full[c] = par0[c];
+      int nFree = (int)gPhi0FreeIx.size();
+      Rcpp::NumericVector parFree(nFree), loFree(nFree), hiFree(nFree);
+      for (int fi = 0; fi < nFree; fi++) {
+        int c = gPhi0FreeIx[(size_t)fi];
+        parFree[fi] = par0[c];
+        loFree[fi] = lo[c];
+        hiFree[fi] = hi[c];
+      }
+      Rcpp::List ret = boundedOpt(Rcpp::_["par"] = parFree, Rcpp::_["fn"] = fn,
+                                  Rcpp::_["lower"] = loFree, Rcpp::_["upper"] = hiFree);
       Rcpp::NumericVector rx = ret["x"];
-      for (int c = 0; c < nphi0; c++) xmin[c] = rx[c];
+      for (int c = 0; c < nphi0; c++) xmin[c] = par0[c];
+      for (int fi = 0; fi < nFree; fi++) xmin[gPhi0FreeIx[(size_t)fi]] = rx[fi];
     }
     _saemFreezeOde = false;
     for (int c = 0; c < nphi0; c++) {
@@ -804,6 +841,7 @@ public:
       mprior_phi0.col(c).fill(cur + pas(kiter) * (xmin[c] - cur));
     }
     MCOV0 = solve(COV0.t() * COV0, COV0.t() * mprior_phi0);
+    if (fixedIx0.n_elem > 0) MCOV0(jcov0(fixedIx0)) = mcov0Fixed;
   }
 
   void set_fn(user_funct f) {
@@ -4079,7 +4117,10 @@ private:
 
 // phi0 objective trampoline for the general-likelihood direct optimization.
 static double gPhi0ObjR(Rcpp::NumericVector p) {
-  return gPhi0Self->phi0Objective(p.begin());
+  for (size_t i = 0; i < gPhi0FreeIx.size(); ++i) {
+    gPhi0Full[gPhi0FreeIx[i]] = p[i];
+  }
+  return gPhi0Self->phi0Objective(gPhi0Full.memptr());
 }
 
 static double gPhi0Obj1DR(double x) {


### PR DESCRIPTION
Fixes two failures on `main`, each of which turned out to be a real bug that the test was correctly catching (neither was a stale assertion).

## 1. SAEM estimated a `fix()`ed non-mu-referenced theta

`test-bounded-transform.R:153` -- `td1 <- fix(0, 0.5, 1)` came back as `0.5256326`.

This is not a bounded-transform issue: the transform correctly skips fixed params (`preProcessBoundedTransform.R:41`), and the drift is identical with no bounds at all, while FOCEI holds the same `fix()` at `0.5`. The UI plumbing was also correct (`saemFixed["td1"]=TRUE`, `saemInit$theta` carries the `FIXED` annotation, `fixed.i0=0` reaches the kernel).

The cause is `refinePhi0Lik` in `src/saem.cpp` -- the direct phi0 optimization that owns phi0 under the default `nonMuTheta="regress"` (and for general-likelihood models). Once it takes over, the stochastic update that restores `MCOV0(fixedIx0)` is skipped (`skipStochPhi0`), so nothing puts a fixed value back. Two defects:

1. every phi0 coordinate was optimized, fixed or not;
2. even with the coordinate held, the closing `MCOV0 = solve(...)` rewrote all of `MCOV0`, redistributing the fixed value across the design (`0.5 -> 0.25` with two phi0 thetas).

Now only the free coordinates are optimized, and the fixed `MCOV0` entries are restored after the solve. Free-parameter estimates are bit-identical (`0.7268958`, `0.7454354`, `0.1970684`), so only fixed thetas change.

## 2. `freezeResidGrad` raised theta resets from inside the gradient

`test-issue-641.R` died on "Maximum number of theta resets (10) exceeded". Bisected to `c7f8a7ff` ("freezeResidGrad Phases 3-5"); parent `bcc2c8ec` passes. The #641 scaleC fix itself was never broken (`tvemax` still resolves to scaleC 40).

`foceiResidFreezeBuildAt` solves at the unperturbed theta to cache each subject's base states/EBE, but ran with `op_focei.calcGrad` still `0`. That reaches the outer-state sites gated on `!calcGrad` -- notably the ETA-drift `thetaReset()` -- so a model whose etas drift raised "theta reset" from inside `numericGrad`, restarting the fit on every gradient until the 10-reset limit tripped. Setting `calcGrad` around the base solve also matches how the perturbed evaluations are solved.

Note: `issue-641` is not in `.slowBatches`, so it runs on every push/PR -- CI on `main` is currently red from `c7f8a7ff`, and this unblocks it.

## Verification

The freeze is fixed, not disabled: `nFreezeResidGrad = 22` on the #641 model, which converges to the pre-regression values (`tvemax 22.522`, `objf 191.497`).

Clean rebuild, rebased onto `e15950f4`:

| file | result |
|---|---|
| `test-bounded-transform.R` | FAIL 0 / PASS 58 |
| `test-issue-641.R` | FAIL 0 / PASS 3 |
| `test-focei-freeze-resid-grad.R` | FAIL 0 / PASS 7 |
| `test-focei-theta-reset-bounds.R` | FAIL 0 / PASS 4 |
| `test-saem-nonmutheta.R` | FAIL 0 / PASS 7 |

Plus, pre-rebase, 8 focei files (122 assertions) and 9 SAEM files, FAIL 0 throughout. Since `calcGrad` is on the gradient path for every FOCEi fit, that broader focei sweep was the main regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)