### PR TITLE
perf(npag/npb): parallelize npb solve loops, cut redundant npag builds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -291,8 +291,7 @@
   Gibbs step for `mix()` models) now solve their per-subject conditional
   likelihoods in parallel over subjects, matching the already-parallel Psi build.
   The proposal and accept/reject draws stay serial in their original order, so a
-  fixed-seed fit is bit-for-bit identical regardless of thread count
-  (`rxode2::setRxThreads()`).
+  fixed-seed fit is bit-for-bit identical regardless of thread count.
 
 - `est="npag"` is faster: it no longer does a redundant full conditional-density
   build at the first cycle (the degeneracy check now reads the working build's
@@ -300,6 +299,11 @@
   default and configurable via `npagControl(dfScan=)` (`-1` auto, `0` to skip the
   certificate, or an explicit scan size).  Neither change affects the fitted
   support, Omega, thetas, or objective.
+
+- `npagControl(cores=)` and `npbControl(cores=)` set the number of threads used
+  for the parallel per-subject conditional-likelihood solves.  The default
+  (`NULL`) uses the current `rxode2` thread count (`rxode2::getRxThreads()`); an
+  integer sets the thread count for the fit and restores it afterwards.
 
 - SAEM/fsaem now fit general log-likelihood (`ll() ~ expr`) models.  The solve
   event data keeps `DV` when the model references it (previously dropped, so the

--- a/NEWS.md
+++ b/NEWS.md
@@ -286,6 +286,21 @@
   the posterior-mean draws are pooled, and a Gelman-Rubin R-hat per eta is
   reported in `$env$npbRhat` (~1 at convergence; > ~1.1 flags non-convergence).
 
+- `est="npb"` is faster: the two per-sweep loops that re-solve the ODE serially
+  (the support-location Metropolis-Hastings step, and the mixture-proportion
+  Gibbs step for `mix()` models) now solve their per-subject conditional
+  likelihoods in parallel over subjects, matching the already-parallel Psi build.
+  The proposal and accept/reject draws stay serial in their original order, so a
+  fixed-seed fit is bit-for-bit identical regardless of thread count
+  (`rxode2::setRxThreads()`).
+
+- `est="npag"` is faster: it no longer does a redundant full conditional-density
+  build at the first cycle (the degeneracy check now reads the working build's
+  per-subject maxima), and the one-time D(F) global-optimality scan is smaller by
+  default and configurable via `npagControl(dfScan=)` (`-1` auto, `0` to skip the
+  certificate, or an explicit scan size).  Neither change affects the fitted
+  support, Omega, thetas, or objective.
+
 - SAEM/fsaem now fit general log-likelihood (`ll() ~ expr`) models.  The solve
   event data keeps `DV` when the model references it (previously dropped, so the
   likelihood solve errored "parameter(s) required for solving: DV"); the

--- a/R/npCommon.R
+++ b/R/npCommon.R
@@ -69,6 +69,9 @@
       .npAutoPoints(length(.box$names))
     } else as.integer(.ctl$points)
   .ctl$npCycles <- as.integer(if (is.null(.ctl$cycles)) 100L else .ctl$cycles)
+  # global-optimality (D(F)) Sobol scan size (npag only): -1 auto
+  # (max(2048, 2*npPoints)), 0 to skip the certificate, >0 for an explicit count.
+  .ctl$npDfScan <- as.integer(if (is.null(.ctl$dfScan)) -1L else .ctl$dfScan)
   # gamma scales the residual variance r; a generalized (non-normal) endpoint has
   # r == 1, so the gamma warm-start is a no-op -- force it off there.
   .isGenLik <- .npIsGeneralLik(.ui)
@@ -266,7 +269,7 @@
   .in <- control[[1]]
   .np <- list(points = NA_integer_, cycles = 100L, gammaOptimize = TRUE,
               residOptimize = "alternate", muExpand = FALSE,
-              gridWidth = 4, gridBounds = "auto",
+              gridWidth = 4, gridBounds = "auto", dfScan = -1L,
               alpha = 1.0, burnin = 500L, nsamp = 500L, nchains = 1L,
               propSd = 0.2, seed = 42L)
   for (.n in names(.np)) if (!is.null(.in[[.n]])) .np[[.n]] <- .in[[.n]]
@@ -282,6 +285,7 @@
   .ctl$muExpand <- isTRUE(.np$muExpand)
   .ctl$gridWidth <- as.numeric(.np$gridWidth)
   .ctl$gridBounds <- as.character(.np$gridBounds)
+  .ctl$dfScan <- as.integer(.np$dfScan)
   .ctl$alpha <- as.numeric(.np$alpha)
   .ctl$burnin <- as.integer(.np$burnin)
   .ctl$nsamp <- as.integer(.np$nsamp)

--- a/R/npCommon.R
+++ b/R/npCommon.R
@@ -97,6 +97,19 @@
   env$impmapControl <- .control
   env$est <- est
   .ui <- env$ui
+  # honor npagControl(cores=)/npbControl(cores=): the parallel per-subject solves
+  # in the kernels use the solve's thread count (op->cores), which rxode2 sizes
+  # from getRxThreads() when the inner solve is built inside .npFamilyFit.  Set
+  # the thread count for the fit (default: the current rxode2 threads) and restore
+  # it afterwards; the fit results are independent of the thread count.
+  .nCores <- if (is.null(.ctl$npCores) || is.na(.ctl$npCores)) {
+    rxode2::getRxThreads()
+  } else as.integer(.ctl$npCores)
+  if (!is.na(.nCores) && .nCores >= 1L && rxode2::getRxThreads() != .nCores) {
+    .oldThreads <- rxode2::getRxThreads()
+    rxode2::setRxThreads(.nCores)
+    on.exit(rxode2::setRxThreads(.oldThreads), add = TRUE)
+  }
   .npFamilyFit(env, .ui, ...)
 }
 
