### PR TITLE
feat(vae): estimate model-declared covariate coefficients (covariateSelection=FALSE)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -624,6 +624,13 @@
 
 ### Estimation
 
+- `est="vae"` with `covariateSelection=FALSE` now estimates the covariate
+  coefficients written into the model -- both linear (`beta*WT`) and transformed
+  (`beta*log(WT/70)`) effects -- rather than holding them at their `ini()` value.
+  They are fit in place by the regress M-step regardless of `nonMuTheta`
+  (previously fixed under `nonMuTheta="none"` and errored under `"fix"`/`"eta"`);
+  a coefficient set with `ini(... ~ fix())` still stays fixed.
+
 - `est="impmap"` now estimates the non-mu structural and residual-error thetas of a
   general (custom `ll()`) likelihood model.  For such an endpoint `rx_pred_` is the
   log-likelihood itself and `rx_r_` is `0`, so the Gauss-Newton M-step skipped every

--- a/R/preProcessVaeNonMuTheta.R
+++ b/R/preProcessVaeNonMuTheta.R
@@ -29,6 +29,47 @@
   .txt
 }
 
+#' Covariate-coefficient thetas of a VAE model (the parameters that multiply a
+#' data covariate in a mu-referenced expression).  Read-only over the SHARED
+#' `muRefCovariateDataFrame`/`allCovs` UI fields -- the same covariate identity
+#' SAEM (saemMuRefCovariateDataFrame) and FOCEI (muRefClassify groups) consume --
+#' so nothing here mutates the shared covariate representation.
+#'
+#' Two categories are returned:
+#'  (a) linear effects rxode2 records in `muRefCovariateDataFrame` (`beta*WT`);
+#'  (b) transformed effects it does NOT (`beta*log(WT/70)`) -- detected as a
+#'      non-mu, non-error theta whose EVERY referencing model line also mentions
+#'      a data covariate (a plain structural theta appears in at least one
+#'      covariate-free line, so it is not mis-caught).
+#' User-fixed coefficients (`fix=TRUE`) are dropped.
+#' @param ui rxode2 ui
+#' @return character vector of theta names (possibly empty)
+#' @noRd
+.vaeCovariateCoefThetas <- function(ui) {
+  .idf <- ui$iniDf
+  .th <- .idf[!is.na(.idf$ntheta) & is.na(.idf$err) & !isTRUE2(.idf$fix), , drop = FALSE]
+  if (nrow(.th) == 0L) return(character(0))
+  .thNames <- .th$name
+  .mu <- if (is.null(ui$muRefDataFrame)) character(0) else ui$muRefDataFrame$theta
+  ## (a) rxode2-recognized linear mu-ref covariate coefficients
+  .linear <- if (is.null(ui$muRefCovariateDataFrame)) character(0)
+             else as.character(ui$muRefCovariateDataFrame$covariateParameter)
+  ## (b) transformed covariate effects: a non-mu theta whose referencing lines
+  ## ALL reference a data covariate
+  .covData <- ui$allCovs
+  .transformed <- character(0)
+  if (length(.covData) > 0L) {
+    for (.p in setdiff(.thNames, .mu)) {
+      .lines <- Filter(function(e) .p %in% all.vars(e), ui$lstExpr)
+      if (length(.lines) == 0L) next
+      if (all(vapply(.lines, function(e) any(.covData %in% all.vars(e)), logical(1)))) {
+        .transformed <- c(.transformed, .p)
+      }
+    }
+  }
+  intersect(unique(c(.linear, .transformed)), .thNames)
+}
+
 #' Structural population thetas that are NOT mu-referenced (candidates for a
 #' VAE-injected eta): a theta that appears in the model, is not a residual-error
 #' or covariate-coefficient theta, is not fixed, and has no eta referencing it.
@@ -41,7 +82,10 @@
   if (nrow(.th) == 0L) return(character(0))
   .mu <- if (is.null(ui$muRefDataFrame)) character(0) else ui$muRefDataFrame$theta
   .cov <- if (is.null(ui$muRefCovariateDataFrame)) character(0) else ui$muRefCovariateDataFrame$theta
