### PR TITLE
Fix restart crash for mu-referenced / variant FOCEi controls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -489,6 +489,15 @@
 
 ### Estimation
 
+- A mu-referenced or method-variant FOCEi fit (`ifocei`, `mfocei`, `foce`,
+  `focep`, `agq`, `laplace`, and the `*f` fast variants such as `ifoceif`) that
+  needed to restart -- for example after a zero/bad-gradient theta reset -- died
+  with `focei$control must be a focei control object`.  These controls are all
+  built by `foceiControl()` and then reclassed to their own class, so they do
+  not carry `"foceiControl"` in their class vector, and the restart-path
+  environment check rejected them even though the fit had been set up from a
+  valid control.  The check now recognises the whole FOCEi control family.
+
 - Models that combine `linCmt()` with ODEs (for example a solved PK driving an
   effect-compartment ODE) now estimate correctly with the FOCEi and nlm
   families; the linear compartments are solved as ODEs for those methods.

--- a/R/focei.R
+++ b/R/focei.R
@@ -2285,6 +2285,28 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   }
 }
 
+# Control classes of the FOCEi family.  Every one is built by foceiControl()
+# and then reclassed (see foceiControl(), and the mu-referenced / method
+# variants in muRefControl.R, fo.R, foce.R, ...), so it carries all of
+# foceiControl()'s fields and .foceiFitInternal() accepts it -- but its class
+# vector does NOT include "foceiControl".  Enumerated here so the restart-path
+# validation below recognises them; add a new family control's class when one
+# is introduced.
+.nlmixrFoceiFamilyControlClasses <- c(
+  "foceiControl", "foceControl", "focepControl",
+  "foControl", "foiControl",
+  "mfoceiControl", "ifoceiControl", "mfoceControl", "ifoceControl",
+  "mfocepControl", "ifocepControl",
+  "agqControl", "magqControl", "iagqControl",
+  "laplaceControl", "mlaplaceControl", "ilaplaceControl",
+  "impmapControl")
+
+# TRUE for foceiControl and every control built from it (see
+# .nlmixrFoceiFamilyControlClasses).
+.nlmixrIsFoceiFamilyControl <- function(x) {
+  inherits(x, "foceiControl") || any(class(x) %in% .nlmixrFoceiFamilyControlClasses)
+}
+
 .nlmixrCheckFoceiEnvironment <- function(ret) {
   checkmate::assertDataFrame(ret$dataSav, .var.name="focei$dataSav")
   checkmate::assertNumeric(ret$thetaIni, any.missing=FALSE,
@@ -2304,7 +2326,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   }
   checkmate::assertMatrix(ret$etaMat, mode="double", null.ok=TRUE,
                           any.missing=FALSE, .var.name="focei$etaMat")
-  if (!inherits(ret$control, "foceiControl")) {
+  if (!.nlmixrIsFoceiFamilyControl(ret$control)) {
     stop("focei$control must be a focei control object",
          call.=FALSE)
   }

--- a/tests/testthat/test-focei-family-control.R
+++ b/tests/testthat/test-focei-family-control.R
@@ -1,0 +1,52 @@
+nmTest({
+  # A FOCEi-family control is built by foceiControl() and then reclassed to its
+  # own class -- the mu-referenced and method variants (ifocei, mfocei, foce,
+  # ...) do NOT keep "foceiControl" in their class vector.  The estimation
+  # restart path re-validates the environment with .nlmixrCheckFoceiEnvironment,
+  # which used to require inherits(control, "foceiControl") and so aborted any
+  # restart of a mu-referenced fit with
+  #   "focei$control must be a focei control object"
+  # even though the fit itself was set up from a valid control.  The check now
+  # accepts the whole family via .nlmixrIsFoceiFamilyControl().
+
+  test_that(".nlmixrIsFoceiFamilyControl accepts every FOCEi-family control", {
+    .family <- c("focei", "foce", "focep", "fo", "foi",
+                 "mfocei", "ifocei", "mfoce", "ifoce",
+                 "mfocep", "ifocep",
+                 "agq", "magq", "iagq",
+                 "laplace", "mlaplace", "ilaplace")
+    for (.m in .family) {
+      .ctl <- do.call(paste0(.m, "Control"), list())
+      expect_true(nlmixr2est:::.nlmixrIsFoceiFamilyControl(.ctl),
+                  info = paste0(.m, "Control (class ",
+                                paste(class(.ctl), collapse = ","), ")"))
+    }
+  })
+
+  test_that(".nlmixrIsFoceiFamilyControl rejects non-FOCEi controls", {
+    for (.m in c("saem", "nlme", "nlm")) {
+      .ctl <- do.call(paste0(.m, "Control"), list())
+      expect_false(nlmixr2est:::.nlmixrIsFoceiFamilyControl(.ctl),
+                   info = paste0(.m, "Control"))
+    }
+  })
+
+  test_that(".nlmixrCheckFoceiEnvironment does not reject a mu-referenced control", {
+    # a minimal environment with the fields the check inspects; the control is
+    # an ifoceiControl, which pre-fix tripped the class assertion
+    .env <- new.env()
+    .env$dataSav <- data.frame(ID = 1L, TIME = 0, DV = 1)
+    .env$thetaIni <- c(1, 2)
+    .env$skipCov <- NULL
+    .env$rxInv <- structure(list(), class = "rxSymInvCholEnv")
+    .env$lower <- c(-Inf, -Inf)
+    .env$upper <- c(Inf, Inf)
+    .env$etaMat <- NA
+    .env$control <- ifoceiControl()
+    expect_error(nlmixr2est:::.nlmixrCheckFoceiEnvironment(.env), NA)
+    # and it still rejects an unrelated control
+    .env$control <- saemControl()
+    expect_error(nlmixr2est:::.nlmixrCheckFoceiEnvironment(.env),
+                 "focei control object")
+  })
+})


### PR DESCRIPTION
## The bug

A FOCEi-family fit whose control is not literally a `foceiControl` aborted on
any **restart** with:

```
focei$control must be a focei control object
```

Every mu-referenced or method variant — `ifocei`, `mfocei`, `foce`, `focep`,
`agq`, `laplace`, and the `*f` fast variants such as `ifoceif` — builds its
control with `foceiControl(...)` and then reclasses it to its own class
(`class(.control) <- "ifoceiControl"`, etc.). So the object carries all of
`foceiControl()`'s fields but **not** `"foceiControl"` in its class vector.

The restart path re-validates the environment with
`.nlmixrCheckFoceiEnvironment()`, whose control check was:

```r
if (!inherits(ret$control, "foceiControl")) {
  stop("focei$control must be a focei control object", call.=FALSE)
}
```

That is `FALSE` for the reclassed family controls, so a restart — e.g. after a
zero/bad-gradient theta reset — died even though the fit had been set up from a
perfectly valid control. A plain `focei` fit was unaffected (its control *is* a
`foceiControl`), which is why this stayed hidden.

## The fix

Recognise the whole family via a new `.nlmixrIsFoceiFamilyControl()` predicate,
backed by an enumerated list of the classes `foceiControl()` builds. The check
only runs on the restart path, so the blast radius is limited to the exact
failure.

## Verification

- New `tests/testthat/test-focei-family-control.R` (22 checks): the predicate
  accepts all 17 family controls and rejects `saem`/`nlme`/`nlm`; and
  `.nlmixrCheckFoceiEnvironment()` no longer rejects an `ifoceiControl` while
  still rejecting a `saemControl` — the exact assertion that failed.
- Surfaced while fitting a delay-differential-equation model with
  `est="ifoceif"`: the fit hit a theta reset and then this crash on restart.
  With the fix the same fit runs to completion.

## Note

The underlying design smell — family controls dropping `"foceiControl"` from
their class vector — is left as-is here; making them inherit `foceiControl`
would be cleaner but touches ~17 control constructors and their conversion
branches. This change fixes the user-visible crash minimally. Found alongside a
companion rxode2 fix (nlmixr2/rxode2#1138) for the same DDE workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)