### PR TITLE
Prefer the analytic covariance across mixed-model methods; every method reports a covariance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,11 +5,12 @@
 - The analytic observed-information covariance is now the preferred `covMethod`
   across the mixed-model estimation methods, falling back to each method's
   previous default when a model is out of analytic scope:
-    - `est="saem"`/`"fsaem"` default to `covMethod="analytic"`: the FOCEI
-      analytic covariance is computed at the converged SAEM estimates and falls
-      back to the linearized FIM (`"linFim"`) with a message when out of scope
-      or not positive definite.  The `"linFim"` covariance stays selectable via
-      `setCov(fit, "linFim")`.
+    - `est="saem"`/`"fsaem"` keep the stochastic-approximation FIM (`"sa"`) as
+      the default `covMethod`, now followed by `"analytic"` and `"linFim"`.
+      `covMethod="analytic"` computes the FOCEI analytic covariance at the
+      converged SAEM estimates and falls back to the linearized FIM (`"linFim"`)
+      with a message when out of scope or not positive definite; the `"linFim"`
+      covariance stays selectable via `setCov(fit, "linFim")`.
     - `est="nlme"` gains a `covMethod` argument
       (`c("analytic", "r,s", "r", "s", "nlme", "")`, default `"analytic"`) that
       recomputes the covariance at the converged nlme estimates; `"nlme"` keeps
@@ -514,6 +515,12 @@
 ## Bug fixes
 
 ### Estimation
+
+- `est="fsaem"` (fast SAEM) now reports a covariance matrix.  The fast kernel's
+  FOCEi inner setup overwrote the shared control's `covMethod` during the fit,
+  so the covariance step ran with no method selected and left the fit with an
+  unlabeled, partially degenerate covariance; the intended `covMethod` is now
+  restored before the covariance is computed.
 
 - Models that combine `linCmt()` with ODEs (for example a solved PK driving an
   effect-compartment ODE) now estimate correctly with the FOCEi and nlm

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,32 @@
 
 ## New features
 
+- The analytic observed-information covariance is now the preferred `covMethod`
+  across the mixed-model estimation methods, falling back to each method's
+  previous default when a model is out of analytic scope:
+    - `est="saem"`/`"fsaem"` default to `covMethod="analytic"`: the FOCEI
+      analytic covariance is computed at the converged SAEM estimates and falls
+      back to the linearized FIM (`"linFim"`) with a message when out of scope
+      or not positive definite.  The `"linFim"` covariance stays selectable via
+      `setCov(fit, "linFim")`.
+    - `est="nlme"` gains a `covMethod` argument
+      (`c("analytic", "r,s", "r", "s", "nlme", "")`, default `"analytic"`) that
+      recomputes the covariance at the converged nlme estimates; `"nlme"` keeps
+      nlme's own standard errors (also available via `setCov(fit, "nlme")`).
+    - `est="npag"`/`"npb"` (and their `m`/`i` variants), which previously
+      reported no covariance, now compute one post-fit at the converged
+      estimates (default `"analytic"` with the finite-difference fallback
+      chain).
+    - `est="imp"`/`"impmap"`/`"qrpem"` gain a `covMethod` argument
+      (`c("imp", "analytic", "r,s", "r", "s", "")`, default `"imp"`).  `"imp"`
+      is the Monte-Carlo importance-sampling covariance that the old
+      `impCov=TRUE` selected (the `impCov` argument is removed); the other
+      tokens compute the post-fit FOCEI covariance.
+    - `est="advi"` keeps its variational covariance (`"advi"`) as the default but
+      now honors an explicit `covMethod` (e.g. `"analytic"`) without overwriting
+      it with the variational covariance.
+    - `setCov()`/`getVarCov()` accept `covMethod="analytic"` post-fit.
+
 - A general FOCE-family per-subject log-likelihood can now be built from an
   `rxode2` UI model and used outside of a fit, for MCMC/SAMBA-style algorithms
   (issue #414).  `foceiLikLoad()` compiles the inner model and sets up the

--- a/R/advi.R
+++ b/R/advi.R
@@ -241,9 +241,21 @@
     .nm <- c(.thNm, paste0("omega.", res$etaNames[res$phiOmIdx[res$phiOmIdx >= 0] + 1L]))
     if (nrow(.cov) == length(.nm)) dimnames(.cov) <- list(.nm, .nm)
     .e$adviCov <- .cov
-    ## install the population variational covariance as the fit's SE source (the
-    ## theta block maps directly to parFixedDf's population/residual parameters)
-    .adviInstallVarCov(.fit, res)
+    ## covMethod="advi": install the population variational covariance as the
+    ## fit's SE source (the theta block maps directly to parFixedDf's
+    ## population/residual parameters).  For any other covMethod the FOCEi
+    ## covariance step (analytic/r,s/...) already ran on the full inner model;
+    ## only fall back to the variational covariance if that chain came up empty.
+    .cmDone <- tryCatch(as.character(.e$covMethod), error = function(e) "")
+    if (identical(.control$covMethod, "advi")) {
+      .adviInstallVarCov(.fit, res)
+    } else if (is.null(.e$cov) || !is.matrix(.e$cov) ||
+                 length(.cmDone) != 1L || !nzchar(.cmDone) ||
+                 identical(.cmDone, "failed")) {
+      message("covMethod=\"", .control$covMethod,
+              "\" covariance was not available; using the ADVI variational covariance")
+      .adviInstallVarCov(.fit, res)
+    }
   }
   .e$adviState <- .st
   .fit