-  .cand <- setdiff(.th$name, c(.mu, .cov))
+  ## covariate coefficients are estimated by the regress M-step (see .vaeDataPrep),
+  ## not by nonMuTheta eta/fix injection -- exclude them here
+  .covCoef <- .vaeCovariateCoefThetas(ui)
+  .cand <- setdiff(.th$name, c(.mu, .cov, .covCoef))
   if (length(.cand) == 0L) return(character(0))
   ## keep only thetas that actually appear in a model expression (so an eta can be
   ## attached to a structural line)
@@ -132,6 +176,13 @@ isTRUE2 <- function(x) !is.na(x) & x
   .mode <- if (is.null(control$nonMuTheta)) "regress" else control$nonMuTheta
   ## reset per-fit record of injected etas (read by the VAE output collapse)
   nlmixr2global$nlmixr2EstEnv$vaeNonMuEtas <- character(0)
+  ## covariateSelection=FALSE: model-declared covariate coefficients are estimated
+  ## by the regress M-step regardless of nonMuTheta (see .vaeDataPrep) -- note it
+  .covCoef <- if (isFALSE(control$covariateSelection)) .vaeCovariateCoefThetas(ui) else character(0)
+  if (length(.covCoef) > 0L) {
+    .pre <- "estimating covariate coef(s): "
+    warning(.pre, .vaeTruncList(.covCoef, prefix = .pre), call. = FALSE)
+  }
   if (identical(.mode, "none")) return(NULL)
   .thetas <- .vaeNonMuThetas(ui)
   if (length(.thetas) == 0L) return(NULL)

--- a/R/vae.R
+++ b/R/vae.R
@@ -32,8 +32,11 @@
 #'   FOCE with R frozen at the population prediction), `"focep"` (FOCE+, no
 #'   interaction but R evaluated at the live conditional eta), or `"laplace"`.
 #' @param covariateSelection When `TRUE` (default) perform automated BICc-ELBO
-#'   covariate selection during training; when `FALSE` fit the given fixed
-#'   covariate structure only (faster population-only mode).
+#'   covariate selection during training; when `FALSE` fit only the covariate
+#'   structure written in the model.  In the `FALSE` case the model-declared
+#'   covariate coefficients (both linear `beta*WT` effects and transformed ones
+#'   such as `beta*log(WT/70)`) are estimated in place by the regress M-step
+#'   regardless of `nonMuTheta`; a `ini(... ~ fix())` coefficient stays fixed.
 #' @param nonMuTheta How to treat a structural population `theta` that has no
 #'   random effect (is not mu-referenced) so it can still be estimated by the VAE
 #'   (which only estimates parameters that occupy the latent space).  For the

--- a/R/vaeData.R
+++ b/R/vaeData.R
@@ -8,6 +8,45 @@
 .vaeReservedCols <- c("ID", "TIME", "DV", "EVID", "AMT", "CMT", "MDV", "SS", "II",
                       "ADDL", "RATE", "DUR", "DVID", "CENS", "LIMIT", "OCC")
 
