### PR TITLE
vae: nonMuTheta="grad" and two-stage regress for log-likelihood endpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,11 @@
   `theo_sd` with a non-mu-referenced `tv` it lands within 0.0005 of the FOCEi
   maximum-likelihood value against 0.0025 for `"regress"`.  It is chosen for that
   accuracy, not for speed -- it runs slower than `"regress"` (1.47x with one
-  non-mu theta, 1.13x with three).  A
-  model outside analytic scope (`ll()` endpoints, `linCmt()`, IOV) reverts to
-  `"regress"` with a note in `$runInfo`.
+  non-mu theta, 1.13x with three).  It covers a conditionally Gaussian model and
+  a single non-Gaussian (`ll()`/generalized) endpoint, which differentiates the
+  log-density directly.  A model outside analytic scope (`linCmt()`, IOV, `fo`, a
+  multi-endpoint or censored `ll()` model) reverts to `"regress"` with a note in
+  `$runInfo`.
 
 - `est="vae"` `residOptimize="twoStage"` now applies to a log-likelihood
   (`ll()`) or generalized endpoint.  Stage two eligibility was "the parameter has

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,17 @@
   model outside analytic scope (`ll()` endpoints, `linCmt()`, IOV) reverts to
   `"regress"` with a note in `$runInfo`.
 
+- `est="vae"` `residOptimize="twoStage"` now applies to a log-likelihood
+  (`ll()`) or generalized endpoint.  Stage two eligibility was "the parameter has
+  a slot in the error-parameter vector", and such a model has none, so stage two
+  never ran and `"twoStage"` silently behaved like the experimental joint
+  `"optimize"` solve.  Eligibility is now decided per parameter -- an error
+  parameter (as before), OR a parameter no `d/dt()` right-hand side, initial
+  condition or dosing modifier can reach -- so a theta read only by the
+  log-density is optimized in its own frozen-ODE block as intended.  A
+  multi-endpoint model with one Gaussian and one `ll()` endpoint gets both its
+  error parameter and its log-density-only theta into stage two.
+
 - The `est="vae"` ELBO now includes the transform-both-sides Jacobian, so a model
   with `lnorm()`/`boxCox()`/`yeoJohnson()` reports its objective on the DV scale
   -- matching what `est="focei"` already does -- instead of the transformed

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -1249,22 +1249,16 @@
 #' gate: `linCmt()`, `fo`, the distribution/error-model scope, IOV, and a model
 #' with no eta.  A later build or solve failure still falls back at runtime.
 #'
-#' An `ll()`/generalized endpoint is NOT yet accepted here, even though every
-#' piece above it is ready: `.foceiLLGradInScope(ui, "vae")` is TRUE for such a
-#' model, `.foceiOuterDirsLL` builds its direction set, and
-#' `.foceiAnalyticGradSetup`/`.foceiAnalyticGradCore` already route it (on
-#' `ef$isLL`) to the direct-log-density core.  The blocker is one level down, in
-#' the SOLVE POOL: `nonMuTheta="grad"` makes `.vaeInnerSetup` size the shared
-#' pool with the augmented outer model (42 states / 34 lhs on a one-compartment
-#' `ll()` fit) and pin the inner MAP to `neqOverride = 4`.  That arrangement is
-#' correct for a Gaussian model but corrupts the heap for an `ll()` one -- the
-#' same fit runs clean under `nonMuTheta="regress"` (no `poolModel`), and with
-#' `"grad"` it faults before the first gradient solve even starts.  Accepting
-#' `ll()` here would hand users a segfault, so it stays out until the pool
-#' arrangement is fixed in `vaeInnerSetup_`.
+#' Two admissible shapes, the same pair `.foceiAnalyticGradSetup` dispatches on:
+#' a conditionally Gaussian endpoint (the `(f,R)` direction set) or a single
+#' non-Gaussian `ll()`/generalized endpoint (the direct-log-density set).  The
+#' VAE consumes either through the SAME `.foceiAnalyticGradCore` entry, which
+#' routes on `ef$isLL`.
 #' @noRd
 .vaeGradInScope <- function(ui) {
-  !is.null(tryCatch(.foceiOuterDirs(ui, "vae"), error = function(e) NULL))
+  if (!is.null(tryCatch(.foceiOuterDirs(ui, "vae"), error = function(e) NULL))) return(TRUE)
+  isTRUE(.foceiLLGradInScope(ui, "vae")) &&
+    !is.null(tryCatch(.foceiOuterDirsLL(ui), error = function(e) NULL))
 }
 
 #' Direction set for the augmented outer-gradient model, computed from the UI

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -1092,7 +1092,7 @@
   # ll()/generalized likelihood (needOptimHess -> interaction=0, EXACT inner
   # Hessian): rx_pred_ is the log-density, so skip the Gaussian ErrFull and set up
   # the direct-log-density core (.foceiAnalyticGradCoreLL).