@@ -269,7 +282,7 @@
   .in <- control[[1]]
   .np <- list(points = NA_integer_, cycles = 100L, gammaOptimize = TRUE,
               residOptimize = "alternate", muExpand = FALSE,
-              gridWidth = 4, gridBounds = "auto", dfScan = -1L,
+              gridWidth = 4, gridBounds = "auto", dfScan = -1L, npCores = NA_integer_,
               alpha = 1.0, burnin = 500L, nsamp = 500L, nchains = 1L,
               propSd = 0.2, seed = 42L)
   for (.n in names(.np)) if (!is.null(.in[[.n]])) .np[[.n]] <- .in[[.n]]
@@ -286,6 +299,7 @@
   .ctl$gridWidth <- as.numeric(.np$gridWidth)
   .ctl$gridBounds <- as.character(.np$gridBounds)
   .ctl$dfScan <- as.integer(.np$dfScan)
+  .ctl$npCores <- as.integer(.np$npCores)
   .ctl$alpha <- as.numeric(.np$alpha)
   .ctl$burnin <- as.integer(.np$burnin)
   .ctl$nsamp <- as.integer(.np$nsamp)

--- a/R/npCommon.R
+++ b/R/npCommon.R
@@ -33,6 +33,32 @@
   max(2028L, as.integer(512L * max(1L, as.integer(neta))))
 }
 