+# Finite fallback bound (+/-) for an unbounded model-declared covariate coefficient
+# regressed by the VAE M-step; keeps the 1-D optimize() step from running away.
+# Generous on a transformed/log scale (an effect past this is implausible); a user
+# ini() bound overrides it.
+.vaeCovCoefBound <- 10
+
+# Max plausible log-scale effect used to derive a SCALE-AWARE fallback bound for a
+# raw linear covariate coefficient (beta*COV): |beta*max|COV|| <= this, so the
+# bound shrinks as the covariate magnitude grows (a raw WT coefficient is ~1/WT).
+.vaeCovCoefEffect <- 5
+
+#' Scale-aware finite fallback bounds for unbounded covariate coefficients.
+#'
+#' For a linear mu-ref covariate coefficient (in `muRefCovariateDataFrame`) the
+#' sane magnitude scales like `1/max|COV|`, so a fixed wide bound makes the 1-D
+#' optimize() overshoot a shallow interior optimum.  Scale that coefficient's
+#' bound by the covariate's data magnitude; leave transformed/unrecognized
+#' coefficients (already O(1) regressors) at the flat `.vaeCovCoefBound`.
+#' @param ui rxode2 ui
+#' @param data raw (un-normalized) modeling data
+#' @param names covariate-coefficient theta names needing a bound
+#' @return named numeric of positive half-widths (one per `names`)
+#' @noRd
+.vaeCovCoefBoundVec <- function(ui, data, names) {
+  .b <- setNames(rep(.vaeCovCoefBound, length(names)), names)
+  .mrc <- ui$muRefCovariateDataFrame
+  if (is.null(.mrc) || nrow(.mrc) == 0L) return(.b)
+  .dd <- as.data.frame(data); colnames(.dd) <- toupper(colnames(.dd))
+  for (.nm in names) {
+    .w <- which(.mrc$covariateParameter == .nm)
+    if (length(.w) == 0L) next
+    .cov <- toupper(.mrc$covariate[.w[1]])
+    if (is.null(.dd[[.cov]])) next
+    .mx <- max(abs(as.numeric(.dd[[.cov]])), na.rm = TRUE)
+    if (is.finite(.mx) && .mx > 0) .b[.nm] <- min(.vaeCovCoefBound, .vaeCovCoefEffect / .mx)
+  }
+  .b
+}
+
 #' Discover + encode subject-level covariates for the VAE search
 #' @param d normalized data.frame (upper-case column names)
 #' @param ids unique subject ids in estimation order