-  if (.foceiLLGradInScope(ui)) {
+  if (.foceiLLGradInScope(ui, caller)) {
     .map <- .foceiEtaThetaMap(ui); neta <- length(.map$etaNames)
     .dir <- .foceiOuterDirsLL(ui); if (is.null(.dir)) return(NULL)
     .oe <- .foceiEstOmegaDeriv(ui, Om, e); if (is.null(.oe)) return(NULL)
@@ -1248,6 +1248,20 @@
 #' Cheap direction-set probe -- no symengine/gcc pass -- covering every static
 #' gate: `linCmt()`, `fo`, the distribution/error-model scope, IOV, and a model
 #' with no eta.  A later build or solve failure still falls back at runtime.
+#'
+#' An `ll()`/generalized endpoint is NOT yet accepted here, even though every
+#' piece above it is ready: `.foceiLLGradInScope(ui, "vae")` is TRUE for such a
+#' model, `.foceiOuterDirsLL` builds its direction set, and
+#' `.foceiAnalyticGradSetup`/`.foceiAnalyticGradCore` already route it (on
+#' `ef$isLL`) to the direct-log-density core.  The blocker is one level down, in
+#' the SOLVE POOL: `nonMuTheta="grad"` makes `.vaeInnerSetup` size the shared
+#' pool with the augmented outer model (42 states / 34 lhs on a one-compartment
+#' `ll()` fit) and pin the inner MAP to `neqOverride = 4`.  That arrangement is
+#' correct for a Gaussian model but corrupts the heap for an `ll()` one -- the
+#' same fit runs clean under `nonMuTheta="regress"` (no `poolModel`), and with
+#' `"grad"` it faults before the first gradient solve even starts.  Accepting
+#' `ll()` here would hand users a segfault, so it stays out until the pool
+#' arrangement is fixed in `vaeInnerSetup_`.
 #' @noRd
 .vaeGradInScope <- function(ui) {
   !is.null(tryCatch(.foceiOuterDirs(ui, "vae"), error = function(e) NULL))
@@ -1277,8 +1291,12 @@
 #' the Gaussian (f,R) path.  Phase 1 scope: a single non-Gaussian endpoint, no
 #' linCmt/bounded transform/IOV/FO, at least one eta.  (Multi-endpoint, censoring,
 #' and nAGQ are handled by falling back to the finite-difference gradient.)
+#'
+#' `caller` only reaches the bounded-transform gate, which focei must fail and
+#' the VAE need not -- see `.analyticGradAllowsBoundedTr`.  Defaulted, so the
+#' focei callers keep their exact behavior.
 #' @noRd
-.foceiLLGradInScope <- function(ui) {
+.foceiLLGradInScope <- function(ui, caller = .analyticGradCaller(ui)) {
   tryCatch({
     if (!.hasRxSens()) return(FALSE)
     .pd <- ui$predDfFocei
@@ -1291,7 +1309,7 @@
     # Hessian/gradient at build time (see .foceiMaybeAddHdEta2).  A residual TRUE here marks
     # a case the promotion cannot cover -- out of scope like the Gaussian path.
     if (isTRUE(any(ui$predDfFocei$linCmt))) return(FALSE)
-    if (!is.null(ui$boundedTransforms) && length(ui$boundedTransforms) > 0L) return(FALSE)
+    if (!.analyticGradAllowsBoundedTr(ui, caller)) return(FALSE)
     if (isTRUE(as.logical(rxode2::rxGetControl(ui, "fo", FALSE)))) return(FALSE)
     if (as.integer(rxode2::rxGetControl(ui, "nAGQ", 1L)) > 1L) return(FALSE)
     if (length(.uiIovEnv$iovVars) > 0L) return(FALSE)
@@ -1336,7 +1354,7 @@ rxUiGet.foceiOuter <- function(x, ...) {
   # direction builder declines (ErrFull is norm-only), but rx_pred_ is the
   # log-density and the same augmented model supplies its 1st/2nd-order eta/theta
   # derivatives -- build over the ll() direction set instead.
-  if (is.null(.dir) && .foceiLLGradInScope(.ui)) .dir <- .foceiOuterDirsLL(.ui)
+  if (is.null(.dir) && .foceiLLGradInScope(.ui, .caller)) .dir <- .foceiOuterDirsLL(.ui)
   if (is.null(.dir)) return(NULL)
   .foceiAnalyticAugModelDirs(.ui, .dir$dirs)
 }

--- a/R/vae.R
+++ b/R/vae.R
@@ -186,7 +186,9 @@
 #'     a single additive error this is exactly the optimum (`sqrt(SSE/n)`); for
 #'     any other error model it is either a different estimator or, for the forms
 #'     with no closed form (`pow`, Box-Cox, Yeo-Johnson), no estimator at all --
-#'     the parameter stays at its `ini()` value.
+#'     the parameter stays at its `ini()` value.  There is no moment estimator for
+#'     a log-likelihood (`ll()`) parameter either, so those also stay at `ini()`;
+#'     use `"twoStage"` for such a model.
 #'   * `"twoStage"` (default): block coordinate descent, as `npag`'s
 #'     `residOptimize = "alternate"` does.  Stage
 #'     one optimizes the non-mu-referenced structural thetas with the residual
@@ -197,6 +199,15 @@
 #'     -- the same structure SAEM uses.  On `theo_sd` this beats the moment
 #'     estimator on both a pure-additive model (objective 131.79 vs 131.81) and a
 #'     combined one (121.03 vs 122.47).
+#'
+#'     Which parameters stage two owns is decided per parameter: an error
+#'     parameter, or one that no `d/dt()` right-hand side, initial condition or
+#'     dosing modifier can reach.  The second case is what a log-likelihood
+#'     (`ll()`) or generalized endpoint needs -- its residual-like parameters are
+#'     plain thetas with no error row, and on the error-only rule stage two was
+#'     empty for such a model, silently making `"twoStage"` behave like
+#'     `"optimize"`.  When no regressed theta qualifies (every one feeds the
+#'     solve) stage two has nothing to do and `residOptimize` has no effect.
 #'   * `"optimize"` (EXPERIMENTAL, diagnostic): a single JOINT solve over the
 #'     structural and residual parameters together, against the full outer
 #'     objective.  Fine with one free residual parameter, but with `add` and

--- a/R/vae.R
+++ b/R/vae.R
@@ -86,9 +86,11 @@
 #'     it and a single solve does not, but it does not close).  Choose it for
 #'     accuracy: the exact gradient lands closer to the maximum-likelihood value
 #'     than the derivative-free search (`theo_sd` non-mu `tv`: 3.4294 vs 3.4324,
-#'     against a FOCEi MLE of 3.4293).  Falls back to `"regress"` when the model
-#'     is out of analytic scope (`ll()` endpoints, `linCmt()`, IOV, ...);
-#'     `nonMuEtaOmega` is unused.
+#'     against a FOCEi MLE of 3.4293).  Applies to a conditionally Gaussian model
+#'     and to a single non-Gaussian (`ll()`/generalized) endpoint, which
+#'     differentiates the log-density directly.  Falls back to `"regress"` when
+#'     the model is out of analytic scope (`linCmt()`, IOV, `fo`, a
+#'     multi-endpoint or censored `ll()` model, ...); `nonMuEtaOmega` is unused.
 #'   * `"eta"`: inject the eta with an ESTIMATED omega (starting at
 #'     `nonMuEtaOmega`); the typical value is estimated and appears in the
 #'     iteration table.

--- a/R/vaeData.R
+++ b/R/vaeData.R
@@ -349,7 +349,8 @@ vaeCovariates <- function(data, warn = TRUE) {
   .no <- rep(FALSE, length(thetaNames))
   .lst <- tryCatch(ui$lstExpr, error = function(e) NULL)
   if (is.null(.lst) || length(.lst) == 0L) return(.no)
-  if (length(tryCatch(rxode2::rxState(ui), error = function(e) character(0))) == 0L) return(.no)
+  .states <- tryCatch(rxode2::rxState(ui), error = function(e) character(0))
+  if (length(.states) == 0L) return(.no)
   .isAssign <- function(.ex) is.call(.ex) && length(.ex) == 3L &&
     (identical(.ex[[1]], as.name("<-")) || identical(.ex[[1]], as.name("=")) ||
        identical(.ex[[1]], as.name("~")))
@@ -364,38 +365,52 @@ vaeCovariates <- function(data, warn = TRUE) {
       grepl("^[A-Za-z._][A-Za-z0-9._]* *\\( *0 *\\)$", .txt) ||
       grepl("^(f|alag|lag|rate|dur) *\\(", .txt)
   }
-  ## endpoint variables, used below to spot the observation-model lines
-  .endpointVars <- tryCatch(as.character(ui$predDf$var), error = function(e) character(0))
+  ## `x_0 <- ...` is rxode2's other spelling of the `x(0) <- ...` initial
+  ## condition.  It is a plain NAME, so without this it would look like an
+  ## ordinary intermediate and its rhs would never seed the solve.
+  .initNames <- paste0(.states, "_0")
   .seed <- character(0); .map <- list()
-  for (.ex in .lst) {
-    if (!.isAssign(.ex)) next
+  .add <- function(.ex) {
     .rhs <- .syms(.ex[[3]])
-    .tilde <- identical(.ex[[1]], as.name("~"))
     if (is.name(.ex[[2]])) {
-      ## Key a plain variable with as.character(), the SAME way .syms() renders a
-      ## reference to it.  deparse() is a rendering of the symbol rather than the
-      ## symbol itself, so keying on it makes the fixpoint depend on quoting
-      ## behavior; a key that failed to match a reference would drop an edge and
-      ## call a theta ODE-free -- the unsafe direction.
+      ## Key by as.character(), the SAME way .syms() renders a reference, so the
+      ## fixpoint does not depend on deparse quoting.
       .nm <- as.character(.ex[[2]])
-      ## `x ~ add(...)` / `x ~ pois(...)`: the observation model, not the solve.
-      ## Only a `~` line qualifies -- `cp <- center / v` defines a variable a
-      ## `d/dt()` may well read, and dropping it would hide a real dependency.
-      if (.tilde && .nm %in% .endpointVars) next
-      .map[[.nm]] <- unique(c(.map[[.nm]], .rhs))
-    } else {
-      .txt <- paste(deparse(.ex[[2]]), collapse = "")
-      if (.solveLhs(.txt)) {
-        .seed <- c(.seed, .rhs)
-      } else if (.tilde && grepl("^ll *\\(", .txt)) {
-        next                                 # ll(x) ~ <density>: likelihood only
-      } else {
-        ## an lhs shape not recognized above may still feed the solve -- take its
-        ## rhs as reachable rather than guess (the safe direction: stage 1)
-        .seed <- c(.seed, .rhs)
-      }
+      if (.nm %in% .initNames) { .seed <<- c(.seed, .rhs); return(invisible()) }
+      ## Every other name assignment -- including a `~` endpoint line -- becomes a
+      ## map edge.  Do NOT special-case the endpoint variable: `conc ~ central / v`
+      ## can define a variable that a `d/dt()` also reads, and dropping it would
+      ## hide the dependency.  Keeping the edge is at worst conservative (an error
+      ## parameter reached this way stays in stage 1, and it is stage-2 eligible
+      ## via the err rule anyway).
+      .map[[.nm]] <<- unique(c(.map[[.nm]], .rhs))
+      return(invisible())
     }
+    .txt <- paste(deparse(.ex[[2]]), collapse = "")
+    ## `ll(x) ~ <density>` is the likelihood; seeding it would make every
+    ## log-density symbol look solve-reachable and defeat the whole scan.
+    if (identical(.ex[[1]], as.name("~")) && grepl("^ll *\\(", .txt)) return(invisible())
+    ## solve-defining, or an lhs shape not recognized here: treat the rhs as
+    ## reachable rather than guess (the safe direction: stage 1)
+    .seed <<- c(.seed, .rhs)
+    invisible()
   }
+  ## Walk into control flow: rxode2 models may wrap assignments in `if`/`else`
+  ## blocks, and an assignment feeding a d/dt inside one must still be collected.
+  ## A gating CONDITION is seeded too -- it decides whether a d/dt runs, so the
+  ## solve depends on it.
+  .walk <- function(.ex) {
+    if (!is.call(.ex)) return(invisible())
+    if (.isAssign(.ex)) return(.add(.ex))
+    if (identical(.ex[[1]], as.name("if")) || identical(.ex[[1]], as.name("while"))) {
+      .seed <<- c(.seed, .syms(.ex[[2]]))
+      for (.k in seq_along(.ex)[-(1:2)]) .walk(.ex[[.k]])
+      return(invisible())
+    }
+    for (.k in seq_along(.ex)[-1L]) .walk(.ex[[.k]])
+    invisible()
+  }
+  for (.ex in .lst) .walk(.ex)
   .seen <- unique(.seed); .todo <- .seen
   while (length(.todo) > 0L) {
     .nxt <- unique(unlist(.map[intersect(.todo, names(.map))], use.names = FALSE))

--- a/R/vaeData.R
+++ b/R/vaeData.R
@@ -321,6 +321,14 @@ vaeCovariates <- function(data, warn = TRUE) {
 #' @noRd
 .vaeRegressStage2 <- function(ui, regressNames, regressErrIdx0) {
   if (length(regressNames) == 0L) return(integer(0))
+  ## Recycling here would silently mis-mask: a structural theta labelled stage 2
+  ## gets optimized against a frozen ODE, which is wrong rather than merely slow.
+  ## The two are built together in .vaeDataPrep, so a mismatch is a caller bug --
+  ## fail loudly at prep time instead.
+  if (length(regressErrIdx0) != length(regressNames)) {
+    stop("vae: regressErrIdx0 (", length(regressErrIdx0), ") must match ",
+         "regressNames (", length(regressNames), ")", call. = FALSE)
+  }
   .isErr <- regressErrIdx0 >= 0L
   .odeFree <- tryCatch(.vaeOdeFreeThetas(ui, regressNames),
                        error = function(e) rep(FALSE, length(regressNames)))
@@ -334,11 +342,11 @@ vaeCovariates <- function(data, warn = TRUE) {
 #' and therefore only ever answers FALSE where the truth is TRUE -- the safe
 #' direction (the theta stays in stage 1, as it is today).
 #' @param ui rxode2 ui object
-#' @param names candidate names
+#' @param thetaNames candidate names
 #' @return logical vector, `TRUE` when no solve-defining expression reaches the name
 #' @noRd
-.vaeOdeFreeThetas <- function(ui, names) {
-  .no <- rep(FALSE, length(names))
+.vaeOdeFreeThetas <- function(ui, thetaNames) {
+  .no <- rep(FALSE, length(thetaNames))
   .lst <- tryCatch(ui$lstExpr, error = function(e) NULL)
   if (is.null(.lst) || length(.lst) == 0L) return(.no)
   if (length(tryCatch(rxode2::rxState(ui), error = function(e) character(0))) == 0L) return(.no)
@@ -356,27 +364,36 @@ vaeCovariates <- function(data, warn = TRUE) {
       grepl("^[A-Za-z._][A-Za-z0-9._]* *\\( *0 *\\)$", .txt) ||
       grepl("^(f|alag|lag|rate|dur) *\\(", .txt)
   }
-  ## the observation model, which the SOLVE does not read: `ll(x) ~ <density>`
-  ## and the error-model endpoint lines (`x ~ add(...)`, `x ~ pois(...)`).  ONLY a
-  ## `~` line qualifies -- `cp <- center / v` defines a variable a `d/dt()` may
-  ## well read, and dropping it would hide a real dependency.
+  ## endpoint variables, used below to spot the observation-model lines
   .endpointVars <- tryCatch(as.character(ui$predDf$var), error = function(e) character(0))
   .seed <- character(0); .map <- list()
   for (.ex in .lst) {
     if (!.isAssign(.ex)) next
     .rhs <- .syms(.ex[[3]])
-    .txt <- paste(deparse(.ex[[2]]), collapse = "")
     .tilde <- identical(.ex[[1]], as.name("~"))
-    if (.solveLhs(.txt)) {
-      .seed <- c(.seed, .rhs)
-    } else if (.tilde && (grepl("^ll *\\(", .txt) || .txt %in% .endpointVars)) {
-      next                                   # likelihood only -- never reaches the solve
-    } else if (is.name(.ex[[2]])) {
-      .map[[.txt]] <- unique(c(.map[[.txt]], .rhs))
+    if (is.name(.ex[[2]])) {
+      ## Key a plain variable with as.character(), the SAME way .syms() renders a
+      ## reference to it.  deparse() is a rendering of the symbol rather than the
+      ## symbol itself, so keying on it makes the fixpoint depend on quoting
+      ## behavior; a key that failed to match a reference would drop an edge and
+      ## call a theta ODE-free -- the unsafe direction.
+      .nm <- as.character(.ex[[2]])
+      ## `x ~ add(...)` / `x ~ pois(...)`: the observation model, not the solve.
+      ## Only a `~` line qualifies -- `cp <- center / v` defines a variable a
+      ## `d/dt()` may well read, and dropping it would hide a real dependency.
+      if (.tilde && .nm %in% .endpointVars) next
+      .map[[.nm]] <- unique(c(.map[[.nm]], .rhs))
     } else {
-      ## an lhs shape not recognized above may still feed the solve -- take its
-      ## rhs as reachable rather than guess (the safe direction: stage 1)
-      .seed <- c(.seed, .rhs)
+      .txt <- paste(deparse(.ex[[2]]), collapse = "")
+      if (.solveLhs(.txt)) {
+        .seed <- c(.seed, .rhs)
+      } else if (.tilde && grepl("^ll *\\(", .txt)) {
+        next                                 # ll(x) ~ <density>: likelihood only
+      } else {
+        ## an lhs shape not recognized above may still feed the solve -- take its
+        ## rhs as reachable rather than guess (the safe direction: stage 1)
+        .seed <- c(.seed, .rhs)
+      }
     }
   }
   .seen <- unique(.seed); .todo <- .seen
@@ -385,7 +402,7 @@ vaeCovariates <- function(data, warn = TRUE) {
     .todo <- setdiff(.nxt, .seen)
     .seen <- c(.seen, .todo)
   }
-  !(as.character(names) %in% .seen)
+  !(as.character(thetaNames) %in% .seen)
 }
 
 #' Prepare VAE inputs from a ui + data

--- a/R/vaeData.R
+++ b/R/vaeData.R
@@ -351,6 +351,17 @@ vaeCovariates <- function(data, warn = TRUE) {
   if (is.null(.lst) || length(.lst) == 0L) return(.no)
   .states <- tryCatch(rxode2::rxState(ui), error = function(e) character(0))
   if (length(.states) == 0L) return(.no)
+  ## A linCmt() model solves compartments from parameters read by NAME (cl, v,
+  ## ka, ...) that are not syntactically connected to the linCmt() call, so the
+  ## assignment-graph scan cannot trace them.  When a linCmt() appears alongside
+  ## ODE states (e.g. linCmt PK + a PD compartment), classify NOTHING as ODE-free
+  ## -- everything stays in stage 1, and an error parameter is still stage-2
+  ## eligible via the err rule.  (predDf$linCmt is FALSE here because the endpoint
+  ## is the ODE state, so scan the expressions.)
+  .hasLinCmt <- any(vapply(.lst, function(.e)
+    grepl("(^|[^A-Za-z0-9._])linCmt[BAC]? *\\(",
+          paste(deparse(.e), collapse = " ")), logical(1)))
+  if (.hasLinCmt) return(.no)
   .isAssign <- function(.ex) is.call(.ex) && length(.ex) == 3L &&
     (identical(.ex[[1]], as.name("<-")) || identical(.ex[[1]], as.name("=")) ||
        identical(.ex[[1]], as.name("~")))

--- a/R/vaeData.R
+++ b/R/vaeData.R
@@ -294,6 +294,100 @@ vaeCovariates <- function(data, warn = TRUE) {
   do.call(rbind, .rows)
 }
 
+#' Which regressed thetas may be optimized in `residOptimize="twoStage"` stage 2.
+#'
+#' Stage 2 pins the ODE states from stage 1 and re-optimizes with only the
+#' candidate moving, so a parameter is eligible exactly when the state trajectory
+#' cannot depend on it.  The rule is PER PARAMETER:
+#'
+#'   eligible = it is an `err` parameter, OR no solve-defining expression reaches it
+#'
+#' The `err` half is the historic rule and keeps every error parameter in stage 2
+#' exactly as before.  The second half is what an `ll()`/generalized endpoint
+#' needs: its residual-like parameters are plain thetas with no `err` row, so on
+#' the old rule stage 2 was empty and `"twoStage"` silently degraded to the joint
+#' `"optimize"` solve.
+#'
+#' A model-level "does this model have error parameters" short-circuit would NOT
+#' do -- a multi-endpoint model with one Gaussian and one `ll()` endpoint has
+#' `err` rows AND log-density-only thetas, and both belong in stage 2.
+#'
+#' Deliberately conservative in the risky direction: an unparsable model, or one
+#' with no ODE states to pin, contributes nothing beyond the `err` set.
+#' @param ui rxode2 ui object
+#' @param regressNames regressed theta names, in `regressThetaIdx0` order
+#' @param regressErrIdx0 0-based slot in `a` per regressed name, -1 when not one
+#' @return integer 0/1 per regressed name
+#' @noRd
+.vaeRegressStage2 <- function(ui, regressNames, regressErrIdx0) {
+  if (length(regressNames) == 0L) return(integer(0))
+  .isErr <- regressErrIdx0 >= 0L
+  .odeFree <- tryCatch(.vaeOdeFreeThetas(ui, regressNames),
+                       error = function(e) rep(FALSE, length(regressNames)))
+  as.integer(.isErr | .odeFree)
+}
+
+#' Names the ODE state trajectory provably cannot depend on.
+#'
+#' Fixpoint over the model assignments, seeded from every expression that feeds
+#' the solve.  Assignment ORDER is ignored, which can only over-collect symbols
+#' and therefore only ever answers FALSE where the truth is TRUE -- the safe
+#' direction (the theta stays in stage 1, as it is today).
+#' @param ui rxode2 ui object
+#' @param names candidate names
+#' @return logical vector, `TRUE` when no solve-defining expression reaches the name
+#' @noRd
+.vaeOdeFreeThetas <- function(ui, names) {
+  .no <- rep(FALSE, length(names))
+  .lst <- tryCatch(ui$lstExpr, error = function(e) NULL)
+  if (is.null(.lst) || length(.lst) == 0L) return(.no)
+  if (length(tryCatch(rxode2::rxState(ui), error = function(e) character(0))) == 0L) return(.no)
+  .isAssign <- function(.ex) is.call(.ex) && length(.ex) == 3L &&
+    (identical(.ex[[1]], as.name("<-")) || identical(.ex[[1]], as.name("=")) ||
+       identical(.ex[[1]], as.name("~")))
+  .syms <- function(.e) {
+    if (is.name(.e)) return(as.character(.e))
+    if (is.call(.e)) return(unlist(lapply(as.list(.e)[-1L], .syms), use.names = FALSE))
+    character(0)
+  }
+  ## a solve-defining left-hand side: d/dt(x), x(0), and the dosing modifiers
+  .solveLhs <- function(.txt) {
+    grepl("^d */ *dt *\\(", .txt) ||
+      grepl("^[A-Za-z._][A-Za-z0-9._]* *\\( *0 *\\)$", .txt) ||
+      grepl("^(f|alag|lag|rate|dur) *\\(", .txt)
+  }
+  ## the observation model, which the SOLVE does not read: `ll(x) ~ <density>`
+  ## and the error-model endpoint lines (`x ~ add(...)`, `x ~ pois(...)`).  ONLY a
+  ## `~` line qualifies -- `cp <- center / v` defines a variable a `d/dt()` may
+  ## well read, and dropping it would hide a real dependency.
+  .endpointVars <- tryCatch(as.character(ui$predDf$var), error = function(e) character(0))
+  .seed <- character(0); .map <- list()
+  for (.ex in .lst) {
+    if (!.isAssign(.ex)) next
+    .rhs <- .syms(.ex[[3]])
+    .txt <- paste(deparse(.ex[[2]]), collapse = "")
+    .tilde <- identical(.ex[[1]], as.name("~"))
+    if (.solveLhs(.txt)) {
+      .seed <- c(.seed, .rhs)
+    } else if (.tilde && (grepl("^ll *\\(", .txt) || .txt %in% .endpointVars)) {
+      next                                   # likelihood only -- never reaches the solve
+    } else if (is.name(.ex[[2]])) {
+      .map[[.txt]] <- unique(c(.map[[.txt]], .rhs))
+    } else {
+      ## an lhs shape not recognized above may still feed the solve -- take its
+      ## rhs as reachable rather than guess (the safe direction: stage 1)
+      .seed <- c(.seed, .rhs)
+    }
+  }
+  .seen <- unique(.seed); .todo <- .seen
+  while (length(.todo) > 0L) {
+    .nxt <- unique(unlist(.map[intersect(.todo, names(.map))], use.names = FALSE))
+    .todo <- setdiff(.nxt, .seen)
+    .seen <- c(.seen, .todo)
+  }
+  !(as.character(names) %in% .seen)
+}
+
 #' Prepare VAE inputs from a ui + data
 #' @param ui rxode2 ui object
 #' @param data estimation data (ID/TIME/DV/EVID/... columns)
@@ -591,6 +685,8 @@ vaeCovariates <- function(data, warn = TRUE) {
   .errThetaIdx <- as.integer(.errRow$ntheta)
   .errType <- as.character(.errRow$err)
   .errLower <- as.numeric(.errRow$lower); .errUpper <- as.numeric(.errRow$upper)
+  ## residOptimize="twoStage" stage-2 eligibility (see .vaeRegressStage2)
+  .regressStage2 <- .vaeRegressStage2(ui, .regressNames, .regressErrIdx0)
 
   ## per-subject decoder inputs + gather all obs for standardization
   subj <- vector("list", N)
@@ -665,7 +761,7 @@ vaeCovariates <- function(data, warn = TRUE) {
        errThetaIdx = .errThetaIdx, errType = .errType,
        errLower = .errLower, errUpper = .errUpper,
        regressNames = .regressNames, regressThetaIdx0 = .regressThetaIdx0,
-       regressErrIdx0 = .regressErrIdx0,
+       regressErrIdx0 = .regressErrIdx0, regressStage2 = .regressStage2,
        regressLower = .regressLower, regressUpper = .regressUpper,
        zPop = .zPop, omega = .omega, a = .a,
        subj = subj, dataIn = dataIn, lengths = lengths, covIn = covIn,

--- a/R/vaeFit.R
+++ b/R/vaeFit.R
@@ -213,6 +213,8 @@
   ## thetas the C++ M-step regresses with bobyqa (empty when not in regress mode)
   prepC$regressThetaIdx0 <- as.integer(prep$regressThetaIdx0)
   prepC$regressErrIdx0 <- as.integer(prep$regressErrIdx0)
+  ## residOptimize="twoStage": which of those go to stage 2 (the frozen-ODE block)
+  prepC$regressStage2 <- as.integer(prep$regressStage2)
   prepC$regressLower <- as.numeric(prep$regressLower)
   prepC$regressUpper <- as.numeric(prep$regressUpper)
   ## latent dims whose structural theta is fixed (held at ini by the M-step)
@@ -264,6 +266,7 @@
        mu = .fit$mu, zPopMat = .fit$zPopMat, prep = prep,
        regressTheta = setNames(as.numeric(.fit$regressTheta), prep$regressNames),
        nRegGrad = as.integer(.fit$nRegGrad), nRegFallback = as.integer(.fit$nRegFallback),
+       nStage2 = as.integer(.fit$nStage2),
        nMix = nMix, mixProb = mixProb, mixnum = as.integer(.fit$mixnum))
 }
 

--- a/R/vaeGrad.R
+++ b/R/vaeGrad.R
@@ -89,6 +89,13 @@
   .vaeGradEnv$regNames <- NULL
   .vaeGradEnv$cores <- NULL
   .vaeGradEnv$failed <- NULL
+  ## .vaeGradEval passes this env to .foceiAnalyticGradCore as `startedEnv`, which
+  ## caches compiled models in it (.foceiGradHess2 for the ll() core, and for the
+  ## Gaussian core .foceiGradAugNode / .analyticStarted).  Those are per-fit and
+  ## hold compiled models, so drop them with the rest.
+  rm(list = intersect(c(".foceiGradHess2", ".foceiGradAugNode", ".analyticStarted"),
+                      ls(.vaeGradEnv, all.names = TRUE)),
+     envir = .vaeGradEnv)
   invisible(NULL)
 }
 
@@ -161,12 +168,17 @@
       .vaeGradEnv$am <- .am
     }
     .th <- setNames(as.numeric(thVals), paste0("THETA_", seq_along(thVals), "_"))
+    ## startedEnv: the ll() core caches the eta-only 2nd-order model (innerHess2)
+    ## there and reuses it for the dH/dtheta perturbation batch.  Without it every
+    ## M-step re-resolves it and then solves the FULL outer model 2*(nth+nom)
+    ## times instead of the much smaller eta-only one.  .vaeGradEnv is per-fit
+    ## (.vaeGradReset clears the slot), which is the lifetime focei gives it too.
     .r <- .foceiAnalyticGradCore(.ui, .th, ebes, .vaeGradEnv$ids, .vaeGradEnv$data,
                                  .Om, .st$ef, .st$dir, .st$dOiEst, .st$tr28,
                                  .st$omNames, .foceiAnalyticSolveTol(.ui),
                                  interaction = .st$interaction,
                                  foceType = .st$foceType, am = .vaeGradEnv$am,
-                                 nAGQ = .st$nAGQ)
+                                 nAGQ = .st$nAGQ, startedEnv = .vaeGradEnv)
     if (is.null(.r) || is.null(.r$g)) return(NULL)
     .g <- .r$g[.reg]
     ## a regressed theta the gradient does not carry (not in thStruct) means the

--- a/R/vaeInner.R
+++ b/R/vaeInner.R
@@ -46,6 +46,12 @@
   .env$control$printTop <- FALSE
   if (is.null(.env$control$nF)) .env$control$nF <- 0L
   .env$control$needOptimHess <- isTRUE(any(.ui$predDfFocei$distribution != "norm"))
+  ## A non-Gaussian endpoint has no eta-epsilon interaction term to carry: rx_pred_
+  ## IS the log-density.  The focei flow pairs needOptimHess with interaction=0 for
+  ## that reason (.foceiFitInternal); this entry must do the same, or the inner
+  ## problem is set up for the FOCEi (f,R) kernel while the objective runs the
+  ## exact-Hessian one.
+  if (isTRUE(.env$control$needOptimHess)) .env$control$interaction <- 0L
   ## AGQ off
   .env$aqn <- 0L; .env$qx <- double(0); .env$qw <- double(0); .env$qfirst <- FALSE
   .env$nAGQ <- 0L; .env$aqLow <- -Inf; .env$aqHi <- Inf; .env$nEstOmega <- 0L

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -172,7 +172,9 @@ closing tail.  `FALSE` regresses the current posterior means.}
     a single additive error this is exactly the optimum (`sqrt(SSE/n)`); for
     any other error model it is either a different estimator or, for the forms
     with no closed form (`pow`, Box-Cox, Yeo-Johnson), no estimator at all --
-    the parameter stays at its `ini()` value.
+    the parameter stays at its `ini()` value.  There is no moment estimator for
+    a log-likelihood (`ll()`) parameter either, so those also stay at `ini()`;
+    use `"twoStage"` for such a model.
   * `"twoStage"` (default): block coordinate descent, as `npag`'s
     `residOptimize = "alternate"` does.  Stage
     one optimizes the non-mu-referenced structural thetas with the residual
@@ -183,6 +185,15 @@ closing tail.  `FALSE` regresses the current posterior means.}
     -- the same structure SAEM uses.  On `theo_sd` this beats the moment
     estimator on both a pure-additive model (objective 131.79 vs 131.81) and a
     combined one (121.03 vs 122.47).
+
+    Which parameters stage two owns is decided per parameter: an error
+    parameter, or one that no `d/dt()` right-hand side, initial condition or
+    dosing modifier can reach.  The second case is what a log-likelihood
+    (`ll()`) or generalized endpoint needs -- its residual-like parameters are
+    plain thetas with no error row, and on the error-only rule stage two was
+    empty for such a model, silently making `"twoStage"` behave like
+    `"optimize"`.  When no regressed theta qualifies (every one feeds the
+    solve) stage two has nothing to do and `residOptimize` has no effect.
   * `"optimize"` (EXPERIMENTAL, diagnostic): a single JOINT solve over the
     structural and residual parameters together, against the full outer
     objective.  Fine with one free residual parameter, but with `add` and

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -285,9 +285,11 @@ results.}
     it and a single solve does not, but it does not close).  Choose it for
     accuracy: the exact gradient lands closer to the maximum-likelihood value
     than the derivative-free search (`theo_sd` non-mu `tv`: 3.4294 vs 3.4324,
-    against a FOCEi MLE of 3.4293).  Falls back to `"regress"` when the model
-    is out of analytic scope (`ll()` endpoints, `linCmt()`, IOV, ...);
-    `nonMuEtaOmega` is unused.
+    against a FOCEi MLE of 3.4293).  Applies to a conditionally Gaussian model
+    and to a single non-Gaussian (`ll()`/generalized) endpoint, which
+    differentiates the log-density directly.  Falls back to `"regress"` when
+    the model is out of analytic scope (`linCmt()`, IOV, `fo`, a
+    multi-endpoint or censored `ll()` model, ...); `nonMuEtaOmega` is unused.
   * `"eta"`: inject the eta with an ESTIMATED omega (starting at
     `nonMuEtaOmega`); the typical value is estimated and appears in the
     iteration table.

--- a/plans/vae-loglik-grad-and-two-stage-regress.md
+++ b/plans/vae-loglik-grad-and-two-stage-regress.md
@@ -1,5 +1,46 @@
 # VAE + log-likelihood endpoints: `nonMuTheta="grad"` and the two-stage regress
 
+## STATUS
+
+**Gap 2 (two-stage regress) is DONE.**  Eligibility is decided per parameter --
+an `err` parameter, or one no solve-defining expression reaches -- so an `ll()`
+endpoint's log-density-only thetas reach stage 2, including in a multi-endpoint
+model that also has `err` rows.  `gVaeFreezeObjR` gained the theta write path.
+Verified by unit tests plus two fits (`test-vae-ll-grad-fit.R`).
+
+**Gap 1 (`nonMuTheta="grad"` for `ll()`) is BLOCKED, and the blocker is not what
+this plan assumed.**  Everything above the solve works: `.foceiLLGradInScope(ui,
+"vae")` is TRUE, `.foceiOuterDirsLL` builds the direction set,
+`.foceiAnalyticGradSetup` returns `ef$isLL`, and `.foceiAnalyticGradCore` routes
+to the log-density core.  Widening `.vaeGradInScope` to accept `ll()` makes the
+fit SEGFAULT.
+
+Measured, on a one-compartment `ll()` model:
+
+- The fault is heap corruption: R aborts inside its own byte-compiler
+  (`compiler:::tryCmpfun`) on entry to `.foceiAnalyticGradCore`, i.e. BEFORE any
+  gradient solve has run.
+- It is not the pooled column layout -- forcing `.vaeOuterCols` to `NULL` (the
+  plain `rxSolve` path) still faults.
+- It is not the `dH/dtheta` batch -- stubbing `.foceiAnalyticSolveConfigsLL` /
+  `.foceiAnalyticHess2ConfigsLL` to `NULL` still faults.
+- The SAME model and data fit cleanly under `nonMuTheta="regress"`.
+
+`"regress"` is the only one of those that does not set `poolModel`.  So the
+trigger is the `"grad"` pool arrangement itself: `.vaeInnerSetup` sizes the
+shared solve pool with the augmented outer model (42 states / 34 lhs here) and
+pins the inner MAP to `neqOverride = 4`.  That is correct for a Gaussian model
+and corrupts the heap for an `ll()` one.  The fix belongs in `vaeInnerSetup_`,
+not in the R scope gate.
+
+`.vaeGradInScope` therefore still declines `ll()`, with the reasoning inline; the
+supporting work (caller-aware `.foceiLLGradInScope`, `startedEnv` reuse in
+`.vaeGradEval`, `.vaeGradReset` hygiene, and a `predHess2Offset` reset in
+`vaeInnerSetup_` so a stale offset from an earlier focei `ll()` `fast=TRUE` fit
+cannot leak in) is in place and tested.  Re-enable the `ll()` branch and restore
+the two `"grad"` fit tests together once the pool arrangement is fixed.
+
+
 Two gaps left open when PR #807 (analytic `fast=TRUE` for `ll()`/generalized
 endpoints) merged.  Both are about the VAE M-step, which #807 did not touch.
 

--- a/plans/vae-loglik-grad-and-two-stage-regress.md
+++ b/plans/vae-loglik-grad-and-two-stage-regress.md
@@ -8,37 +8,43 @@ endpoint's log-density-only thetas reach stage 2, including in a multi-endpoint
 model that also has `err` rows.  `gVaeFreezeObjR` gained the theta write path.
 Verified by unit tests plus two fits (`test-vae-ll-grad-fit.R`).
 
-**Gap 1 (`nonMuTheta="grad"` for `ll()`) is BLOCKED, and the blocker is not what
-this plan assumed.**  Everything above the solve works: `.foceiLLGradInScope(ui,
-"vae")` is TRUE, `.foceiOuterDirsLL` builds the direction set,
-`.foceiAnalyticGradSetup` returns `ef$isLL`, and `.foceiAnalyticGradCore` routes
-to the log-density core.  Widening `.vaeGradInScope` to accept `ll()` makes the
-fit SEGFAULT.
+**Gap 1 (`nonMuTheta="grad"` for `ll()`) is DONE.**  The scope gate now accepts a
+single non-Gaussian endpoint through the log-density direction set.
 
-Measured, on a one-compartment `ll()` model:
+Getting there meant fixing a memory bug that the first attempt at the scope widen
+exposed as a segfault.  How it was found, since the symptom pointed nowhere near
+the cause:
 
-- The fault is heap corruption: R aborts inside its own byte-compiler
-  (`compiler:::tryCmpfun`) on entry to `.foceiAnalyticGradCore`, i.e. BEFORE any
-  gradient solve has run.
-- It is not the pooled column layout -- forcing `.vaeOuterCols` to `NULL` (the
-  plain `rxSolve` path) still faults.
-- It is not the `dH/dtheta` batch -- stubbing `.foceiAnalyticSolveConfigsLL` /
-  `.foceiAnalyticHess2ConfigsLL` to `NULL` still faults.
-- The SAME model and data fit cleanly under `nonMuTheta="regress"`.
+- The fault presented as heap corruption -- R aborting inside its own
+  byte-compiler on entry to `.foceiAnalyticGradCore`, i.e. before any gradient
+  solve ran.
+- Bisecting by stubbing showed it was NOT the pooled column layout, NOT the
+  `dH/dtheta` batch, and NOT the gradient at all: it still faulted with the
+  gradient never invoked, and a Gaussian model with the same single eta and the
+  same pool arrangement was clean.  So it was `ll()`-specific.
+- AddressSanitizer did NOT reproduce it (it only instruments this package, not
+  rxode2, and its redzones absorbed the write).  Valgrind named it exactly:
+  an invalid write at `vaeInnerUpdateParCore` (`inner.cpp`), past the end of
+  `inds_focei`.
 
-`"regress"` is the only one of those that does not set `poolModel`.  So the
-trigger is the `"grad"` pool arrangement itself: `.vaeInnerSetup` sizes the
-shared solve pool with the augmented outer model (42 states / 34 lhs here) and
-pins the inner MAP to `neqOverride = 4`.  That is correct for a Gaussian model
-and corrupts the heap for an `ll()` one.  The fix belongs in `vaeInnerSetup_`,
-not in the R scope gate.
+Two fixes, both correct on their own merits:
 
-`.vaeGradInScope` therefore still declines `ll()`, with the reasoning inline; the
-supporting work (caller-aware `.foceiLLGradInScope`, `startedEnv` reuse in
-`.vaeGradEval`, `.vaeGradReset` hygiene, and a `predHess2Offset` reset in
+1. `.vaeInnerSetup` now pairs `needOptimHess` with `interaction = 0`, which is
+   what the focei flow (`.foceiFitInternal`) has always done -- a non-Gaussian
+   endpoint has no eta-epsilon interaction term because `rx_pred_` IS the
+   log-density.  Leaving `interaction = 1` set the inner problem up for the
+   `(f,R)` kernel while the objective ran the exact-Hessian one.
+2. `inds_focei`'s slot count is recorded in `nIndsFocei` at both allocation sites
+   and the loop in `vaeInnerUpdateParCore` is bounded by it, instead of by a
+   freshly-read `getRxNsubAndMix(rx)`.  The two allocation sites use different
+   counts (`getRxNsub` vs `getRxNsubAndMix`), and the global `rx` a later caller
+   reads is not necessarily the solve `inds_focei` was sized against -- so this
+   class of overflow can no longer happen silently.
+
+Also carried: caller-aware `.foceiLLGradInScope`, `startedEnv`/`innerHess2` reuse
+in `.vaeGradEval`, `.vaeGradReset` hygiene, and a `predHess2Offset` reset in
 `vaeInnerSetup_` so a stale offset from an earlier focei `ll()` `fast=TRUE` fit
-cannot leak in) is in place and tested.  Re-enable the `ll()` branch and restore
-the two `"grad"` fit tests together once the pool arrangement is fixed.
+cannot leak in.
 
 
 Two gaps left open when PR #807 (analytic `fast=TRUE` for `ll()`/generalized

--- a/plans/vae-loglik-grad-and-two-stage-regress.md
+++ b/plans/vae-loglik-grad-and-two-stage-regress.md
@@ -1,0 +1,180 @@
+# VAE + log-likelihood endpoints: `nonMuTheta="grad"` and the two-stage regress
+
+Two gaps left open when PR #807 (analytic `fast=TRUE` for `ll()`/generalized
+endpoints) merged.  Both are about the VAE M-step, which #807 did not touch.
+
+## Established facts
+
+Probed on the merged tree with a Poisson model
+(`cp ~ pois(lambda)`, one non-mu structural theta `lb`, `kd` fixed):
+
+| probe | value |
+| --- | --- |
+| `.foceiLLGradInScope(ui)` | `TRUE` |
+| `.foceiOuterDirsLL(ui)` | non-`NULL` (LL direction set builds) |
+| `.foceiOuterDirs(ui, "vae")` | `NULL` (Gaussian `ErrFull` declines) |
+| `.vaeGradInScope(ui)` | `FALSE` |
+| `ui$iniDf$err` | all `NA` -- so `a` (error-param vector) is EMPTY |
+
+## Gap 1 -- `nonMuTheta="grad"` declines every `ll()` model
+
+### Diagnosis
+
+The gradient machinery is already wired end to end for this case:
+
+- `.foceiAnalyticGradSetup(ui, th, Om, caller = "vae")` takes its
+  `.foceiLLGradInScope()` branch regardless of caller and returns
+  `ef = list(isLL = TRUE)`.
+- `.foceiAnalyticGradCore()` dispatches on `ef$isLL` to
+  `.foceiAnalyticGradCoreLL()`, so `.vaeGradEval()`'s existing call already
+  routes correctly.
+- `rxUiGet.foceiOuter` falls back to `.foceiOuterDirsLL()` for an `ll()` model.
+
+The single blocker is the scope probe.  `.vaeGradInScope()` is
+`!is.null(.foceiOuterDirs(ui, "vae"))`, and `.foceiOuterDirs()` requires
+`.foceiAnalyticErrFull()`, which is Gaussian-only.  `vae.R` (the
+`identical(env$vaeControl$nonMuTheta, "grad")` block) therefore downgrades to
+`"regress"` and warns "analytic gradient out of scope".
+
+### Change
+
+1. Widen `.vaeGradInScope()` to `Gaussian dirs OR .foceiLLGradInScope(ui)`.
+   Keep it a cheap static probe (no symengine/gcc pass).
+2. `.vaeGradInit()` sets `.vaeGradEnv$outerCols <- .vaeOuterCols(.am)` to enable
+   the pooled `vaeOuterSolve_` read path.  `.vaeOuterCols()` resolves
+   `rx_predf_`/`f1`/`f2` against the Gaussian `.foceiAnalyticCols()` layout and
+   sets `hasR` from `am$hasRvar`.  **Required guard:** confirm what it returns
+   for an LL augmented model.  A `NULL` is safe (the solve stays on the slower
+   `rxSolve` path); a non-`NULL` but wrong layout would make the pooled reader
+   write the wrong columns.  If the layout is not provably identical, gate
+   `outerCols` to the Gaussian case and let LL use the `rxSolve` path.
+3. `.foceiAnalyticGradCoreLL()` takes `startedEnv` to reuse `innerHess2` (the
+   cheaper eta-only second-order model) for the `dH/dtheta` perturbation batch.
+   `.vaeGradEval()` passes none, so LL vae would solve the full outer model
+   `2*(nth+nom)` times per M-step.  Give `.vaeGradEnv` the same cached slot
+   (`.foceiGradHess2`) and pass it -- this is the difference between usable and
+   not on a real model.
+4. `.foceiAnalyticGradCoreLL()` returns `etaP = NULL`; `.vaeGradEval()` reads
+   only `.r$g`, so no change -- but assert it, since a future Eq-48 warm start
+   in the vae path would silently get nothing.
+
+### Verification -- exercised, not asserted
+
+The existing `test-vae-nonmutheta-grad.R` checks scope gates and counters.  For
+`ll()` the requirement is a real fit:
+
+- New fit test: a Poisson (or `ll()`) model with at least one non-mu structural
+  theta, fit twice -- `nonMuTheta="grad"` and `nonMuTheta="regress"` -- with the
+  same seed.  Assert the two land on the same parameters within tolerance, which
+  is the same shape as #807's `fast=TRUE` vs `fast=FALSE` assertion.
+- Assert the gradient path was actually TAKEN, not silently fallen back:
+  `nRegGrad > 0` and `nRegFallback == 0` in the fit's counters (the mechanism
+  evidence the repo already requires of fast-path tests), plus absence of the
+  "analytic gradient out of scope" `$runInfo` warning.
+- Finite-difference cross-check of one `.vaeGradEval()` return against a central
+  difference of the M-step objective, at a fixed theta/eta/omega.  This is the
+  test that would catch a wrong pooled-column layout from item 2.
+
+Placement: the FD cross-check and scope probes are cheap -- add to the essential
+`test-vae-nonmutheta-grad.R`.  The two-fit agreement test is a multi-fit file --
+new `test-vae-ll-grad-fit.R` added to a `.slowBatches` batch (batch 6 holds the
+VAE internals; check its measured time before adding).
+
+## Gap 2 -- the two-stage regress never engages for `ll()`
+
+### Diagnosis
+
+`residOptimize="twoStage"` (the DEFAULT) is block coordinate descent:
+
+- stage 1: non-mu structural thetas, residuals held -- `gVaeThetaObjR`
+- stage 2: residual parameters alone, ODE frozen -- `gVaeFreezeObjR`
+
+Eligibility for stage 2 is `regErrMapV[j] >= 0`, i.e. the regressed theta has a
+slot in `a`.  `a` is built in `.vaeDataPrep` from `iniDf[!is.na(iniDf$err), ]`.
+An `ll()`/generalized model has NO `err` rows (confirmed above), so:
+
+- `residByOpt` is `false` and `sub` is empty -- **stage 2 never runs**;
+- every regressed theta falls into stage 1, so `"twoStage"` silently degenerates
+  to a single joint solve, which is exactly the `"optimize"` mode the docs call
+  EXPERIMENTAL and warn diverges on near-collinear parameters;
+- `residOptimize` is a no-op for these models -- `"moment"`, `"twoStage"` and
+  `"optimize"` all do the same thing;
+- the `vaeUpdateErr` moment warm start is a no-op.
+
+The stage-2 objective itself is NOT the blocker.  `gVaeFreezeObjR` calls
+`vaeInnerLikCore` -- the same likelihood the fit reports, distribution-agnostic.
+It is already correct for `ll()`.  Two things are wrong: the eligibility rule,
+and the candidate write path.
+
+### Change
+
+**(a) Generalize the eligibility rule from "has an `err` slot" to "the ODE solve
+is invariant to it".**  That is the actual precondition for stage 2: it pins the
+ODE states from stage 1 and re-evaluates with only the candidate moving, so any
+parameter the states do not depend on is eligible.  For a Gaussian model the
+`err` thetas are exactly that set, so the rule reduces to today's behavior and
+Gaussian fits are unchanged (assert this).  For an `ll()` model it picks up the
+thetas that appear only in the log-density expression -- e.g. an overdispersion
+or scale parameter -- which is the intended stage-2 population.
+
+Detection: scan the `d/dt()` right-hand sides and state initial conditions for a
+transitive dependency on the theta, via rxode2 model vars.  Decide the mechanism
+first (a dependency helper may already exist); on any doubt classify as
+structural, which is the current, safe behavior.
+
+**(b) Give `gVaeFreezeObjR` the theta write path it lacks.**  It substitutes
+candidates only into `a` (`gVaeElsMap[k] >= 0` guards the write) and then calls
+`vaeBuildTh(..., gVaeRegErrIdx0, ac)`, which writes `a` over the ERROR theta
+positions.  A plain non-`err` theta has neither, so the objective would be FLAT
+in the candidate and bobyqa would not move it.  Mirror `gVaeThetaObjR`'s dual
+write: always write the theta slot, additionally write the `a` slot when mapped.
+This needs a `gVaeEls*` companion to `gVaeElsMap` carrying the theta indices.
+
+**(c) Decide and document the `"moment"` case.**  There is no closed-form moment
+estimator for an `ll()` parameter.  Either keep the parameter at its `ini()`
+value (today's behavior for `pow`/Box-Cox, already documented) or route
+`"moment"` to stage 2 for these models.  Prefer the first -- consistent with the
+existing documented gap -- and say so in `?vaeControl`.
+
+**(d) If stage 2 stays empty for a model** (no ODE-invariant regressed theta,
+e.g. a plain Poisson whose only free theta is structural), that is legitimate,
+not a failure -- but `residOptimize` is then genuinely inert.  Do not warn per
+iteration; the roxygen note from (c) covers it.
+
+### Verification -- exercised, not asserted
+
+- New fit test: an `ll()` model with BOTH a structural non-mu theta and an
+  ODE-invariant one (a scale/overdispersion parameter inside the `ll()`
+  expression).  Fit with `residOptimize="twoStage"` and assert the
+  ODE-invariant theta MOVED off its `ini()` value and the objective is no worse
+  than the joint `"optimize"` solve on the same seed.  A test that only checks
+  the fit completes would pass today, when stage 2 never runs.
+- Mechanism evidence: assert stage 2 was entered -- surface a per-fit counter
+  (number of stage-2 solves) the way `nRegGrad`/`nRegFallback` already work for
+  the gradient path.  Without it a regression in the eligibility scan is silent.
+- Regression guard: an existing Gaussian `residOptimize` fit
+  (`test-vae-residopt.R`) must be bit-identical after (a).  This is the test
+  that protects the reclassification.
+
+## Sequencing
+
+1. Gap 1 items 1-2 (scope widen + `outerCols` guard) + the FD cross-check test.
+   Self-contained, R-only, no C++.
+2. Gap 1 items 3-4 (`innerHess2` reuse) + the two-fit agreement test.
+3. Gap 2 (b) -- the `gVaeFreezeObjR` write path -- with a Gaussian
+   bit-identity check.  C++; remember `rm -f src/*.o src/*.so`.
+4. Gap 2 (a) -- the eligibility scan -- plus the stage-2 counter and both fit
+   tests.
+5. (c) docs, `NEWS.md` under `## New features`, and `.slowBatches` placement.
+
+Steps 1-2 and 3-4 are independent and can land as separate PRs.
+
+## Notes
+
+- The `est="focei"` path is unaffected throughout; every change is behind the
+  vae M-step or a scope probe that focei does not consult.
+- `.vaeGradInScope()` returning `TRUE` for `ll()` means `rxUiGet.foceiOuter`
+  builds the LL augmented model for vae fits that previously built nothing --
+  confirm the vae shared solve pool is still sized for it
+  (`.vaeInnerSetup` `poolModel`), since that pool sizing is what the
+  `neqOverride` inner Newton depends on.

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -10471,6 +10471,14 @@ static void vaeInnerLikCore(const arma::mat& etaMat, int cores, bool grad, bool 
                             std::vector<std::vector<double> >* pr = NULL) {
   const int nid = (int)etaMat.n_rows;
   const int neta = (int)etaMat.n_cols;
+  // Every per-id branch below indexes inds_focei[id] for id in [0, nid).  In the
+  // VAE flow nid is N*(components) and inds_focei was sized the same way at
+  // setup, so this cannot exceed the allocation -- but a caller that passed more
+  // etas than the setup allocated would corrupt the heap silently.  Fail loud.
+  if (nid > nIndsFocei) {
+    stop("vaeInnerLikCore: %d etas exceed the %d allocated inner slots "
+         "(inner setup and the eta matrix disagree)", nid, nIndsFocei);
+  }
   obj.set_size(nid);
   if (grad) lp.set_size(nid, neta);
   if (preds) { pf.clear(); pf.resize(nid); if (pr != NULL) { pr->clear(); pr->resize(nid); } }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -644,6 +644,12 @@ static inline bool etaInBound(double *eta) {
 }
 
 focei_ind *inds_focei = NULL;
+// Number of focei_ind slots inds_focei currently holds.  Any loop over
+// inds_focei must bound itself by THIS, not by a freshly-read subject count:
+// the two allocation sites below use different counts (getRxNsub vs
+// getRxNsubAndMix), and the global rx a later caller reads is not necessarily
+// the solve inds_focei was sized against.
+int nIndsFocei = 0;
 
 // FOCE eta=0 population-R cache.  rPop depends only on theta, so it is constant
 // across the whole inner optimization and only needs recomputing when theta
@@ -715,6 +721,7 @@ extern "C" void rxOptionsFreeFocei() {
 
   if (inds_focei != NULL) R_Free(inds_focei);
   inds_focei=NULL;
+  nIndsFocei = 0;
 
   op_focei.alloc = false;
   op_focei.didPredSolve = false;
@@ -4748,6 +4755,7 @@ static inline void foceiSetupNoEta_(){
 
   if (inds_focei != NULL) R_Free(inds_focei);
   inds_focei = R_Calloc(getRxNsub(rx), focei_ind);
+  nIndsFocei = (int)getRxNsub(rx);
   op_focei.gEtaGTransN=(op_focei.neta)*getRxNsub(rx);
 
   if (op_focei.gthetaGrad != NULL && op_focei.mGthetaGrad) R_Free(op_focei.gthetaGrad);
@@ -4805,6 +4813,7 @@ static inline void foceiSetupEta_(NumericMatrix etaMat0){
 
   if (inds_focei != NULL) R_Free(inds_focei);
   inds_focei = R_Calloc(getRxNsubAndMix(rx), focei_ind);
+  nIndsFocei = (int)getRxNsubAndMix(rx);
   // Size the FOCE eta=0 population-R cache alongside inds_focei (single-threaded
   // here); gen = -1 forces a compute on each subject's first inner call.
   _foceRPopCache.assign(getRxNsubAndMix(rx), arma::vec());
@@ -10416,7 +10425,13 @@ static void vaeInnerUpdateParCore(const arma::vec& thFull, const arma::vec& omeg
   // likInner0 short-circuits on an unchanged eta (fInd->oldEta), which is only
   // safe while theta/omega are fixed -- force a re-solve (like impForceResolve)
   rx = getRxSolve_();
-  for (int id = getRxNsubAndMix(rx); id--;) inds_focei[id].setup = 0;
+  // Bound by the slots inds_focei actually has, NOT by a freshly-read
+  // getRxNsubAndMix(rx): those disagree when the current global solve is not the
+  // one inds_focei was sized against, and the difference was a write past the end
+  // of the array (valgrind: invalid write here, into an unrelated freed block).
+  int nInd = nIndsFocei;
+  if (nInd > (int)getRxNsubAndMix(rx)) nInd = (int)getRxNsubAndMix(rx);
+  for (int id = nInd; id--;) inds_focei[id].setup = 0;
 }
 
 //[[Rcpp::export]]

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -648,8 +648,19 @@ focei_ind *inds_focei = NULL;
 // inds_focei must bound itself by THIS, not by a freshly-read subject count:
 // the two allocation sites below use different counts (getRxNsub vs
 // getRxNsubAndMix), and the global rx a later caller reads is not necessarily
-// the solve inds_focei was sized against.
+// the solve inds_focei was sized against.  getRxNsubAndMix() is
+// getRxNsub(rx) * (mixIdxN + 1) -- BOTH factors are mutable globals that a later
+// caller can read back different from what was in effect at setup.
 int nIndsFocei = 0;
+
+// Slots it is safe to touch in inds_focei.  Used by the "force a re-solve"
+// loops, which run long after setup from entry points (VAE M-step, the general
+// likelihood API) that may have swapped the global solve underneath.  Shared so
+// the two call sites cannot drift apart.
+static inline int foceiIndSetupN(rx_solve* rxl) {
+  int cur = (int)getRxNsubAndMix(rxl);
+  return (nIndsFocei < cur) ? nIndsFocei : cur;
+}
 
 // FOCE eta=0 population-R cache.  rPop depends only on theta, so it is constant
 // across the whole inner optimization and only needs recomputing when theta
@@ -10429,9 +10440,7 @@ static void vaeInnerUpdateParCore(const arma::vec& thFull, const arma::vec& omeg
   // getRxNsubAndMix(rx): those disagree when the current global solve is not the
   // one inds_focei was sized against, and the difference was a write past the end
   // of the array (valgrind: invalid write here, into an unrelated freed block).
-  int nInd = nIndsFocei;
-  if (nInd > (int)getRxNsubAndMix(rx)) nInd = (int)getRxNsubAndMix(rx);
-  for (int id = nInd; id--;) inds_focei[id].setup = 0;
+  for (int id = foceiIndSetupN(rx); id--;) inds_focei[id].setup = 0;
 }
 
 //[[Rcpp::export]]
@@ -12620,7 +12629,9 @@ RObject foceiLikSetTheta_(NumericVector theta) {
   // likInner0 short-circuits on an unchanged eta (fInd->oldEta), only safe while
   // theta/omega are fixed -- force a re-solve after a theta change.
   rx = getRxSolve_();
-  for (int id = getRxNsubAndMix(rx); id--;) inds_focei[id].setup = 0;
+  // Same bound as vaeInnerUpdateParCore: this entry point is called long after
+  // setup, so getRxNsubAndMix(rx) can exceed what inds_focei was allocated for.
+  for (int id = foceiIndSetupN(rx); id--;) inds_focei[id].setup = 0;
   return R_NilValue;
 }
 

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -10258,6 +10258,13 @@ static NumericVector _vaeInitPar;
 RObject vaeInnerSetup_(Environment e) {
   op_focei.canDoFD = false;
   op_focei.nEstOmega = e.exists("nEstOmega") ? as<int>(e["nEstOmega"]) : 0;
+  // op_focei persists across fits and this path never loads rxHess2, so a stale
+  // offset left by an earlier focei ll() fast=TRUE fit would send calcEtaHessian
+  // into the exact-Hessian branch against a model that is not loaded here.
+  // foceiFitCpp_ resets this for the same reason; do it on this entry too.
+  op_focei.predHess2Offset = -1;
+  op_focei.hess2Neq = 0;
+  op_focei.hess2Nlhs = 0;
   setupAq0_(e);
   List model = e["model"];
   RObject inner = model.containsElementNamed("innerLlik") ? model["innerLlik"] : model["inner"];
@@ -13401,7 +13408,8 @@ static arma::ivec gVaeRegErrMap;
 // Candidate substitution for the residual optimizer: gVaeElsMap relates the
 // optimizer's parameter slots to positions in `a`, and gVaeElsA is the base `a`
 // so a FIXED residual parameter keeps its value.
-static arma::ivec gVaeElsMap;     // optimizer slot k -> index in `a`
+static arma::ivec gVaeElsMap;     // optimizer slot k -> index in `a`, or -1
+static arma::ivec gVaeElsTh;      // optimizer slot k -> index in the full theta
 static arma::vec  gVaeElsA;       // base `a`; held params keep these values
 
 // ---- stage-2 objective through likInner0 with the ODE FROZEN ---------------
@@ -13458,9 +13466,19 @@ static inline void vaeRestoreFrozen(int id) {
 // states, and re-evaluate the SAME likelihood the fit reports.
 static double gVaeFreezeObjR(Rcpp::NumericVector p) {
   arma::vec ac = gVaeElsA;
-  for (arma::uword k = 0; k < gVaeElsMap.n_elem && k < (arma::uword)p.size(); ++k)
-    if (gVaeElsMap[k] >= 0 && gVaeElsMap[k] < (int)ac.n_elem) ac[gVaeElsMap[k]] = p[k];
-  arma::vec thv = vaeBuildTh(gVaeRegThBase, gVaeRegZpopIdx0, gVaeRegBaseline,
+  arma::vec thc = gVaeRegThBase;
+  // Dual write, exactly as gVaeThetaObjR does: the theta slot ALWAYS, plus the
+  // `a` slot when the parameter is an error parameter (vaeBuildTh writes `a` back
+  // over the error theta positions, so for those the `a` write is what survives).
+  // A plain ll() theta has no `a` slot at all -- without the theta write the
+  // objective is flat in it and bobyqa never moves it.
+  for (arma::uword k = 0; k < (arma::uword)p.size(); ++k) {
+    if (k < gVaeElsTh.n_elem && gVaeElsTh[k] >= 0 && gVaeElsTh[k] < (int)thc.n_elem)
+      thc[gVaeElsTh[k]] = p[k];
+    if (k < gVaeElsMap.n_elem && gVaeElsMap[k] >= 0 && gVaeElsMap[k] < (int)ac.n_elem)
+      ac[gVaeElsMap[k]] = p[k];
+  }
+  arma::vec thv = vaeBuildTh(thc, gVaeRegZpopIdx0, gVaeRegBaseline,
                              gVaeRegErrIdx0, ac);
   vaeInnerUpdateParCore(thv, gVaeRegOmega);
   for (int id = 0; id < (int)gVaeFreezeEta.n_rows; ++id) vaeRestoreFrozen(id);
@@ -13566,6 +13584,23 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
   for (arma::uword j = 0; j < regErrMapV.n_elem; ++j) if (regErrMapV[j] >= 0) residByOpt = true;
   const bool residTwoStage = control.containsElementNamed("residOptimize") &&
     as<std::string>(control["residOptimize"]) == "twoStage";
+  // Stage-2 (frozen-ODE block) eligibility, classified per parameter in R by
+  // .vaeRegressStage2: an err parameter (the historic rule -- every one of those
+  // is still stage 2), or one no d/dt right-hand side, initial condition or
+  // dosing modifier can reach.  The second half is what an ll()/generalized
+  // endpoint needs: it has NO err rows, so on the old rule stage 2 was always
+  // empty there and "twoStage" silently degraded to the joint "optimize" solve.
+  // Falls back to the err-only set when R sent no mask.
+  arma::ivec regStage2V = prep.containsElementNamed("regressStage2") ?
+    vaeToIvec(prep["regressStage2"]) : arma::ivec();
+  if (regStage2V.n_elem != regThetaIdx0v.n_elem) {
+    regStage2V.set_size(regThetaIdx0v.n_elem);
+    for (arma::uword j = 0; j < regThetaIdx0v.n_elem; ++j)
+      regStage2V[j] = (j < regErrMapV.n_elem && regErrMapV[j] >= 0) ? 1 : 0;
+  }
+  bool stage2Any = false;
+  for (arma::uword j = 0; j < regStage2V.n_elem; ++j) if (regStage2V[j] > 0) stage2Any = true;
+  int nStage2 = 0;   // stage-2 solves actually run (mechanism evidence for the tests)
   arma::uvec regIdx(regThetaIdx0v.n_elem);
   for (arma::uword j = 0; j < regThetaIdx0v.n_elem; ++j) regIdx[j] = (arma::uword)regThetaIdx0v[j];
   arma::vec regLower = as<arma::vec>(prep["regressLower"]);
@@ -13958,10 +13993,10 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
       // two-stage: stage 1 optimizes the structural thetas with the residuals
       // held, so restrict the active set here and do the residuals in stage 2
       arma::uvec stage1Idx = regIdx; arma::ivec stage1Map = regErrMapV;
-      if (residTwoStage && residByOpt) {
+      if (residTwoStage && stage2Any) {
         std::vector<arma::uword> keep;
         for (int j = 0; j < m; ++j)
-          if (!(j < (int)regErrMapV.n_elem && regErrMapV[j] >= 0)) keep.push_back((arma::uword)j);
+          if (!(j < (int)regStage2V.n_elem && regStage2V[j] > 0)) keep.push_back((arma::uword)j);
         // Restrict stage 1 to the structural thetas whenever ANY parameter is
         // residual.  When `keep` is EMPTY the set is residual-only (the common
         // case: every structural parameter mu-referenced, so only the error
@@ -13985,7 +14020,7 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
       std::vector<int> s1Src(m1);
       { int c2 = 0;
         for (int j = 0; j < m; ++j)
-          if (m1 == m || !(j < (int)regErrMapV.n_elem && regErrMapV[j] >= 0)) s1Src[c2++] = j; }
+          if (m1 == m || !(j < (int)regStage2V.n_elem && regStage2V[j] > 0)) s1Src[c2++] = j; }
       for (int jj = 0; jj < m1; ++jj) {
         int j = s1Src[jj];
         // An error parameter's live value is `a`, not the (stale) theta slot, and
@@ -14028,10 +14063,10 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
       // joint solve over near-collinear parameters at frozen etas is what walks
       // to a corner; splitting the blocks shrinks each solve and removes the
       // structural/residual coupling from it.
-      if (residTwoStage && residByOpt) {
+      if (residTwoStage && stage2Any) {
         std::vector<arma::uword> sub;
         for (int j = 0; j < m; ++j)
-          if (j < (int)regErrMapV.n_elem && regErrMapV[j] >= 0) sub.push_back((arma::uword)j);
+          if (j < (int)regStage2V.n_elem && regStage2V[j] > 0) sub.push_back((arma::uword)j);
         if (!sub.empty()) {   // NOT `sub.size() < m`: a residual-only set is stage 2's job
           arma::uvec sIdx(sub);
           // re-publish the base with stage-1's structural values baked in
@@ -14041,12 +14076,21 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
           Rcpp::NumericVector p2(sIdx.n_elem), l2(sIdx.n_elem), u2(sIdx.n_elem);
           for (arma::uword k = 0; k < sIdx.n_elem; ++k) {
             arma::uword j = sIdx[k];
-            sReg[k] = regIdx[j]; sMap[k] = regErrMapV[j];
-            p2[k] = a[sMap[k]]; l2[k] = regLower[j]; u2[k] = regUpper[j];
+            sReg[k] = regIdx[j]; sMap[k] = (j < (int)regErrMapV.n_elem) ? regErrMapV[j] : -1;
+            // an err parameter's live value is `a`; a plain (ll()) theta's is the
+            // theta slot, which is also where its candidate has to be written
+            p2[k] = (sMap[k] >= 0) ? a[sMap[k]] : th[regIdx[j]];
+            l2[k] = regLower[j]; u2[k] = regUpper[j];
+            if (R_FINITE(l2[k]) && p2[k] < l2[k]) p2[k] = l2[k];
+            if (R_FINITE(u2[k]) && p2[k] > u2[k]) p2[k] = u2[k];
           }
           gVaeElsA = a;
           gVaeElsMap.set_size(sIdx.n_elem);
-          for (arma::uword k = 0; k < sIdx.n_elem; ++k) gVaeElsMap[k] = sMap[k];
+          gVaeElsTh.set_size(sIdx.n_elem);
+          for (arma::uword k = 0; k < sIdx.n_elem; ++k) {
+            gVaeElsMap[k] = sMap[k];
+            gVaeElsTh[k] = (int)sReg[k];
+          }
           // pin the ODE states at the stage-1 structural values, then optimize the
           // residual parameters against the real likelihood with only r moving
           gVaeRegThBase = th;
@@ -14062,16 +14106,19 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
                                      Rcpp::_["lower"] = l2, Rcpp::_["upper"] = u2,
                                      Rcpp::_["control"] = Rcpp::List::create(Rcpp::_["rhoend"] = vaeResidRhoend));
           Rcpp::NumericVector x2 = r2["x"];
+          nStage2++;
           for (arma::uword k = 0; k < sIdx.n_elem; ++k) {
             arma::uword j = sIdx[k];
-            double cur = a[sMap[k]];
+            double cur = (sMap[k] >= 0) ? a[sMap[k]] : th[regIdx[j]];
             double upd = cur + gamma * (x2[k] - cur);
             if (R_FINITE(regLower[j]) && upd < regLower[j]) upd = regLower[j];
             if (R_FINITE(regUpper[j]) && upd > regUpper[j]) upd = regUpper[j];
             if (!R_FINITE(upd)) continue;
-            th[regIdx[j]] = upd; a[sMap[k]] = upd;
+            th[regIdx[j]] = upd;
+            if (sMap[k] >= 0) a[sMap[k]] = upd;
           }
           vaeFreezeClear();
+          gVaeElsTh.reset();
           gVaeRegIdx = regIdx; gVaeRegErrMap = regErrMapV;  // restore
         }
       }
@@ -14122,7 +14169,8 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
                       _["selected"] = selected, _["elboTrace"] = elboTrace,
                       _["parHist"] = parHist, _["mu"] = last.mu, _["zPopMat"] = zPopMatOut,
                       _["mixnum"] = mixnumOut, _["regressTheta"] = regressThetaOut,
-                      _["nRegGrad"] = nRegGrad, _["nRegFallback"] = nRegFallback);
+                      _["nRegGrad"] = nRegGrad, _["nRegFallback"] = nRegFallback,
+                      _["nStage2"] = nStage2);
 }
 
 // Test-facing entry point for the exact L0/BIC best-subset kernel used by the VAE

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -76,8 +76,8 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   # (VAE internals + a few slow structural tests), moved out of the essential
   # push/PR subset to trim its wall time / reclamation exposure.
   c("vae-encoder", "vae-train", "vae-decoder", "vae-elbo", "vae-inner",
-    "vae-fixbounds", "vae-parhist", "vae-iov", "vae-grad-fit", "split",
-    "unary-mu", "timing"),
+    "vae-fixbounds", "vae-parhist", "vae-iov", "vae-grad-fit", "vae-ll-grad-fit",
+    "split", "unary-mu", "timing"),
   # batch 7 -- advi (variational inference) multi-iteration fits
   c("advi-repro", "advi-focei-agreement", "advi-neonatal", "advi-fullrank",
     "advi-fullbayes"),

--- a/tests/testthat/test-vae-dataprep.R
+++ b/tests/testthat/test-vae-dataprep.R
@@ -98,6 +98,14 @@ nmTest({
     expect_equal(.vaeRegressStage2(lui, character(0), integer(0)), integer(0))
   })
 
+  test_that("a mismatched err-index length is rejected, not recycled", {
+    ## Recycling would silently mis-mask: a structural theta labelled stage 2 is
+    ## then optimized against a frozen ODE, which is wrong rather than slow.
+    lui <- rxode2::assertRxUi(.llMod())
+    expect_error(.vaeRegressStage2(lui, c("lka", "lcl", "lsd"), c(-1L, -1L)),
+                 "must match")
+  })
+
   test_that("a model with BOTH err rows and an ll() endpoint gets both in stage 2", {
     ## The case a model-level "does this model have err parameters" short-circuit
     ## would get wrong: `add.sd` is flagged err, `lsd` is the ll() endpoint's

--- a/tests/testthat/test-vae-dataprep.R
+++ b/tests/testthat/test-vae-dataprep.R
@@ -33,4 +33,105 @@ nmTest({
     expect_equal(prep$Nobs, nrow(d))       # every row treated as an observation
     expect_true(all(vapply(prep$subj, function(s) all(s$ev$EVID == 0L), logical(1))))
   })
+
+  ## residOptimize="twoStage" stage-2 eligibility.  Stage 2 pins the ODE states
+  ## from stage 1, so a parameter belongs there exactly when the state trajectory
+  ## cannot depend on it.  Fast: classification only, no fit.
+  .llMod <- function() {
+    ini({ lka <- 0.4; lcl <- -0.9; lb <- log(3); lsd <- log(1.2); eta.b ~ 0.1 })
+    model({
+      ka <- exp(lka); cl <- exp(lcl)
+      d / dt(depot) <- -ka * depot
+      d / dt(central) <- ka * depot - cl * central
+      mu <- exp(lb + eta.b) * central
+      sd <- exp(lsd)
+      ll(cp) ~ -0.5 * log(2 * pi) - log(sd) - 0.5 * ((DV - mu) / sd)^2
+    })
+  }
+  .gMod <- function() {
+    ini({ tka <- 0.45; tcl <- 1; tv <- c(2, 3.45, 5); add.sd <- c(0, 0.7, 5)
+      eta.ka ~ 0.6; eta.cl ~ 0.3 })
+    model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+      d / dt(depot) <- -ka * depot
+      d / dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd) })
+  }
+
+  test_that("the ODE-invariance scan separates structural from log-density thetas", {
+    ui <- rxode2::assertRxUi(.llMod())
+    ## lka/lcl reach a d/dt right-hand side; lb/lsd are read only by the density
+    expect_equal(.vaeOdeFreeThetas(ui, c("lka", "lcl", "lb", "lsd")),
+                 c(FALSE, FALSE, TRUE, TRUE))
+  })
+
+  test_that("a variable feeding d/dt keeps its dependency through the endpoint name", {
+    ## The dangerous direction: `conc` is BOTH the endpoint variable and an input
+    ## to d/dt.  Its `<-` definition must stay in the dependency map, or lv would
+    ## be called ODE-free and stage 2 would optimize it against a frozen solve.
+    .trapMod <- function() {
+      ini({ lk <- -1; lv <- 1; lsd <- log(0.7); eta.b ~ 0.1 })
+      model({
+        k <- exp(lk); v <- exp(lv)
+        conc <- central / v
+        d / dt(central) <- -k * conc + eta.b * 0
+        sd <- exp(lsd)
+        ll(conc) ~ -log(sd) - 0.5 * ((DV - conc) / sd)^2
+      })
+    }
+    ui <- suppressWarnings(rxode2::assertRxUi(.trapMod()))
+    expect_equal(.vaeOdeFreeThetas(ui, c("lk", "lv", "lsd")),
+                 c(FALSE, FALSE, TRUE))
+  })
+
+  test_that("stage-2 eligibility keeps every err parameter", {
+    ## the historic half of the rule: an err parameter is always stage 2, and a
+    ## structural theta that reaches d/dt is not
+    gui <- rxode2::assertRxUi(.gMod())
+    expect_equal(.vaeRegressStage2(gui, c("tv", "add.sd"), c(-1L, 0L)),
+                 c(0L, 1L))
+    ## an ll() model has no err rows, so only the structural proxy contributes
+    lui <- rxode2::assertRxUi(.llMod())
+    expect_equal(.vaeRegressStage2(lui, c("lka", "lcl", "lsd"), c(-1L, -1L, -1L)),
+                 c(0L, 0L, 1L))
+    ## no regressed parameters at all -> empty, not an error
+    expect_equal(.vaeRegressStage2(lui, character(0), integer(0)), integer(0))
+  })
+
+  test_that("a model with BOTH err rows and an ll() endpoint gets both in stage 2", {
+    ## The case a model-level "does this model have err parameters" short-circuit
+    ## would get wrong: `add.sd` is flagged err, `lsd` is the ll() endpoint's
+    ## log-density-only scale.  Both belong in stage 2; the structural thetas do
+    ## not.  Under an err-only rule `lsd` would silently stay in stage 1.
+    .mixMod <- function() {
+      ini({ lka <- 0.4; lcl <- -0.9; lb <- log(3); add.sd <- 1.2; lsd <- log(0.5)
+        eta.b ~ 0.1 })
+      model({
+        ka <- exp(lka); cl <- exp(lcl)
+        d / dt(depot) <- -ka * depot
+        d / dt(central) <- ka * depot - cl * central
+        cp <- central
+        cp ~ add(add.sd)
+        mu <- exp(lb + eta.b) * central
+        sd <- exp(lsd)
+        ll(ef) ~ -log(sd) - 0.5 * ((DV - mu) / sd)^2
+      })
+    }
+    ui <- rxode2::assertRxUi(.mixMod())
+    expect_true(sum(!is.na(ui$iniDf$err) & !is.na(ui$iniDf$ntheta)) > 0L)  # has err rows
+    expect_equal(.vaeRegressStage2(ui, c("lka", "lcl", "add.sd", "lsd"),
+                                   c(-1L, -1L, 0L, -1L)),
+                 c(0L, 0L, 1L, 1L))
+  })
+
+  test_that(".vaeDataPrep surfaces the stage-2 mask for an ll() model", {
+    ui <- rxode2::assertRxUi(.llMod())
+    d <- data.frame(ID = rep(1:3, each = 4), TIME = rep(c(1, 2, 4, 8), 3),
+                    DV = stats::rnorm(12, 5, 1), EVID = 0L, AMT = 0)
+    prep <- .vaeDataPrep(ui, d, vaeControl(nonMuTheta = "regress"))
+    expect_length(prep$a, 0L)                                # no err parameter
+    expect_equal(length(prep$regressStage2), length(prep$regressNames))
+    ## lsd is the only stage-2 parameter; every structural one stays in stage 1
+    expect_equal(prep$regressNames[prep$regressStage2 > 0L], "lsd")
+  })
 })

--- a/tests/testthat/test-vae-dataprep.R
+++ b/tests/testthat/test-vae-dataprep.R
@@ -133,6 +133,27 @@ nmTest({
                  c(FALSE, FALSE, TRUE))
   })
 
+  test_that("a linCmt() parameter is never called ODE-free", {
+    ## linCmt() solves PK compartments from parameters read by NAME, which the
+    ## assignment-graph scan cannot trace.  In a mixed linCmt() + ODE model the
+    ## PK thetas (tcl, tv) must NOT be reported ODE-free, or stage 2 would
+    ## optimize them against a frozen PK solve.
+    ui <- suppressWarnings(rxode2::assertRxUi(function() {
+      ini({ tcl <- 1.1; tv <- 3.9; te0 <- 2.3; tkout <- -2.3; prop.err <- 0.1
+        eta.e0 ~ 0.1 })
+      model({
+        cl <- exp(tcl); v <- exp(tv)
+        cp <- linCmt()
+        e0 <- exp(te0 + eta.e0); kout <- exp(tkout); kin <- e0 * kout
+        d / dt(pd) <- kin - kout * pd
+        pd ~ prop(prop.err)
+      })
+    }))
+    ## the whole model bails to "nothing ODE-free" -- conservative and safe
+    expect_equal(.vaeOdeFreeThetas(ui, c("tcl", "tv", "tkout")),
+                 c(FALSE, FALSE, FALSE))
+  })
+
   test_that("stage-2 eligibility keeps every err parameter", {
     ## the historic half of the rule: an err parameter is always stage 2, and a
     ## structural theta that reaches d/dt is not

--- a/tests/testthat/test-vae-dataprep.R
+++ b/tests/testthat/test-vae-dataprep.R
@@ -84,6 +84,55 @@ nmTest({
                  c(FALSE, FALSE, TRUE))
   })
 
+  ## Three ways a theta can reach the solve that a top-level, assignment-only
+  ## scan misses.  Each misclassified the theta as ODE-free -- the UNSAFE
+  ## direction, since stage 2 would then optimize it against a frozen solve.
+  test_that("a state_0 initial condition is a solve dependency", {
+    ui <- rxode2::assertRxUi(function() {
+      ini({ lcl <- -1; linit <- 1; lsd <- 0; eta.b ~ 0.1 })
+      model({
+        cl <- exp(lcl)
+        central_0 <- exp(linit)          # rxode2's other spelling of central(0)
+        d / dt(central) <- -cl * central
+        sd <- exp(lsd)
+        ll(cp) ~ -log(sd) - 0.5 * ((DV - central * exp(eta.b)) / sd)^2
+      })
+    })
+    expect_equal(.vaeOdeFreeThetas(ui, c("lcl", "linit", "lsd")),
+                 c(FALSE, FALSE, TRUE))
+  })
+
+  test_that("an assignment inside if/else is a solve dependency", {
+    ui <- rxode2::assertRxUi(function() {
+      ini({ lcl <- -1; lsd <- 0; eta.b ~ 0.1 })
+      model({
+        if (TIME > 0) { cl <- exp(lcl) } else { cl <- exp(lcl) }
+        d / dt(central) <- -cl * central
+        sd <- exp(lsd)
+        ll(cp) ~ -log(sd) - 0.5 * ((DV - central * exp(eta.b)) / sd)^2
+      })
+    })
+    expect_equal(.vaeOdeFreeThetas(ui, c("lcl", "lsd")), c(FALSE, TRUE))
+  })
+
+  test_that("a `~` defined variable feeding d/dt is a solve dependency", {
+    ## `conc` is both the endpoint variable and a d/dt input; skipping the `~`
+    ## line because the name is an endpoint would drop the edge to `lv`.
+    ui <- suppressWarnings(rxode2::assertRxUi(function() {
+      ini({ lk <- -1; lv <- 1; lsd <- 0; eta.b ~ 0.1 })
+      model({
+        k <- exp(lk); v <- exp(lv)
+        conc ~ central / v
+        d / dt(central) <- -k * central
+        d / dt(effect) <- 1 - conc * effect
+        sd <- exp(lsd)
+        ll(conc) ~ -log(sd) - 0.5 * ((DV - conc * exp(eta.b)) / sd)^2
+      })
+    }))
+    expect_equal(.vaeOdeFreeThetas(ui, c("lk", "lv", "lsd")),
+                 c(FALSE, FALSE, TRUE))
+  })
+
   test_that("stage-2 eligibility keeps every err parameter", {
     ## the historic half of the rule: an err parameter is always stage 2, and a
     ## structural theta that reaches d/dt is not

--- a/tests/testthat/test-vae-ll-grad-fit.R
+++ b/tests/testthat/test-vae-ll-grad-fit.R
@@ -1,14 +1,13 @@
 ## est="vae" with a log-likelihood endpoint: the two M-step gaps left open when
 ## the analytic fast=TRUE ll() gradient landed.
 ##
-## residOptimize="twoStage" stage 2 was gated on "has a slot in `a`", and an
-## ll() model has no error-parameter rows, so stage 2 never ran and "twoStage"
-## degraded to the joint "optimize" solve.  These fits assert stage 2 runs and
-## actually moves the log-density-only theta.
-##
-## (The nonMuTheta="grad" ll() fits that belong here are NOT present: that path is
-## gated off in .vaeGradInScope because the "grad" pool arrangement corrupts the
-## heap for an ll() model.  Add them when that is fixed.)
+## 1. nonMuTheta="grad" declined every ll() model -- .vaeGradInScope only probed
+##    the Gaussian (f,R) direction set -- so it silently ran the bobyqa
+##    regression instead.  These fits assert the gradient path is TAKEN.
+## 2. residOptimize="twoStage" stage 2 was gated on "has a slot in `a`", and an
+##    ll() model has no error-parameter rows, so stage 2 never ran and "twoStage"
+##    degraded to the joint "optimize" solve.  These fits assert stage 2 runs and
+##    actually moves the log-density-only theta.
 ##
 ## Fit-based and multi-iteration: weekly batch, not the push/PR subset.
 
@@ -48,6 +47,34 @@ nmTest({
                covariateSelection = FALSE, seed = 3L,
                itersBurnIn = 12L, iters = 34L, klWarmup = 6L, gammaIter = 24L, ...)
   }
+
+  test_that("nonMuTheta='grad' takes the gradient path on an ll() model", {
+    skip_on_cran()
+    .dat <- .mkDat()
+    .r <- suppressWarnings(suppressMessages(
+      nlmixr2(.llMod(), .dat, est = "vae", control = .ctl(nonMuTheta = "grad"))))
+    ## the mechanism assertion: without the scope widen this is 0 gradient calls
+    ## and the fit silently runs bobyqa instead
+    expect_true(.r$nRegGrad > 0L)
+    expect_true(all(is.finite(.r$regressTheta)))
+  })
+
+  test_that("'grad' and 'regress' agree on the same ll() model", {
+    skip_on_cran()
+    .dat <- .mkDat()
+    .g <- suppressWarnings(suppressMessages(
+      nlmixr2(.llMod(), .dat, est = "vae", control = .ctl(nonMuTheta = "grad"))))
+    .b <- suppressWarnings(suppressMessages(
+      nlmixr2(.llMod(), .dat, est = "vae", control = .ctl(nonMuTheta = "regress"))))
+    ## the two M-steps target different functionals (the gradient differentiates
+    ## the marginal Laplace objective, bobyqa optimizes the joint at frozen etas),
+    ## so this is an agreement band, not an identity
+    for (.n in names(.g$regressTheta)) {
+      expect_equal(unname(.g$regressTheta[[.n]]), unname(.b$regressTheta[[.n]]),
+                   tolerance = 0.25)
+    }
+    expect_equal(unname(.g$zPop), unname(.b$zPop), tolerance = 0.25)
+  })
 
   test_that("twoStage stage 2 runs and moves the log-density-only theta", {
     skip_on_cran()

--- a/tests/testthat/test-vae-ll-grad-fit.R
+++ b/tests/testthat/test-vae-ll-grad-fit.R
@@ -1,0 +1,93 @@
+## est="vae" with a log-likelihood endpoint: the two M-step gaps left open when
+## the analytic fast=TRUE ll() gradient landed.
+##
+## residOptimize="twoStage" stage 2 was gated on "has a slot in `a`", and an
+## ll() model has no error-parameter rows, so stage 2 never ran and "twoStage"
+## degraded to the joint "optimize" solve.  These fits assert stage 2 runs and
+## actually moves the log-density-only theta.
+##
+## (The nonMuTheta="grad" ll() fits that belong here are NOT present: that path is
+## gated off in .vaeGradInScope because the "grad" pool arrangement corrupts the
+## heap for an ll() model.  Add them when that is fixed.)
+##
+## Fit-based and multi-iteration: weekly batch, not the push/PR subset.
+
+nmTest({
+  ## Gaussian likelihood written out as ll(), which makes lsd a PLAIN theta
+  ## (no `err` row) that appears ONLY in the log-density -- the stage-2 case.
+  ## lka/lcl feed d/dt, so they stay in stage 1.
+  .llMod <- function() {
+    ini({ lka <- 0.4; lcl <- -0.9; lb <- log(3); lsd <- log(1.2); eta.b ~ 0.1 })
+    model({
+      ka <- exp(lka); cl <- exp(lcl)
+      d / dt(depot) <- -ka * depot
+      d / dt(central) <- ka * depot - cl * central
+      mu <- exp(lb + eta.b) * central
+      sd <- exp(lsd)
+      ll(cp) ~ -0.5 * log(2 * pi) - log(sd) - 0.5 * ((DV - mu) / sd)^2
+    })
+  }
+
+  .mkDat <- function(seed = 7L, N = 24L) {
+    .testSeed(seed)
+    .t <- c(0.5, 1, 2, 4, 6, 8, 12, 24)
+    do.call(rbind, lapply(seq_len(N), function(i) {
+      .e <- data.frame(ID = i, TIME = 0, DV = NA_real_, EVID = 1, AMT = 100)
+      .b <- exp(log(3) + stats::rnorm(1, 0, 0.3))
+      .ka <- exp(0.4); .cl <- exp(-0.9)
+      .cen <- 100 * .ka / (.ka - .cl) * (exp(-.cl * .t) - exp(-.ka * .t))
+      .o <- data.frame(ID = i, TIME = .t,
+                       DV = .b * .cen + stats::rnorm(length(.t), 0, 1.2),
+                       EVID = 0, AMT = 0)
+      rbind(.e, .o)
+    }))
+  }
+
+  .ctl <- function(...) {
+    vaeControl(print = 0L, calcTables = FALSE, returnVae = TRUE,
+               covariateSelection = FALSE, seed = 3L,
+               itersBurnIn = 12L, iters = 34L, klWarmup = 6L, gammaIter = 24L, ...)
+  }
+
+  test_that("twoStage stage 2 runs and moves the log-density-only theta", {
+    skip_on_cran()
+    .dat <- .mkDat()
+    .r <- suppressWarnings(suppressMessages(
+      nlmixr2(.llMod(), .dat, est = "vae",
+              control = .ctl(nonMuTheta = "regress", residOptimize = "twoStage"))))
+    ## the mechanism assertion: stage 2 was entered.  Before the eligibility
+    ## generalization an ll() model had NO stage-2 parameter, so this was 0 and
+    ## "twoStage" was indistinguishable from the joint "optimize" solve.
+    expect_true(.r$nStage2 > 0L)
+    ## and it actually moved lsd off its ini() value, toward the simulated 1.2
+    expect_false(isTRUE(all.equal(unname(.r$regressTheta[["lsd"]]), log(1.2),
+                                  tolerance = 1e-8)))
+    expect_lt(abs(.r$regressTheta[["lsd"]] - log(1.2)), 0.6)
+    ## the structural thetas stayed in stage 1 and are still sane
+    expect_true(all(is.finite(.r$regressTheta[c("lka", "lcl")])))
+  })
+
+  test_that("a Gaussian twoStage fit is unchanged by the eligibility rule", {
+    skip_on_cran()
+    ## regression guard for the reclassification: an err parameter is stage 2 and
+    ## a structural theta that reaches d/dt is not -- exactly as before.
+    .gMod <- function() {
+      ini({ tka <- 0.45; tcl <- 1; tv <- c(2, 3.45, 5); add.sd <- c(0, 0.7, 5)
+        eta.ka ~ 0.6; eta.cl ~ 0.3 })
+      model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+        d / dt(depot) <- -ka * depot
+        d / dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd) })
+    }
+    .ui <- rxode2::assertRxUi(.gMod())
+    ## tv is structural (feeds d/dt through v) and add.sd is the error param
+    expect_equal(.vaeRegressStage2(.ui, c("tv", "add.sd"), c(-1L, 0L)),
+                 c(0L, 1L))
+    .r <- suppressWarnings(suppressMessages(
+      nlmixr2(.gMod(), nlmixr2data::theo_sd, est = "vae",
+              control = .ctl(nonMuTheta = "regress", residOptimize = "twoStage"))))
+    expect_true(.r$nStage2 > 0L)
+    expect_true(is.finite(.r$a[["add.sd"]]))
+  })
+})

--- a/tests/testthat/test-vae-nonmutheta-grad.R
+++ b/tests/testthat/test-vae-nonmutheta-grad.R
@@ -71,22 +71,33 @@ nmTest({
     expect_false(.vaeGradInScope(rxode2::assertRxUi(.linMod())))
   })
 
-  test_that("the ll() gradient pieces are ready but the vae probe still declines", {
+  test_that("scope probe accepts an ll() model through the log-density set", {
     ui <- rxode2::assertRxUi(.llMod())
     ## the Gaussian (f,R) direction builder declines -- ErrFull is norm-only ...
     expect_null(.foceiOuterDirs(ui, "vae"))
-    ## ... while the log-density route is fully built: scope gate, direction set,
-    ## and the caller policy all accept this model
+    ## ... and the log-density route is what makes it in scope
     expect_true(.foceiLLGradInScope(ui, "vae"))
     expect_false(is.null(.foceiOuterDirsLL(ui)))
-    ## but the vae probe MUST still decline: nonMuTheta="grad" sizes the shared
-    ## solve pool with the augmented model and pins the inner MAP under
-    ## neqOverride, and that arrangement corrupts the heap for an ll() model (the
-    ## same fit is clean under "regress").  Until vaeInnerSetup_ is fixed,
-    ## accepting it here would be a segfault, not a feature.  Flip this assertion
-    ## and re-enable the ll() branch of .vaeGradInScope together.
-    expect_false(.vaeGradInScope(ui))
+    expect_true(.vaeGradInScope(ui))
+    ## an ll() linCmt() model is still out of scope on both routes
     expect_false(.vaeGradInScope(rxode2::assertRxUi(.linMod())))
+  })
+
+  test_that("an ll() inner problem pairs needOptimHess with interaction=0", {
+    ## A non-Gaussian endpoint has no eta-epsilon interaction term (rx_pred_ IS
+    ## the log-density).  The focei flow forces interaction=0 alongside
+    ## needOptimHess; .vaeInnerSetup must too.  Leaving interaction=1 set the
+    ## inner problem up for the (f,R) kernel while the objective ran the
+    ## exact-Hessian one, which wrote past the end of inds_focei.
+    ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(.llMod()))
+    ctl <- vaeControl(nonMuTheta = "grad", print = 0L, covariateSelection = FALSE)
+    d <- data.frame(ID = rep(1:2, each = 3), TIME = rep(c(1, 4, 12), 2),
+                    DV = c(20, 30, 15, 22, 28, 16), EVID = 0L, AMT = 0)
+    prep <- .vaeDataPrep(ui, d, ctl)
+    env <- .vaeInnerSetup(ui, d, matrix(0, prep$N, prep$zDim), ctl)
+    on.exit(.vaeInnerFree(), add = TRUE)
+    expect_true(env$control$needOptimHess)
+    expect_equal(env$control$interaction, 0L)
   })
 
   test_that("the ll() bounded-transform gate follows the caller policy", {

--- a/tests/testthat/test-vae-nonmutheta-grad.R
+++ b/tests/testthat/test-vae-nonmutheta-grad.R
@@ -16,6 +16,19 @@ nmTest({
       cp <- center / v
       cp ~ add(add.sd) })
   }
+  ## a log-likelihood endpoint: no `err` rows at all, so `lsd` is a PLAIN theta
+  ## reachable only from the log-density.  lka/lcl feed d/dt.
+  .llMod <- function() {
+    ini({ lka <- 0.4; lcl <- -0.9; lb <- log(3); lsd <- log(1.2); eta.b ~ 0.1 })
+    model({
+      ka <- exp(lka); cl <- exp(lcl)
+      d / dt(depot) <- -ka * depot
+      d / dt(central) <- ka * depot - cl * central
+      mu <- exp(lb + eta.b) * central
+      sd <- exp(lsd)
+      ll(cp) ~ -0.5 * log(2 * pi) - log(sd) - 0.5 * ((DV - mu) / sd)^2
+    })
+  }
   ## same model through linCmt(): no symbolic state sensitivities -> out of scope
   .linMod <- function() {
     ini({ tka <- 0.45; tcl <- 1; tv <- c(2, 3.45, 5); add.sd <- c(0, 0.7, 5)
@@ -56,6 +69,33 @@ nmTest({
   test_that("scope probe accepts an ODE model and rejects linCmt()", {
     expect_true(.vaeGradInScope(rxode2::assertRxUi(.odeMod())))
     expect_false(.vaeGradInScope(rxode2::assertRxUi(.linMod())))
+  })
+
+  test_that("the ll() gradient pieces are ready but the vae probe still declines", {
+    ui <- rxode2::assertRxUi(.llMod())
+    ## the Gaussian (f,R) direction builder declines -- ErrFull is norm-only ...
+    expect_null(.foceiOuterDirs(ui, "vae"))
+    ## ... while the log-density route is fully built: scope gate, direction set,
+    ## and the caller policy all accept this model
+    expect_true(.foceiLLGradInScope(ui, "vae"))
+    expect_false(is.null(.foceiOuterDirsLL(ui)))
+    ## but the vae probe MUST still decline: nonMuTheta="grad" sizes the shared
+    ## solve pool with the augmented model and pins the inner MAP under
+    ## neqOverride, and that arrangement corrupts the heap for an ll() model (the
+    ## same fit is clean under "regress").  Until vaeInnerSetup_ is fixed,
+    ## accepting it here would be a segfault, not a feature.  Flip this assertion
+    ## and re-enable the ll() branch of .vaeGradInScope together.
+    expect_false(.vaeGradInScope(ui))
+    expect_false(.vaeGradInScope(rxode2::assertRxUi(.linMod())))
+  })
+
+  test_that("the ll() bounded-transform gate follows the caller policy", {
+    ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(.llMod()))
+    ui$boundedTransforms <- list(list(name = "lsd"))
+    ## focei reports a natural-scale gradient (needs a Jacobian correction it does
+    ## not apply); the vae consumes the unconstrained scale it steps on
+    expect_false(.foceiLLGradInScope(ui, "focei"))
+    expect_true(.foceiLLGradInScope(ui, "vae"))
   })
 
   test_that("vaeControl accepts mStepObjective and defaults to 'outer'", {


### PR DESCRIPTION
## Summary

Closes the two `est="vae"` M-step gaps left open when the analytic `fast=TRUE`
`ll()` gradient landed (#807). Along the way this fixes a memory-corruption bug
in the FOCEi inner setup that is not specific to this feature.

## 1. `nonMuTheta="grad"` declined every `ll()` model

`.vaeGradInScope()` only probed the Gaussian `(f,R)` direction set, so a
log-likelihood or generalized endpoint silently fell back to the bobyqa
regression. Everything below the scope gate was already wired --
`.foceiAnalyticGradSetup` returns `ef$isLL` and `.foceiAnalyticGradCore` routes
on it -- so the gate now also accepts a single non-Gaussian endpoint through the
log-density direction set.

`.foceiLLGradInScope()` gained a `caller` argument so the bounded-transform gate
follows the same per-caller policy the Gaussian path uses (focei must bail, the
VAE need not). `.vaeGradEval` now passes `startedEnv` so the `ll()` core reuses
the cheaper eta-only second-order model instead of re-resolving it and solving
the full outer model `2*(nth+nom)` times per M-step.

## 2. `residOptimize="twoStage"` never engaged for `ll()`

Stage-2 eligibility was "the parameter has a slot in the error-parameter vector
`a`". An `ll()`/generalized model has no `err` rows at all, so stage 2 was always
empty and `"twoStage"` silently behaved like the experimental joint `"optimize"`
solve -- `residOptimize` was effectively inert for those models.

Eligibility is now decided **per parameter**: an `err` parameter (the historic
rule, unchanged), **or** a parameter no `d/dt()` right-hand side, initial
condition or dosing modifier can reach. A model-level "does this model have `err`
rows" short-circuit would be wrong -- a multi-endpoint model with one Gaussian
and one `ll()` endpoint has `err` rows *and* log-density-only thetas, and both
belong in stage 2.

`gVaeFreezeObjR` also gained the theta write path it lacked: it substituted
candidates only into `a`, so a plain `ll()` theta left the objective flat and
bobyqa never moved it. A new `nStage2` counter surfaces that stage 2 actually
ran.

The ODE-invariance scan is deliberately conservative: an unparsable model, or one
with no ODE states to pin, contributes nothing beyond the `err` set. Only `~`
endpoint lines are skipped -- a `<-` definition is never skipped, because
`conc <- central/v` can feed a `d/dt()` *and* be the endpoint variable, and
dropping it would call `lv` ODE-free and optimize it against a frozen solve.
There is a test for exactly that case.

## 3. Memory fix (not specific to this feature)

Enabling the `ll()` gradient segfaulted. The symptom pointed nowhere near the
cause -- R aborting inside its own byte-compiler on entry to
`.foceiAnalyticGradCore`. Bisecting ruled out the pooled column layout, the
`dH/dtheta` batch, and the gradient entirely (it still faulted with the gradient
never invoked, while a Gaussian model with the same single eta and the same pool
was clean).

AddressSanitizer did **not** reproduce it -- it instruments this package but not
rxode2, and its redzones absorbed the write. Valgrind named it exactly: an
invalid write in `vaeInnerUpdateParCore`, past the end of `inds_focei`.

Two fixes, each correct on its own merits:

- `.vaeInnerSetup` now pairs `needOptimHess` with `interaction = 0`, which is
  what the focei flow (`.foceiFitInternal`) has always done: a non-Gaussian
  endpoint has no eta-epsilon interaction term because `rx_pred_` **is** the
  log-density. Leaving `interaction = 1` set the inner problem up for the `(f,R)`
  kernel while the objective ran the exact-Hessian one.
- `inds_focei`'s slot count is recorded in `nIndsFocei` at both allocation sites
  and the loop is bounded by it, instead of by a freshly-read
  `getRxNsubAndMix(rx)`. The two allocation sites use **different** counts
  (`getRxNsub` vs `getRxNsubAndMix`), and the global `rx` a later caller reads is
  not necessarily the solve `inds_focei` was sized against -- so this class of
  overflow can no longer happen silently. This is hardening of pre-existing code:
  that loop was one mismatched solve away from corrupting memory in any caller,
  not only the `ll()` VAE path.

Also resets `predHess2Offset`/`hess2Neq`/`hess2Nlhs` on the `vaeInnerSetup_`
entry: `op_focei` persists across fits and this path never loads `rxHess2`, so a
stale offset from an earlier focei `ll()` `fast=TRUE` fit would send
`calcEtaHessian` into the exact-Hessian branch against a model that is not
loaded.

## Testing

- `test-vae-nonmutheta-grad.R` (essential): `ll()` scope probes, the caller
  policy for bounded transforms, and a unit test pinning the
  `needOptimHess`/`interaction=0` pairing.
- `test-vae-dataprep.R` (essential): the ODE-invariance scan, the endpoint-name
  trap case, per-parameter stage-2 eligibility, and the multi-endpoint
  Gaussian + `ll()` case.
- `test-vae-ll-grad-fit.R` (new, weekly batch 6): four fits -- `grad` takes the
  gradient path (`nRegGrad > 0`), `grad` and `regress` agree, `twoStage` stage 2
  runs (`nStage2 > 0`) and moves the log-density-only theta, and a Gaussian
  `twoStage` fit still behaves.

These are exercised fits with mechanism assertions, not value-only checks: a
silent fallback to bobyqa, or a stage 2 that never runs, would otherwise pass.

Verified locally: `test-vae-nonmutheta-grad`, `test-vae-ll-grad-fit`,
`test-vae-dataprep` and `test-vae-residopt` all pass. The repro that used to
segfault now runs to completion under valgrind with **zero invalid reads/writes**
(three invalid writes at `vaeInnerUpdateParCore` before the fix); the remaining
valgrind output is uninitialised-value noise from R/BLAS with no R suppression
file, and no invalid access in any of its 519 contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaX5jsK9yobGAVF4JWZ6yV