+# Validate the npag `dfScan` control: a single finite integer that is -1 (auto),
+# 0 (skip the D(F) certificate), or a positive scan size.  Fails fast so a stray
+# value (e.g. -5) cannot silently behave like auto.
+#' @noRd
+.npAssertDfScan <- function(dfScan) {
+  if (length(dfScan) != 1L || is.na(dfScan) || !is.finite(dfScan) ||
+        as.integer(dfScan) != dfScan || dfScan < -1L) {
+    stop("'dfScan' must be a single integer: -1 (auto), 0 (skip), or a positive scan size",
+         call. = FALSE)
+  }
+  as.integer(dfScan)
+}
+
+# Validate the npag/npb `cores` control: NULL (use the current rxode2 thread
+# count, stored as NA) or a single positive integer thread count.
+#' @noRd
+.npAssertCores <- function(cores) {
+  if (is.null(cores)) return(NA_integer_)
+  if (length(cores) != 1L || is.na(cores) || !is.finite(cores) ||
+        as.integer(cores) != cores || cores < 1L) {
+    stop("'cores' must be NULL or a single positive integer number of threads",
+         call. = FALSE)
+  }
+  as.integer(cores)
+}
+
 #' @noRd
 .npEstCore <- function(env, est, muModel = NULL, ...) {
   .ui <- env$ui

--- a/R/npag.R
+++ b/R/npag.R
@@ -88,6 +88,11 @@
 #'   parameter's ini-block lower/upper bounds where finite (else auto); `"both"`
 #'   uses the ini bounds when present and auto otherwise.  For a high-dimensional
 #'   model, bounded ini estimates + `"ini"` keep the grid in range.
+#' @param dfScan Size of the Sobol scan used for the D(F) global-optimality
+#'   certificate: `-1` (default) auto-sizes it to `max(2048, 2 * points)`, `0`
+#'   skips the certificate (`npagDF` is `NA`), and a positive value sets an
+#'   explicit scan size.  The scan does not affect the fit, only the reported
+#'   certificate; a smaller scan is faster.
 #' @param ... Parameters passed to [impmapControl()].
 #' @return An `impmapControl` object tagged for the npag engine.
 #' @export
@@ -98,13 +103,14 @@
 npagControl <- function(points = NULL, cycles = 100L, gammaOptimize = TRUE,
                         residOptimize = c("alternate", "final", "none"),
                         muExpand = FALSE, gridWidth = 4,
-                        gridBounds = c("auto", "ini", "both"), ...) {
+                        gridBounds = c("auto", "ini", "both"), dfScan = -1L, ...) {
   .ctl <- impmapControl(...)
   .ctl$est <- "npag"
   # NULL -> auto (scaled with the number of dimensions in .npEstCore); NA is the
   # sentinel that survives the control round-trip.
   .ctl$points <- if (is.null(points)) NA_integer_ else as.integer(points)
   .ctl$cycles <- as.integer(cycles)
+  .ctl$dfScan <- as.integer(dfScan)
   .ctl$gammaOptimize <- isTRUE(gammaOptimize)
   .ctl$residOptimize <- match.arg(residOptimize)
   .ctl$muExpand <- isTRUE(muExpand)

--- a/R/npag.R
+++ b/R/npag.R
@@ -115,9 +115,9 @@ npagControl <- function(points = NULL, cycles = 100L, gammaOptimize = TRUE,
   # sentinel that survives the control round-trip.
   .ctl$points <- if (is.null(points)) NA_integer_ else as.integer(points)
   .ctl$cycles <- as.integer(cycles)
-  .ctl$dfScan <- as.integer(dfScan)
+  .ctl$dfScan <- .npAssertDfScan(dfScan)
   # NA -> use the default rxode2 thread count (resolved in .npEstCore)
-  .ctl$npCores <- if (is.null(cores)) NA_integer_ else as.integer(cores)
+  .ctl$npCores <- .npAssertCores(cores)
   .ctl$gammaOptimize <- isTRUE(gammaOptimize)
   .ctl$residOptimize <- match.arg(residOptimize)
   .ctl$muExpand <- isTRUE(muExpand)

--- a/R/npag.R
+++ b/R/npag.R
@@ -93,6 +93,10 @@
 #'   skips the certificate (`npagDF` is `NA`), and a positive value sets an
 #'   explicit scan size.  The scan does not affect the fit, only the reported
 #'   certificate; a smaller scan is faster.
+#' @param cores Number of threads used for the parallel per-subject conditional-
+#'   likelihood solves.  `NULL` (default) uses the current `rxode2` thread count
+#'   (`rxode2::getRxThreads()`); an integer sets the thread count for the fit
+#'   (restored afterwards).  Results are independent of the thread count.
 #' @param ... Parameters passed to [impmapControl()].
 #' @return An `impmapControl` object tagged for the npag engine.
 #' @export
@@ -103,7 +107,8 @@
 npagControl <- function(points = NULL, cycles = 100L, gammaOptimize = TRUE,
                         residOptimize = c("alternate", "final", "none"),
                         muExpand = FALSE, gridWidth = 4,
-                        gridBounds = c("auto", "ini", "both"), dfScan = -1L, ...) {
+                        gridBounds = c("auto", "ini", "both"), dfScan = -1L,
+                        cores = NULL, ...) {
   .ctl <- impmapControl(...)
   .ctl$est <- "npag"
   # NULL -> auto (scaled with the number of dimensions in .npEstCore); NA is the
@@ -111,6 +116,8 @@ npagControl <- function(points = NULL, cycles = 100L, gammaOptimize = TRUE,
   .ctl$points <- if (is.null(points)) NA_integer_ else as.integer(points)
   .ctl$cycles <- as.integer(cycles)
   .ctl$dfScan <- as.integer(dfScan)
+  # NA -> use the default rxode2 thread count (resolved in .npEstCore)
+  .ctl$npCores <- if (is.null(cores)) NA_integer_ else as.integer(cores)
   .ctl$gammaOptimize <- isTRUE(gammaOptimize)
   .ctl$residOptimize <- match.arg(residOptimize)
   .ctl$muExpand <- isTRUE(muExpand)

--- a/R/npb.R
+++ b/R/npb.R
@@ -44,6 +44,11 @@
 #'   multiplier (gamma); the residual thetas are fit directly.
 #' @param cycles Unused for npb (kept for control compatibility).
 #' @param gammaOptimize Unused for npb (kept for control compatibility).
+#' @param cores Number of threads used for the parallel per-subject conditional-
+#'   likelihood solves in the Gibbs sweeps.  `NULL` (default) uses the current
+#'   `rxode2` thread count (`rxode2::getRxThreads()`); an integer sets the thread
+#'   count for the fit (restored afterwards).  With a fixed `seed` the fit is
+#'   bit-for-bit identical regardless of the thread count.
 #' @param ... Parameters passed to [impmapControl()].
 #' @return An `impmapControl` object tagged for the npb engine.
 #' @export
@@ -55,11 +60,13 @@ npbControl <- function(points = 50L, alpha = 1.0, burnin = 500L, nsamp = 500L,
                        nchains = 1L, propSd = 0.2, seed = 42L,
                        residOptimize = c("alternate", "final", "none"),
                        cycles = 100L,
-                       gammaOptimize = FALSE, muExpand = FALSE, ...) {
+                       gammaOptimize = FALSE, muExpand = FALSE, cores = NULL, ...) {
   .ctl <- impmapControl(...)
   .ctl$est <- "npb"
   .ctl$points <- as.integer(points)
   .ctl$cycles <- as.integer(cycles)
+  # NA -> use the default rxode2 thread count (resolved in .npEstCore)
+  .ctl$npCores <- if (is.null(cores)) NA_integer_ else as.integer(cores)
   .ctl$gammaOptimize <- isTRUE(gammaOptimize)
   .ctl$residOptimize <- match.arg(residOptimize)
   .ctl$muExpand <- isTRUE(muExpand)

--- a/R/npb.R
+++ b/R/npb.R
@@ -66,7 +66,7 @@ npbControl <- function(points = 50L, alpha = 1.0, burnin = 500L, nsamp = 500L,
   .ctl$points <- as.integer(points)
   .ctl$cycles <- as.integer(cycles)
   # NA -> use the default rxode2 thread count (resolved in .npEstCore)
-  .ctl$npCores <- if (is.null(cores)) NA_integer_ else as.integer(cores)
+  .ctl$npCores <- .npAssertCores(cores)
   .ctl$gammaOptimize <- isTRUE(gammaOptimize)
   .ctl$residOptimize <- match.arg(residOptimize)
   .ctl$muExpand <- isTRUE(muExpand)

--- a/man/npagControl.Rd
+++ b/man/npagControl.Rd
@@ -12,6 +12,7 @@ npagControl(
   muExpand = FALSE,
   gridWidth = 4,
   gridBounds = c("auto", "ini", "both"),
+  dfScan = -1L,
   ...
 )
 }
@@ -71,6 +72,12 @@ uses `+/- gridWidth * initial eta SD`; `"ini"` uses each mu-referenced
 parameter's ini-block lower/upper bounds where finite (else auto); `"both"`
 uses the ini bounds when present and auto otherwise.  For a high-dimensional
 model, bounded ini estimates + `"ini"` keep the grid in range.}
+
+\item{dfScan}{Size of the Sobol scan used for the D(F) global-optimality
+certificate: `-1` (default) auto-sizes it to `max(2048, 2 * points)`, `0`
+skips the certificate (`npagDF` is `NA`), and a positive value sets an
+explicit scan size.  The scan does not affect the fit, only the reported
+certificate; a smaller scan is faster.}
 
 \item{...}{Parameters passed to [impmapControl()].}
 }

--- a/man/npagControl.Rd
+++ b/man/npagControl.Rd
@@ -13,6 +13,7 @@ npagControl(
   gridWidth = 4,
   gridBounds = c("auto", "ini", "both"),
   dfScan = -1L,
+  cores = NULL,
   ...
 )
 }
@@ -78,6 +79,11 @@ certificate: `-1` (default) auto-sizes it to `max(2048, 2 * points)`, `0`
 skips the certificate (`npagDF` is `NA`), and a positive value sets an
 explicit scan size.  The scan does not affect the fit, only the reported
 certificate; a smaller scan is faster.}
+
+\item{cores}{Number of threads used for the parallel per-subject conditional-
+likelihood solves.  `NULL` (default) uses the current `rxode2` thread count
+(`rxode2::getRxThreads()`); an integer sets the thread count for the fit
+(restored afterwards).  Results are independent of the thread count.}
 
 \item{...}{Parameters passed to [impmapControl()].}
 }

--- a/man/npbControl.Rd
+++ b/man/npbControl.Rd
@@ -16,6 +16,7 @@ npbControl(
   cycles = 100L,
   gammaOptimize = FALSE,
   muExpand = FALSE,
+  cores = NULL,
   ...
 )
 }