@@ -142,21 +181,45 @@ vaeCovariates <- function(data, warn = TRUE) {
   .zPopLower[!.isFree] <- as.numeric(.thRows$lower[.zPopThetaIdx[!.isFree]])
   .zPopUpper[!.isFree] <- as.numeric(.thRows$upper[.zPopThetaIdx[!.isFree]])
 
-  ## nonMuTheta="regress": the non-mu-referenced fixed-effect thetas (no eta, no
-  ## error, no covariate coefficient) are estimated directly by a bounded bobyqa
-  ## regression in the M-step.  Carry their 0-based index into the full theta
-  ## vector (`.th`, ntheta order) plus the ini() bounds (NA -> +-Inf).
+  ## Fixed-effect thetas estimated directly by a bounded bobyqa regression in the
+  ## M-step (vs. the latent-space zPop update).  Two sources, unioned:
+  ##  * nonMuTheta="regress": non-mu-referenced structural thetas (no eta); and
+  ##  * covariateSelection=FALSE: model-declared covariate coefficients -- always
+  ##    estimated in place, independent of nonMuTheta, so the mu-referenced
+  ##    covariate expression the user wrote is fit rather than held fixed.
+  ## Carry each 0-based index into the full theta vector (`.th`, ntheta order)
+  ## plus the ini() bounds (NA -> +-Inf).
   .regressNames <- character(0)
   .regressThetaIdx0 <- integer(0)
   .regressLower <- numeric(0); .regressUpper <- numeric(0)
   if (identical(control$nonMuTheta, "regress")) {
     .regressNames <- .vaeNonMuThetas(ui)
-    if (length(.regressNames) > 0L) {
-      .ri <- match(.regressNames, .thRows$name)
-      .regressThetaIdx0 <- as.integer(.ri - 1L)
-      .lo <- as.numeric(.thRows$lower[.ri]); .hi <- as.numeric(.thRows$upper[.ri])
-      .regressLower <- ifelse(is.na(.lo), -Inf, .lo)
-      .regressUpper <- ifelse(is.na(.hi), Inf, .hi)
+  }
+  .covCoefNames <- character(0)
+  if (isFALSE(control$covariateSelection)) {
+    .covCoefNames <- .vaeCovariateCoefThetas(ui)
+    .regressNames <- c(.regressNames, .covCoefNames)
+  }
+  .regressNames <- unique(.regressNames)
+  if (length(.regressNames) > 0L) {
+    .ri <- match(.regressNames, .thRows$name)
+    .regressThetaIdx0 <- as.integer(.ri - 1L)
+    .lo <- as.numeric(.thRows$lower[.ri]); .hi <- as.numeric(.thRows$upper[.ri])
+    .regressLower <- ifelse(is.na(.lo), -Inf, .lo)
+    .regressUpper <- ifelse(is.na(.hi), Inf, .hi)
+    ## An UNBOUNDED covariate coefficient regressed alone routes through the 1-D
+    ## optimize() branch of .boundedResidOpt, which searches the whole interval and
+    ## overshoots a shallow interior optimum on a too-wide interval.  Give an
+    ## unbounded coefficient a finite, scale-aware fallback interval (user ini()
+    ## bounds still win); structural regress thetas keep their bounds (bobyqa is
+    ## stable, so they are left alone).
+    .isCov <- .regressNames %in% .covCoefNames
+    .noLo <- .isCov & !is.finite(.regressLower)
+    .noHi <- .isCov & !is.finite(.regressUpper)
+    if (any(.noLo | .noHi)) {
+      .bnd <- .vaeCovCoefBoundVec(ui, data, .regressNames[.isCov])
+      .regressLower[.noLo] <- -.bnd[.regressNames[.noLo]]
+      .regressUpper[.noHi] <- .bnd[.regressNames[.noHi]]
     }
   }
 

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -79,8 +79,11 @@ value giving a sharp initial posterior). `NULL` uses a small default per
 individual parameter. This is distinct from the `ini()` omega.}
 
 \item{covariateSelection}{When `TRUE` (default) perform automated BICc-ELBO
-covariate selection during training; when `FALSE` fit the given fixed
-covariate structure only (faster population-only mode).}
+covariate selection during training; when `FALSE` fit only the covariate
+structure written in the model.  In the `FALSE` case the model-declared
+covariate coefficients (both linear `beta*WT` effects and transformed ones
+such as `beta*log(WT/70)`) are estimated in place by the regress M-step
+regardless of `nonMuTheta`; a `ini(... ~ fix())` coefficient stays fixed.}
 
 \item{covSelectAlpha}{Starting multiplier for the covariate-selection L0
 penalty, ramped linearly from `covSelectAlpha` down to `1` over the

--- a/tests/testthat/test-vae-covariate-estimate.R
+++ b/tests/testthat/test-vae-covariate-estimate.R
@@ -1,0 +1,98 @@
+## With covariateSelection=FALSE the covariate coefficients WRITTEN in the model
+## (linear beta*WT and transformed beta*log(WT/70)) must be estimated by the
+## regress M-step regardless of nonMuTheta -- previously they were held fixed
+## under "none" and errored under "fix"/"eta".  Covariate identity is read from
+## the shared muRefCovariateDataFrame/allCovs (never mutated).  Fast: no fit; the
+## end-to-end "coefficient moves" checks live in the slow test-vae-covariate.R.
+
+nmTest({
+  ## linear (rxode2 records it in muRefCovariateDataFrame) covariate on cl
+  .lin <- function() {
+    ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; cl.wt <- 0.01; add.err <- 0.7; eta.cl ~ 0.1 })
+    model({ ka <- exp(tka); cl <- exp(tcl + cl.wt * WT + eta.cl); v <- exp(tv)
+      d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v; cp ~ add(add.err) })
+  }
+  ## transformed (NOT recognized as a mu-ref covariate) effect on cl
+  .tr <- function() {
+    ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; cl.wt <- 0.1; add.err <- 0.7; eta.cl ~ 0.1 })
+    model({ ka <- exp(tka); cl <- exp(tcl + cl.wt * log(WT / 70) + eta.cl); v <- exp(tv)
+      d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v; cp ~ add(add.err) })
+  }
+  d <- nlmixr2data::theo_sd
+
+  test_that(".vaeCovariateCoefThetas detects linear and transformed coefficients", {
+    expect_equal(.vaeCovariateCoefThetas(rxode2::assertRxUi(.lin())), "cl.wt")
+    expect_equal(.vaeCovariateCoefThetas(rxode2::assertRxUi(.tr())), "cl.wt")
+  })
+
+  test_that(".vaeCovariateCoefThetas drops a user-fixed coefficient", {
+    fx <- function() {
+      ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; cl.wt <- fix(0.01); add.err <- 0.7; eta.cl ~ 0.1 })
+      model({ ka <- exp(tka); cl <- exp(tcl + cl.wt * WT + eta.cl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v; cp ~ add(add.err) })
+    }
+    expect_equal(.vaeCovariateCoefThetas(rxode2::assertRxUi(fx())), character(0))
+  })
+
+  test_that(".vaeNonMuThetas excludes covariate coefficients (they are not structural)", {
+    ## cl.wt must NOT be offered to nonMuTheta eta/fix injection
+    expect_false("cl.wt" %in% .vaeNonMuThetas(rxode2::assertRxUi(.lin())))
+    expect_false("cl.wt" %in% .vaeNonMuThetas(rxode2::assertRxUi(.tr())))
+  })
+
+  test_that("covariateSelection=FALSE regresses the coefficient in every nonMuTheta mode", {
+    for (m in c("regress", "none", "fix", "eta")) {
+      p <- suppressWarnings(.vaeDataPrep(rxode2::assertRxUi(.tr()), d,
+                                         vaeControl(covariateSelection = FALSE, nonMuTheta = m)))
+      expect_true("cl.wt" %in% p$regressNames, info = m)
+      i <- match("cl.wt", p$regressNames)
+      expect_true(is.finite(p$regressLower[i]) && is.finite(p$regressUpper[i]), info = m)
+    }
+  })
+
+  test_that("covariateSelection=TRUE does NOT force the coefficient into the regress set", {
+    ## default nonMuTheta='regress' still picks up genuine non-mu structural thetas
+    ## (tka, tv) but the coefficient is left to the selection machinery
+    p <- suppressWarnings(.vaeDataPrep(rxode2::assertRxUi(.tr()), d,
+                                       vaeControl(covariateSelection = TRUE, nonMuTheta = "none")))
+    expect_false("cl.wt" %in% p$regressNames)
+  })
+
+  test_that("a fixed coefficient is not regressed", {
+    fx <- function() {
+      ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; cl.wt <- fix(0.01); add.err <- 0.7; eta.cl ~ 0.1 })
+      model({ ka <- exp(tka); cl <- exp(tcl + cl.wt * WT + eta.cl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v; cp ~ add(add.err) })
+    }
+    p <- suppressWarnings(.vaeDataPrep(rxode2::assertRxUi(fx()), d,
+                                       vaeControl(covariateSelection = FALSE, nonMuTheta = "none")))
+    expect_false("cl.wt" %in% p$regressNames)
+  })
+
+  test_that("the unbounded fallback bound is scale-aware (tighter for a raw covariate)", {
+    ## raw WT (~O(70)) => bound ~ 1/max|WT|, much tighter than the log-scale default
+    pLin <- suppressWarnings(.vaeDataPrep(rxode2::assertRxUi(.lin()), d,
+                                          vaeControl(covariateSelection = FALSE, nonMuTheta = "none")))
+    pTr <- suppressWarnings(.vaeDataPrep(rxode2::assertRxUi(.tr()), d,
+                                         vaeControl(covariateSelection = FALSE, nonMuTheta = "none")))
+    bLin <- pLin$regressUpper[match("cl.wt", pLin$regressNames)]
+    bTr <- pTr$regressUpper[match("cl.wt", pTr$regressNames)]
+    expect_lt(bLin, bTr)
+    expect_equal(bLin, .vaeCovCoefEffect / max(abs(d$WT)))
+  })
+
+  test_that("the fit surfaces a 'estimating covariate coef(s)' note and never errors", {
+    for (m in c("none", "fix", "eta", "regress")) {
+      w <- character(0)
+      withCallingHandlers(
+        .preProcessVaeNonMuTheta(rxode2::assertRxUi(.tr()), "vae", d,
+                                 vaeControl(covariateSelection = FALSE, nonMuTheta = m)),
+        warning = function(cnd) { w <<- c(w, conditionMessage(cnd)); invokeRestart("muffleWarning") })
+      expect_true(any(grepl("estimating covariate coef", w)), info = m)
+    }
+  })
+})

