### PR TITLE
feat(vae): configurable branch-and-bound strategy (fifo/lifo/lc)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## New features
 
+- `vaeControl(bnbStrategy=)` selects the frontier discipline for the exact
+  branch-and-bound covariate selection in `est="vae"`: `"lifo"` (default, the
+  existing last-in-first-out depth-first search), `"fifo"` (first-in-first-out)
+  or `"lc"` (least cost / best-first).  The solver is exact, so the selected
+  covariates are identical for every strategy; only the search order differs.
+
 - `est="vae"` can now estimate structural population parameters that have no
   random effect (are not mu-referenced).  Previously such a `theta` was frozen at
   its `ini()` value because the VAE only estimates parameters in the latent space.

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -309,8 +309,8 @@ vaeTrainCpp_ <- function(params, prep, control, nMix, mixProbR, cores, row0, par
     .Call(`_nlmixr2est_vaeTrainCpp_`, params, prep, control, nMix, mixProbR, cores, row0, parNames, iterPrintControl, xform, structIdx0)
 }
 
-vaeBestSubset_ <- function(mu, covMat, omega, isFree, penaltyPerCov) {
-    .Call(`_nlmixr2est_vaeBestSubset_`, mu, covMat, omega, isFree, penaltyPerCov)
+vaeBestSubset_ <- function(mu, covMat, omega, isFree, penaltyPerCov, strategy = "lifo") {
+    .Call(`_nlmixr2est_vaeBestSubset_`, mu, covMat, omega, isFree, penaltyPerCov, strategy)
 }
 
 boxCox_ <- function(x = 1L, lambda = 1, yj = 0L) {

--- a/R/vae.R
+++ b/R/vae.R
@@ -65,6 +65,11 @@
 #'   reference implementation's `linspace(alpha, 1, kl_iter)`).  Values `> 1`
 #'   penalize covariate entry more heavily early in training; `1` disables the
 #'   ramp.
+#' @param bnbStrategy Frontier discipline for the exact branch-and-bound covariate
+#'   selection: `"lifo"` (default, last-in-first-out depth-first search),
+#'   `"fifo"` (first-in-first-out) or `"lc"` (least cost / best-first).  The
+#'   solver is exact, so the selected covariates are identical for every strategy;
+#'   only the search order (and thus efficiency) differs.
 #' @param objf Which objective-function value is active for AIC/BIC/BICc. Both
 #'   the linearization and importance-sampling -2LL are always computed and
 #'   stored; this selects the default active one.
@@ -114,6 +119,7 @@ vaeControl <- function(seed = 42L,
                        sigma0 = NULL,
                        covariateSelection = TRUE,
                        covSelectAlpha = 2,
+                       bnbStrategy = c("lifo", "fifo", "lc"),
                        nonMuTheta = c("regress", "eta", "fix", "none"),
                        nonMuEtaOmega = 0.01,
                        likelihood = c("focei", "foce", "focep", "laplace"),
@@ -160,6 +166,7 @@ vaeControl <- function(seed = 42L,
   }
   checkmate::assertLogical(covariateSelection, len = 1, any.missing = FALSE)
   checkmate::assertNumeric(covSelectAlpha, lower = 1, finite = TRUE, any.missing = FALSE, len = 1)
+  bnbStrategy <- match.arg(bnbStrategy)
   nonMuTheta <- match.arg(nonMuTheta)
   checkmate::assertNumeric(nonMuEtaOmega, lower = 0, finite = TRUE, any.missing = FALSE, len = 1)
   checkmate::assertIntegerish(nIsSample, lower = 1, any.missing = FALSE, len = 1)
@@ -240,6 +247,7 @@ vaeControl <- function(seed = 42L,
                sigma0 = sigma0,
                covariateSelection = covariateSelection,
                covSelectAlpha = covSelectAlpha,
+               bnbStrategy = bnbStrategy,
                nonMuTheta = nonMuTheta,
                nonMuEtaOmega = nonMuEtaOmega,
                likelihood = likelihood,

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -17,6 +17,7 @@ vaeControl(
   sigma0 = NULL,
   covariateSelection = TRUE,
   covSelectAlpha = 2,
+  bnbStrategy = c("lifo", "fifo", "lc"),
   nonMuTheta = c("regress", "eta", "fix", "none"),
   nonMuEtaOmega = 0.01,
   likelihood = c("focei", "foce", "focep", "laplace"),
@@ -86,6 +87,12 @@ penalty, ramped linearly from `covSelectAlpha` down to `1` over the
 reference implementation's `linspace(alpha, 1, kl_iter)`).  Values `> 1`
 penalize covariate entry more heavily early in training; `1` disables the
 ramp.}
+
+\item{bnbStrategy}{Frontier discipline for the exact branch-and-bound covariate
+selection: `"lifo"` (default, last-in-first-out depth-first search),
+`"fifo"` (first-in-first-out) or `"lc"` (least cost / best-first).  The
+solver is exact, so the selected covariates are identical for every strategy;
+only the search order (and thus efficiency) differs.}
 
 \item{nonMuTheta}{How to treat a structural population `theta` that has no
   random effect (is not mu-referenced) so it can still be estimated by the VAE

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1204,8 +1204,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // vaeBestSubset_
-List vaeBestSubset_(arma::mat mu, arma::mat covMat, arma::vec omega, LogicalVector isFree, double penaltyPerCov);
-RcppExport SEXP _nlmixr2est_vaeBestSubset_(SEXP muSEXP, SEXP covMatSEXP, SEXP omegaSEXP, SEXP isFreeSEXP, SEXP penaltyPerCovSEXP) {
+List vaeBestSubset_(arma::mat mu, arma::mat covMat, arma::vec omega, LogicalVector isFree, double penaltyPerCov, std::string strategy);
+RcppExport SEXP _nlmixr2est_vaeBestSubset_(SEXP muSEXP, SEXP covMatSEXP, SEXP omegaSEXP, SEXP isFreeSEXP, SEXP penaltyPerCovSEXP, SEXP strategySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1214,7 +1214,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< arma::vec >::type omega(omegaSEXP);
     Rcpp::traits::input_parameter< LogicalVector >::type isFree(isFreeSEXP);
     Rcpp::traits::input_parameter< double >::type penaltyPerCov(penaltyPerCovSEXP);
-    rcpp_result_gen = Rcpp::wrap(vaeBestSubset_(mu, covMat, omega, isFree, penaltyPerCov));
+    Rcpp::traits::input_parameter< std::string >::type strategy(strategySEXP);
+    rcpp_result_gen = Rcpp::wrap(vaeBestSubset_(mu, covMat, omega, isFree, penaltyPerCov, strategy));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/init.c
+++ b/src/init.c
@@ -38,7 +38,7 @@ extern SEXP _nlmixr2est_vaeInnerSetup_(SEXP);
 extern SEXP _nlmixr2est_vaeInnerUpdatePar_(SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeTrainCpp_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeElboStepCpp_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP _nlmixr2est_vaeBestSubset_(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP _nlmixr2est_vaeBestSubset_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeDecoderPxz_(SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeDecoderSolveSubject_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeDecoderElboStep_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -194,7 +194,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_vaeInnerUpdatePar_", (DL_FUNC) &_nlmixr2est_vaeInnerUpdatePar_, 2},
   {"_nlmixr2est_vaeTrainCpp_", (DL_FUNC) &_nlmixr2est_vaeTrainCpp_, 11},
   {"_nlmixr2est_vaeElboStepCpp_", (DL_FUNC) &_nlmixr2est_vaeElboStepCpp_, 11},
-  {"_nlmixr2est_vaeBestSubset_", (DL_FUNC) &_nlmixr2est_vaeBestSubset_, 5},
+  {"_nlmixr2est_vaeBestSubset_", (DL_FUNC) &_nlmixr2est_vaeBestSubset_, 6},
   {"_nlmixr2est_vaeDecoderPxz_", (DL_FUNC) &_nlmixr2est_vaeDecoderPxz_, 2},
   {"_nlmixr2est_vaeDecoderSolveSubject_", (DL_FUNC) &_nlmixr2est_vaeDecoderSolveSubject_, 6},
   {"_nlmixr2est_vaeDecoderElboStep_", (DL_FUNC) &_nlmixr2est_vaeDecoderElboStep_, 14},

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -12834,6 +12834,16 @@ static arma::uvec vaeSubsetCols(const std::vector<int>& idx) {
 // recursive depth-first order and is the default.
 enum VaeBnbStrategy { VAE_BNB_LIFO, VAE_BNB_FIFO, VAE_BNB_LC };
 
+// Map a control/argument string to the enum, failing fast on an unknown value so a
+// hand-rolled control list or corrupted serialized object cannot silently fall back
+// to LIFO.  A genuinely missing field is defaulted by the caller before this point.
+static VaeBnbStrategy vaeParseBnbStrategy(const std::string& s) {
+  if (s == "lifo") return VAE_BNB_LIFO;
+  if (s == "fifo") return VAE_BNB_FIFO;
+  if (s == "lc")   return VAE_BNB_LC;
+  Rcpp::stop("bnbStrategy must be one of 'lifo', 'fifo', 'lc'");
+}
+
 struct VaeBnbCtx {
   const arma::mat* X;   // [N, 1 + nCov], col 0 is the intercept
   const arma::vec* y;   // [N]
@@ -12845,33 +12855,49 @@ struct VaeBnbCtx {
   arma::vec bestCoef;
 };
 
+// Order-independent tie-break: on an exact score tie prefer the lexicographically
+// smaller sorted support so the incumbent is deterministic regardless of the frontier
+// discipline (otherwise "first encountered" would depend on the search order).  Exact
+// equality -- not a tolerance -- is what keeps the winner well defined and transitive.
+static bool vaeSelLess(std::vector<int> a, std::vector<int> b) {
+  std::sort(a.begin(), a.end());
+  std::sort(b.begin(), b.end());
+  return a < b;  // std::vector lexicographic compare
+}
+
 // Evaluate the model whose support is exactly `inSet`; update the incumbent.
 static void vaeBnbLeaf(VaeBnbCtx& c, const std::vector<int>& inSet) {
   arma::uvec cols = vaeSubsetCols(inSet);
   arma::vec coef;
   double rss = vaeOlsRss(*c.X, cols, *c.y, &coef);
   double score = rss / c.omega + c.penalty * (double)inSet.size();
-  if (score < c.bestScore) { c.bestScore = score; c.bestSel = inSet; c.bestCoef = coef; }
+  if (score < c.bestScore ||
+      (score == c.bestScore && vaeSelLess(inSet, c.bestSel))) {
+    c.bestScore = score; c.bestSel = inSet; c.bestCoef = coef;
+  }
 }
 
-// One node of the search: commit `inSet`, `freeSet` remains to branch on, `evalSelf`
-// gates the leaf eval of `inSet` (the exclude child inherits an inSet its parent
-// already evaluated), and `lb` is the precomputed subtree lower bound used both as
-// the least-cost priority key and for a re-check prune at pop time.
+// One node of the search: commit `inSet`; the free covariates still to branch on are
+// the prefix freeSet0[0, freeSize) (freeSet is only ever suffix-popped, so a length
+// suffices -- no per-node copy).  `evalSelf` gates the leaf eval of `inSet` (the
+// exclude child inherits an inSet its parent already evaluated), and `lb` is the
+// precomputed subtree lower bound used both as the least-cost priority key and for a
+// re-check prune at pop time.
 struct VaeBnbNode {
   std::vector<int> inSet;
-  std::vector<int> freeSet;
+  int freeSize;
   bool evalSelf;
   double lb;
 };
 
 // Subtree lower bound: no superset of inSet (adding any free covariates) can beat the
 // OLS fit that uses ALL of them, and each committed covariate already costs `penalty`.
-// Adding columns only lowers RSS, so this bounds the whole subtree.
+// Adding columns only lowers RSS, so this bounds the whole subtree.  The free set is
+// freeSet0[0, freeSize).
 static double vaeBnbLowerBound(VaeBnbCtx& c, const std::vector<int>& inSet,
-                               const std::vector<int>& freeSet) {
+                               const std::vector<int>& freeSet0, int freeSize) {
   std::vector<int> all = inSet;
-  all.insert(all.end(), freeSet.begin(), freeSet.end());
+  all.insert(all.end(), freeSet0.begin(), freeSet0.begin() + freeSize);
   double rssFull = vaeOlsRss(*c.X, vaeSubsetCols(all), *c.y, nullptr);
   return rssFull / c.omega + c.penalty * (double)inSet.size();
 }
@@ -12886,8 +12912,8 @@ struct VaeBnbNodeWorse {
 // branched first, "include" child first -- identical branching to the former
 // recursion; only the frontier container differs.
 static void vaeBnbSearch(VaeBnbCtx& c, const std::vector<int>& freeSet0) {
-  VaeBnbNode root; root.inSet.clear(); root.freeSet = freeSet0;
-  root.evalSelf = true; root.lb = vaeBnbLowerBound(c, root.inSet, root.freeSet);
+  VaeBnbNode root; root.inSet.clear(); root.freeSize = (int)freeSet0.size();
+  root.evalSelf = true; root.lb = vaeBnbLowerBound(c, root.inSet, freeSet0, root.freeSize);
   std::vector<VaeBnbNode> stack;                       // LIFO
   std::deque<VaeBnbNode> queue;                        // FIFO
   std::priority_queue<VaeBnbNode, std::vector<VaeBnbNode>, VaeBnbNodeWorse> pq;  // LC
@@ -12910,18 +12936,18 @@ static void vaeBnbSearch(VaeBnbCtx& c, const std::vector<int>& freeSet0) {
       node = stack.back(); stack.pop_back(); break;
     }
     if (node.evalSelf) vaeBnbLeaf(c, node.inSet);
-    if (node.freeSet.empty()) continue;
+    if (node.freeSize == 0) continue;
     // re-check with the current incumbent: bestScore may have improved since this
     // node was generated, keeping the prune admissible under any frontier order.
     if (node.lb >= c.bestScore) continue;
-    int j = node.freeSet.back();
-    std::vector<int> childFree = node.freeSet; childFree.pop_back();
+    int j = freeSet0[node.freeSize - 1];       // strongest remaining free covariate
+    int childFree = node.freeSize - 1;
     VaeBnbNode inc;  inc.inSet = node.inSet; inc.inSet.push_back(j);
-    inc.freeSet = childFree; inc.evalSelf = true;
-    inc.lb = vaeBnbLowerBound(c, inc.inSet, inc.freeSet);
-    VaeBnbNode exc;  exc.inSet = node.inSet; exc.freeSet = childFree;
+    inc.freeSize = childFree; inc.evalSelf = true;
+    inc.lb = vaeBnbLowerBound(c, inc.inSet, freeSet0, childFree);
+    VaeBnbNode exc;  exc.inSet = node.inSet; exc.freeSize = childFree;
     exc.evalSelf = false;  // inSet already evaluated by the parent; bound tightens as j drops out
-    exc.lb = vaeBnbLowerBound(c, exc.inSet, exc.freeSet);
+    exc.lb = vaeBnbLowerBound(c, exc.inSet, freeSet0, childFree);
     switch (c.strategy) {
     case VAE_BNB_FIFO: queue.push_back(inc); queue.push_back(exc); break;
     case VAE_BNB_LC:   pq.push(inc); pq.push(exc); break;
@@ -13092,8 +13118,7 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
   // (the former recursive depth-first order) for older serialized control objects.
   const std::string bnbStrat = control.containsElementNamed("bnbStrategy") ?
     as<std::string>(control["bnbStrategy"]) : "lifo";
-  const VaeBnbStrategy bnbStrategy = (bnbStrat == "fifo") ? VAE_BNB_FIFO :
-    (bnbStrat == "lc") ? VAE_BNB_LC : VAE_BNB_LIFO;
+  const VaeBnbStrategy bnbStrategy = vaeParseBnbStrategy(bnbStrat);
   const int printCtl = as<int>(control["print"]);
   arma::vec mixProb(mixProbR.begin(), mixProbR.size());
   const int nCov = covMat.n_cols;
@@ -13334,8 +13359,7 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
 List vaeBestSubset_(arma::mat mu, arma::mat covMat, arma::vec omega,
                     LogicalVector isFree, double penaltyPerCov,
                     std::string strategy = "lifo") {
-  const VaeBnbStrategy bnbStrategy = (strategy == "fifo") ? VAE_BNB_FIFO :
-    (strategy == "lc") ? VAE_BNB_LC : VAE_BNB_LIFO;
+  const VaeBnbStrategy bnbStrategy = vaeParseBnbStrategy(strategy);
   const int zDim = (int)mu.n_cols;
   const int N = (int)mu.n_rows;
   const int nCov = (int)covMat.n_cols;

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -29,6 +29,8 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <deque>
+#include <queue>
 
 // Set while inside the parallel inner optimization region: R-API calls and
 // running-mean accumulation are deferred to the post-parallel phase. Atomic
@@ -12826,11 +12828,18 @@ static arma::uvec vaeSubsetCols(const std::vector<int>& idx) {
   return cols;
 }
 
+// Branch-and-bound frontier discipline for the covariate M-step.  The solver is
+// exact (the prune is admissible), so the strategy only changes visitation order /
+// search efficiency, never the selected subset.  VAE_BNB_LIFO reproduces the former
+// recursive depth-first order and is the default.
+enum VaeBnbStrategy { VAE_BNB_LIFO, VAE_BNB_FIFO, VAE_BNB_LC };
+
 struct VaeBnbCtx {
   const arma::mat* X;   // [N, 1 + nCov], col 0 is the intercept
   const arma::vec* y;   // [N]
   double omega;
   double penalty;       // per-covariate L0 cost
+  VaeBnbStrategy strategy;
   double bestScore;
   std::vector<int> bestSel;
   arma::vec bestCoef;
@@ -12845,35 +12854,88 @@ static void vaeBnbLeaf(VaeBnbCtx& c, const std::vector<int>& inSet) {
   if (score < c.bestScore) { c.bestScore = score; c.bestSel = inSet; c.bestCoef = coef; }
 }
 
-// Branch on freeSet (pre-sorted ascending by univariate strength so the strongest
-// covariate -- freeSet.back() -- is branched first, "include" child first).
-// evalSelf gates the leaf eval of `inSet`: the exclude child inherits the parent's
-// inSet, which the parent already evaluated, so it passes false to avoid re-fitting.
-static void vaeBnbRec(VaeBnbCtx& c, std::vector<int>& inSet, std::vector<int>& freeSet,
-                      bool evalSelf) {
-  if (evalSelf) vaeBnbLeaf(c, inSet);   // candidate: exclude all remaining free
-  if (freeSet.empty()) return;
-  // lower bound: no superset of inSet (adding any free covariates) can beat the
-  // OLS fit that uses ALL of them, and each committed covariate already costs
-  // `penalty`.  Adding columns only lowers RSS, so this bounds the whole subtree.
+// One node of the search: commit `inSet`, `freeSet` remains to branch on, `evalSelf`
+// gates the leaf eval of `inSet` (the exclude child inherits an inSet its parent
+// already evaluated), and `lb` is the precomputed subtree lower bound used both as
+// the least-cost priority key and for a re-check prune at pop time.
+struct VaeBnbNode {
+  std::vector<int> inSet;
+  std::vector<int> freeSet;
+  bool evalSelf;
+  double lb;
+};
+
+// Subtree lower bound: no superset of inSet (adding any free covariates) can beat the
+// OLS fit that uses ALL of them, and each committed covariate already costs `penalty`.
+// Adding columns only lowers RSS, so this bounds the whole subtree.
+static double vaeBnbLowerBound(VaeBnbCtx& c, const std::vector<int>& inSet,
+                               const std::vector<int>& freeSet) {
   std::vector<int> all = inSet;
   all.insert(all.end(), freeSet.begin(), freeSet.end());
   double rssFull = vaeOlsRss(*c.X, vaeSubsetCols(all), *c.y, nullptr);
-  double lb = rssFull / c.omega + c.penalty * (double)inSet.size();
-  if (lb >= c.bestScore) return;        // prune
-  int j = freeSet.back(); freeSet.pop_back();
-  inSet.push_back(j);                   // include j -> new subset, evaluate it
-  vaeBnbRec(c, inSet, freeSet, true);
-  inSet.pop_back();
-  vaeBnbRec(c, inSet, freeSet, false);  // exclude j -> same inSet, already evaluated
-  freeSet.push_back(j);                 // restore for the caller
+  return rssFull / c.omega + c.penalty * (double)inSet.size();
+}
+
+// min-heap on the lower bound for VAE_BNB_LC (best-first / least-cost)
+struct VaeBnbNodeWorse {
+  bool operator()(const VaeBnbNode& a, const VaeBnbNode& b) const { return a.lb > b.lb; }
+};
+
+// Explicit-worklist branch-and-bound driven by c.strategy.  freeSet is pre-sorted
+// ascending by univariate strength so the strongest covariate (freeSet.back()) is
+// branched first, "include" child first -- identical branching to the former
+// recursion; only the frontier container differs.
+static void vaeBnbSearch(VaeBnbCtx& c, const std::vector<int>& freeSet0) {
+  VaeBnbNode root; root.inSet.clear(); root.freeSet = freeSet0;
+  root.evalSelf = true; root.lb = vaeBnbLowerBound(c, root.inSet, root.freeSet);
+  std::vector<VaeBnbNode> stack;                       // LIFO
+  std::deque<VaeBnbNode> queue;                        // FIFO
+  std::priority_queue<VaeBnbNode, std::vector<VaeBnbNode>, VaeBnbNodeWorse> pq;  // LC
+  switch (c.strategy) {
+  case VAE_BNB_FIFO: queue.push_back(root); break;
+  case VAE_BNB_LC:   pq.push(root); break;
+  default:           stack.push_back(root); break;
+  }
+  for (;;) {
+    VaeBnbNode node;
+    switch (c.strategy) {
+    case VAE_BNB_FIFO:
+      if (queue.empty()) return;
+      node = queue.front(); queue.pop_front(); break;
+    case VAE_BNB_LC:
+      if (pq.empty()) return;
+      node = pq.top(); pq.pop(); break;
+    default:
+      if (stack.empty()) return;
+      node = stack.back(); stack.pop_back(); break;
+    }
+    if (node.evalSelf) vaeBnbLeaf(c, node.inSet);
+    if (node.freeSet.empty()) continue;
+    // re-check with the current incumbent: bestScore may have improved since this
+    // node was generated, keeping the prune admissible under any frontier order.
+    if (node.lb >= c.bestScore) continue;
+    int j = node.freeSet.back();
+    std::vector<int> childFree = node.freeSet; childFree.pop_back();
+    VaeBnbNode inc;  inc.inSet = node.inSet; inc.inSet.push_back(j);
+    inc.freeSet = childFree; inc.evalSelf = true;
+    inc.lb = vaeBnbLowerBound(c, inc.inSet, inc.freeSet);
+    VaeBnbNode exc;  exc.inSet = node.inSet; exc.freeSet = childFree;
+    exc.evalSelf = false;  // inSet already evaluated by the parent; bound tightens as j drops out
+    exc.lb = vaeBnbLowerBound(c, exc.inSet, exc.freeSet);
+    switch (c.strategy) {
+    case VAE_BNB_FIFO: queue.push_back(inc); queue.push_back(exc); break;
+    case VAE_BNB_LC:   pq.push(inc); pq.push(exc); break;
+    default:           stack.push_back(exc); stack.push_back(inc); break;  // include pops first
+    }
+  }
 }
 
 static VaeSubsetFit vaeBestSubsetL0(const arma::vec& y, const arma::mat& X,
-                                    double omega, double penalty) {
+                                    double omega, double penalty,
+                                    VaeBnbStrategy strategy = VAE_BNB_LIFO) {
   const int nCov = (int)X.n_cols - 1;
   VaeBnbCtx c;
-  c.X = &X; c.y = &y; c.omega = omega; c.penalty = penalty;
+  c.X = &X; c.y = &y; c.omega = omega; c.penalty = penalty; c.strategy = strategy;
   c.bestScore = std::numeric_limits<double>::infinity();
   // order covariates by univariate strength (RSS of [intercept, x_j] ascending
   // -> stronger last) so the branch order finds good incumbents early.
@@ -12886,9 +12948,9 @@ static VaeSubsetFit vaeBestSubsetL0(const arma::vec& y, const arma::mat& X,
             [](const std::pair<double,int>& a, const std::pair<double,int>& b) {
               return a.first > b.first;  // weakest first, strongest at back()
             });
-  std::vector<int> freeSet(nCov), inSet;
+  std::vector<int> freeSet(nCov);
   for (int j = 0; j < nCov; ++j) freeSet[j] = strength[j].second;
-  vaeBnbRec(c, inSet, freeSet, true);
+  vaeBnbSearch(c, freeSet);
   VaeSubsetFit out;
   // No finite-scoring model was ever recorded (e.g. non-positive omega or a
   // non-finite y made every score NaN/inf).  Fall back to the intercept-only
@@ -13026,6 +13088,12 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
   // a missing field means no ramp existed, so default to 1.0 (ramp disabled).
   const double covSelectAlpha = control.containsElementNamed("covSelectAlpha") ?
     as<double>(control["covSelectAlpha"]) : 1.0;
+  // branch-and-bound frontier discipline for the covariate M-step; default lifo
+  // (the former recursive depth-first order) for older serialized control objects.
+  const std::string bnbStrat = control.containsElementNamed("bnbStrategy") ?
+    as<std::string>(control["bnbStrategy"]) : "lifo";
+  const VaeBnbStrategy bnbStrategy = (bnbStrat == "fifo") ? VAE_BNB_FIFO :
+    (bnbStrat == "lc") ? VAE_BNB_LC : VAE_BNB_LIFO;
   const int printCtl = as<int>(control["print"]);
   arma::vec mixProb(mixProbR.begin(), mixProbR.size());
   const int nCov = covMat.n_cols;
@@ -13135,7 +13203,7 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
         // fixed structural theta: hold the intercept at ini, add no covariates
         if (zPopFixR[k]) { intercept[k] = zPop[k]; zPopMat.col(k).fill(zPop[k]); continue; }
         arma::vec yk = last.mu.col(k);
-        VaeSubsetFit fit = vaeBestSubsetL0(yk, X, omega[k], covPenalty);
+        VaeSubsetFit fit = vaeBestSubsetL0(yk, X, omega[k], covPenalty, bnbStrategy);
         arma::vec bestCoef = fit.coef;
         double ic = bestCoef[0];
         if (R_FINITE(zPopLower[k]) && ic < zPopLower[k]) ic = zPopLower[k];
@@ -13264,7 +13332,10 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
 // without invoking the full training loop.
 //[[Rcpp::export]]
 List vaeBestSubset_(arma::mat mu, arma::mat covMat, arma::vec omega,
-                    LogicalVector isFree, double penaltyPerCov) {
+                    LogicalVector isFree, double penaltyPerCov,
+                    std::string strategy = "lifo") {
+  const VaeBnbStrategy bnbStrategy = (strategy == "fifo") ? VAE_BNB_FIFO :
+    (strategy == "lc") ? VAE_BNB_LC : VAE_BNB_LIFO;
   const int zDim = (int)mu.n_cols;
   const int N = (int)mu.n_rows;
   const int nCov = (int)covMat.n_cols;
@@ -13281,7 +13352,7 @@ List vaeBestSubset_(arma::mat mu, arma::mat covMat, arma::vec omega,
   arma::umat selected(zDim, nCov, arma::fill::zeros);
   for (int k = 0; k < zDim; ++k) {
     if (isFree[k]) continue;
-    VaeSubsetFit fit = vaeBestSubsetL0(mu.col(k), X, omega[k], penaltyPerCov);
+    VaeSubsetFit fit = vaeBestSubsetL0(mu.col(k), X, omega[k], penaltyPerCov, bnbStrategy);
     intercept[k] = fit.coef.n_elem ? fit.coef[0] : 0.0;
     for (size_t s = 0; s < fit.sel.size(); ++s) {
       beta(k, fit.sel[s]) = fit.coef[s + 1];

--- a/tests/testthat/test-vae-miqp.R
+++ b/tests/testthat/test-vae-miqp.R
@@ -76,6 +76,15 @@ nmTest({
     }
   })
 
+  test_that("vaeBestSubset_ rejects an unknown branch-and-bound strategy", {
+    g <- readRDS(test_path("baselines", "vae-miqp-golden.rds"))
+    ci <- g[[1]]; ip <- ci$inputs
+    omega <- rep_len(ip$omega, ci$zDim)
+    isFree <- rep_len(ip$isFree, ci$zDim)
+    expect_error(vaeBestSubset_(ip$mu, ip$covMat, omega, isFree, ci$penalty, "bogus"),
+                 "lifo")
+  })
+
   test_that("bnbStrategy is tunable in vaeControl and defaults to lifo", {
     expect_equal(vaeControl()$bnbStrategy, "lifo")
     expect_equal(vaeControl(bnbStrategy = "fifo")$bnbStrategy, "fifo")

--- a/tests/testthat/test-vae-miqp.R
+++ b/tests/testthat/test-vae-miqp.R
@@ -58,6 +58,34 @@ nmTest({
     }
   })
 
+  test_that("bnbStrategy fifo/lc reach the identical exact optimum as the default lifo", {
+    ## the solver is exact, so every frontier discipline must return the same
+    ## selection/coefficients -- only the search order differs.  Exercised across
+    ## the golden fixture (mechanism is actually wired through to the kernel).
+    g <- readRDS(test_path("baselines", "vae-miqp-golden.rds"))
+    for (nm in names(g)) {
+      ci <- g[[nm]]; ip <- ci$inputs
+      omega <- rep_len(ip$omega, ci$zDim)
+      isFree <- rep_len(ip$isFree, ci$zDim)
+      base <- vaeBestSubset_(ip$mu, ip$covMat, omega, isFree, ci$penalty, "lifo")
+      for (strat in c("fifo", "lc")) {
+        alt <- vaeBestSubset_(ip$mu, ip$covMat, omega, isFree, ci$penalty, strat)
+        expect_equal(alt, base,
+                     info = paste0("strategy ", strat, " differs from lifo in case ", ci$name))
+      }
+    }
+  })
+
+  test_that("bnbStrategy is tunable in vaeControl and defaults to lifo", {
+    expect_equal(vaeControl()$bnbStrategy, "lifo")
+    expect_equal(vaeControl(bnbStrategy = "fifo")$bnbStrategy, "fifo")
+    expect_equal(vaeControl(bnbStrategy = "lc")$bnbStrategy, "lc")
+    ## round-trips through the list -> vaeControl reconstruction used at dispatch
+    ctl <- vaeControl(bnbStrategy = "lc")
+    expect_equal(do.call(vaeControl, unclass(ctl))$bnbStrategy, "lc")
+    expect_error(vaeControl(bnbStrategy = "bogus"))
+  })
+
   test_that("covSelectAlpha is tunable in vaeControl and defaults to the reference 2", {
     expect_equal(vaeControl()$covSelectAlpha, 2)
     expect_equal(vaeControl(covSelectAlpha = 3)$covSelectAlpha, 3)


### PR DESCRIPTION
## Summary

Exposes the frontier discipline of the exact L0/BIC covariate-selection branch-and-bound in `est="vae"` as a `vaeControl()` option:

- `vaeControl(bnbStrategy = c("lifo", "fifo", "lc"))`
  - `"lifo"` -- **default**, last-in-first-out. This is exactly the strategy that was already implemented: the old code was a recursive depth-first search whose frontier is the C++ call stack (LIFO).
  - `"fifo"` -- first-in-first-out (breadth-first).
  - `"lc"` -- least cost / best-first (expands the node with the lowest lower bound first).

The solver is **exact** (the RSS lower-bound prune is admissible), so the strategy only changes search order / efficiency -- never the selected covariates. All three strategies return bit-identical selections.

## Implementation

- `src/inner.cpp`: added a `VaeBnbStrategy` enum and refactored the recursive `vaeBnbRec` into an explicit worklist driven by the strategy (`std::vector` stack for LIFO, `std::deque` for FIFO, `std::priority_queue` keyed on the subtree lower bound for LC). LIFO reproduces the former branching order exactly. The option is read from the control list in `vaeTrainCpp_` and threaded into `vaeBestSubsetL0`.
- `R/vae.R`: new `bnbStrategy` formal with `match.arg` validation, `.ret` entry, and roxygen `@param`.
- `src/init.c` / RcppExports: the test export `vaeBestSubset_` gained a `strategy` arg (arity 5->6, updated per the manual `init.c` convention).
- `tests/testthat/test-vae-miqp.R`: asserts fifo/lc reach the identical optimum as lifo across the golden fixture, and that the control defaults to `"lifo"` and rejects bad values.
- `NEWS.md`, `man/vaeControl.Rd`.

## Verification

- `test-vae-miqp.R`: 43 pass, 0 fail (existing golden tests + new strategy tests).
- End-to-end: ran the actual `.vaeTrain` loop on theophylline under all three strategies -- identical `selected`/`beta`/`omega`, confirming the option flows through the real training path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)