@@ -52,6 +53,12 @@ multiplier (gamma); the residual thetas are fit directly.}
 \item{cycles}{Unused for npb (kept for control compatibility).}
 
 \item{gammaOptimize}{Unused for npb (kept for control compatibility).}
+
+\item{cores}{Number of threads used for the parallel per-subject conditional-
+likelihood solves in the Gibbs sweeps.  `NULL` (default) uses the current
+`rxode2` thread count (`rxode2::getRxThreads()`); an integer sets the thread
+count for the fit (restored afterwards).  With a fixed `seed` the fit is
+bit-for-bit identical regardless of the thread count.}
 
 \item{...}{Parameters passed to [impmapControl()].}
 }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -10599,20 +10599,47 @@ void npbSampleMixProbs(const arma::mat& subEta, double alpha0) {
   if (nMix <= 1 || op_focei.mixIdxN == 0) return;
   int nsub = (int)subEta.n_rows;
   int neta = (int)subEta.n_cols;
+  rx = getRxSolve_();
+  rx_solving_options *op = getSolvingOptions(rx);
+  int cores = getOpCores(op);
+  // Parallel: each subject's per-component log-weight log(mixProb_m)+condLik and
+  // its max, into G (nsub x nMix) + gmax (nsub).  No RNG here, so the serial
+  // categorical draws below keep their original order and the fit stays
+  // reproducible bit-for-bit.
+  arma::mat G(nsub, nMix, arma::fill::value(R_NegInf));
+  arma::vec gmaxv(nsub, arma::fill::value(R_NegInf));
+  const bool doParallel = (cores > 1) && solveMethodThreadSafe(op);
+  if (doParallel) { sortIds(rx, 2); _innerParallel.store(1, std::memory_order_release); }
+#ifdef _OPENMP
+#pragma omp parallel for num_threads(cores) schedule(dynamic) if(doParallel)
+#endif
+  for (int i = 0; i < nsub; ++i) {
+    int base = doParallel ? (getOrdId(rx, i) - 1) : i;
+#ifdef _OPENMP
+    if (doParallel) setRxThreadId(omp_get_thread_num());
+#endif
+    std::vector<double> eta(neta);
+    for (int j = 0; j < neta; ++j) eta[j] = subEta(base, j);
+    double gm = R_NegInf;
+    for (int m = 0; m < nMix; ++m) {
+      double cl = npEvalCondLik(&eta[0], base + m * nsub);
+      double g = std::log(std::max(1e-300, impMixProb(m))) + cl;
+      G(base, m) = g;
+      if (std::isfinite(g) && g > gm) gm = g;
+    }
+    gmaxv[base] = gm;
+#ifdef _OPENMP
+    if (doParallel) setRxThreadId(-1);
+#endif
+  }
+  if (doParallel) { _innerParallel.store(0, std::memory_order_release); sortIds(rx, 0); }
+  // Serial categorical draw per subject (unchanged RNG order), then Dirichlet.
   std::vector<double> counts(nMix, alpha0);       // Dirichlet prior concentration
   for (int i = 0; i < nsub; ++i) {
-    std::vector<double> eta(neta);
-    for (int j = 0; j < neta; ++j) eta[j] = subEta(i, j);
-    std::vector<double> g(nMix); double gmax = R_NegInf;
-    for (int m = 0; m < nMix; ++m) {
-      double cl = npEvalCondLik(&eta[0], i + m * nsub);
-      g[m] = std::log(std::max(1e-300, impMixProb(m))) + cl;
-      if (std::isfinite(g[m]) && g[m] > gmax) gmax = g[m];
-    }
     int mi = 0;
-    if (std::isfinite(gmax)) {
-      double gsum = 0.0;
-      for (int m = 0; m < nMix; ++m) { g[m] = std::exp(g[m] - gmax); gsum += g[m]; }
+    if (std::isfinite(gmaxv[i])) {
+      std::vector<double> g(nMix); double gsum = 0.0;
+      for (int m = 0; m < nMix; ++m) { g[m] = std::exp(G(i, m) - gmaxv[i]); gsum += g[m]; }
       double u = R::unif_rand() * gsum, c = 0.0;
       for (int m = 0; m < nMix; ++m) { c += g[m]; mi = m; if (u <= c) break; }
     } else {
@@ -10677,6 +10704,49 @@ void npBuildPsiCore(const arma::mat& etaPoints, int cores, arma::mat& psi) {
   }
 }
 
+// Per-subject conditional-likelihood contributions for the npb support-location
+// MH step (src/npb.cpp step c).  For each physical subject, k = z[subject]; when
+// that cluster is occupied it computes the current and proposed conditional
+// log-likelihoods at the cluster's current/proposed support eta (curLoc[k] /
+// propLoc[k], each length neta).  Solves are subject-parallel using the same
+// discipline as npBuildPsiCore; no RNG/R-API inside.  Results are written per
+// physical subject id into curContrib/propContrib (0 for a subject whose cluster
+// is empty).  The caller does the (serial) proposal draws and accept/reject, so
+// the RNG stream -- and thus reproducibility -- is unchanged.
+void npbSupportMHContrib(const std::vector<int>& z, const std::vector<char>& occ,
+                         std::vector<std::vector<double> >& curLoc,
+                         std::vector<std::vector<double> >& propLoc,
+                         std::vector<double>& curContrib,
+                         std::vector<double>& propContrib) {
+  rx = getRxSolve_();
+  rx_solving_options *op = getSolvingOptions(rx);
+  int cores = getOpCores(op);
+  int nsub = (int)getRxNsub(rx);
+  int K = (int)occ.size();
+  curContrib.assign(nsub, 0.0);
+  propContrib.assign(nsub, 0.0);
+  const bool doParallel = (cores > 1) && solveMethodThreadSafe(op);
+  if (doParallel) { sortIds(rx, 2); _innerParallel.store(1, std::memory_order_release); }
+#ifdef _OPENMP
+#pragma omp parallel for num_threads(cores) schedule(dynamic) if(doParallel)
+#endif
+  for (int i = 0; i < nsub; ++i) {
+    int base = doParallel ? (getOrdId(rx, i) - 1) : i;
+#ifdef _OPENMP
+    if (doParallel) setRxThreadId(omp_get_thread_num());
+#endif
+    int k = (base >= 0 && base < (int)z.size()) ? z[base] : -1;
+    if (k >= 0 && k < K && occ[k]) {
+      curContrib[base] = npEvalCondLik(&curLoc[k][0], base);
+      propContrib[base] = npEvalCondLik(&propLoc[k][0], base);
+    }
+#ifdef _OPENMP
+    if (doParallel) setRxThreadId(-1);
+#endif
+  }
+  if (doParallel) { _innerParallel.store(0, std::memory_order_release); sortIds(rx, 0); }
+}
+
 // Build the UNNORMALIZED Psi at a residual-error multiplier gamma.  Same as
 // npBuildPsiCore but with op_focei.npResidScale = gamma held over the solve, so
 // the returned p(y_i | point) are on a single absolute scale (no per-row
@@ -10700,7 +10770,7 @@ void npBuildPsiCoreGamma(const arma::mat& etaPoints, int cores, double gamma,
 // row maxima are returned in *offset so the true log-likelihood is
 // burke_objf + offset.
 void npBuildPsiCoreScaled(const arma::mat& etaPoints, int cores, double gamma,
-                          arma::mat& psi, double* offset) {
+                          arma::mat& psi, double* offset, arma::vec* rowMax) {
   rx = getRxSolve_();
   rx_solving_options *op = getSolvingOptions(rx);
   cores = min2(cores, getOpCores(op));
@@ -10734,6 +10804,7 @@ void npBuildPsiCoreScaled(const arma::mat& etaPoints, int cores, double gamma,
   op_focei.npResidScale = savedScale;
   arma::vec m = (nPoint > 0) ? arma::max(lp, 1) : arma::vec(nsub, arma::fill::zeros);
   if (offset != nullptr) *offset = arma::accu(m);
+  if (rowMax != nullptr) *rowMax = m;
   psi.set_size(nsub, nPoint);
   for (int k = 0; k < nPoint; ++k) {
     for (int i = 0; i < nsub; ++i) psi(i, k) = std::exp(lp(i, k) - m[i]);

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -10270,6 +10270,24 @@ List vaeInnerLik(NumericMatrix etaMat, int cores, bool grad = false, bool preds 
 // Reuses the FOCEi inner solve set up by vaeInnerSetup_ -- so it inherits the ODE
 // solve, residual-error models, transform-both-sides and censoring unchanged.
 
+// RAII for the npb/npag subject-parallel solve scopes: on construction it turns
+// on the inner parallel mode (sort ids + the _innerParallel flag); on
+// destruction it guarantees the reset/un-sort on EVERY exit path, including an
+// exception escaping a solve, so a later serial solve never sees a stale sort or
+// flag.  A no-op when `on` is false (the serial path).
+struct NpInnerParallelScope {
+  rx_solve* rx_;
+  bool on_;
+  NpInnerParallelScope(rx_solve* rxIn, bool on) : rx_(rxIn), on_(on) {
+    if (on_) { sortIds(rx_, 2); _innerParallel.store(1, std::memory_order_release); }
+  }
+  ~NpInnerParallelScope() {
+    if (on_) { _innerParallel.store(0, std::memory_order_release); sortIds(rx_, 0); }
+  }
+  NpInnerParallelScope(const NpInnerParallelScope&) = delete;
+  NpInnerParallelScope& operator=(const NpInnerParallelScope&) = delete;
+};
+
 // Conditional log-likelihood log p(y_i | eta) for subject id (no Omega prior).
 // Returns -Inf if any observation had a non-finite density (e.g. a bad solve).
 double npEvalCondLik(double *eta, int id) {
@@ -10528,7 +10546,8 @@ void npMixEMUpdate(const arma::mat& etaPoints, const arma::vec& lam, int cores) 
   arma::mat runMax(nsub, nMix); runMax.fill(R_NegInf);
   arma::mat runSum(nsub, nMix, arma::fill::zeros);
   const bool doParallel = (cores > 1) && solveMethodThreadSafe(op);
-  if (doParallel) { sortIds(rx, 2); _innerParallel.store(1, std::memory_order_release); }
+  {
+  NpInnerParallelScope npScope(rx, doParallel);
   for (int k = 0; k < nPoint; ++k) {
     std::vector<double> eta(neta);
     for (int j = 0; j < neta; ++j) eta[j] = etaPoints(k, j);
@@ -10558,7 +10577,7 @@ void npMixEMUpdate(const arma::mat& etaPoints, const arma::vec& lam, int cores) 
 #endif
     }
   }
-  if (doParallel) { _innerParallel.store(0, std::memory_order_release); sortIds(rx, 0); }
+  }
   // responsibilities -> mean over subjects -> new proportions
   arma::vec newProb(nMix, arma::fill::zeros);
   for (int i = 0; i < nsub; ++i) {
@@ -10609,7 +10628,8 @@ void npbSampleMixProbs(const arma::mat& subEta, double alpha0) {
   arma::mat G(nsub, nMix, arma::fill::value(R_NegInf));
   arma::vec gmaxv(nsub, arma::fill::value(R_NegInf));
   const bool doParallel = (cores > 1) && solveMethodThreadSafe(op);
-  if (doParallel) { sortIds(rx, 2); _innerParallel.store(1, std::memory_order_release); }
+  {
+  NpInnerParallelScope npScope(rx, doParallel);
 #ifdef _OPENMP
 #pragma omp parallel for num_threads(cores) schedule(dynamic) if(doParallel)
 #endif
@@ -10632,7 +10652,7 @@ void npbSampleMixProbs(const arma::mat& subEta, double alpha0) {
     if (doParallel) setRxThreadId(-1);
 #endif
   }
-  if (doParallel) { _innerParallel.store(0, std::memory_order_release); sortIds(rx, 0); }
+  }
   // Serial categorical draw per subject (unchanged RNG order), then Dirichlet.
   std::vector<double> counts(nMix, alpha0);       // Dirichlet prior concentration
   for (int i = 0; i < nsub; ++i) {
@@ -10714,8 +10734,8 @@ void npBuildPsiCore(const arma::mat& etaPoints, int cores, arma::mat& psi) {
 // is empty).  The caller does the (serial) proposal draws and accept/reject, so
 // the RNG stream -- and thus reproducibility -- is unchanged.
 void npbSupportMHContrib(const std::vector<int>& z, const std::vector<char>& occ,
-                         std::vector<std::vector<double> >& curLoc,
-                         std::vector<std::vector<double> >& propLoc,
+                         const std::vector<std::vector<double> >& curLoc,
+                         const std::vector<std::vector<double> >& propLoc,
                          std::vector<double>& curContrib,
                          std::vector<double>& propContrib) {
   rx = getRxSolve_();
@@ -10726,7 +10746,8 @@ void npbSupportMHContrib(const std::vector<int>& z, const std::vector<char>& occ
   curContrib.assign(nsub, 0.0);
   propContrib.assign(nsub, 0.0);
   const bool doParallel = (cores > 1) && solveMethodThreadSafe(op);
-  if (doParallel) { sortIds(rx, 2); _innerParallel.store(1, std::memory_order_release); }
+  {
+  NpInnerParallelScope npScope(rx, doParallel);
 #ifdef _OPENMP
 #pragma omp parallel for num_threads(cores) schedule(dynamic) if(doParallel)
 #endif
@@ -10737,14 +10758,18 @@ void npbSupportMHContrib(const std::vector<int>& z, const std::vector<char>& occ
 #endif
     int k = (base >= 0 && base < (int)z.size()) ? z[base] : -1;
     if (k >= 0 && k < K && occ[k]) {
-      curContrib[base] = npEvalCondLik(&curLoc[k][0], base);
-      propContrib[base] = npEvalCondLik(&propLoc[k][0], base);
+      // Local per-thread copies: npEvalCondLik takes double* and shared clusters
+      // (multiple subjects with the same k) must not alias one buffer.
+      std::vector<double> curEta(curLoc[k]);
+      std::vector<double> propEta(propLoc[k]);
+      curContrib[base] = npEvalCondLik(&curEta[0], base);
+      propContrib[base] = npEvalCondLik(&propEta[0], base);
     }
 #ifdef _OPENMP
     if (doParallel) setRxThreadId(-1);
 #endif
   }
-  if (doParallel) { _innerParallel.store(0, std::memory_order_release); sortIds(rx, 0); }
+  }
 }
 
 // Build the UNNORMALIZED Psi at a residual-error multiplier gamma.  Same as
@@ -10782,7 +10807,8 @@ void npBuildPsiCoreScaled(const arma::mat& etaPoints, int cores, double gamma,
   double savedScale = op_focei.npResidScale;
   op_focei.npResidScale = gamma;   // likInner0 scales r by gamma^2 (incl. cens/tbs)
   const bool doParallel = (cores > 1) && solveMethodThreadSafe(op);
-  if (doParallel) { sortIds(rx, 2); _innerParallel.store(1, std::memory_order_release); }
+  {
+  NpInnerParallelScope npScope(rx, doParallel);
   for (int k = 0; k < nPoint; ++k) {
     std::vector<double> eta(neta);
     for (int j = 0; j < neta; ++j) eta[j] = etaPoints(k, j);
@@ -10800,7 +10826,7 @@ void npBuildPsiCoreScaled(const arma::mat& etaPoints, int cores, double gamma,
 #endif
     }
   }
-  if (doParallel) { _innerParallel.store(0, std::memory_order_release); sortIds(rx, 0); }
+  }
   op_focei.npResidScale = savedScale;
   arma::vec m = (nPoint > 0) ? arma::max(lp, 1) : arma::vec(nsub, arma::fill::zeros);
   if (offset != nullptr) *offset = arma::accu(m);

--- a/src/np.h
+++ b/src/np.h
@@ -77,8 +77,8 @@ void npBuildPsiCoreScaled(const arma::mat& etaPoints, int cores, double gamma,
 // caller keeps the (serial) proposal + accept/reject draws.  Implemented in
 // inner.cpp, used by npb.cpp.
 void npbSupportMHContrib(const std::vector<int>& z, const std::vector<char>& occ,
-                         std::vector<std::vector<double> >& curLoc,
-                         std::vector<std::vector<double> >& propLoc,
+                         const std::vector<std::vector<double> >& curLoc,
+                         const std::vector<std::vector<double> >& propLoc,
                          std::vector<double>& curContrib,
                          std::vector<double>& propContrib);
 

--- a/src/np.h
+++ b/src/np.h
@@ -62,8 +62,25 @@ void npFreezeClear();
 // conditional likelihood so censoring and transform-both-sides are handled at the
 // scaled error.  Row-normalized (log-sum-exp) for numerical stability; the true
 // log-likelihood is burke_objf + *offset.
+// rowMax (optional): the per-subject pre-normalization max log conditional
+// likelihood over the support points.  A subject whose value is non-finite
+// (-Inf) had zero density at every support point (degenerate); lets the caller
+// detect that without a separate raw Psi build.
 void npBuildPsiCoreScaled(const arma::mat& etaPoints, int cores, double gamma,
-                          arma::mat& psi, double* offset);
+                          arma::mat& psi, double* offset, arma::vec* rowMax = nullptr);
+
+// Subject-parallel conditional-likelihood contributions for the npb
+// support-location MH step: for each physical subject, k = z[subject]; when
+// occupied, computes the current/proposed conditional log-likelihoods at the
+// cluster's current/proposed support eta (curLoc[k] / propLoc[k]) into
+// curContrib/propContrib (indexed by physical subject id).  No RNG inside; the
+// caller keeps the (serial) proposal + accept/reject draws.  Implemented in
+// inner.cpp, used by npb.cpp.
+void npbSupportMHContrib(const std::vector<int>& z, const std::vector<char>& occ,
+                         std::vector<std::vector<double> >& curLoc,
+                         std::vector<std::vector<double> >& propLoc,
+                         std::vector<double>& curContrib,
+                         std::vector<double>& propContrib);
 
 // Shared fit finalization for the nonparametric engines: given the discrete
 // mixing distribution (support points in eta space + weights) and the per-subject

--- a/src/npag.cpp
+++ b/src/npag.cpp
@@ -169,6 +169,7 @@ double npOptimizeResid(const arma::mat& support, const arma::vec& weights,
 struct npagCtl {
   int points = 2028;    // initial Sobol grid size
   int cycles = 100;     // maximum cycles
+  int dfScan = -1;      // D(F) certificate scan size (-1 auto, 0 skip, >0 explicit)
   int cores = 1;
   double ratio = 1e-3;  // weight-threshold condensation (max*ratio)
   double qrTol = 1e-8;  // QR rank-revealing tolerance
@@ -281,29 +282,27 @@ static npagResult npagRunCycle(const arma::vec& lower, const arma::vec& upper,
     // builds Psi through likInner0 (npBuildPsiCoreScaled) so censoring and
     // transform-both-sides are handled at the scaled residual error.
     double obj0 = 0.0, offset = 0.0;
+    // capture the per-row max (pre-normalization) at cycle 1 for the degeneracy
+    // check below -- avoids a separate raw Psi build over the whole initial grid.
+    arma::vec rowMax;
+    arma::vec* rowMaxPtr = (cycle == 1) ? &rowMax : nullptr;
     if (ctl.gammaOptimize) {
-      npBuildPsiCoreScaled(theta, ctl.cores, gamma, psi, &offset);
+      npBuildPsiCoreScaled(theta, ctl.cores, gamma, psi, &offset, rowMaxPtr);
     } else {
       // per-row log-sum-exp normalized (the removed maxima are returned in offset)
       // so a hard subject's conditional density cannot underflow a whole Psi row to
       // zero -- which would abort condensation (npCondenseQR).  Burke's weights are
       // invariant to per-row scaling; the objective adds offset back.
-      npBuildPsiCoreScaled(theta, ctl.cores, 1.0, psi, &offset);
+      npBuildPsiCoreScaled(theta, ctl.cores, 1.0, psi, &offset, rowMaxPtr);
     }
     // a subject whose conditional density is 0 at EVERY support point makes the
     // Burke IPM (and condensation) degenerate -- report it clearly.  The usual cause
     // is a transform-both-sides link evaluated where the structural prediction is
     // non-positive (e.g. lnorm/log at an observation whose model prediction is 0).
-    // Check on the RAW (unnormalized) build: the per-row log-sum-exp normalization of
-    // the working psi masks a zero row (exp(-Inf) becomes a NaN the offset absorbs),
-    // so a raw exp(condLik) is what reliably exposes the degeneracy.  One extra Psi
-    // build, only at cycle 1.
+    // The build's per-row max (pre log-sum-exp normalization) is -Inf exactly for
+    // such a subject, so it detects the degeneracy without a separate raw Psi build.
     if (cycle == 1) {
-      arma::mat psiRaw;
-      npBuildPsiCore(theta, ctl.cores, psiRaw);
-      arma::vec rowSum = arma::sum(psiRaw, 1);
-      arma::uvec bad = arma::find_nonfinite(rowSum);
-      if (bad.is_empty()) bad = arma::find(rowSum <= 0.0);
+      arma::uvec bad = arma::find_nonfinite(rowMax);
       if (!bad.is_empty()) {
         throw std::runtime_error(
           "npag/npb: " + std::to_string(bad.n_elem) + " subject(s) (first at index " +
@@ -463,6 +462,8 @@ void npagOuter(Environment e) {
   npagCtl ctl;
   ctl.points = as<int>(control["npPoints"]);
   ctl.cycles = as<int>(control["npCycles"]);
+  if (control.containsElementNamed("npDfScan"))
+    ctl.dfScan = as<int>(control["npDfScan"]);
   ctl.cores = impCores();
   ctl.gammaOptimize = as<bool>(control["npGammaOptimize"]);
   ctl.trace = true;
@@ -567,13 +568,16 @@ void npagOuter(Environment e) {
   // (so p(y_i|theta) and p(y_i|F) share the fitted residual scale) over a fresh
   // Sobol scan of the box; at the NPML max D(theta,F) ~ 0 (a large positive value
   // means the grid missed a mode -- not the global optimum).
+  // dfScan == 0 skips the certificate (leaves npagDF = NA); >0 sets the scan
+  // size explicitly; -1 (default) auto-sizes it.  The scan is one-time overhead
+  // that does not change the fit, so a smaller scan just weakens the certificate.
   double npagDF = NA_REAL;
-  {
+  if (ctl.dfScan != 0) {
     arma::mat psiSup;
     npBuildPsiCoreGamma(r.theta, ctl.cores, r.gamma, psiSup);  // nsub x nspp (unnormalized)
     arma::vec pyf = psiSup * r.lambda;                 // p(y_i|F)
     pyf = arma::clamp(pyf, 1e-300, arma::datum::inf);
-    int nScan = std::max(2048, 4 * ctl.points);
+    int nScan = (ctl.dfScan > 0) ? ctl.dfScan : std::max(2048, 2 * ctl.points);
     arma::mat scan = npSobolGrid(nScan, lower, upper);
     arma::mat psiScan;
     npBuildPsiCoreGamma(scan, ctl.cores, r.gamma, psiScan);    // nsub x nScan

--- a/src/npb.cpp
+++ b/src/npb.cpp
@@ -239,26 +239,47 @@ void npbOuter(Environment e) {
       w[k] = std::exp(cumLog1mV) * vv;
       cumLog1mV += std::log(std::max(1e-300, 1.0 - vv));
     }
-    // (c) support locations: MH for occupied clusters, fresh G_0 draw otherwise
+    // (c) support locations: MH for occupied clusters, fresh G_0 draw otherwise.
+    // The proposal + accept/reject draws stay serial and in their original order
+    // (so the RNG stream, and thus reproducibility, is unchanged); only the
+    // per-subject conditional-likelihood solves are parallelized
+    // (npbSupportMHContrib).  Serial pre-pass draws the proposals and priors:
+    std::vector<char> occ(K, 0);
+    std::vector<std::vector<double> > curLoc(K), propLoc(K);
+    std::vector<double> curPrior(K, 0.0), propPrior(K, 0.0), acceptU(K, 0.0);
     for (int k = 0; k < K; ++k) {
       if (nk[k] == 0) {
         for (int j = 0; j < neta; ++j) phi(k, j) = R::rnorm(0.0, g0sd[j]);
         continue;
       }
+      occ[k] = 1;
       arma::rowvec cur = phi.row(k), prop = cur;
       for (int j = 0; j < neta; ++j) prop[j] += R::rnorm(0.0, propSd);
-      double curLp = 0.0, propLp = 0.0;
+      acceptU[k] = R::unif_rand();  // drawn now (before the solves) to keep RNG order
+      double cP = 0.0, pP = 0.0;
       for (int j = 0; j < neta; ++j) {
-        curLp += -0.5 * cur[j] * cur[j] / g0var[j];
-        propLp += -0.5 * prop[j] * prop[j] / g0var[j];
+        cP += -0.5 * cur[j] * cur[j] / g0var[j];
+        pP += -0.5 * prop[j] * prop[j] / g0var[j];
       }
-      std::vector<double> curEta(cur.begin(), cur.end()), propEta(prop.begin(), prop.end());
-      for (int i = 0; i < nsub; ++i) {
-        if (z[i] != k) continue;
-        curLp += npEvalCondLik(&curEta[0], i);
-        propLp += npEvalCondLik(&propEta[0], i);
-      }
-      if (std::log(R::unif_rand()) < propLp - curLp) phi.row(k) = prop;
+      curPrior[k] = cP; propPrior[k] = pP;
+      curLoc[k].assign(cur.begin(), cur.end());
+      propLoc[k].assign(prop.begin(), prop.end());
+    }
+    // parallel solves of each subject's cur/prop conditional log-likelihood
+    std::vector<double> curContrib, propContrib;
+    npbSupportMHContrib(z, occ, curLoc, propLoc, curContrib, propContrib);
+    // serial reduction (in ascending subject order per cluster, matching the old
+    // accumulation exactly) + accept/reject
+    std::vector<double> curLp(K), propLp(K);
+    for (int k = 0; k < K; ++k) { curLp[k] = curPrior[k]; propLp[k] = propPrior[k]; }
+    for (int i = 0; i < nsub; ++i) {
+      int k = z[i];
+      if (k >= 0 && k < K && occ[k]) { curLp[k] += curContrib[i]; propLp[k] += propContrib[i]; }
+    }
+    for (int k = 0; k < K; ++k) {
+      if (!occ[k]) continue;
+      if (std::log(acceptU[k]) < propLp[k] - curLp[k])
+        for (int j = 0; j < neta; ++j) phi(k, j) = propLoc[k][j];
     }
     // (c2) residual/regressor optimization (alternate): re-fit the residual thetas
     // against the current draw's mixing distribution during burn-in, then hold them


### PR DESCRIPTION
## Summary

Speeds up the two nonparametric estimation engines, `est="npag"` and `est="npb"`. The shared Psi builder (`npBuildPsiCore*`) was already OpenMP-parallel over subjects; this PR addresses the remaining **serial** solve loops in npb and the **redundant** solve passes in npag.

| Phase | Change |
|-------|--------|
| **P1** | Parallelize npb's support-location Metropolis-Hastings solve loop (new `npbSupportMHContrib` helper) — was `2·nsub` serial ODE solves *per Gibbs sweep* |
| **P2** | Parallelize `npbSampleMixProbs` (the mixture-proportion Gibbs step) — serial per-subject solves each sweep for `mix()` models |
| **P3** | npag's cycle-1 degeneracy check now reads the working build's per-subject maxima (new optional `rowMax` out-param on `npBuildPsiCoreScaled`) instead of doing a **separate full raw Psi build** over the whole initial grid |
| **P4** | npag's one-time D(F) global-optimality scan is smaller by default (`2·points`) and configurable via `npagControl(dfScan=)` (`-1` auto, `0` skip, `>0` explicit) |

The npb parallelization keeps the proposal/accept-reject **RNG draws serial and in their original order**, so a fixed-seed fit is bit-for-bit identical regardless of thread count. Parallelism keys off `rxode2::setRxThreads()` (via `impCores()`) — no new required control option. No `[[Rcpp::export]]` signatures change, so `src/init.c` / `RcppExports` are untouched. Neither npag change affects the fitted support, Omega, thetas, or objective.

## Verification

- **P1/P2 reproducibility:** npb `logLik`, support, `posteriorEta`, and mixture `npbMixProb` are **bit-for-bit identical** at 1 vs 4 threads; npb ran **~2.4× faster** at 4 threads (5.5s → 2.3s).
- **P3/P4:** npag fits with a finite objective and D(F); `dfScan=0` skips the certificate (`npagDF = NA`) **without changing the fit**.
- **Regression:** `test-npb-fit.R`, `test-npag-mixture.R`, `test-npag-cycle.R` all pass (43 assertions, 0 failures), including npb reproducibility and the mixture-npb Gibbs sampling that exercises P2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ay5BUQGDuhn8V2ah8872ca