--- a/tests/testthat/test-vae-covariate.R
+++ b/tests/testthat/test-vae-covariate.R
@@ -125,4 +125,23 @@ nmTest({
     expect_true(any(grepl("CovSel ramp", allout)))
     expect_true(any(grepl("covariate-selection L0-penalty warmup", allout)))
   })
+
+  test_that("covariateSelection=FALSE estimates a model-declared coefficient (end-to-end)", {
+    skip_on_cran()
+    ## nonMuTheta='none' would formerly hold cl.wt fixed; it must now be regressed,
+    ## move off its init, and appear as a parameter-history column
+    cov <- function() {
+      ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; cl.wt <- 0.1; add.err <- 0.7; eta.cl ~ 0.1 })
+      model({ ka <- exp(tka); cl <- exp(tcl + cl.wt * log(WT / 70) + eta.cl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v; cp ~ add(add.err) })
+    }
+    ctl <- vaeControl(covariateSelection = FALSE, nonMuTheta = "none", itersBurnIn = 3L,
+                      klWarmup = 5L, iters = 15L, seed = 1L, print = 0L, calcTables = FALSE)
+    fit <- suppressWarnings(nlmixr2(cov, nlmixr2data::theo_sd, est = "vae", control = ctl))
+    est <- fit$parFixedDf["cl.wt", "Estimate"]
+    expect_true(is.finite(est))
+    expect_false(isTRUE(all.equal(est, 0.1)))        # moved off the init
+    expect_true("cl.wt" %in% colnames(fit$parHist)) # the regress M-step ran on it
+  })
 })


