### PR TITLE
fix: revdep regressions (babelmixr2 fmeMcmc, admixr2 adfo segfault)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -865,6 +865,14 @@
   degenerate simulated covariance sets the subject's NPDE to `NA` instead of
   aborting.
 
+- Fixed a segfault when a dataset has no observed subject at all (every subject
+  is a placeholder with no `EVID==0` row, as in an aggregate-data output eval
+  such as `babelmixr2`/`admixr2`).  The no-observation-subject drop now keeps
+  the rows when there is no observed subject to fall back to, and `foceiSetup_`
+  no longer reads an empty id vector out of bounds.  `.nlmSetupEnv()` also now
+  supplies a default `iterPrintControl` when an external caller omits it,
+  instead of erroring with `Index out of bounds: [index='iterPrintControl']`.
+
 ### Output, tables, and printing
 
 - For models without etas, the `BSV(SD)` and `Shrink(SD)%` columns are no longer

--- a/R/focei.R
+++ b/R/focei.R
@@ -2152,7 +2152,12 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   # subject count (issue #606).
   .obsId <- sort(unique(.dat$ID[.dat$EVID == 0]))
   .dropId <- setdiff(seq_along(.idLvl), .obsId)
-  if (length(.dropId) > 0L) {
+  # Only drop no-observation subjects when at least one subject *does* have an
+  # observation.  A dataset with no EVID==0 rows at all (e.g. an aggregate-data
+  # output eval, as in admixr2, whose subjects are all placeholders) must keep
+  # its rows -- dropping every subject leaves an empty solve and matches the
+  # pre-issue-#606 behavior these callers rely on.
+  if (length(.dropId) > 0L && length(.obsId) > 0L) {
     warning("IDs without observations dropped: ",
             paste(.idLvl[.dropId], collapse = " "), call. = FALSE)
     .dat <- .dat[.dat$ID %in% .obsId, , drop = FALSE]

--- a/R/nlmShared.R
+++ b/R/nlmShared.R
@@ -64,6 +64,15 @@
   if (!any(names(.ctl) == "hessErr")) {
     .ctl$hessErr <-   (.Machine$double.eps)^(1/3)
   }
+  # nlmSetup (nlm.cpp) reads control$iterPrintControl; external callers that
+  # hand-build a control (e.g. babelmixr2 fmeMcmc) may omit it, so synthesize
+  # one from the scalar print args instead of erroring in C.
+  if (!inherits(.ctl$iterPrintControl, "iterPrintControl")) {
+    .ctl$iterPrintControl <-
+      .absorbIterPrintControl(print = if (is.null(.ctl$print)) 1L else .ctl$print,
+                              printNcol = .ctl$printNcol,
+                              useColor = .ctl$useColor)
+  }
 
   .env <- new.env(parent=emptyenv())
   .env$rxControl <- .ctl$rxControl

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -5224,7 +5224,9 @@ NumericVector foceiSetup_(const RObject &obj,
     stop("Can't find ID in dataset.");
   }
   IntegerVector ids = as<IntegerVector>(df[idn]);
-  int last = ids[ids.size()-1]-1;
+  // Guard an empty dataset (e.g. an aggregate-data output eval whose placeholder
+  // subject carries no observations): ids[ids.size()-1] would read out of bounds.
+  int last = ids.size() > 0 ? ids[ids.size()-1]-1 : 0;
   for (unsigned int j = ids.size(); j--;){
     if (last != ids[j]){
       last = ids[j];

--- a/tests/testthat/test-saem-no-obs-subject.R
+++ b/tests/testthat/test-saem-no-obs-subject.R
@@ -115,6 +115,27 @@ nmTest({
     }
   })
 
+  test_that("a dataset with no observed subjects at all keeps its rows (aggregate-data / admixr2)", {
+    # Aggregate-data output evals (e.g. admixr2's est="adfo") hand FOCEI a
+    # dataset whose subjects are placeholders with no EVID==0 observation.
+    # Dropping *every* subject leaves an empty solve; foceiSetup_ then read
+    # ids[ids.size()-1] out of bounds and segfaulted.  With no observed subject
+    # to keep, the rows must be preserved (pre-#606 behavior).
+    d <- nlmixr2data::theo_sd[nlmixr2data::theo_sd$ID %in% 1:2, ]
+    d$DV[d$EVID == 0] <- NA_real_            # every subject: dose, but no measurement
+
+    fit <- suppressWarnings(suppressMessages(
+      .nlmixr(one.compartment, d, est = "focei",
+              control = foceiControl(print = 0, maxOuterIterations = 0,
+                                     maxInnerIterations = 0, covMethod = ""))))
+    expect_true(inherits(fit, "nlmixr2FitData"))
+    # nothing is dropped -- there is no observed subject to keep
+    expect_equal(
+      sum(grepl("IDs without observations dropped", fit$runInfo, fixed = TRUE)),
+      0L)
+    expect_setequal(as.integer(as.character(unique(as.data.frame(fit)$ID))), 1:2)
+  })
+
   test_that("a fit with all subjects observed is unaffected by the no-obs drop (#687)", {
     d <- nlmixr2data::theo_sd[nlmixr2data::theo_sd$ID %in% 1:3, ]
     fit <- suppressWarnings(suppressMessages(


### PR DESCRIPTION
## Reverse-dependency check

Ran a reverse-dependency check of `nlmixr2est` 6.2.0 (`main`) against the CRAN revdeps. All 12 load cleanly and reference only symbols that still exist; full `R CMD check` on the estimation-heavy set surfaced two regressions relative to the last CRAN release (6.0.1), both fixed here.

### 1. `babelmixr2` `est="fmeMcmc"` — `Index out of bounds: [index='iterPrintControl']`
The nlm-family C setup (`nlm.cpp`) now reads `control$iterPrintControl`, but an external caller that hand-builds a control object (babelmixr2's `fmeMcmc`) can omit it. `.nlmSetupEnv()` (an exported entry point) now synthesizes a default `iterPrintControl` from the scalar print args when one is absent, instead of erroring in C.

### 2. `admixr2` `est="adfo"` — segfault
The issue-#606 fix drops subjects that lack an `EVID==0` observation. For an aggregate-data output eval whose subjects are all placeholders (every `DV` `NA`), that dropped **every** subject, leaving an empty solve; `foceiSetup_` then read `ids[ids.size()-1]` out of bounds and segfaulted.

- The drop now only applies when at least one observed subject remains, restoring the pre-#606 behavior these aggregate-data callers relied on in 6.0.1.
- `foceiSetup_` additionally guards the empty-id case defensively.

## Validation
- Minimal all-`NA`-DV FOCEI fit (segfaulted before) → completes.
- `babelmixr2::nlmixr(..., est="fmeMcmc")` → completes.
- `admixr2` `adfo` example → produces an `admFit`.
- `R CMD check` on both revdeps: ERRORs gone (only the standard "CRAN incoming feasibility" WARNING + local compile-flag NOTE remain).
- Existing #606/#687 no-observation-subject tests still pass; added a regression test for the all-no-observation dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)