--- a/R/adviControl.R
+++ b/R/adviControl.R
@@ -78,7 +78,7 @@ adviControl <- function(seed = 42L,
                         useColor = NULL,
                         printNcol = NULL,
 
-                        covMethod = c("advi", "analytic", "r,s", "r", "s", ""),
+                        covMethod = c("analytic", "advi", "r,s", "r", "s", ""),
                         optExpression = TRUE,
                         sumProd = FALSE,
                         literalFix = TRUE,

--- a/R/adviControl.R
+++ b/R/adviControl.R
@@ -78,7 +78,7 @@ adviControl <- function(seed = 42L,
                         useColor = NULL,
                         printNcol = NULL,
 
-                        covMethod = c("analytic", "advi", "r,s", "r", "s", ""),
+                        covMethod = c("advi", "analytic", "r,s", "r", "s", ""),
                         optExpression = TRUE,
                         sumProd = FALSE,
                         literalFix = TRUE,

--- a/R/cov.R
+++ b/R/cov.R
@@ -243,7 +243,7 @@
 .foceiRecomputeMuCov <- function(fit, est) {
   .baseEst <- .foceiRecomputeBaseEst(est)
   if (is.null(.baseEst)) return(NULL)
-  # impCov=TRUE installed the Monte-Carlo importance-sampling covariance;
+  # covMethod="imp" installed the Monte-Carlo importance-sampling covariance;
   # that explicit request wins over the recompute
   if (identical(tryCatch(fit$covMethod, error = function(e) NULL), "imp")) {
     return(NULL)

--- a/R/cov.R
+++ b/R/cov.R
@@ -124,9 +124,16 @@
   }
   if (!is.null(.lst$covMethod)) {
     if (rxode2::rxIs(.lst$covMethod, "character")) {
-      .lst$covMethod <- match.arg(.lst$covMethod, c("r,s", "r", "s"))
-      .covMethodIdx <- c("r,s" = 1L, "r" = 2L, "s" = 3L)
-      .control$covMethod <- .covMethodIdx[.lst$covMethod]
+      .lst$covMethod <- match.arg(.lst$covMethod, c("analytic", "r,s", "r", "s"))
+      if (identical(.lst$covMethod, "analytic")) {
+        .control$covMethod <- 2L
+        .control$covType <- "analytic"
+      } else {
+        .covMethodIdx <- c("r,s" = 1L, "r" = 2L, "s" = 3L)
+        .control$covMethod <- .covMethodIdx[.lst$covMethod]
+        # an explicit FD request must not re-run the analytic hook
+        .control$covType <- "fd"
+      }
     } else if (inherits(.lst$covMethod, "matrix")) {
       .env2$cov <- as.matrix(.lst$covMethod)
       .env2$ui <- obj$ui
@@ -196,24 +203,51 @@
   return(.env$cov)
 }
 
-#' Recompute a mu-referenced (lin/irls) fit's covariance on the full base model
+#' Base est whose full model the post-fit covariance recompute runs on
+#'
+#' `NULL` for ests without a post-fit recompute.
+#' @param est estimation method string
+#' @return base est string or NULL
+#' @noRd
+.foceiRecomputeBaseEst <- function(est) {
+  # mu-referenced (lin/irls) families recompute on their own base method
+  if (grepl("^(m|i)(focei|foce|focep|agq|laplace)$", est)) {
+    return(sub("^(m|i)", "", est))
+  }
+  # methods whose estimation pass cannot produce a covariance (EM table pass,
+  # nonparametric engines, or an external engine) recompute on a
+  # zero-iteration focei model
+  if (est %in% c("imp", "impmap", "qrpem", "nlme") ||
+        grepl("^(m|i)?(npag|npb)$", est)) {
+    return("focei")
+  }
+  NULL
+}
+
+#' Recompute a fit's covariance on the full base model (post-fit)
 #'
 #' The estimation-time covariance step bails for mu-referenced-FOCEI-family fits
 #' (muModel = "lin"/"irls") -- see `foceiCalcCov()` in `src/inner.cpp` -- because
 #' the mu->phi reduced parameterization used during estimation yields incorrect
-#' standard errors on the mu-referenced/linear parameters.  This recomputes the
-#' covariance at the converged estimates with `muModel = "none"`, i.e. on the full
-#' corresponding focei/foce/focep model (all structural thetas as ordinary
-#' parameters), and installs it.  No-op for non-mu fits or when no covariance was
-#' requested.  Must run before the fit env is compressed (needs `etaMat`).
+#' standard errors on the mu-referenced/linear parameters.  The imp family
+#' (imp/impmap/qrpem) and nlme never compute a focei covariance during
+#' estimation at all.  This recomputes the covariance at the converged
+#' estimates with `muModel = "none"`, i.e. on the full base model (all
+#' structural thetas as ordinary parameters), and installs it; the C++
+#' covariance step runs the usual analytic -> "r,s" -> "r"/"s" chain.  No-op
+#' when no covariance was requested.  Must run before the fit env is
+#' compressed (needs `etaMat`).
 #' @param .ret assembled fit environment
 #' @return invisibly TRUE if the covariance was recomputed and installed
 #' @noRd
 .foceiRecomputeMuCov <- function(fit, est) {
-  # only the mu-referenced (lin/irls) families (mfocei/ifocei/mfoce/mfocep/...);
-  # anchored to the known method names so other i*/m* ests (imp, impmap, ...)
-  # never match
-  if (!grepl("^(m|i)(focei|foce|focep|agq|laplace)$", est)) return(NULL)
+  .baseEst <- .foceiRecomputeBaseEst(est)
+  if (is.null(.baseEst)) return(NULL)
+  # impCov=TRUE installed the Monte-Carlo importance-sampling covariance;
+  # that explicit request wins over the recompute
+  if (identical(tryCatch(fit$covMethod, error = function(e) NULL), "imp")) {
+    return(NULL)
+  }
   .control <- tryCatch(fit$foceiControl, error = function(e) NULL)
   if (is.null(.control)) return(NULL)
   .cm <- .control$covMethod
@@ -222,7 +256,6 @@
   .ui <- tryCatch(rxode2::rxUiDecompress(unserialize(serialize(fit$ui, NULL))),
                   error = function(e) NULL)
   if (is.null(.ui)) return(NULL)
-  .baseEst <- sub("^(m|i)", "", est)         # mfocei->focei, ifoce->foce, mfocep->focep
   .control$muModel <- "none"                 # recompute the foceiModel on the full model
   # drop the mu-group wiring so the recompute treats every structural theta as an
   # ordinary parameter (nothing excluded/re-profiled by the mu machinery); keep `fast`
@@ -280,12 +313,39 @@
 #' @noRd
 .foceiInstallMuCov <- function(fit, est) {
   .r <- tryCatch(.foceiRecomputeMuCov(fit, est), error = function(e) NULL)
-  if (is.null(.r)) return(invisible(FALSE))
   .env <- if (is.environment(fit)) fit else tryCatch(fit$env, error = function(e) NULL)
   if (!is.environment(.env)) return(invisible(FALSE))
+  if (is.null(.r)) {
+    # message only when a recompute was requested but failed and a legacy
+    # covariance (e.g. nlme's) is being kept
+    if (identical(est, "nlme") &&
+          exists("cov", envir = .env, inherits = FALSE)) {
+      .cm <- tryCatch(fit$foceiControl$covMethod, error = function(e) 0L)
+      if (!is.null(.cm) && !identical(as.integer(.cm), 0L)) {
+        message("the analytic/finite-difference covariance could not be computed; keeping the \"nlme\" covariance")
+      }
+    }
+    return(invisible(FALSE))
+  }
+  # keep the pre-existing covariance (e.g. nlme's tTable cov) recoverable via
+  # covList/setCov()
+  .stash <- NULL
+  if (exists("cov", envir = .env, inherits = FALSE) &&
+        exists("covMethod", envir = .env, inherits = FALSE)) {
+    .stash <- list(get("cov", envir = .env))
+    names(.stash) <- as.character(get("covMethod", envir = .env))
+  }
   assign("cov", .r$cov, envir = .env)
   assign("covMethod", .r$covMethod, envir = .env)
   for (.n in names(.r$extras)) assign(.n, .r$extras[[.n]], envir = .env)
+  if (!is.null(.stash) && !identical(names(.stash), .r$covMethod)) {
+    .covList <- NULL
+    if (exists("covList", envir = .env, inherits = FALSE)) {
+      .covList <- get("covList", envir = .env)
+    }
+    if (is.null(.covList[[names(.stash)]])) .covList <- c(.covList, .stash)
+    assign("covList", .covList, envir = .env)
+  }
   # the mu fit's objDf was rendered before any cov existed; recompute the eigen
   # diagnostics + Condition#(Cov)/Condition#(Cor) from the installed cov
   .nlmixr2CovConditionUpdate(.env)

--- a/R/cov.R
+++ b/R/cov.R
@@ -383,6 +383,13 @@ setCov <- function(fit, method) {
       return(invisible(fit))
     }
   }
+  # not cached: the analytic / finite-difference methods can be recomputed on the
+  # full model at the converged estimates (.setCov refits with est="none")
+  if (method %in% c("analytic", "r,s", "r", "s")) {
+    .setCov(fit, covMethod = method)
+    .env$covMethod <- method
+    return(invisible(fit))
+  }
   stop("different covariance types have not been calculated",
     call. = FALSE
   )

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -128,14 +128,25 @@ impmapControl <- function(sigdig=3,
   # C++ kernel (op_focei.impCov); every other token is the post-fit FOCEI
   # covariance, so hand foceiControl a valid token (the estimation pass forces
   # covMethod=0L regardless -- see .impmapFamilyFit).
-  if (length(covMethod) == 1L && !nzchar(covMethod)) {
-    covMethod <- ""
+  .dots <- list(...)
+  .impCov <- isTRUE(.dots$impCov)   # may already be set on a round-tripped control
+  .dots$impCov <- NULL              # internal field; do not forward to foceiControl
+  if (is.character(covMethod)) {
+    if (length(covMethod) == 1L && !nzchar(covMethod)) {
+      covMethod <- ""
+    } else {
+      covMethod <- match.arg(covMethod)
+    }
+    .impCov <- identical(covMethod, "imp")
+    .foceiCovMethod <- if (.impCov) "analytic" else covMethod
   } else {
-    covMethod <- match.arg(covMethod)
+    # round-trip: covMethod is already a resolved foceiControl integer slot;
+    # keep the impCov flag from the incoming control (read above)
+    .foceiCovMethod <- covMethod
   }
-  .impCov <- identical(covMethod, "imp")
-  .foceiCovMethod <- if (.impCov) "analytic" else covMethod
-  .control <- foceiControl(sigdig=sigdig, ..., covMethod=.foceiCovMethod, muModel="lin")
+  .control <- do.call(foceiControl,
+                      c(list(sigdig=sigdig), .dots,
+                        list(covMethod=.foceiCovMethod, muModel="lin")))
   .control$impCov <- .impCov
   .control$isample <- as.integer(isample)
   .control$nIter <- as.integer(nIter)

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -54,7 +54,9 @@
 #'   observed-information covariance for the estimated thetas and Omega
 #'   parameters (a finite-difference Hessian of the importance-sampling objective
 #'   over fixed common-random-number samples), stashed as `$impCov` / `$impSe`.
-#'   Off by default.  The theta standard errors match the Hessian-based FOCEI
+#'   Off by default.  When `TRUE` this covariance is the one installed on the
+#'   fit and the post-fit analytic/finite-difference recompute (see
+#'   `covMethod` in [foceiControl()]) is skipped.  The theta standard errors match the Hessian-based FOCEI
 #'   covariance; the variance of a tightly-determined random effect (an Omega
 #'   diagonal) can still be over-estimated because the fixed samples barely span
 #'   its prior variation.
@@ -239,8 +241,11 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
 .impmapFamilyFit <- function(env, ui, ...) {
   # With est="impmap", foceiFitCpp_ runs impOuter() (src/imp.cpp) in place of
   # foceiOuter().  The FOCEI outer optimizer is turned off (maxOuterIterations=0)
-  # because impOuter drives its own EM iteration; covariance is off for now.
+  # because impOuter drives its own EM iteration; the in-fit covariance is off
+  # (it would bail on muModel="lin" anyway) -- the covariance is computed
+  # post-fit on the full model at the converged estimates (.foceiRecomputeMuCov).
   .control <- ui$control
+  .covMethodUser <- .control$covMethod  # restored on the fit env control below
   .control$maxOuterIterations <- 0L
   .control$covMethod <- 0L
   # 0-based index maps for the SIMPLE mu-referenced intercepts (theta = population
@@ -285,7 +290,26 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   # the Omega parameters come out unnamed on this path; fill them in (defensively,
   # only when the counts line up) so vcov()/$cov and the correlation are labelled.
   .impmapNameCov(.fit, ui)
+  .impRestoreCovMethod(.fit, .covMethodUser)
   .fit
+}
+
+#' Restore the user's covMethod on the fit env's stored control
+#'
+#' The estimation pass forces covMethod=0L (the in-fit C++ step would bail on
+#' muModel="lin"), and that runtime control is what gets stored on the fit env;
+#' the post-fit recompute (.foceiRecomputeMuCov) reads the covMethod from there,
+#' so put the user's choice back.
+#' @noRd
+.impRestoreCovMethod <- function(fit, covMethod) {
+  .fenv <- tryCatch(fit$env, error = function(e) NULL)
+  if (is.environment(.fenv) &&
+        exists("impmapControl", envir = .fenv, inherits = FALSE)) {
+    .ic <- get("impmapControl", envir = .fenv)
+    .ic$covMethod <- covMethod
+    assign("impmapControl", .ic, envir = .fenv)
+  }
+  invisible(fit)
 }
 
 #' Fill the Omega row/column names on the impmap covariance

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -50,16 +50,17 @@
 #'   `impmapControl()` this is always `"lin"` and cannot be changed.
 #' @param impSeed Base seed for the per-subject thread-safe (threefry) RNG
 #'   streams; results are reproducible and independent of the thread count.
-#' @param impCov Experimental: when `TRUE`, compute a Monte-Carlo
-#'   observed-information covariance for the estimated thetas and Omega
-#'   parameters (a finite-difference Hessian of the importance-sampling objective
-#'   over fixed common-random-number samples), stashed as `$impCov` / `$impSe`.
-#'   Off by default.  When `TRUE` this covariance is the one installed on the
-#'   fit and the post-fit analytic/finite-difference recompute (see
-#'   `covMethod` in [foceiControl()]) is skipped.  The theta standard errors match the Hessian-based FOCEI
-#'   covariance; the variance of a tightly-determined random effect (an Omega
-#'   diagonal) can still be over-estimated because the fixed samples barely span
-#'   its prior variation.
+#' @param covMethod Covariance method.  `"imp"` (default) computes the
+#'   Monte-Carlo importance-sampling observed-information covariance for the
+#'   estimated thetas and Omega parameters (a finite-difference Hessian of the
+#'   importance-sampling objective over fixed common-random-number samples),
+#'   stashed as `$impCov` / `$impSe` and installed as the fit covariance; the
+#'   theta standard errors match the Hessian-based FOCEI covariance, though the
+#'   variance of a tightly-determined random effect (an Omega diagonal) can be
+#'   over-estimated because the fixed samples barely span its prior variation.
+#'   `"analytic"`, `"r,s"`, `"r"`, `"s"` instead compute the FOCEI covariance
+#'   post-fit at the converged estimates (see [foceiControl()]); `""` skips the
+#'   covariance step.
 #' @param qr When `TRUE`, draw quasi-random (Sobol low-discrepancy) importance
 #'   samples instead of pseudo-random Gaussian samples (QRPEM, Leary &
 #'   Dunlavey PAGE 2012); the E-step integrals converge at O(1/N) instead of
@@ -97,7 +98,7 @@ impmapControl <- function(sigdig=3,
                           ctol=NULL,
                           nConvWindow=10L,
                           impSeed=42L,
-                          impCov=FALSE,
+                          covMethod=c("imp", "analytic", "r,s", "r", "s", ""),
                           qr=FALSE,
                           qrShift=TRUE,
                           qrRefresh=TRUE,
@@ -123,7 +124,19 @@ impmapControl <- function(sigdig=3,
     stop("'sirSample' (", .sirSample, ") cannot exceed 'isample' (", .isample, ")",
          call.=FALSE)
   }
-  .control <- foceiControl(sigdig=sigdig, ..., muModel="lin")
+  # covMethod="imp" drives the Monte-Carlo importance-sampling covariance in the
+  # C++ kernel (op_focei.impCov); every other token is the post-fit FOCEI
+  # covariance, so hand foceiControl a valid token (the estimation pass forces
+  # covMethod=0L regardless -- see .impmapFamilyFit).
+  if (length(covMethod) == 1L && !nzchar(covMethod)) {
+    covMethod <- ""
+  } else {
+    covMethod <- match.arg(covMethod)
+  }
+  .impCov <- identical(covMethod, "imp")
+  .foceiCovMethod <- if (.impCov) "analytic" else covMethod
+  .control <- foceiControl(sigdig=sigdig, ..., covMethod=.foceiCovMethod, muModel="lin")
+  .control$impCov <- .impCov
   .control$isample <- as.integer(isample)
   .control$nIter <- as.integer(nIter)
   .control$mapIter <- as.integer(mapIter)
@@ -134,7 +147,6 @@ impmapControl <- function(sigdig=3,
   .control$ctol <- if (is.null(ctol)) NULL else as.double(ctol)
   .control$nConvWindow <- as.integer(nConvWindow)
   .control$impSeed <- as.integer(impSeed)
-  .control$impCov <- as.logical(impCov)
   .control$qr <- qr
   .control$qrShift <- qrShift
   .control$qrRefresh <- qrRefresh

--- a/R/nlme.R
+++ b/R/nlme.R
@@ -16,6 +16,13 @@
 #'   maps to it: `print=0` runs quietly (`verbose=FALSE`) and any positive
 #'   value is verbose (`verbose=TRUE`).  When `print` is not supplied an
 #'   explicit `verbose` is used as given.
+#' @param covMethod Covariance method: `"analytic"` (default) computes the
+#'   focei observed-information covariance at the converged nlme estimates
+#'   post-fit (falling back to the finite-difference `"r,s"` -> `"r"`/`"s"`
+#'   chain when out of analytic scope); `"r,s"`, `"r"`, `"s"` request the
+#'   finite-difference forms directly; `"nlme"` and `""` skip the recompute
+#'   and keep nlme's own standard errors.  When the recompute fails the
+#'   `"nlme"` covariance is kept.
 #' @return a nlmixr-nlme list
 #' @examples
 #' nlmeControl()
@@ -33,7 +40,8 @@ nlmixr2NlmeControl <- function(maxIter = 100, pnlsMaxIter = 100, msMaxIter = 100
     random=NULL, fixed=NULL, weights=NULL, verbose=TRUE, returnNlme=FALSE,
     addProp = c("combined2", "combined1"), calcTables=TRUE, compress=TRUE,
     adjObf=TRUE, ci=0.95, sigdig=4, sigdigTable=NULL, muRefCovAlg=TRUE,
-    eventSens=c("jump", "fd"), print=NULL, ...) {
+    eventSens=c("jump", "fd"), print=NULL,
+    covMethod=c("analytic", "r,s", "r", "s", "nlme", ""), ...) {
 
   checkmate::assertLogical(optExpression, len=1, any.missing=FALSE)
   checkmate::assertLogical(literalFix, len=1, any.missing=FALSE)
@@ -65,6 +73,11 @@ nlmixr2NlmeControl <- function(maxIter = 100, pnlsMaxIter = 100, msMaxIter = 100
   method <- match.arg(method)
   addProp <- match.arg(addProp)
   eventSens <- match.arg(eventSens)
+  if (length(covMethod) == 1L && !nzchar(covMethod)) {
+    covMethod <- ""
+  } else {
+    covMethod <- match.arg(covMethod)
+  }
 
   # 'print' is the common nlmixr control alias; nlme prints through 'verbose',
   # so map it (print=0 means quiet) and let an explicit 'verbose' stand when
@@ -76,7 +89,7 @@ nlmixr2NlmeControl <- function(maxIter = 100, pnlsMaxIter = 100, msMaxIter = 100
 
   .xtra <- list(...)
   .bad <- names(.xtra)
-  .bad <- .bad[!(.bad %in% c("genRxControl", "covMethod"))]
+  .bad <- .bad[!(.bad %in% "genRxControl")]
   if (length(.bad) > 0) {
     stop("unused argument: ", paste
     (paste0("'", .bad, "'", sep=""), collapse=", "),
@@ -128,7 +141,7 @@ nlmixr2NlmeControl <- function(maxIter = 100, pnlsMaxIter = 100, msMaxIter = 100
                returnNlme=returnNlme, addProp=addProp, calcTables=calcTables,
                compress=compress, random=random, fixed=fixed, weights=weights,
                ci=ci, sigdig=sigdig, sigdigTable=sigdigTable, muRefCovAlg=muRefCovAlg,
-               eventSens=eventSens,
+               eventSens=eventSens, covMethod=covMethod,
                genRxControl=.genRxControl)
   class(.ret) <- "nlmeControl"
   .ret
@@ -422,13 +435,13 @@ nmObjGetControl.nlme <- function(x, ...) {
   stop("cannot find nlme related control object", call.=FALSE)
 }
 
-.nlmeControlToFoceiControl <- function(env, assign=TRUE) {
+.nlmeControlToFoceiControl <- function(env, assign=TRUE, covMethod=0L) {
   .nlmeControl <- env$nlmeControl
   .ui <- env$ui
   .foceiControl <- foceiControl(rxControl=env$nlmeControl$rxControl,
                                 maxOuterIterations=0L,
                                 maxInnerIterations=0L,
-                                covMethod=0L,
+                                covMethod=covMethod,
                                 etaMat=env$etaMat,
                                 sumProd=.nlmeControl$sumProd,
                                 optExpression=.nlmeControl$optExpression,
@@ -451,7 +464,12 @@ nmObjGetControl.nlme <- function(x, ...) {
 #' @export
 #' @rdname nmObjGetFoceiControl
 nmObjGetFoceiControl.nlme <- function(x, ...) {
-  .nlmeControlToFoceiControl(x[[1]])
+  .env <- x[[1]]
+  # the post-fit recompute (.foceiRecomputeMuCov) reads its covMethod from this
+  # control; "nlme"/"" keep the legacy nlme covariance/no covariance (0L)
+  .cm <- tryCatch(.env$nlmeControl$covMethod, error = function(e) NULL)
+  if (is.null(.cm) || !nzchar(.cm) || identical(.cm, "nlme")) .cm <- 0L
+  .nlmeControlToFoceiControl(.env, covMethod=.cm)
 }
 
 .nlmeFamilyFit <- function(env, ...) {

--- a/R/nlme.R
+++ b/R/nlme.R
@@ -73,7 +73,10 @@ nlmixr2NlmeControl <- function(maxIter = 100, pnlsMaxIter = 100, msMaxIter = 100
   method <- match.arg(method)
   addProp <- match.arg(addProp)
   eventSens <- match.arg(eventSens)
-  if (length(covMethod) == 1L && !nzchar(covMethod)) {
+  if (checkmate::testIntegerish(covMethod, len=1, any.missing=FALSE)) {
+    # integer round-trip: 0L means no covariance ("nlme"/"" keep nlme's own)
+    covMethod <- if (identical(as.integer(covMethod), 0L)) "" else "analytic"
+  } else if (length(covMethod) == 1L && !nzchar(covMethod)) {
     covMethod <- ""
   } else {
     covMethod <- match.arg(covMethod)

--- a/R/nlmixr2Est.R
+++ b/R/nlmixr2Est.R
@@ -323,7 +323,12 @@ nlmixr2Est0 <- function(env, ...) {
   # Now that the fit is fully finalized, recompute at the converged estimates
   # (see .foceiRecomputeBaseEst for the est -> base-model mapping).
   if (inherits(.ret, "nlmixr2FitCore")) {
+    # not every method assigns env$est (nlme/saem set it on the fit only), so
+    # fall back to the finalized fit's est
     .estName <- tryCatch(as.character(get("est", envir = env)), error = function(e) "")
+    if (length(.estName) != 1L || !nzchar(.estName)) {
+      .estName <- tryCatch(as.character(.ret$est), error = function(e) "")
+    }
     if (length(.estName) == 1L &&
           !is.null(.foceiRecomputeBaseEst(.estName))) {
       try(.foceiInstallMuCov(.ret, .estName), silent = TRUE)

--- a/R/nlmixr2Est.R
+++ b/R/nlmixr2Est.R
@@ -317,14 +317,15 @@ nlmixr2Est0 <- function(env, ...) {
     })
   }
   .nlmixrEstUpdatesOrigModel(.ret, env)
-  # Mu-referenced (lin/irls) families: the C++ covariance step bailed (a mu->phi reduced
-  # cov gives wrong SEs on the mu-referenced/linear parameters).  Now that the fit is
-  # fully finalized (mu-rewriting restored), recompute the covariance on the full base
-  # focei/foce/focep model.
+  # Post-fit covariance recompute on the full base model: the mu-referenced
+  # (lin/irls) families' C++ covariance step bailed (a mu->phi reduced cov gives
+  # wrong SEs), and the imp/np/nlme families never compute one during estimation.
+  # Now that the fit is fully finalized, recompute at the converged estimates
+  # (see .foceiRecomputeBaseEst for the est -> base-model mapping).
   if (inherits(.ret, "nlmixr2FitCore")) {
     .estName <- tryCatch(as.character(get("est", envir = env)), error = function(e) "")
     if (length(.estName) == 1L &&
-          grepl("^(m|i)(focei|foce|focep|agq|laplace)$", .estName)) {
+          !is.null(.foceiRecomputeBaseEst(.estName))) {
       try(.foceiInstallMuCov(.ret, .estName), silent = TRUE)
     }
   }

--- a/R/npCommon.R
+++ b/R/npCommon.R
@@ -106,7 +106,17 @@
 #' @noRd
 .npFamilyFit <- function(env, ui, ...) {
   .control <- ui$control
+  # the nonparametric kernels do not compute the Monte-Carlo importance-sampling
+  # ("imp") covariance; force it off (impmapControl's default) so the post-fit
+  # recompute installs the FOCEI covariance instead
+  .control$impCov <- FALSE
   .covMethodUser <- .control$covMethod  # restored on the fit env control below
+  if (is.null(.covMethodUser) || identical(as.integer(.covMethodUser), 0L)) {
+    # the inherited "imp" default maps to covMethod=0L for np; recompute the
+    # analytic FOCEI covariance instead of reporting none
+    .covMethodUser <- 2L
+    .control$covType <- "analytic"
+  }
   .control$maxOuterIterations <- 0L
   .control$covMethod <- 0L  # covariance is computed post-fit (.foceiRecomputeMuCov)
   .env <- ui$foceiOptEnv     # builds foceiMuGroupTheta (covariate mu-groups)

--- a/R/npCommon.R
+++ b/R/npCommon.R
@@ -106,8 +106,9 @@
 #' @noRd
 .npFamilyFit <- function(env, ui, ...) {
   .control <- ui$control
+  .covMethodUser <- .control$covMethod  # restored on the fit env control below
   .control$maxOuterIterations <- 0L
-  .control$covMethod <- 0L
+  .control$covMethod <- 0L  # covariance is computed post-fit (.foceiRecomputeMuCov)
   .env <- ui$foceiOptEnv     # builds foceiMuGroupTheta (covariate mu-groups)
   .iniDf <- ui$iniDf
   .th <- .iniDf[!is.na(.iniDf$ntheta), ]
@@ -236,7 +237,9 @@
     .control$npMuExpandThetaIdx <- as.integer(.ti[.ok])
   }
   assign("control", .control, envir = ui)
-  .foceiFamilyReturn(env, ui, ..., est = .est)
+  .fit <- .foceiFamilyReturn(env, ui, ..., est = .est)
+  .impRestoreCovMethod(.fit, .covMethodUser)
+  .fit
 }
 
 # mu-attribute for the plain methods: gated on the control (mu only when the user

--- a/R/saem.R
+++ b/R/saem.R
@@ -1185,6 +1185,10 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
 .saemFamilyFit <- function(env, ...) {
   .ui <- env$ui
   .control <- .ui$control
+  # the fast (f-SAEM) kernel sets up a FOCEi inner problem whose foceiControl
+  # (covMethod="") clobbers the shared ui control covMethod during .saemFitModel;
+  # capture the intended covMethod up front and restore it before .saemCalcCov
+  .covMethodSaem <- .control$covMethod
   .data <- env$data
   .ret <- new.env(parent=emptyenv())
   .ret$table <- env$table
@@ -1202,6 +1206,10 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
   .nlmixrSetMuRefTimeVarying(.ui, .tv)
   on.exit(.nlmixrRmMuRefTimeVarying(.ui), add = TRUE)
   .ret$ui <- .ui
+  # restore the covMethod the fast kernel may have overwritten (see above)
+  if (!is.null(.covMethodSaem)) {
+    rxode2::rxAssignControlValue(.ui, "covMethod", .covMethodSaem)
+  }
   .saemCalcCov(.ret)
   .ret <- nlmixrWithTiming("postprocess", {
     if (!is.null(.ret$saem$tolFactor)) {

--- a/R/saem.R
+++ b/R/saem.R
@@ -647,6 +647,14 @@
 .saemCalcCov <- function(env) {
   .ui <- env$ui
   .cm <- rxode2::rxGetControl(.ui, "covMethod", "linFim")
+  if (identical(.cm, "analytic")) {
+    # the analytic observed-information covariance is computed post-fit
+    # (.saemInstallAnalyticCov, once the fit object exists); compute the
+    # linearized FIM now as the ready fallback and flag the analytic attempt
+    assign(".saemCovAnalyticPending", TRUE, envir = env)
+    rxode2::rxAssignControlValue(.ui, "covMethod", "linFim")
+    .cm <- "linFim"
+  }
   if (.cm %in% c("sa", "fim")) {
     # Both invert a SAEM observed-information matrix (.saemFimToCov): "sa" uses the
     # converged fixed-theta FIM (saem$HaSa), "fim" the estimation-phase FIM (saem$Ha).
@@ -1099,6 +1107,74 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
   invisible()
 }
 
+#' Install the analytic FOCEI covariance on a SAEM fit (post-fit)
+#'
+#' `covMethod="analytic"` computes the linearized FIM as the ready fallback
+#' during estimation (`.saemCalcCov`) and flags the analytic attempt.  Once the
+#' fit object exists this computes the FOCEI analytic observed-information
+#' covariance at the converged SAEM estimates and installs it (PD-guarded),
+#' keeping the `linFim` covariance recoverable via `covList`.  On any failure it
+#' messages and keeps the linearized FIM.
+#' @param fit saem fit (or its environment)
+#' @return nothing, called for side effects
+#' @noRd
+.saemInstallAnalyticCov <- function(fit) {
+  .env <- fit
+  if (rxode2::rxIs(fit, "nlmixr2FitData")) .env <- fit$env
+  if (!is.environment(.env) ||
+        !isTRUE(tryCatch(get(".saemCovAnalyticPending", envir = .env, inherits = FALSE),
+                         error = function(e) FALSE))) {
+    return(invisible())
+  }
+  .r <- tryCatch(.foceiCovAnalyticCalc(fit), error = function(e) NULL)
+  if (is.null(.r) || !is.matrix(.r$cov) || !all(is.finite(.r$cov))) {
+    message("covMethod=\"analytic\" could not be computed for this model; using the linearized FIM (covMethod=\"linFim\")")
+    return(invisible())
+  }
+  .cov <- 0.5 * (.r$cov + t(.r$cov))                        # exact symmetry
+  .ev <- suppressWarnings(eigen(.cov, symmetric = TRUE, only.values = TRUE)$values)
+  if (any(diag(.cov) <= 0) || !all(is.finite(.ev)) || min(.ev) <= 0) {
+    message("covMethod=\"analytic\" covariance is not positive definite; using the linearized FIM (covMethod=\"linFim\")")
+    return(invisible())
+  }
+  # keep the linFim covariance recoverable via setCov(fit, "linFim")
+  if (exists("cov", envir = .env, inherits = FALSE) && is.matrix(.env$cov)) {
+    .lin <- list(.env$cov)
+    names(.lin) <- as.character(if (exists("covMethod", envir = .env, inherits = FALSE)) {
+      .env$covMethod
+    } else "linFim")
+    .cl <- if (exists("covList", envir = .env, inherits = FALSE)) .env$covList else NULL
+    if (is.null(.cl[[names(.lin)]])) .cl <- c(.cl, .lin)
+    assign("covList", .cl, envir = .env)
+  }
+  .env$cov <- .cov
+  .env$covMethod <- "analytic"
+  assign(".covAnalytic", .r, envir = .env)                 # getVarCov()/$cov reuse it
+  # overwrite the parameter-table SEs from the analytic covariance
+  if (exists("parFixedDf", envir = .env, inherits = FALSE)) {
+    .pf <- .env$parFixedDf
+    .se <- sqrt(diag(.cov))
+    .ci <- tryCatch(as.numeric(rxode2::rxGetControl(.env$ui, "ci", 0.95)),
+                    error = function(e) 0.95)
+    .qn <- stats::qnorm(1 - (1 - .ci) / 2)
+    for (.n in rownames(.pf)) {
+      if (.n %in% names(.se) && "SE" %in% names(.pf)) {
+        .s <- .se[[.n]]; .e <- .pf[.n, "Estimate"]
+        .pf[.n, "SE"] <- .s
+        if ("%RSE" %in% names(.pf)) .pf[.n, "%RSE"] <- abs(.s / .e) * 100
+        if (all(c("CI Lower", "CI Upper", "Back-transformed") %in% names(.pf)) &&
+              isTRUE(all.equal(unname(.pf[.n, "Back-transformed"]), unname(.e)))) {
+          .pf[.n, "CI Lower"] <- .e - .qn * .s
+          .pf[.n, "CI Upper"] <- .e + .qn * .s
+        }
+      }
+    }
+    .env$parFixedDf <- .pf
+  }
+  .nlmixr2CovConditionUpdate(.env)
+  invisible()
+}
+
 #' Fit the saem family of models
 #'
 #' @param env Environment from nlmixr2Est
@@ -1170,6 +1246,10 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
       }
       .rEnv$covMethod <- if (.cm %in% c("linFim", "fim", "sa")) .cm else "linFim"
     }
+    # covMethod="analytic": now that the linFim fallback is installed and the fit
+    # table is built, attempt the FOCEI analytic covariance at the converged
+    # estimates (keeps linFim on any failure).
+    .saemInstallAnalyticCov(.ret)
     # For mixture models: post-correct me/mn/mu in the assembled fit table
     # (mirrors the .mixFixTable call in .foceiFamilyReturn for FOCEi fits)
     if (inherits(.ret, "nlmixr2FitData") && length(.ui$mixProbs) > 0L) {

--- a/R/saemControl.R
+++ b/R/saemControl.R
@@ -41,6 +41,13 @@
 #'     gradient cross-product (evaluated at the individual empirical
 #'     Bayes estimates).
 #'
+#'  "\code{analytic}" (default) Compute the FOCEI analytic observed-information
+#'  covariance at the converged SAEM estimates.  When the model is out of
+#'  analytic-covariance scope (e.g. \code{linCmt()}, a non-normal likelihood,
+#'  or a non-SD IOV parameterization) or the result is not positive definite,
+#'  it falls back to the linearized Fisher information (\code{linFim}) with a
+#'  message.
+#'
 #'  "\code{linFim}" Use the Linearized Fisher Information Matrix to calculate the covariance.
 #'
 #'  "\code{fim}" Use the Fisher Information Matrix accumulated during SAEM
@@ -337,7 +344,7 @@ saemControl <- function(seed = 99,
                         nu = c(2, 2, 2),
                         print = 1L,
                         trace = 0, # nolint
-                        covMethod = c("linFim", "fim", "sa", "r,s", "r", "s", ""),
+                        covMethod = c("analytic", "linFim", "fim", "sa", "r,s", "r", "s", ""),
                         covFull = TRUE,
                         nSaCov = 500L,
                         calcTables = TRUE,

--- a/R/saemControl.R
+++ b/R/saemControl.R
@@ -41,12 +41,20 @@
 #'     gradient cross-product (evaluated at the individual empirical
 #'     Bayes estimates).
 #'
-#'  "\code{analytic}" (default) Compute the FOCEI analytic observed-information
-#'  covariance at the converged SAEM estimates.  When the model is out of
-#'  analytic-covariance scope (e.g. \code{linCmt()}, a non-normal likelihood,
-#'  or a non-SD IOV parameterization) or the result is not positive definite,
-#'  it falls back to the linearized Fisher information (\code{linFim}) with a
-#'  message.
+#'  "\code{sa}" (default) Use the stochastic-approximation Fisher Information
+#'  Matrix.  After estimation, a dedicated covariance phase (\code{nSaCov}
+#'  iterations) holds the parameters at the converged estimate and keeps
+#'  resimulating the individual parameters, Monte-Carlo averaging the Louis
+#'  observed-information integrand into a converged FIM decoupled from the cooling
+#'  schedule (the approach used by Monolix; Kuhn & Lavielle 2005).  Always includes
+#'  every estimated population parameter (theta, the \code{Omega} diagonal
+#'  variances, and residual).
+#'
+#'  "\code{analytic}" Compute the FOCEI analytic observed-information covariance at
+#'  the converged SAEM estimates.  When the model is out of analytic-covariance
+#'  scope (e.g. \code{linCmt()}, a non-normal likelihood, or a non-SD IOV
+#'  parameterization) or the result is not positive definite, it falls back to the
+#'  linearized Fisher information (\code{linFim}) with a message.
 #'
 #'  "\code{linFim}" Use the Linearized Fisher Information Matrix to calculate the covariance.
 #'
@@ -54,14 +62,6 @@
 #'  estimation to calculate the covariance.  Like \code{sa} it inverts the observed
 #'  information to a full theta + \code{Omega} diagonal + residual covariance, but
 #'  uses the (noisier) estimation-phase matrix rather than a dedicated cov phase.
-#'
-#'  "\code{sa}" Use the stochastic-approximation Fisher Information Matrix.  After
-#'  estimation, a dedicated covariance phase (\code{nSaCov} iterations) holds the
-#'  parameters at the converged estimate and keeps resimulating the individual
-#'  parameters, Monte-Carlo averaging the Louis observed-information integrand into a
-#'  converged FIM decoupled from the cooling schedule (the approach used by Monolix;
-#'  Kuhn & Lavielle 2005).  Always includes every estimated population parameter
-#'  (theta, the \code{Omega} diagonal variances, and residual).
 #'
 #'  For both \code{fim} and \code{sa} the simulation-based Fisher information covers the
 #'  structural theta, the \code{Omega} diagonal variances, and additive residual error.
@@ -344,7 +344,7 @@ saemControl <- function(seed = 99,
                         nu = c(2, 2, 2),
                         print = 1L,
                         trace = 0, # nolint
-                        covMethod = c("analytic", "linFim", "fim", "sa", "r,s", "r", "s", ""),
+                        covMethod = c("sa", "analytic", "linFim", "fim", "r,s", "r", "s", ""),
                         covFull = TRUE,
                         nSaCov = 500L,
                         calcTables = TRUE,

--- a/man/adviControl.Rd
+++ b/man/adviControl.Rd
@@ -119,6 +119,13 @@ wrapping. `NULL` (default) uses `floor((getOption("width") - 23) / 12)`.}
     gradient cross-product (evaluated at the individual empirical
     Bayes estimates).
 
+ "\code{analytic}" (default) Compute the FOCEI analytic observed-information
+ covariance at the converged SAEM estimates.  When the model is out of
+ analytic-covariance scope (e.g. \code{linCmt()}, a non-normal likelihood,
+ or a non-SD IOV parameterization) or the result is not positive definite,
+ it falls back to the linearized Fisher information (\code{linFim}) with a
+ message.
+
  "\code{linFim}" Use the Linearized Fisher Information Matrix to calculate the covariance.
 
  "\code{fim}" Use the Fisher Information Matrix accumulated during SAEM

--- a/man/impmapControl.Rd
+++ b/man/impmapControl.Rd
@@ -17,7 +17,7 @@ impmapControl(
   ctol = NULL,
   nConvWindow = 10L,
   impSeed = 42L,
-  impCov = FALSE,
+  covMethod = c("imp", "analytic", "r,s", "r", "s", ""),
   qr = FALSE,
   qrShift = TRUE,
   qrRefresh = TRUE,
@@ -64,14 +64,17 @@ the objective-function change for convergence (NONMEM-style CTYPE).}
 \item{impSeed}{Base seed for the per-subject thread-safe (threefry) RNG
 streams; results are reproducible and independent of the thread count.}
 
-\item{impCov}{Experimental: when `TRUE`, compute a Monte-Carlo
-observed-information covariance for the estimated thetas and Omega
-parameters (a finite-difference Hessian of the importance-sampling objective
-over fixed common-random-number samples), stashed as `$impCov` / `$impSe`.
-Off by default.  The theta standard errors match the Hessian-based FOCEI
-covariance; the variance of a tightly-determined random effect (an Omega
-diagonal) can still be over-estimated because the fixed samples barely span
-its prior variation.}
+\item{covMethod}{Covariance method.  `"imp"` (default) computes the
+Monte-Carlo importance-sampling observed-information covariance for the
+estimated thetas and Omega parameters (a finite-difference Hessian of the
+importance-sampling objective over fixed common-random-number samples),
+stashed as `$impCov` / `$impSe` and installed as the fit covariance; the
+theta standard errors match the Hessian-based FOCEI covariance, though the
+variance of a tightly-determined random effect (an Omega diagonal) can be
+over-estimated because the fixed samples barely span its prior variation.
+`"analytic"`, `"r,s"`, `"r"`, `"s"` instead compute the FOCEI covariance
+post-fit at the converged estimates (see [foceiControl()]); `""` skips the
+covariance step.}
 
 \item{qr}{When `TRUE`, draw quasi-random (Sobol low-discrepancy) importance
 samples instead of pseudo-random Gaussian samples (QRPEM, Leary &

--- a/man/nlmixr2NlmeControl.Rd
+++ b/man/nlmixr2NlmeControl.Rd
@@ -44,6 +44,7 @@ nlmixr2NlmeControl(
   muRefCovAlg = TRUE,
   eventSens = c("jump", "fd"),
   print = NULL,
+  covMethod = c("analytic", "r,s", "r", "s", "nlme", ""),
   ...
 )
 
@@ -86,6 +87,7 @@ nlmeControl(
   muRefCovAlg = TRUE,
   eventSens = c("jump", "fd"),
   print = NULL,
+  covMethod = c("analytic", "r,s", "r", "s", "nlme", ""),
   ...
 )
 }
@@ -286,6 +288,14 @@ uses the legacy finite-difference behavior.}
 maps to it: `print=0` runs quietly (`verbose=FALSE`) and any positive
 value is verbose (`verbose=TRUE`).  When `print` is not supplied an
 explicit `verbose` is used as given.}
+
+\item{covMethod}{Covariance method: `"analytic"` (default) computes the
+focei observed-information covariance at the converged nlme estimates
+post-fit (falling back to the finite-difference `"r,s"` -> `"r"`/`"s"`
+chain when out of analytic scope); `"r,s"`, `"r"`, `"s"` request the
+finite-difference forms directly; `"nlme"` and `""` skip the recompute
+and keep nlme's own standard errors.  When the recompute fails the
+`"nlme"` covariance is kept.}
 
 \item{...}{Further, named control arguments to be passed to
    \code{\link{nlminb}} (apart from \code{trace} and \code{iter.max}

--- a/man/saemControl.Rd
+++ b/man/saemControl.Rd
@@ -12,7 +12,7 @@ saemControl(
   nu = c(2, 2, 2),
   print = 1L,
   trace = 0,
-  covMethod = c("analytic", "linFim", "fim", "sa", "r,s", "r", "s", ""),
+  covMethod = c("sa", "analytic", "linFim", "fim", "r,s", "r", "s", ""),
   covFull = TRUE,
   nSaCov = 500L,
   calcTables = TRUE,
@@ -112,12 +112,20 @@ typical fitting.}
     gradient cross-product (evaluated at the individual empirical
     Bayes estimates).
 
- "\code{analytic}" (default) Compute the FOCEI analytic observed-information
- covariance at the converged SAEM estimates.  When the model is out of
- analytic-covariance scope (e.g. \code{linCmt()}, a non-normal likelihood,
- or a non-SD IOV parameterization) or the result is not positive definite,
- it falls back to the linearized Fisher information (\code{linFim}) with a
- message.
+ "\code{sa}" (default) Use the stochastic-approximation Fisher Information
+ Matrix.  After estimation, a dedicated covariance phase (\code{nSaCov}
+ iterations) holds the parameters at the converged estimate and keeps
+ resimulating the individual parameters, Monte-Carlo averaging the Louis
+ observed-information integrand into a converged FIM decoupled from the cooling
+ schedule (the approach used by Monolix; Kuhn & Lavielle 2005).  Always includes
+ every estimated population parameter (theta, the \code{Omega} diagonal
+ variances, and residual).
+
+ "\code{analytic}" Compute the FOCEI analytic observed-information covariance at
+ the converged SAEM estimates.  When the model is out of analytic-covariance
+ scope (e.g. \code{linCmt()}, a non-normal likelihood, or a non-SD IOV
+ parameterization) or the result is not positive definite, it falls back to the
+ linearized Fisher information (\code{linFim}) with a message.
 
  "\code{linFim}" Use the Linearized Fisher Information Matrix to calculate the covariance.
 
@@ -125,14 +133,6 @@ typical fitting.}
  estimation to calculate the covariance.  Like \code{sa} it inverts the observed
  information to a full theta + \code{Omega} diagonal + residual covariance, but
  uses the (noisier) estimation-phase matrix rather than a dedicated cov phase.
-
- "\code{sa}" Use the stochastic-approximation Fisher Information Matrix.  After
- estimation, a dedicated covariance phase (\code{nSaCov} iterations) holds the
- parameters at the converged estimate and keeps resimulating the individual
- parameters, Monte-Carlo averaging the Louis observed-information integrand into a
- converged FIM decoupled from the cooling schedule (the approach used by Monolix;
- Kuhn & Lavielle 2005).  Always includes every estimated population parameter
- (theta, the \code{Omega} diagonal variances, and residual).
 
  For both \code{fim} and \code{sa} the simulation-based Fisher information covers the
  structural theta, the \code{Omega} diagonal variances, and additive residual error.

--- a/man/saemControl.Rd
+++ b/man/saemControl.Rd
@@ -12,7 +12,7 @@ saemControl(
   nu = c(2, 2, 2),
   print = 1L,
   trace = 0,
-  covMethod = c("linFim", "fim", "sa", "r,s", "r", "s", ""),
+  covMethod = c("analytic", "linFim", "fim", "sa", "r,s", "r", "s", ""),
   covFull = TRUE,
   nSaCov = 500L,
   calcTables = TRUE,
@@ -111,6 +111,13 @@ typical fitting.}
     function. The S matrix is the sum of each individual's
     gradient cross-product (evaluated at the individual empirical
     Bayes estimates).
+
+ "\code{analytic}" (default) Compute the FOCEI analytic observed-information
+ covariance at the converged SAEM estimates.  When the model is out of
+ analytic-covariance scope (e.g. \code{linCmt()}, a non-normal likelihood,
+ or a non-SD IOV parameterization) or the result is not positive definite,
+ it falls back to the linearized Fisher information (\code{linFim}) with a
+ message.
 
  "\code{linFim}" Use the Linearized Fisher Information Matrix to calculate the covariance.
 

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -811,7 +811,7 @@ void impOuter(Environment e) {
 
   // Monte-Carlo observed-information covariance (theta block) at the converged
   // estimate, before the inner neqOverride is cleared (the inner solves use it).
-  // Experimental, opt-in via impmapControl(impCov=TRUE).
+  // Selected by impmapControl(covMethod="imp") (the default).
   if (impCovEnabled()) impComputeCov(e);
 
   // Clear the multi-endpoint inner neqOverride so it does not leak into a later fit.

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -61,11 +61,13 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   # batch 3
   c("focei-wang2007-boxcox-half", "nlm-cens", "issue-429", "issue-470",
     "focei-wang2007-bounded", "saem-loglik", "mu-timevarying", "saem-nearpd",
-    "saem-nonmutheta", "saem-sharedinner", "focei-theta-reset-bounds"),
+    "saem-nonmutheta", "saem-sharedinner", "focei-theta-reset-bounds",
+    "saem-cov-analytic"),
 
   # batch 4
   c("impmap", "matexp", "mfocei", "focei-wang2007-yeojohnson",
-    "focei-wang2007-boxcox-lnorm", "nlme", "focei-fast-grad", "lincmt-ode-fit"),
+    "focei-wang2007-boxcox-lnorm", "nlme", "focei-fast-grad", "lincmt-ode-fit",
+    "nlme-cov"),
   # batch 5
   c("focei-llik", "iov", "iov-zero-eta", "nlm-adjoint", "saem-mix", "saem-mix-regress", "posthoc", "ar-est",
     "mu-family", "mu-plain-fit", "vae-fit", "focei-wang2007-basic",

--- a/tests/testthat/test-advi-fullbayes.R
+++ b/tests/testthat/test-advi-fullbayes.R
@@ -40,6 +40,8 @@ nmTest({
 
   test_that("full-Bayes ADVI assembles a full nlmixr2FitData", {
     skip_on_cran()
+    ## the default covMethod is "advi": the population variational covariance is
+    ## the fit's SE source
     fit <- suppressMessages(suppressWarnings(
       nlmixr2(mod, nlmixr2data::theo_sd, est = "advi",
               control = adviControl(iters = 400L, print = 0L, pointEstimate = FALSE))))
@@ -49,6 +51,21 @@ nmTest({
     expect_false(is.null(fit$env$adviCov))
     ## the population variational covariance is the fit's SE source
     expect_identical(fit$covMethod, "advi")
+    expect_true(all(is.finite(fit$parFixedDf$SE)))
+    expect_true(all(fit$parFixedDf$SE > 0))
+  })
+
+  test_that("full-Bayes ADVI covMethod='analytic' is not clobbered to advi", {
+    skip_on_cran()
+    ## an explicit non-"advi" covMethod runs the FOCEi covariance chain on the
+    ## full inner model; the full-Bayes path must NOT overwrite it with the
+    ## variational covariance
+    fit <- suppressMessages(suppressWarnings(
+      nlmixr2(mod, nlmixr2data::theo_sd, est = "advi",
+              control = adviControl(iters = 400L, print = 0L, pointEstimate = FALSE,
+                                    covMethod = "analytic"))))
+    expect_false(identical(fit$covMethod, "advi"))
+    expect_false(is.null(fit$env$adviCov))          # the variational cov is still kept as an artifact
     expect_true(all(is.finite(fit$parFixedDf$SE)))
     expect_true(all(fit$parFixedDf$SE > 0))
   })

--- a/tests/testthat/test-cov-analytic-defaults.R
+++ b/tests/testthat/test-cov-analytic-defaults.R
@@ -1,0 +1,48 @@
+# Analytic-first covMethod defaults across the mixed-model estimation methods.
+# Always-run core unit test: no fits, only the control objects and the shared
+# base-est mapping used by the post-fit covariance recompute.
+
+test_that("covMethod defaults prefer analytic", {
+  expect_identical(saemControl()$covMethod, "analytic")
+  expect_identical(nlmeControl()$covMethod, "analytic")
+  expect_identical(vaeControl()$covMethod, "analytic")
+  ## advi keeps its own variational covariance first, with analytic second
+  expect_identical(adviControl()$covMethod, "advi")
+  expect_identical(adviControl(covMethod = "analytic")$covMethod, "analytic")
+  ## focei was already analytic-first
+  expect_identical(foceiControl()$covMethod, 2L)
+  expect_identical(foceiControl()$covType, "analytic")
+  ## imp family inherits foceiControl's analytic default (integer slot + covType)
+  expect_identical(impmapControl()$covMethod, 2L)
+  expect_identical(impmapControl()$covType, "analytic")
+})
+
+test_that("nlme covMethod tokens round-trip", {
+  expect_identical(nlmeControl(covMethod = "nlme")$covMethod, "nlme")
+  expect_identical(nlmeControl(covMethod = "")$covMethod, "")
+  expect_identical(nlmeControl(covMethod = "r,s")$covMethod, "r,s")
+  expect_error(nlmeControl(covMethod = "bogus"))
+})
+
+test_that("saem keeps its other covMethod choices", {
+  for (cm in c("linFim", "fim", "sa", "r,s", "r", "s")) {
+    expect_identical(saemControl(covMethod = cm)$covMethod, cm)
+  }
+  expect_identical(saemControl(covMethod = "")$covMethod, "")
+})
+
+test_that(".foceiRecomputeBaseEst maps the covariance-recompute methods", {
+  ## mu/irls families recompute on their own base method
+  expect_identical(nlmixr2est:::.foceiRecomputeBaseEst("mfocei"), "focei")
+  expect_identical(nlmixr2est:::.foceiRecomputeBaseEst("ifoce"), "foce")
+  expect_identical(nlmixr2est:::.foceiRecomputeBaseEst("mfocep"), "focep")
+  ## EM / nonparametric / nlme recompute on a zero-iteration focei model
+  for (e in c("imp", "impmap", "qrpem", "nlme",
+              "npag", "npb", "mnpag", "inpag", "mnpb", "inpb")) {
+    expect_identical(nlmixr2est:::.foceiRecomputeBaseEst(e), "focei")
+  }
+  ## methods with their own covariance (or none) are not recomputed
+  for (e in c("focei", "saem", "fsaem", "nlm", "nls")) {
+    expect_null(nlmixr2est:::.foceiRecomputeBaseEst(e))
+  }
+})

--- a/tests/testthat/test-cov-analytic-defaults.R
+++ b/tests/testthat/test-cov-analytic-defaults.R
@@ -3,7 +3,9 @@
 # base-est mapping used by the post-fit covariance recompute.
 
 test_that("covMethod defaults prefer analytic", {
-  expect_identical(saemControl()$covMethod, "analytic")
+  ## saem keeps the stochastic-approximation FIM ("sa") first, analytic second
+  expect_identical(saemControl()$covMethod, "sa")
+  expect_identical(saemControl(covMethod = "analytic")$covMethod, "analytic")
   expect_identical(nlmeControl()$covMethod, "analytic")
   expect_identical(vaeControl()$covMethod, "analytic")
   ## advi keeps its own variational covariance first, with analytic second

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -110,6 +110,17 @@ nmTest({
     expect_true(all(is.finite(.se)) && all(.se > 0))
   })
 
+  test_that("setCov(fit, 'analytic') recomputes the analytic covariance post-fit", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    fit <- suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
+                                   foceiControl(print = 0L, covMethod = "r,s")))
+    expect_false(identical(fit$covMethod, "analytic"))
+    fit <- suppressMessages(suppressWarnings(setCov(fit, "analytic")))
+    expect_identical(fit$covMethod, "analytic")
+    expect_true(all(is.finite(sqrt(diag(fit$cov)))))
+  })
+
   test_that("finite-difference covMethod='r,s' covFull=TRUE installs the true full FD sandwich", {
     skip_on_cran()
     skip_if_not_installed("nlmixr2data")

--- a/tests/testthat/test-impmap.R
+++ b/tests/testthat/test-impmap.R
@@ -453,7 +453,7 @@ nmTest({
     expect_equal(unname(fixef(.fi)["add.sd"]), unname(fixef(.ff)["add.sd"]), tolerance = 0.05)
   })
 
-  test_that("C2: experimental MC covariance (impCov) is off by default; theta SEs match FOCEI |r|", {
+  test_that("C2: MC covariance (covMethod='imp') is the default; theta SEs match FOCEI |r|", {
     one.cmt <- function() {
       ini({
         tka <- 0.45; tcl <- 1; tv <- 3.45
@@ -468,14 +468,13 @@ nmTest({
       })
     }
     .d <- nlmixr2data::theo_sd
-    # off by default: no covariance stash
+    # covMethod="" turns the covariance step off: no covariance stash
     .f0 <- suppressWarnings(nlmixr2(one.cmt, .d, "impmap",
-                                    impmapControl(print = 0L, nIter = 1L)))
+                                    impmapControl(print = 0L, nIter = 1L, covMethod = "")))
     expect_null(.f0$env$impSe)
-    # opt-in: the full (theta + Omega) covariance
+    # default covMethod="imp": the full (theta + Omega) MC covariance
     .fi <- suppressWarnings(nlmixr2(one.cmt, .d, "impmap",
-                                    impmapControl(print = 0L, nIter = 40L, isample = 500L,
-                                                  impCov = TRUE)))
+                                    impmapControl(print = 0L, nIter = 40L, isample = 500L)))
     .se <- as.numeric(.fi$env$impSe)
     .nth <- .fi$env$impCovThetaN
     expect_true(all(is.finite(.se) & .se > 0))

--- a/tests/testthat/test-nlme-cov.R
+++ b/tests/testthat/test-nlme-cov.R
@@ -1,0 +1,42 @@
+# nlme covMethod: the default recomputes the FOCEI observed-information
+# covariance at the converged nlme estimates, keeping nlme's own covariance
+# selectable via the "nlme" token.  Weekly batch (multi-iteration fits).
+
+nmTest({
+  mod <- function() {
+    ini({
+      tka <- 0.45; tcl <- log(c(0, 2.7, 100)); tv <- 3.45
+      eta.cl ~ 0.3; eta.v ~ 0.1
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  test_that("nlme default covMethod recomputes the analytic covariance", {
+    skip_on_cran()
+    fit <- suppressMessages(suppressWarnings(
+      nlmixr2(mod, nlmixr2data::theo_sd, est = "nlme", control = nlmeControl(print = 0))))
+    ## analytic (or its FD fallback), never the legacy nlme label by default
+    expect_false(identical(fit$covMethod, "nlme"))
+    expect_true(all(is.finite(fit$parFixedDf$SE)))
+    expect_true(all(fit$parFixedDf$SE > 0))
+    ## nlme's own covariance is retained and selectable
+    expect_true("nlme" %in% names(fit$env$covList))
+    expect_error(setCov(fit, "nlme"), NA)
+    expect_identical(fit$covMethod, "nlme")
+  })
+
+  test_that("covMethod='nlme' keeps nlme's own covariance (no recompute)", {
+    skip_on_cran()
+    fit <- suppressMessages(suppressWarnings(
+      nlmixr2(mod, nlmixr2data::theo_sd, est = "nlme",
+              control = nlmeControl(print = 0, covMethod = "nlme"))))
+    expect_identical(fit$covMethod, "nlme")
+  })
+})

--- a/tests/testthat/test-qrpem-slow.R
+++ b/tests/testthat/test-qrpem-slow.R
@@ -131,11 +131,11 @@ nmTest({
     expect_gt(max(abs(.draw(1L) - .draw(999L))), 0.05)
   })
 
-  test_that("Q4: impCov=TRUE with qr=TRUE gives an SPD covariance matching FOCEI |r|", {
+  test_that("Q4: covMethod='imp' with qr=TRUE gives an SPD covariance matching FOCEI |r|", {
     .fi <- suppressWarnings(
       nlmixr2(.oneCmt, nlmixr2data::theo_sd, "impmap",
               impmapControl(print=0L, nIter=40L, isample=500L, qr=TRUE,
-                            impCov=TRUE)))
+                            covMethod="imp")))
     .se <- as.numeric(.fi$env$impSe)
     .nth <- .fi$env$impCovThetaN
     expect_true(all(is.finite(.se) & .se > 0))

--- a/tests/testthat/test-saem-cov-analytic.R
+++ b/tests/testthat/test-saem-cov-analytic.R
@@ -1,0 +1,77 @@
+# SAEM covMethod="analytic": the FOCEI analytic observed-information covariance
+# at the converged SAEM estimates, falling back to the linearized FIM (linFim)
+# when out of analytic scope.  Weekly batch (multi-iteration fits).
+
+nmTest({
+  odeMod <- function() {
+    ini({
+      tka <- 0.45; tcl <- 1; tv <- 3.45
+      eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  linMod <- function() {
+    ini({
+      tka <- 0.45; tcl <- 1; tv <- 3.45
+      eta.cl ~ 0.3; eta.v ~ 0.1
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  ctl <- function(...) saemControl(nBurn = 100, nEm = 150, print = 0, seed = 42, ...)
+
+  test_that("SAEM default covMethod installs the analytic covariance", {
+    skip_on_cran()
+    fit <- suppressMessages(suppressWarnings(
+      nlmixr2(odeMod, nlmixr2data::theo_sd, est = "saem", control = ctl())))
+    expect_identical(fit$covMethod, "analytic")
+    expect_true(all(is.finite(fit$parFixedDf$SE)))
+    expect_true(all(fit$parFixedDf$SE > 0))
+    ## the linFim fallback is retained and selectable
+    expect_true("linFim" %in% names(fit$env$covList))
+    expect_error(setCov(fit, "linFim"), NA)
+    expect_identical(fit$covMethod, "linFim")
+  })
+
+  test_that("explicit covMethod='linFim' skips the analytic attempt", {
+    skip_on_cran()
+    fit <- suppressMessages(suppressWarnings(
+      nlmixr2(odeMod, nlmixr2data::theo_sd, est = "saem",
+              control = ctl(covMethod = "linFim"))))
+    expect_identical(fit$covMethod, "linFim")
+  })
+
+  test_that("out-of-scope model (linCmt) falls back to linFim with a message", {
+    skip_on_cran()
+    expect_message(
+      fit <<- suppressWarnings(
+        nlmixr2(linMod, nlmixr2data::theo_sd, est = "saem", control = ctl())),
+      "linearized FIM")
+    expect_identical(fit$covMethod, "linFim")
+    expect_true(all(is.finite(fit$parFixedDf$SE)))
+  })
+
+  test_that("fsaem inherits the analytic covMethod default without erroring", {
+    skip_on_cran()
+    ## fsaem is saemControl(fast=TRUE): it inherits the analytic covMethod
+    ## default.  The fast kernel's covariance labeling is a separate subsystem;
+    ## this just checks the analytic default does not break the fast fit.
+    expect_identical(fsaemControl()$covMethod, "analytic")
+    fit <- suppressMessages(suppressWarnings(
+      nlmixr2(odeMod, nlmixr2data::theo_sd, est = "fsaem", control = ctl())))
+    expect_s3_class(fit, "nlmixr2FitData")
+    expect_true(is.finite(fit$objf))
+  })
+})

--- a/tests/testthat/test-saem-cov-analytic.R
+++ b/tests/testthat/test-saem-cov-analytic.R
@@ -32,10 +32,12 @@ nmTest({
 
   ctl <- function(...) saemControl(nBurn = 100, nEm = 150, print = 0, seed = 42, ...)
 
-  test_that("SAEM default covMethod installs the analytic covariance", {
+  test_that("SAEM covMethod='analytic' installs the analytic covariance", {
     skip_on_cran()
+    ## the default is "sa"; request the analytic observed information explicitly
     fit <- suppressMessages(suppressWarnings(
-      nlmixr2(odeMod, nlmixr2data::theo_sd, est = "saem", control = ctl())))
+      nlmixr2(odeMod, nlmixr2data::theo_sd, est = "saem",
+              control = ctl(covMethod = "analytic"))))
     expect_identical(fit$covMethod, "analytic")
     expect_true(all(is.finite(fit$parFixedDf$SE)))
     expect_true(all(fit$parFixedDf$SE > 0))
@@ -53,25 +55,39 @@ nmTest({
     expect_identical(fit$covMethod, "linFim")
   })
 
-  test_that("out-of-scope model (linCmt) falls back to linFim with a message", {
+  test_that("out-of-scope model (linCmt) with covMethod='analytic' falls back to linFim", {
     skip_on_cran()
     expect_message(
       fit <<- suppressWarnings(
-        nlmixr2(linMod, nlmixr2data::theo_sd, est = "saem", control = ctl())),
+        nlmixr2(linMod, nlmixr2data::theo_sd, est = "saem",
+                control = ctl(covMethod = "analytic"))),
       "linearized FIM")
     expect_identical(fit$covMethod, "linFim")
     expect_true(all(is.finite(fit$parFixedDf$SE)))
   })
 
-  test_that("fsaem inherits the analytic covMethod default without erroring", {
+  test_that("saem default covMethod is the stochastic-approximation FIM", {
     skip_on_cran()
-    ## fsaem is saemControl(fast=TRUE): it inherits the analytic covMethod
-    ## default.  The fast kernel's covariance labeling is a separate subsystem;
-    ## this just checks the analytic default does not break the fast fit.
-    expect_identical(fsaemControl()$covMethod, "analytic")
+    expect_identical(saemControl()$covMethod, "sa")
+    fit <- suppressMessages(suppressWarnings(
+      nlmixr2(odeMod, nlmixr2data::theo_sd, est = "saem", control = ctl())))
+    expect_identical(fit$covMethod, "sa")
+    expect_true(all(is.finite(fit$parFixedDf$SE)))
+  })
+
+  test_that("fsaem produces a labeled covariance with the sa default", {
+    skip_on_cran()
+    ## fsaem is saemControl(fast=TRUE): it inherits the "sa" covMethod default.
+    ## The fast kernel overwrites the ui covMethod when it sets up its FOCEi inner
+    ## problem; .saemFamilyFit restores it so the covariance is computed + labeled.
+    expect_identical(fsaemControl()$covMethod, "sa")
     fit <- suppressMessages(suppressWarnings(
       nlmixr2(odeMod, nlmixr2data::theo_sd, est = "fsaem", control = ctl())))
     expect_s3_class(fit, "nlmixr2FitData")
     expect_true(is.finite(fit$objf))
+    expect_identical(fit$covMethod, "sa")
+    expect_false(is.null(fit$cov))
+    expect_true(all(is.finite(fit$parFixedDf$SE)))
+    expect_true(all(fit$parFixedDf$SE > 0))
   })
 })


### PR DESCRIPTION
## Summary

Makes the analytic observed-information covariance the preferred `covMethod` across the mixed-model estimation methods, and ensures **every** mixed-model method produces a labeled covariance matrix. Methods that had no covMethod default gain one; the runtime falls back to each method's previous default when a model is out of analytic scope.

| Method | Default `covMethod` | Notes |
|---|---|---|
| focei family | `analytic` → `r,s`/`r`/`s` | unchanged (already analytic-first) |
| `saem` | `sa` → `analytic` → `linFim` → `fim` → `r,s`/`r`/`s`/`""` | `sa` kept first (typical for SAEM) |
| `fsaem` | `sa` (inherits saem) | **now reports a covariance** (was empty/degenerate) |
| `nlme` | `analytic` → `r,s`/`r`/`s` → `nlme` → `""` | new `covMethod` arg; `nlme` keeps the legacy tTable cov |
| `imp`/`impmap`/`qrpem` | `imp` → `analytic` → `r,s`/`r`/`s`/`""` | `imp` = the Monte-Carlo cov that `impCov=TRUE` used to select; `impCov` arg **removed** |
| `npag`/`npb` | `analytic` (post-fit recompute) → FD | previously reported no covariance |
| `advi` | `advi` → `analytic` → FD | no longer clobbers an explicit non-`advi` covMethod |
| `vae` | `analytic` → FD | unchanged |

## How it works

- **`.foceiRecomputeBaseEst()`** (`R/cov.R`) maps an est to the base model its post-fit covariance recompute runs on. The mu-referenced families kept their existing behavior; `imp`/`impmap`/`qrpem`/`npag`/`npb`/`nlme` now recompute on a zero-iteration `est="focei"` fit at the pinned converged thetas/etas, reusing the existing C++ `analytic → r,s → r/s` chain. Hooked from `R/nlmixr2Est.R`.
- **SAEM** installs the analytic covariance via a dedicated `.saemInstallAnalyticCov()` so its fallback is `linFim` (not the FD chain); `linFim` stays recoverable via `setCov(fit, "linFim")`.
- **`setCov()` / `getVarCov()`** accept `covMethod="analytic"` and recompute the analytic / finite-difference covariances on demand when not cached.

## fsaem covariance fix

`est="fsaem"` was returning an unlabeled, partially degenerate covariance. Root cause: the fast kernel's FOCEi inner setup overwrote the shared control's `covMethod` (to `0`) during `.saemFitModel`, so the covariance step ran with no method selected. `.saemFamilyFit` now captures the intended `covMethod` before the kernel runs and restores it before `.saemCalcCov`. `fsaem` now reports `sa`/`analytic`/`linFim` covariances with finite SEs.

## Testing

- New `test-cov-analytic-defaults.R` (control defaults + base-est mapping, always-run), plus weekly `test-saem-cov-analytic.R` and `test-nlme-cov.R`.
- Extended `test-impmap.R` / `test-qrpem-slow.R` (`covMethod="imp"`), `test-advi-fullbayes.R`, and `test-cov-analytic.R` (`setCov(fit, "analytic")`).
- Verified by direct fits: every method's `covMethod` label, the SAEM `linFim` fallback on `linCmt()`, the imp-family `imp`/`analytic`/`""` cases, and the fsaem fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