### PR DESCRIPTION
## Summary

When `est="vae"` runs with `covariateSelection=FALSE`, the covariate coefficients **written into the model** were held fixed at their `ini()` value under `nonMuTheta="none"` and *errored* under `nonMuTheta="fix"`/`"eta"`. They are now **estimated in place** by the regress M-step regardless of `nonMuTheta`, so the mu-referenced covariate expression the user wrote is actually fit. This covers both:

- linear effects rxode2 records in `muRefCovariateDataFrame` (`cl.wt*WT`); and
- transformed effects it does not (`cl.wt*log(WT/70)`).

A coefficient the user pins with `ini(... ~ fix())` still stays fixed.

## Why it was fixed / isolated to `est="vae"`

`.vaeNonMuThetas()` conflated covariate coefficients with structural non-mu thetas, so they were governed by `nonMuTheta` (wrong for a fixed effect that multiplies a covariate). The fix reads covariate identity from the **shared** `muRefCovariateDataFrame`/`allCovs` (the same table SAEM's `saemMuRefCovariateDataFrame` and FOCEI's `muRefClassify` groups consume) **read-only** -- it is never mutated -- and adds the coefficients only to VAE's private regress M-step. No shared file (`muRefClassify.R`, `saem*`, `focei*`, `mu2.R`) is touched, so SAEM/FOCEI behavior is unchanged (verified: a SAEM + covariate fit is unaffected).

## Runaway guard

An unbounded coefficient regressed alone routes through the 1-D `optimize()` branch of the shared `.boundedResidOpt` (untouched), which overshoots a shallow interior optimum on a too-wide interval -- a raw `beta*WT` coefficient (sane magnitude ~1/WT) otherwise blew up geometrically to ~1e30. Such a coefficient is given a **finite, scale-aware** fallback bound (`.vaeCovCoefEffect / max|COV|` for recognized linear covariates; a flat generous default for already-O(1) transformed regressors). A user `ini()` bound still wins.

## Tests

- `test-vae-covariate-estimate.R` (essential, fast, no fit): classification of linear/transformed coefficients, exclusion of fixed ones and of structural non-mu thetas, regress-set membership across all four `nonMuTheta` modes, the scale-aware bound, and the `runInfo` note -- and that `"fix"`/`"eta"` no longer error.
- `test-vae-covariate.R` (slow): end-to-end fit asserting the coefficient moves off its init and appears as a `parHist` column.

All existing VAE tests (`vae-nonmutheta`, `vae-dataprep`, `vae-covariates`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
