### PR TITLE
feat(vae): L0Learn-accelerated covariate selection for large candidate sets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,7 +84,8 @@ Suggests:
     rmarkdown,
     rlang,
     numDeriv,
-    rstan
+    rstan,
+    L0Learn
 LinkingTo:
     BH,
     n1qn1 (>= 6.0.1-12),

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,8 @@
   runs one per dimension per iteration).  With the suggested `L0Learn` package
   installed, `covSelectMethod="auto"` (the default) has `L0Learn` propose
   candidate supports for any latent dimension holding at least
-  `covSelectMaxExact` (25) candidates, counted after `pinCovariates` trimming.
+  `covSelectMaxExact` (default 17, the measured wall-clock crossover) candidates,
+  counted after `pinCovariates` trimming.
   Those are candidates only: each is scored with the same exact
   `RSS/omega + penalty*|S|` objective, the same OLS and the same tie-break the
   branch-and-bound uses, then improved by an add/drop/swap local search -- so

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,8 +15,10 @@
   `RSS/omega + penalty*|S|` objective, the same OLS and the same tie-break the
   branch-and-bound uses, then improved by an add/drop/swap local search -- so
   `L0Learn`'s own objective and scaling cannot shift a selection.  Below the
-  threshold, and whenever `L0Learn` is not installed, the search stays exact and
-  unchanged.  A fit that used the approximate search says so in `$runInfo` and
+  threshold the search stays exact and unchanged.  When the exact search would be
+  impractical but `L0Learn` is not installed, the fit errors rather than run it
+  silently; `covSelectMaxExact = Inf` forces the exact branch-and-bound
+  everywhere.  A fit that used the approximate search says so in `$runInfo` and
   records it in `fit$vae$covSelectMethodUsed`.
 
 - `est="vae"` gains `vaeControl(nonMuTheta="grad")`, which estimates a structural

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,22 @@
 
 ## New features
 
+- `est="vae"` gains `vaeControl(covSelectMethod=)` and
+  `vaeControl(covSelectMaxExact=)`, which make covariate selection practical on
+  large candidate sets.  The exact branch-and-bound blows up past a few dozen
+  covariates (a single 30-covariate latent dimension takes ~43s, and the M-step
+  runs one per dimension per iteration).  With the suggested `L0Learn` package
+  installed, `covSelectMethod="auto"` (the default) has `L0Learn` propose
+  candidate supports for any latent dimension holding at least
+  `covSelectMaxExact` (25) candidates, counted after `pinCovariates` trimming.
+  Those are candidates only: each is scored with the same exact
+  `RSS/omega + penalty*|S|` objective, the same OLS and the same tie-break the
+  branch-and-bound uses, then improved by an add/drop/swap local search -- so
+  `L0Learn`'s own objective and scaling cannot shift a selection.  Below the
+  threshold, and whenever `L0Learn` is not installed, the search stays exact and
+  unchanged.  A fit that used the approximate search says so in `$runInfo` and
+  records it in `fit$vae$covSelectMethodUsed`.
+
 - `est="vae"` gains `vaeControl(nonMuTheta="grad")`, which estimates a structural
   population `theta` with no random effect using the exact analytic outer
   gradient (the machinery behind `foceiControl(fast=TRUE)`) rather than the

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -297,6 +297,10 @@ vaeBestSubset_ <- function(mu, covMat, omega, isFree, penaltyPerCov, strategy = 
     .Call(`_nlmixr2est_vaeBestSubset_`, mu, covMat, omega, isFree, penaltyPerCov, strategy)
 }
 
+vaeScoreSupports_ <- function(y, covMat, omega, penaltyPerCov, supports, polish = TRUE) {
+    .Call(`_nlmixr2est_vaeScoreSupports_`, y, covMat, omega, penaltyPerCov, supports, polish)
+}
+
 boxCox_ <- function(x = 1L, lambda = 1, yj = 0L) {
     .Call(`_nlmixr2est_boxCox_`, x, lambda, yj)
 }

--- a/R/vae.R
+++ b/R/vae.R
@@ -396,9 +396,13 @@ vaeControl <- function(seed = 42L,
   covSelectMethod <- match.arg(covSelectMethod)
   ## Inf is allowed: it forces the exact branch-and-bound everywhere (the
   ## threshold is never reached), so keep it numeric rather than coercing (which
-  ## would make it NA)
+  ## would make it NA).  A finite value must be a whole number -- reject 17.9
+  ## rather than silently truncating it to 17.
   checkmate::assertNumeric(covSelectMaxExact, lower = 1, len = 1, any.missing = FALSE)
-  if (is.finite(covSelectMaxExact)) covSelectMaxExact <- as.integer(covSelectMaxExact)
+  if (is.finite(covSelectMaxExact)) {
+    checkmate::assertIntegerish(covSelectMaxExact, lower = 1, len = 1, any.missing = FALSE)
+    covSelectMaxExact <- as.integer(covSelectMaxExact)
+  }
   bnbStrategy <- match.arg(bnbStrategy)
   checkmate::assertLogical(parEncoderBackward, len = 1, any.missing = FALSE)
   nonMuTheta <- match.arg(nonMuTheta)

--- a/R/vae.R
+++ b/R/vae.R
@@ -236,6 +236,17 @@
 #'   scale from `"observed"`, which uses only the observed values (on the neonatal
 #'   case study the SD is 1582 against 506).  Affects only the encoder's inputs,
 #'   never the likelihood.
+#' @param covSelectMethod How the covariate M-step searches subsets.  `"bnb"` is
+#'   the exact branch-and-bound; it becomes impractical past a few dozen candidate
+#'   covariates.  `"l0learn"` has the suggested `L0Learn` package propose supports,
+#'   which are then scored and polished with the same exact objective -- so the
+#'   search is approximate but the scoring is not.  `"auto"` (default) uses
+#'   `"l0learn"` for a latent dimension with at least `covSelectMaxExact` candidate
+#'   covariates and `"bnb"` otherwise; without `L0Learn` installed it stays exact
+#'   and warns.
+#' @param covSelectMaxExact Candidate-covariate count at or above which
+#'   `covSelectMethod = "auto"` switches a latent dimension to `L0Learn`.  Counted
+#'   after `pinCovariates` trimming, so it is the size of the search actually run.
 #' @param bnbStrategy Frontier discipline for the exact branch-and-bound covariate
 #'   selection: `"lifo"` (default, last-in-first-out depth-first search),
 #'   `"fifo"` (first-in-first-out) or `"lc"` (least cost / best-first).  The
@@ -317,6 +328,8 @@ vaeControl <- function(seed = 42L,
                        residRhoend = NULL,
                        omegaUpdate = c("suffStat", "blend"),
                        inputScale = c("reference", "observed"),
+                       covSelectMethod = c("auto", "bnb", "l0learn"),
+                       covSelectMaxExact = 25L,
                        bnbStrategy = c("lifo", "fifo", "lc"),
                        parEncoderBackward = !isTRUE(getOption("nlmixr2.identical", FALSE)),
                        nonMuTheta = c("regress", "grad", "eta", "fix", "none"),
@@ -375,6 +388,9 @@ vaeControl <- function(seed = 42L,
   residOptimize <- match.arg(residOptimize)
   omegaUpdate <- match.arg(omegaUpdate)
   inputScale <- match.arg(inputScale)
+  covSelectMethod <- match.arg(covSelectMethod)
+  checkmate::assertIntegerish(covSelectMaxExact, lower = 1, len = 1, any.missing = FALSE)
+  covSelectMaxExact <- as.integer(covSelectMaxExact)
   bnbStrategy <- match.arg(bnbStrategy)
   checkmate::assertLogical(parEncoderBackward, len = 1, any.missing = FALSE)
   nonMuTheta <- match.arg(nonMuTheta)
@@ -480,6 +496,8 @@ vaeControl <- function(seed = 42L,
                residOptimize = residOptimize,
                omegaUpdate = omegaUpdate,
                inputScale = inputScale,
+               covSelectMethod = covSelectMethod,
+               covSelectMaxExact = covSelectMaxExact,
                bnbStrategy = bnbStrategy,
                parEncoderBackward = parEncoderBackward,
                nonMuTheta = nonMuTheta,

--- a/R/vae.R
+++ b/R/vae.R
@@ -242,12 +242,16 @@
 #'   which are then scored and polished with the same exact objective -- so the
 #'   search is approximate but the scoring is not.  `"auto"` (default) uses
 #'   `"l0learn"` for a latent dimension with at least `covSelectMaxExact` candidate
-#'   covariates and `"bnb"` otherwise; without `L0Learn` installed it stays exact
-#'   and warns.
+#'   covariates and `"bnb"` otherwise.  If `L0Learn` is not installed when the
+#'   exact search would be impractical (`"auto"` at or over the threshold, or an
+#'   explicit `"l0learn"`) this errors rather than run the slow exact search
+#'   silently; install `L0Learn`, or set `covSelectMaxExact = Inf` to force the
+#'   exact search everywhere.
 #' @param covSelectMaxExact Candidate-covariate count at or above which
 #'   `covSelectMethod = "auto"` switches a latent dimension to `L0Learn` (default
 #'   `17`, the measured wall-clock crossover).  Counted after `pinCovariates`
-#'   trimming, so it is the size of the search actually run.
+#'   trimming, so it is the size of the search actually run.  `Inf` forces the
+#'   exact branch-and-bound for every dimension.
 #' @param bnbStrategy Frontier discipline for the exact branch-and-bound covariate
 #'   selection: `"lifo"` (default, last-in-first-out depth-first search),
 #'   `"fifo"` (first-in-first-out) or `"lc"` (least cost / best-first).  The
@@ -390,8 +394,11 @@ vaeControl <- function(seed = 42L,
   omegaUpdate <- match.arg(omegaUpdate)
   inputScale <- match.arg(inputScale)
   covSelectMethod <- match.arg(covSelectMethod)
-  checkmate::assertIntegerish(covSelectMaxExact, lower = 1, len = 1, any.missing = FALSE)
-  covSelectMaxExact <- as.integer(covSelectMaxExact)
+  ## Inf is allowed: it forces the exact branch-and-bound everywhere (the
+  ## threshold is never reached), so keep it numeric rather than coercing (which
+  ## would make it NA)
+  checkmate::assertNumeric(covSelectMaxExact, lower = 1, len = 1, any.missing = FALSE)
+  if (is.finite(covSelectMaxExact)) covSelectMaxExact <- as.integer(covSelectMaxExact)
   bnbStrategy <- match.arg(bnbStrategy)
   checkmate::assertLogical(parEncoderBackward, len = 1, any.missing = FALSE)
   nonMuTheta <- match.arg(nonMuTheta)

--- a/R/vae.R
+++ b/R/vae.R
@@ -245,8 +245,9 @@
 #'   covariates and `"bnb"` otherwise; without `L0Learn` installed it stays exact
 #'   and warns.
 #' @param covSelectMaxExact Candidate-covariate count at or above which
-#'   `covSelectMethod = "auto"` switches a latent dimension to `L0Learn`.  Counted
-#'   after `pinCovariates` trimming, so it is the size of the search actually run.
+#'   `covSelectMethod = "auto"` switches a latent dimension to `L0Learn` (default
+#'   `17`, the measured wall-clock crossover).  Counted after `pinCovariates`
+#'   trimming, so it is the size of the search actually run.
 #' @param bnbStrategy Frontier discipline for the exact branch-and-bound covariate
 #'   selection: `"lifo"` (default, last-in-first-out depth-first search),
 #'   `"fifo"` (first-in-first-out) or `"lc"` (least cost / best-first).  The
@@ -329,7 +330,7 @@ vaeControl <- function(seed = 42L,
                        omegaUpdate = c("suffStat", "blend"),
                        inputScale = c("reference", "observed"),
                        covSelectMethod = c("auto", "bnb", "l0learn"),
-                       covSelectMaxExact = 25L,
+                       covSelectMaxExact = 17L,
                        bnbStrategy = c("lifo", "fifo", "lc"),
                        parEncoderBackward = !isTRUE(getOption("nlmixr2.identical", FALSE)),
                        nonMuTheta = c("regress", "grad", "eta", "fix", "none"),

--- a/R/vaeCovSelectL0.R
+++ b/R/vaeCovSelectL0.R
@@ -69,17 +69,22 @@
   .mode <- integer(length(nCand))
   if (.method == "l0learn") {
     if (!.avail) {
-      stop("covSelectMethod=\"l0learn\" needs the L0Learn package; install it",
-           call. = FALSE)
+      stop("covSelectMethod=\"l0learn\" needs the L0Learn package; install it ",
+           "or use covSelectMethod=\"bnb\"", call. = FALSE)
     }
     .mode[nCand > 0L] <- 1L
   } else if (.method == "auto") {
-    .big <- nCand >= as.integer(control$covSelectMaxExact)
+    # covSelectMaxExact may be Inf (force the exact search everywhere), so compare
+    # against the raw value rather than coercing it to integer (as.integer(Inf) is
+    # NA).  At/over the threshold the exact search is impractical, so a missing
+    # L0Learn is an error, not a silent slow fallback.
+    .big <- nCand >= control$covSelectMaxExact
     if (any(.big)) {
       if (.avail) {
         .mode[.big] <- 1L
       } else {
-        .msg <- c(.msg, "exact covariate search is slow here; install L0Learn")
+        stop("covariate search needs L0Learn; install it, or force the exact ",
+             "search with covSelectMaxExact=Inf", call. = FALSE)
       }
     }
   }

--- a/R/vaeCovSelectL0.R
+++ b/R/vaeCovSelectL0.R
@@ -100,16 +100,14 @@
 #' @param allowed list of 0-based allowed covariate columns per dimension, or
 #'   `NULL` when every covariate is a candidate
 #' @return list of length `ncol(y)`; each element is a list of candidate supports
-#'   as 0-based GLOBAL covariate indices, or `NULL` for a branch-and-bound
-#'   dimension
+#'   indexed into that dimension's REDUCED design (the caller already maps those
+#'   back to global covariate columns), or `NULL` for a branch-and-bound dimension
 #' @noRd
 .vaeL0Candidates <- function(y, covMat, mode, allowed = NULL) {
   lapply(seq_len(ncol(y)), function(k) {
     if (mode[k] != 1L) return(NULL)
     .cols <- if (is.null(allowed)) seq_len(ncol(covMat)) - 1L else allowed[[k]]
     if (!length(.cols)) return(list(integer(0)))
-    .sup <- .vaeL0Supports(covMat[, .cols + 1L, drop = FALSE], y[, k])
-    # map the reduced-design indices back to global covariate columns
-    lapply(.sup, function(s) as.integer(.cols[s + 1L]))
+    .vaeL0Supports(covMat[, .cols + 1L, drop = FALSE], y[, k])
   })
 }

--- a/R/vaeCovSelectL0.R
+++ b/R/vaeCovSelectL0.R
@@ -1,0 +1,115 @@
+# L0Learn-backed candidate generation for the VAE covariate M-step.  This is the
+# ONLY file that names L0Learn: it produces CANDIDATE supports, which the C++
+# kernel then re-scores with the exact objective RSS_S/omega + penalty*|S| and
+# polishes.  L0Learn therefore cannot shift a selection through its own internal
+# scaling or lambda grid -- it only decides which subsets get looked at.
+
+#' Is the suggested L0Learn package usable?
+#' @return `TRUE` when `L0Learn` can be loaded
+#' @noRd
+.vaeL0Available <- function() {
+  requireNamespace("L0Learn", quietly = TRUE)
+}
+
+#' Distinct supports visited on one L0Learn regularization path.
+#' @param x covariate matrix (no intercept column)
+#' @param y response vector
+#' @param penalty `"L0"` or `"L0L2"`
+#' @return list of ascending 0-based integer vectors (empty list on failure)
+#' @noRd
+.vaeL0Path <- function(x, y, penalty) {
+  .f <- tryCatch(suppressWarnings(
+    L0Learn::L0Learn.fit(x, y, penalty = penalty, algorithm = "CDPSI",
+                         maxSuppSize = ncol(x))),
+    error = function(e) NULL)
+  if (is.null(.f) || !length(.f$beta)) return(list())
+  # beta is one p x nLambda sparse matrix per gamma; each column is one support
+  unlist(lapply(.f$beta, function(b) {
+    b <- as.matrix(b)
+    lapply(seq_len(ncol(b)), function(j) which(b[, j] != 0) - 1L)
+  }), recursive = FALSE)
+}
+
+#' Candidate supports for one latent dimension.
+#'
+#' Pools the `L0` and `L0L2` paths -- `L0L2` is the reliable one on correlated
+#' designs, which is the pharmacometric norm.  Extra candidates can only improve
+#' the answer because the caller re-scores every one of them.
+#' @param x covariate matrix (no intercept column)
+#' @param y response vector
+#' @return list of ascending 0-based integer vectors, always including the empty
+#'   support so the intercept-only model is never lost
+#' @noRd
+.vaeL0Supports <- function(x, y) {
+  .empty <- list(integer(0))
+  if (!is.matrix(x) || ncol(x) == 0L || nrow(x) < 3L) return(.empty)
+  if (!all(is.finite(x)) || !all(is.finite(y))) return(.empty)
+  .all <- c(.empty, .vaeL0Path(x, y, "L0"), .vaeL0Path(x, y, "L0L2"))
+  .all[!duplicated(vapply(.all, paste, character(1), collapse = ","))]
+}
+
+#' Resolve the per-latent-dimension covariate-selection mode.
+#'
+#' Pure: it emits nothing.  The caller raises the returned messages so they land
+#' in the fit's `$runInfo`, which is how run-time notes reach the user.
+#' @param nCand integer vector of candidate covariate counts, one per latent
+#'   dimension (after `pinCovariates` trimming -- the real search size)
+#' @param control a `vaeControl()` list
+#' @param avail is L0Learn usable (an argument so the fallback branches are
+#'   testable without installing/uninstalling the package)
+#' @return list with `mode` (0 = exact branch-and-bound, 1 = L0Learn per
+#'   dimension), `used` (`"bnb"`, `"l0learn"` or `"mixed"`) and `msg`
+#' @noRd
+.vaeCovSelectModes <- function(nCand, control, avail = .vaeL0Available()) {
+  nCand <- as.integer(nCand)
+  .method <- control$covSelectMethod
+  if (is.null(.method)) .method <- "auto"
+  .avail <- avail
+  .msg <- character(0)
+  .mode <- integer(length(nCand))
+  if (.method == "l0learn") {
+    if (!.avail) {
+      stop("covSelectMethod=\"l0learn\" needs the L0Learn package; install it",
+           call. = FALSE)
+    }
+    .mode[nCand > 0L] <- 1L
+  } else if (.method == "auto") {
+    .big <- nCand >= as.integer(control$covSelectMaxExact)
+    if (any(.big)) {
+      if (.avail) {
+        .mode[.big] <- 1L
+      } else {
+        .msg <- c(.msg, "exact covariate search is slow here; install L0Learn")
+      }
+    }
+  }
+  .used <- if (all(.mode == 1L)) "l0learn" else if (any(.mode == 1L)) "mixed" else "bnb"
+  if (.used != "bnb") {
+    .msg <- c(.msg, "covariate search used L0Learn, not the exact search")
+  }
+  list(mode = .mode, used = .used, msg = .msg)
+}
+
+#' Candidate generator handed to the C++ M-step.
+#'
+#' Called ONCE per training iteration on the main thread (an `Rcpp::Function`
+#' cannot be called from inside the OpenMP loop that scores the candidates).
+#' @param y response matrix, one column per latent dimension
+#' @param covMat covariate design (no intercept column)
+#' @param mode per-dimension mode from [.vaeCovSelectModes()]
+#' @param allowed list of 0-based allowed covariate columns per dimension, or
+#'   `NULL` when every covariate is a candidate
+#' @return list of length `ncol(y)`; each element is a list of candidate supports
+#'   as 0-based GLOBAL covariate indices, or `NULL` for a branch-and-bound
+#'   dimension
+#' @noRd
+.vaeL0Candidates <- function(y, covMat, mode, allowed = NULL) {
+  lapply(seq_len(ncol(y)), function(k) {
+    if (mode[k] != 1L) return(NULL)
+    .cols <- if (is.null(allowed)) seq_len(ncol(covMat)) - 1L else allowed[[k]]
+    if (!length(.cols)) return(list(integer(0)))
+    .sup <- .vaeL0Supports(covMat[, .cols + 1L, drop = FALSE], y[, k])
+    # map the reduced-design indices back to global covariate columns
+    lapply(.sup, function(s) as.integer(.cols[s + 1L]))
+  })
+}

--- a/R/vaeFit.R
+++ b/R/vaeFit.R
@@ -228,6 +228,32 @@
     prepC$covAllow <- matrix(as.integer(prep$covAllow), prep$zDim, ncol(prep$covMat))
   }
 
+  ## covSelectMethod: pick the search per latent dimension from the number of
+  ## candidates that dimension actually has (after any pinCovariates trimming),
+  ## then hand the C++ M-step a closure proposing supports for the L0Learn
+  ## dimensions.  Those are candidates only -- C++ scores every one of them
+  ## against the same exact objective the branch-and-bound uses.
+  .nCov <- ncol(prep$covMat)
+  .allowed <- NULL
+  .nCand <- rep(as.integer(.nCov), prep$zDim)
+  if (!is.null(prepC$covAllow)) {
+    .allowed <- lapply(seq_len(prep$zDim), function(k) which(prepC$covAllow[k, ] == 1L) - 1L)
+    .nCand <- vapply(.allowed, length, integer(1))
+  }
+  ## a free (mixture) or fixed dimension never runs the search
+  .nCand[as.logical(prep$isFree) | as.logical(prep$zPopFix)] <- 0L
+  if (!isTRUE(control$covariateSelection) || .nCov == 0L) .nCand[] <- 0L
+  .modes <- .vaeCovSelectModes(.nCand, control)
+  for (.m in .modes$msg) warning(.m, call. = FALSE)
+  prepC$covSelectMode <- .modes$mode
+  prepC$l0Fn <- NULL
+  if (any(.modes$mode == 1L)) {
+    .covMat <- prep$covMat
+    .mode <- .modes$mode
+    .allow <- .allowed
+    prepC$l0Fn <- function(y) .vaeL0Candidates(y, .covMat, .mode, .allow)
+  }
+
   .cores <- tryCatch({
     .c <- control$rxControl$cores
     if (is.null(.c) || is.na(.c) || .c < 1L) as.integer(rxode2::getRxThreads()) else as.integer(.c)
@@ -267,6 +293,7 @@
        regressTheta = setNames(as.numeric(.fit$regressTheta), prep$regressNames),
        nRegGrad = as.integer(.fit$nRegGrad), nRegFallback = as.integer(.fit$nRegFallback),
        nStage2 = as.integer(.fit$nStage2),
+       covSelectMethodUsed = .modes$used,
        nMix = nMix, mixProb = mixProb, mixnum = as.integer(.fit$mixnum))
 }
 

--- a/R/vaeOutput.R
+++ b/R/vaeOutput.R
@@ -254,6 +254,7 @@
   ## the VAE training artifacts + the ORIGINAL model for $uiIni/$iniDf0
   .ret$vae <- list(elboTrace = fit$elboTrace, beta = fit$beta, selected = fit$selected,
                    covNames = fit$covNames, zPop = fit$zPop, omega = fit$omega, a = fit$a,
+                   covSelectMethodUsed = fit$covSelectMethodUsed,
                    seed = .control$seed)
   ## the VAE optimization walk (standard parHistData -> $parHist accessor)
   if (!is.null(fit$parHist)) .ret$parHistData <- fit$parHist

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -240,13 +240,17 @@ covariates.  `"l0learn"` has the suggested `L0Learn` package propose supports,
 which are then scored and polished with the same exact objective -- so the
 search is approximate but the scoring is not.  `"auto"` (default) uses
 `"l0learn"` for a latent dimension with at least `covSelectMaxExact` candidate
-covariates and `"bnb"` otherwise; without `L0Learn` installed it stays exact
-and warns.}
+covariates and `"bnb"` otherwise.  If `L0Learn` is not installed when the
+exact search would be impractical (`"auto"` at or over the threshold, or an
+explicit `"l0learn"`) this errors rather than run the slow exact search
+silently; install `L0Learn`, or set `covSelectMaxExact = Inf` to force the
+exact search everywhere.}
 
 \item{covSelectMaxExact}{Candidate-covariate count at or above which
 `covSelectMethod = "auto"` switches a latent dimension to `L0Learn` (default
 `17`, the measured wall-clock crossover).  Counted after `pinCovariates`
-trimming, so it is the size of the search actually run.}
+trimming, so it is the size of the search actually run.  `Inf` forces the
+exact branch-and-bound for every dimension.}
 
 \item{bnbStrategy}{Frontier discipline for the exact branch-and-bound covariate
 selection: `"lifo"` (default, last-in-first-out depth-first search),

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -26,6 +26,8 @@ vaeControl(
   residRhoend = NULL,
   omegaUpdate = c("suffStat", "blend"),
   inputScale = c("reference", "observed"),
+  covSelectMethod = c("auto", "bnb", "l0learn"),
+  covSelectMaxExact = 25L,
   bnbStrategy = c("lifo", "fifo", "lc"),
   parEncoderBackward = !isTRUE(getOption("nlmixr2.identical", FALSE)),
   nonMuTheta = c("regress", "grad", "eta", "fix", "none"),
@@ -231,6 +233,19 @@ enters both statistics.  On a ragged dataset that is a materially different
 scale from `"observed"`, which uses only the observed values (on the neonatal
 case study the SD is 1582 against 506).  Affects only the encoder's inputs,
 never the likelihood.}
+
+\item{covSelectMethod}{How the covariate M-step searches subsets.  `"bnb"` is
+the exact branch-and-bound; it becomes impractical past a few dozen candidate
+covariates.  `"l0learn"` has the suggested `L0Learn` package propose supports,
+which are then scored and polished with the same exact objective -- so the
+search is approximate but the scoring is not.  `"auto"` (default) uses
+`"l0learn"` for a latent dimension with at least `covSelectMaxExact` candidate
+covariates and `"bnb"` otherwise; without `L0Learn` installed it stays exact
+and warns.}
+
+\item{covSelectMaxExact}{Candidate-covariate count at or above which
+`covSelectMethod = "auto"` switches a latent dimension to `L0Learn`.  Counted
+after `pinCovariates` trimming, so it is the size of the search actually run.}
 
 \item{bnbStrategy}{Frontier discipline for the exact branch-and-bound covariate
 selection: `"lifo"` (default, last-in-first-out depth-first search),

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -27,7 +27,7 @@ vaeControl(
   omegaUpdate = c("suffStat", "blend"),
   inputScale = c("reference", "observed"),
   covSelectMethod = c("auto", "bnb", "l0learn"),
-  covSelectMaxExact = 25L,
+  covSelectMaxExact = 17L,
   bnbStrategy = c("lifo", "fifo", "lc"),
   parEncoderBackward = !isTRUE(getOption("nlmixr2.identical", FALSE)),
   nonMuTheta = c("regress", "grad", "eta", "fix", "none"),
@@ -244,8 +244,9 @@ covariates and `"bnb"` otherwise; without `L0Learn` installed it stays exact
 and warns.}
 
 \item{covSelectMaxExact}{Candidate-covariate count at or above which
-`covSelectMethod = "auto"` switches a latent dimension to `L0Learn`.  Counted
-after `pinCovariates` trimming, so it is the size of the search actually run.}
+`covSelectMethod = "auto"` switches a latent dimension to `L0Learn` (default
+`17`, the measured wall-clock crossover).  Counted after `pinCovariates`
+trimming, so it is the size of the search actually run.}
 
 \item{bnbStrategy}{Frontier discipline for the exact branch-and-bound covariate
 selection: `"lifo"` (default, last-in-first-out depth-first search),

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1146,6 +1146,22 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// vaeScoreSupports_
+List vaeScoreSupports_(arma::vec y, arma::mat covMat, double omega, double penaltyPerCov, List supports, bool polish);
+RcppExport SEXP _nlmixr2est_vaeScoreSupports_(SEXP ySEXP, SEXP covMatSEXP, SEXP omegaSEXP, SEXP penaltyPerCovSEXP, SEXP supportsSEXP, SEXP polishSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::vec >::type y(ySEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type covMat(covMatSEXP);
+    Rcpp::traits::input_parameter< double >::type omega(omegaSEXP);
+    Rcpp::traits::input_parameter< double >::type penaltyPerCov(penaltyPerCovSEXP);
+    Rcpp::traits::input_parameter< List >::type supports(supportsSEXP);
+    Rcpp::traits::input_parameter< bool >::type polish(polishSEXP);
+    rcpp_result_gen = Rcpp::wrap(vaeScoreSupports_(y, covMat, omega, penaltyPerCov, supports, polish));
+    return rcpp_result_gen;
+END_RCPP
+}
 // boxCox_
 NumericVector boxCox_(NumericVector x, double lambda, int yj);
 RcppExport SEXP _nlmixr2est_boxCox_(SEXP xSEXP, SEXP lambdaSEXP, SEXP yjSEXP) {

--- a/src/init.c
+++ b/src/init.c
@@ -39,6 +39,7 @@ extern SEXP _nlmixr2est_vaeInnerUpdatePar_(SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeTrainCpp_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeElboStepCpp_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeBestSubset_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP _nlmixr2est_vaeScoreSupports_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeDecoderPxz_(SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeDecoderSolveSubject_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeDecoderElboStep_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -191,6 +192,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_vaeTrainCpp_", (DL_FUNC) &_nlmixr2est_vaeTrainCpp_, 11},
   {"_nlmixr2est_vaeElboStepCpp_", (DL_FUNC) &_nlmixr2est_vaeElboStepCpp_, 11},
   {"_nlmixr2est_vaeBestSubset_", (DL_FUNC) &_nlmixr2est_vaeBestSubset_, 6},
+  {"_nlmixr2est_vaeScoreSupports_", (DL_FUNC) &_nlmixr2est_vaeScoreSupports_, 6},
   {"_nlmixr2est_vaeDecoderPxz_", (DL_FUNC) &_nlmixr2est_vaeDecoderPxz_, 2},
   {"_nlmixr2est_vaeDecoderSolveSubject_", (DL_FUNC) &_nlmixr2est_vaeDecoderSolveSubject_, 6},
   {"_nlmixr2est_vaeDecoderElboStep_", (DL_FUNC) &_nlmixr2est_vaeDecoderElboStep_, 14},

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -13755,6 +13755,18 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
     !Rf_isNull(prep["covAllow"]);
   arma::imat covAllow;
   if (haveCovAllow) covAllow = as<arma::imat>(prep["covAllow"]);
+  // covSelectMethod: per-latent-dim search mode, 0 = exact branch-and-bound,
+  // 1 = L0Learn-proposed candidates scored/polished by the same exact objective.
+  // Resolved in R (that is where the suggested-package check and the $runInfo
+  // message live) and handed down with the closure that generates them.
+  arma::ivec covSelMode;
+  if (prep.containsElementNamed("covSelectMode") && !Rf_isNull(prep["covSelectMode"])) {
+    covSelMode = as<arma::ivec>(prep["covSelectMode"]);
+  }
+  const bool haveL0 = prep.containsElementNamed("l0Fn") && !Rf_isNull(prep["l0Fn"]) &&
+    covSelMode.n_elem > 0 && arma::any(covSelMode == 1);
+  Rcpp::Function l0Fn = haveL0 ? as<Rcpp::Function>(prep["l0Fn"]) :
+    Rcpp::Function("identity");
   List yListR = prep["yList"];
   std::vector<std::vector<double> > yList(N);
   for (int i = 0; i < N; ++i) { NumericVector yi = yListR[i]; yList[i].assign(yi.begin(), yi.end()); }
@@ -13953,6 +13965,28 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
       arma::mat X(N, 1 + nCov); X.col(0).ones(); if (nCov > 0) X.cols(1, nCov) = covMat;
       arma::mat zPopMat(N, zDim, arma::fill::zeros);
       intercept.zeros(); beta.zeros(); selected.zeros();
+      // L0Learn candidate generation: ONE R crossing per iteration, on the main
+      // thread, because an Rcpp::Function cannot be called from inside the
+      // OpenMP loop below.  Supports come back indexed into each dim's REDUCED
+      // design, which is what the loop's Xuse already is.
+      std::vector<std::vector<std::vector<int> > > cands;
+      if (haveL0) {
+        arma::mat yAll(N, zDim);
+        for (int k = 0; k < zDim; ++k) {
+          yAll.col(k) = covSelectSmooth ? s1.col(k) : last.mu.col(k);
+        }
+        List cl = as<List>(l0Fn(yAll));
+        cands.resize((size_t)zDim);
+        for (int k = 0; k < zDim && k < cl.size(); ++k) {
+          if (Rf_isNull(cl[k])) continue;
+          List ck = as<List>(cl[k]);
+          cands[(size_t)k].resize((size_t)ck.size());
+          for (int i = 0; i < ck.size(); ++i) {
+            IntegerVector s = as<IntegerVector>(ck[i]);
+            cands[(size_t)k][(size_t)i].assign(s.begin(), s.end());
+          }
+        }
+      }
       // Each latent dim k runs an independent exact L0 branch-and-bound and writes
       // only disjoint cells (intercept[k], beta.row(k), selected.row(k),
       // zPopMat.col(k)); vaeBestSubsetL0 keeps all state in a per-call VaeBnbCtx
@@ -13980,7 +14014,9 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
           if (allowedG.n_elem > 0) Xk.cols(1, allowedG.n_elem) = covMat.cols(allowedG);
         }
         const arma::mat& Xuse = haveCovAllow ? Xk : X;
-        VaeSubsetFit fit = vaeBestSubsetL0(yk, Xuse, omega[k], covPenalty, bnbStrategy);
+        VaeSubsetFit fit = (haveL0 && covSelMode[k] == 1)
+          ? vaeCandidateSubsetL0(yk, Xuse, omega[k], covPenalty, cands[(size_t)k], true)
+          : vaeBestSubsetL0(yk, Xuse, omega[k], covPenalty, bnbStrategy);
         arma::vec bestCoef = fit.coef;
         double ic = bestCoef[0];
         if (R_FINITE(zPopLower[k]) && ic < zPopLower[k]) ic = zPopLower[k];

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -13356,27 +13356,10 @@ static void vaeBnbSearch(VaeBnbCtx& c, const std::vector<int>& freeSet0) {
   }
 }
 
-static VaeSubsetFit vaeBestSubsetL0(const arma::vec& y, const arma::mat& X,
-                                    double omega, double penalty,
-                                    VaeBnbStrategy strategy = VAE_BNB_LIFO) {
-  const int nCov = (int)X.n_cols - 1;
-  VaeBnbCtx c;
-  c.X = &X; c.y = &y; c.omega = omega; c.penalty = penalty; c.strategy = strategy;
-  c.bestScore = std::numeric_limits<double>::infinity();
-  // order covariates by univariate strength (RSS of [intercept, x_j] ascending
-  // -> stronger last) so the branch order finds good incumbents early.
-  std::vector<std::pair<double,int> > strength(nCov);
-  for (int j = 0; j < nCov; ++j) {
-    std::vector<int> one(1, j);
-    strength[j] = std::make_pair(vaeOlsRss(X, vaeSubsetCols(one), y, nullptr), j);
-  }
-  std::sort(strength.begin(), strength.end(),
-            [](const std::pair<double,int>& a, const std::pair<double,int>& b) {
-              return a.first > b.first;  // weakest first, strongest at back()
-            });
-  std::vector<int> freeSet(nCov);
-  for (int j = 0; j < nCov; ++j) freeSet[j] = strength[j].second;
-  vaeBnbSearch(c, freeSet);
+// Shape the incumbent into the returned fit: support ascending, coefficients
+// reordered to match.  Shared by the exact search and the candidate-scoring path
+// so both return the identical layout.
+static VaeSubsetFit vaeFinishSubset(VaeBnbCtx& c, const arma::vec& y) {
   VaeSubsetFit out;
   // No finite-scoring model was ever recorded (e.g. non-positive omega or a
   // non-finite y made every score NaN/inf).  Fall back to the intercept-only
@@ -13399,6 +13382,105 @@ static VaeSubsetFit vaeBestSubsetL0(const arma::vec& y, const arma::mat& X,
     out.coef[s + 1] = c.bestCoef[order[s] + 1];
   }
   return out;
+}
+
+static VaeSubsetFit vaeBestSubsetL0(const arma::vec& y, const arma::mat& X,
+                                    double omega, double penalty,
+                                    VaeBnbStrategy strategy = VAE_BNB_LIFO) {
+  const int nCov = (int)X.n_cols - 1;
+  VaeBnbCtx c;
+  c.X = &X; c.y = &y; c.omega = omega; c.penalty = penalty; c.strategy = strategy;
+  c.bestScore = std::numeric_limits<double>::infinity();
+  // order covariates by univariate strength (RSS of [intercept, x_j] ascending
+  // -> stronger last) so the branch order finds good incumbents early.
+  std::vector<std::pair<double,int> > strength(nCov);
+  for (int j = 0; j < nCov; ++j) {
+    std::vector<int> one(1, j);
+    strength[j] = std::make_pair(vaeOlsRss(X, vaeSubsetCols(one), y, nullptr), j);
+  }
+  std::sort(strength.begin(), strength.end(),
+            [](const std::pair<double,int>& a, const std::pair<double,int>& b) {
+              return a.first > b.first;  // weakest first, strongest at back()
+            });
+  std::vector<int> freeSet(nCov);
+  for (int j = 0; j < nCov; ++j) freeSet[j] = strength[j].second;
+  vaeBnbSearch(c, freeSet);
+  return vaeFinishSubset(c, y);
+}
+
+// ---- approximate path: score externally supplied candidate supports ---------
+// The exact branch-and-bound above is unusable past ~25 covariates (its node
+// count explodes).  The alternative is to have an L0 solver PROPOSE supports and
+// keep every scoring decision here: candidates go through the same vaeBnbLeaf --
+// same OLS, same score, same lexicographic tie-break -- so the proposer's own
+// objective, scaling and lambda grid can never shift a selection.  It only
+// decides which subsets get looked at.
+
+// Score each candidate support against the incumbent.  Out-of-range and repeated
+// indices are dropped so a malformed proposal cannot index past the design.
+static void vaeScoreCandidates(VaeBnbCtx& c, int nCov,
+                               const std::vector<std::vector<int> >& cands) {
+  for (size_t i = 0; i < cands.size(); ++i) {
+    std::vector<int> s;
+    s.reserve(cands[i].size());
+    for (size_t j = 0; j < cands[i].size(); ++j) {
+      int v = cands[i][j];
+      if (v >= 0 && v < nCov) s.push_back(v);
+    }
+    std::sort(s.begin(), s.end());
+    s.erase(std::unique(s.begin(), s.end()), s.end());
+    vaeBnbLeaf(c, s);
+  }
+}
+
+// Add / drop / swap local search from the incumbent, accepting only STRICT score
+// improvements, until a pass finds none.  Recovers the optimum in the cases a
+// coordinate-descent proposer walks past.  Deterministic: the neighborhood is
+// enumerated in a fixed order and vaeBnbLeaf's tie-break is order-independent.
+static void vaeLocalSearchL0(VaeBnbCtx& c, int nCov, int maxPass = 100) {
+  for (int pass = 0; pass < maxPass; ++pass) {
+    const std::vector<int> cur = c.bestSel;
+    const double before = c.bestScore;
+    std::vector<char> inSet((size_t)nCov, 0);
+    for (size_t s = 0; s < cur.size(); ++s) inSet[(size_t)cur[s]] = 1;
+    for (int j = 0; j < nCov; ++j) {                     // add
+      if (inSet[(size_t)j]) continue;
+      std::vector<int> t = cur; t.push_back(j);
+      std::sort(t.begin(), t.end());
+      vaeBnbLeaf(c, t);
+    }
+    for (size_t d = 0; d < cur.size(); ++d) {            // drop
+      std::vector<int> t = cur; t.erase(t.begin() + d);
+      vaeBnbLeaf(c, t);
+    }
+    for (size_t d = 0; d < cur.size(); ++d) {            // swap
+      for (int j = 0; j < nCov; ++j) {
+        if (inSet[(size_t)j]) continue;
+        std::vector<int> t = cur; t[d] = j;
+        std::sort(t.begin(), t.end());
+        vaeBnbLeaf(c, t);
+      }
+    }
+    if (!(c.bestScore < before)) break;                  // local optimum
+  }
+}
+
+// Candidate-scoring counterpart of vaeBestSubsetL0: identical objective and
+// return layout, but the subsets come from `cands` (plus the local search)
+// instead of an exhaustive branch-and-bound.
+static VaeSubsetFit vaeCandidateSubsetL0(const arma::vec& y, const arma::mat& X,
+                                         double omega, double penalty,
+                                         const std::vector<std::vector<int> >& cands,
+                                         bool polish) {
+  const int nCov = (int)X.n_cols - 1;
+  VaeBnbCtx c;
+  c.X = &X; c.y = &y; c.omega = omega; c.penalty = penalty;
+  c.strategy = VAE_BNB_LIFO;  // unused here; the frontier discipline has no role
+  c.bestScore = std::numeric_limits<double>::infinity();
+  vaeBnbLeaf(c, std::vector<int>());   // the intercept-only model is always in play
+  vaeScoreCandidates(c, nCov, cands);
+  if (polish) vaeLocalSearchL0(c, nCov);
+  return vaeFinishSubset(c, y);
 }
 
 // nonMuTheta="regress": bounded bobyqa regression of the non-mu fixed-effect
@@ -14283,6 +14365,33 @@ List vaeBestSubset_(arma::mat mu, arma::mat covMat, arma::vec omega,
   }
   return List::create(_["intercept"] = intercept, _["beta"] = beta,
                       _["selected"] = selected);
+}
+
+// Test-facing entry point for the candidate-scoring path: score `supports` (a
+// list of 0-based integer vectors, e.g. from .vaeL0Supports) with the exact
+// objective and optionally polish.  One latent dimension per call.
+//[[Rcpp::export]]
+List vaeScoreSupports_(arma::vec y, arma::mat covMat, double omega,
+                       double penaltyPerCov, List supports, bool polish = true) {
+  const int N = (int)covMat.n_rows;
+  const int nCov = (int)covMat.n_cols;
+  if ((int)y.n_elem != N) Rcpp::stop("'y' must have length nrow(covMat) (%d)", N);
+  arma::mat X(N, 1 + nCov); X.col(0).ones();
+  if (nCov > 0) X.cols(1, nCov) = covMat;
+  std::vector<std::vector<int> > cands((size_t)supports.size());
+  for (int i = 0; i < supports.size(); ++i) {
+    IntegerVector s = as<IntegerVector>(supports[i]);
+    cands[(size_t)i].assign(s.begin(), s.end());
+  }
+  VaeSubsetFit fit = vaeCandidateSubsetL0(y, X, omega, penaltyPerCov, cands, polish);
+  NumericVector beta(nCov);
+  IntegerVector selected(nCov);
+  for (size_t s = 0; s < fit.sel.size(); ++s) {
+    beta[fit.sel[s]] = fit.coef[s + 1];
+    selected[fit.sel[s]] = 1;
+  }
+  return List::create(_["intercept"] = fit.coef.n_elem ? fit.coef[0] : 0.0,
+                      _["beta"] = beta, _["selected"] = selected);
 }
 
 //[[Rcpp::export]]

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -77,7 +77,7 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   # push/PR subset to trim its wall time / reclamation exposure.
   c("vae-encoder", "vae-train", "vae-decoder", "vae-elbo", "vae-inner",
     "vae-fixbounds", "vae-parhist", "vae-iov", "vae-grad-fit", "vae-ll-grad-fit",
-    "split", "unary-mu", "timing"),
+    "vae-l0learn-fit", "split", "unary-mu", "timing"),
   # batch 7 -- advi (variational inference) multi-iteration fits
   c("advi-repro", "advi-focei-agreement", "advi-neonatal", "advi-fullrank",
     "advi-fullbayes"),

--- a/tests/testthat/test-vae-l0learn-fit.R
+++ b/tests/testthat/test-vae-l0learn-fit.R
@@ -1,0 +1,139 @@
+## est="vae" covariate selection through vaeControl(covSelectMethod=) end to end:
+## does the L0Learn path actually engage, does it report itself, does it agree
+## with the exact branch-and-bound, and is it reproducible.  Runs real (short)
+## fits and a wider kernel parity sweep, so this file is weekly, not essential.
+
+nmTest({
+
+  ## 48 subjects (theo_sd replicated) with 30 subject-constant nuisance
+  ## covariates -- enough columns to cross the covSelectMaxExact threshold and
+  ## enough subjects for the regression to be full rank.
+  wideData <- function(nCov = 30L) {
+    d <- do.call(rbind, lapply(0:3, function(b) {
+      x <- nlmixr2data::theo_sd
+      x$ID <- x$ID + b * 12L
+      x
+    }))
+    .testSeed(42L)
+    ids <- unique(d$ID)
+    cv <- matrix(rnorm(length(ids) * nCov), length(ids), nCov)
+    for (j in seq_len(nCov)) d[[paste0("C", j)]] <- cv[match(d$ID, ids), j]
+    d
+  }
+
+  wideModel <- function() {
+    ini({tka <- 0.45; tcl <- 1; tv <- 3.45
+         eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1; add.sd <- 0.7})
+    model({ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+           linCmt() ~ add(add.sd)})
+  }
+
+  shortCtl <- function(...) {
+    vaeControl(itersBurnIn = 5L, iters = 8L, klWarmup = 4L, gammaIter = 6L,
+               nGradStep = 2L, print = 0L, returnVae = TRUE, ...)
+  }
+
+  test_that("auto engages L0Learn past the threshold and agrees with the exact search", {
+    skip_on_cran()
+    skip_if_not_installed("L0Learn")
+    skip_if_not_installed("nlmixr2data")
+    d <- wideData(30L)
+
+    fL <- suppressWarnings(suppressMessages(
+      nlmixr2(wideModel, d, est = "vae", control = shortCtl())))
+    ## mechanism, not just the result: the approximate path really ran
+    expect_identical(fL$covSelectMethodUsed, "l0learn")
+
+    fB <- suppressWarnings(suppressMessages(
+      nlmixr2(wideModel, d, est = "vae", control = shortCtl(covSelectMethod = "bnb"))))
+    expect_identical(fB$covSelectMethodUsed, "bnb")
+
+    ## the two searches optimize the same objective, so they must agree on the
+    ## selected covariate set
+    expect_identical(fL$selected, fB$selected)
+  })
+
+  test_that("below the threshold nothing switches and nothing is said", {
+    skip_on_cran()
+    skip_if_not_installed("L0Learn")
+    skip_if_not_installed("nlmixr2data")
+    d <- wideData(6L)
+    f <- suppressMessages(nlmixr2(wideModel, d, est = "vae", control = shortCtl()))
+    expect_identical(f$covSelectMethodUsed, "bnb")
+  })
+
+  test_that("an explicit covSelectMethod overrides the threshold both ways", {
+    skip_on_cran()
+    skip_if_not_installed("L0Learn")
+    skip_if_not_installed("nlmixr2data")
+    d <- wideData(6L)
+    ## forced on below the threshold
+    f <- suppressWarnings(suppressMessages(
+      nlmixr2(wideModel, d, est = "vae", control = shortCtl(covSelectMethod = "l0learn"))))
+    expect_identical(f$covSelectMethodUsed, "l0learn")
+    ## raising the threshold keeps a wide problem exact
+    d30 <- wideData(30L)
+    f <- suppressMessages(
+      nlmixr2(wideModel, d30, est = "vae", control = shortCtl(covSelectMaxExact = 100L)))
+    expect_identical(f$covSelectMethodUsed, "bnb")
+  })
+
+  test_that("the approximate search reports itself in runInfo", {
+    skip_on_cran()
+    skip_if_not_installed("L0Learn")
+    skip_if_not_installed("nlmixr2data")
+    d <- wideData(30L)
+    f <- suppressMessages(nlmixr2(wideModel, d, est = "vae",
+                                  control = vaeControl(itersBurnIn = 4L, iters = 5L,
+                                                       klWarmup = 3L, gammaIter = 4L,
+                                                       nGradStep = 2L, print = 0L,
+                                                       calcTables = FALSE)))
+    expect_identical(f$vae$covSelectMethodUsed, "l0learn")
+    ## a non-exact selection must never arrive silently
+    expect_match(f$runInfo, "covariate search used L0Learn", all = FALSE)
+  })
+
+  test_that("the L0Learn path is reproducible", {
+    skip_on_cran()
+    skip_if_not_installed("L0Learn")
+    skip_if_not_installed("nlmixr2data")
+    d <- wideData(30L)
+    a <- suppressWarnings(suppressMessages(
+      nlmixr2(wideModel, d, est = "vae", control = shortCtl())))
+    b <- suppressWarnings(suppressMessages(
+      nlmixr2(wideModel, d, est = "vae", control = shortCtl())))
+    expect_identical(a$selected, b$selected)
+    expect_identical(a$zPop, b$zPop)
+    expect_identical(a$omega, b$omega)
+  })
+
+  test_that("L0Learn candidates plus polish reproduce the exact optimum at scale", {
+    skip_on_cran()
+    skip_if_not_installed("L0Learn")
+    ## wider version of the essential-suite parity check: more replicates, more
+    ## covariates, and both independent and rho=0.7 correlated designs
+    .testSeed(2026L)
+    N <- 150L
+    nRep <- 50L
+    for (rep in seq_len(nRep)) {
+      nCov <- sample(8:16, 1L)
+      X <- matrix(rnorm(N * nCov), N, nCov)
+      if (rep %% 2L == 0L) {
+        f <- rnorm(N)
+        X <- sqrt(0.7) * matrix(f, N, nCov) + sqrt(0.3) * X
+      }
+      k <- sample(0:5, 1L)
+      sel <- if (k > 0) sort(sample.int(nCov, k)) else integer(0)
+      y <- as.numeric(0.5 + (if (k > 0) X[, sel, drop = FALSE] %*%
+                               (runif(k, 1, 3) * sample(c(-1, 1), k, TRUE)) else 0) +
+                        rnorm(N, sd = runif(1, 0.4, 1.5)))
+      omega <- runif(1, 0.2, 1)
+      penalty <- log(N)
+      got <- vaeScoreSupports_(y, X, omega, penalty,
+                               nlmixr2est:::.vaeL0Supports(X, y), polish = TRUE)
+      ref <- vaeBestSubset_(matrix(y, ncol = 1), X, omega, FALSE, penalty)
+      expect_identical(which(got$selected == 1L), which(ref$selected[1, ] == 1L),
+                       info = paste0("rep ", rep, " nCov ", nCov))
+    }
+  })
+})

--- a/tests/testthat/test-vae-l0learn-fit.R
+++ b/tests/testthat/test-vae-l0learn-fit.R
@@ -76,6 +76,10 @@ nmTest({
     f <- suppressMessages(
       nlmixr2(wideModel, d30, est = "vae", control = shortCtl(covSelectMaxExact = 100L)))
     expect_identical(f$covSelectMethodUsed, "bnb")
+    ## covSelectMaxExact=Inf forces the exact search everywhere
+    f <- suppressMessages(
+      nlmixr2(wideModel, d30, est = "vae", control = shortCtl(covSelectMaxExact = Inf)))
+    expect_identical(f$covSelectMethodUsed, "bnb")
   })
 
   test_that("the approximate search reports itself in runInfo", {

--- a/tests/testthat/test-vae-l0learn.R
+++ b/tests/testthat/test-vae-l0learn.R
@@ -111,6 +111,103 @@ nmTest({
     expect_true(all(nchar(msgs) <= 75L))
   })
 
+  ## ---- candidate-scoring kernel (vaeScoreSupports_) -------------------------
+
+  ## exact objective, recomputed in-test so the kernel is checked against a
+  ## reference that does not call it
+  scoreOf <- function(sel, y, X, omega, penalty) {
+    Xs <- cbind(1, X[, sel, drop = FALSE])
+    coef <- qr.solve(Xs, y)
+    sum((y - Xs %*% coef)^2) / omega + penalty * length(sel)
+  }
+  ## every subset of 0..(nCov-1), 0-based, as vaeScoreSupports_ wants them
+  allSupports <- function(nCov) {
+    lapply(0:(2^nCov - 1), function(m) which(bitwAnd(m, bitwShiftL(1L, 0:(nCov - 1))) > 0) - 1L)
+  }
+
+  test_that("scoring the full enumeration reproduces the exact search", {
+    ## the candidate path must differ from the branch-and-bound ONLY in which
+    ## subsets it looks at -- same OLS, same score, same tie-break
+    .testSeed(21L)
+    for (rep in 1:6) {
+      N <- 80L; nCov <- sample(4:9, 1L)
+      X <- matrix(rnorm(N * nCov), N, nCov)
+      k <- sample(0:3, 1L)
+      sel <- if (k > 0) sort(sample.int(nCov, k)) else integer(0)
+      y <- as.numeric(0.7 + (if (k > 0) X[, sel, drop = FALSE] %*% runif(k, 1, 3) else 0) +
+                        rnorm(N, sd = 0.5))
+      omega <- 0.4; penalty <- log(N)
+      ref <- vaeBestSubset_(matrix(y, ncol = 1), X, omega, FALSE, penalty)
+      got <- vaeScoreSupports_(y, X, omega, penalty, allSupports(nCov), polish = FALSE)
+      expect_identical(as.integer(got$selected), as.integer(ref$selected[1, ]),
+                       info = paste0("rep ", rep))
+      expect_equal(got$intercept, as.numeric(ref$intercept[1]), tolerance = 1e-10)
+      expect_equal(as.numeric(got$beta), as.numeric(ref$beta[1, ]), tolerance = 1e-10)
+    }
+  })
+
+  test_that("candidate scoring ignores malformed support indices", {
+    .testSeed(22L)
+    N <- 60L; nCov <- 5L
+    X <- matrix(rnorm(N * nCov), N, nCov)
+    y <- as.numeric(X[, 2] * 2 + rnorm(N, sd = 0.3))
+    omega <- 0.5; penalty <- log(N)
+    clean <- vaeScoreSupports_(y, X, omega, penalty, list(integer(0), 1L), polish = FALSE)
+    ## duplicated, out-of-range and negative entries collapse to the same support
+    dirty <- vaeScoreSupports_(y, X, omega, penalty,
+                               list(integer(0), c(1L, 1L, 99L, -3L)), polish = FALSE)
+    expect_identical(dirty$selected, clean$selected)
+    expect_equal(dirty$beta, clean$beta, tolerance = 1e-12)
+  })
+
+  test_that("the local search never worsens the incumbent and reaches the optimum", {
+    .testSeed(23L)
+    for (rep in 1:8) {
+      N <- 90L; nCov <- sample(5:10, 1L)
+      X <- matrix(rnorm(N * nCov), N, nCov)
+      k <- sample(1:3, 1L)
+      sel <- sort(sample.int(nCov, k))
+      y <- as.numeric(0.3 + X[, sel, drop = FALSE] %*% runif(k, 1.5, 3) + rnorm(N, sd = 0.4))
+      omega <- 0.5; penalty <- log(N)
+      ## deliberately useless candidate set: only the intercept-only model
+      bare <- list(integer(0))
+      noPolish <- vaeScoreSupports_(y, X, omega, penalty, bare, polish = FALSE)
+      polished <- vaeScoreSupports_(y, X, omega, penalty, bare, polish = TRUE)
+      sNo <- scoreOf(which(noPolish$selected == 1L), y, X, omega, penalty)
+      sYes <- scoreOf(which(polished$selected == 1L), y, X, omega, penalty)
+      expect_lte(sYes, sNo)
+      ## and from that bare start it still lands on the exact optimum here
+      ref <- vaeBestSubset_(matrix(y, ncol = 1), X, omega, FALSE, penalty)
+      expect_identical(as.integer(polished$selected), as.integer(ref$selected[1, ]),
+                       info = paste0("rep ", rep))
+    }
+  })
+
+  test_that("L0Learn candidates plus polish match the exact optimum", {
+    skip_if_not_installed("L0Learn")
+    .testSeed(24L)
+    N <- 120L
+    for (rep in 1:10) {
+      nCov <- sample(8:14, 1L)
+      corr <- rep %% 2L == 0L          # half correlated, half independent
+      X <- matrix(rnorm(N * nCov), N, nCov)
+      if (corr) {                      # rho ~ 0.7 common factor
+        f <- rnorm(N)
+        X <- sqrt(0.7) * matrix(f, N, nCov) + sqrt(0.3) * X
+      }
+      k <- sample(1:4, 1L)
+      sel <- sort(sample.int(nCov, k))
+      y <- as.numeric(0.5 + X[, sel, drop = FALSE] %*% runif(k, 1.5, 3) *
+                        sample(c(-1, 1), k, TRUE) + rnorm(N, sd = 0.6))
+      omega <- 0.5; penalty <- log(N)
+      cand <- nlmixr2est:::.vaeL0Supports(X, y)
+      got <- vaeScoreSupports_(y, X, omega, penalty, cand, polish = TRUE)
+      ref <- vaeBestSubset_(matrix(y, ncol = 1), X, omega, FALSE, penalty)
+      expect_identical(as.integer(got$selected), as.integer(ref$selected[1, ]),
+                       info = paste0("rep ", rep, " nCov ", nCov, " corr ", corr))
+    }
+  })
+
   test_that(".vaeL0Candidates maps reduced supports back to global columns", {
     skip_if_not_installed("L0Learn")
     .testSeed(3L)

--- a/tests/testthat/test-vae-l0learn.R
+++ b/tests/testthat/test-vae-l0learn.R
@@ -208,7 +208,7 @@ nmTest({
     }
   })
 
-  test_that(".vaeL0Candidates maps reduced supports back to global columns", {
+  test_that(".vaeL0Candidates proposes per dimension in the reduced design", {
     skip_if_not_installed("L0Learn")
     .testSeed(3L)
     N <- 100L; p <- 10L
@@ -220,12 +220,14 @@ nmTest({
     cand <- nlmixr2est:::.vaeL0Candidates(y, covMat, mode = c(1L, 0L))
     expect_length(cand, 2L)
     expect_null(cand[[2]])
+    ## no pinning: reduced design == full design, so column 4 is index 3
     expect_true(any(vapply(cand[[1]], function(e) identical(e, 3L), logical(1))))
 
-    ## restricted (pinCovariates) candidate columns: only allowed globals appear
+    ## pinCovariates: indices are into the REDUCED design, so they stay in
+    ## 0..(length(allowed)-1) -- the C++ caller maps them back to global columns
     allowed <- list(c(3L, 8L), integer(0))
     cand <- nlmixr2est:::.vaeL0Candidates(y, covMat, mode = c(1L, 1L), allowed = allowed)
-    expect_true(all(unlist(cand[[1]]) %in% c(3L, 8L)))
+    expect_true(all(unlist(cand[[1]]) %in% c(0L, 1L)))
     expect_identical(cand[[2]], list(integer(0)))
   })
 })

--- a/tests/testthat/test-vae-l0learn.R
+++ b/tests/testthat/test-vae-l0learn.R
@@ -82,11 +82,23 @@ nmTest({
     expect_identical(m$used, "bnb")
     expect_length(m$msg, 0L)
 
-    ## "auto" over the threshold but L0Learn missing: exact search anyway, warned
-    m <- nlmixr2est:::.vaeCovSelectModes(nCand, ctl("auto"), avail = FALSE)
+    ## "auto" over the threshold but L0Learn missing: error, not a slow fallback,
+    ## and it names the covSelectMaxExact=Inf escape hatch
+    expect_error(nlmixr2est:::.vaeCovSelectModes(nCand, ctl("auto"), avail = FALSE),
+                 "covSelectMaxExact=Inf")
+
+    ## "auto" below the threshold with L0Learn missing: exact search, no error
+    m <- nlmixr2est:::.vaeCovSelectModes(c(5L, 10L), ctl("auto"), avail = FALSE)
+    expect_identical(m$mode, c(0L, 0L))
+    expect_identical(m$used, "bnb")
+
+    ## covSelectMaxExact=Inf forces the exact search even for a wide problem, so a
+    ## missing L0Learn is fine
+    m <- nlmixr2est:::.vaeCovSelectModes(nCand, ctl("auto", Inf), avail = FALSE)
     expect_identical(m$mode, c(0L, 0L, 0L))
     expect_identical(m$used, "bnb")
-    expect_match(m$msg, "install L0Learn", all = FALSE)
+    m <- nlmixr2est:::.vaeCovSelectModes(nCand, ctl("auto", Inf), avail = TRUE)
+    expect_identical(m$mode, c(0L, 0L, 0L))  # Inf beats availability
 
     ## explicit "l0learn": every dimension with candidates switches
     m <- nlmixr2est:::.vaeCovSelectModes(c(3L, 0L), ctl("l0learn"), avail = TRUE)
@@ -102,11 +114,10 @@ nmTest({
     expect_identical(m$mode, c(0L, 1L))
   })
 
-  test_that("every run-time message stays inside the runInfo one-line budget", {
+  test_that("the run-time message stays inside the runInfo one-line budget", {
     ## $runInfo renders one bullet per warning; CLAUDE.md caps these at 75 chars
     ctl <- list(covSelectMethod = "auto", covSelectMaxExact = 25L)
-    msgs <- c(nlmixr2est:::.vaeCovSelectModes(30L, ctl, avail = TRUE)$msg,
-              nlmixr2est:::.vaeCovSelectModes(30L, ctl, avail = FALSE)$msg)
+    msgs <- nlmixr2est:::.vaeCovSelectModes(30L, ctl, avail = TRUE)$msg
     expect_gt(length(msgs), 0L)
     expect_true(all(nchar(msgs) <= 75L))
   })

--- a/tests/testthat/test-vae-l0learn.R
+++ b/tests/testthat/test-vae-l0learn.R
@@ -114,6 +114,19 @@ nmTest({
     expect_identical(m$mode, c(0L, 1L))
   })
 
+  test_that("vaeControl validates covSelectMaxExact", {
+    ## Inf and whole numbers pass through
+    expect_identical(vaeControl(covSelectMaxExact = Inf)$covSelectMaxExact, Inf)
+    expect_identical(vaeControl(covSelectMaxExact = 20L)$covSelectMaxExact, 20L)
+    expect_identical(vaeControl(covSelectMaxExact = 20)$covSelectMaxExact, 20L)
+    ## a finite non-integer is rejected, not silently truncated to 17
+    expect_error(vaeControl(covSelectMaxExact = 17.9))
+    ## out-of-range / bad values are rejected
+    expect_error(vaeControl(covSelectMaxExact = 0))
+    expect_error(vaeControl(covSelectMaxExact = -5))
+    expect_error(vaeControl(covSelectMethod = "bogus"))
+  })
+
   test_that("the run-time message stays inside the runInfo one-line budget", {
     ## $runInfo renders one bullet per warning; CLAUDE.md caps these at 75 chars
     ctl <- list(covSelectMethod = "auto", covSelectMaxExact = 25L)

--- a/tests/testthat/test-vae-l0learn.R
+++ b/tests/testthat/test-vae-l0learn.R
@@ -1,0 +1,134 @@
+## L0Learn-backed candidate generation for the VAE covariate M-step
+## (R/vaeCovSelectL0.R).  L0Learn only PROPOSES supports; the exact objective
+## RSS_S/omega + penalty*|S| still picks the winner, so these tests check the
+## proposal contract (shape, dedup, determinism, degradation) and the per-eta
+## mode resolution.  Pure linear algebra, no ODE solve: essential.
+
+nmTest({
+
+  test_that(".vaeL0Supports proposes well-formed, deduplicated supports", {
+    skip_if_not_installed("L0Learn")
+    .testSeed(1L)
+    N <- 120L; p <- 12L
+    X <- matrix(rnorm(N * p), N, p)
+    y <- as.numeric(0.5 + X[, c(3, 7, 10)] %*% c(1.5, -2, 1) + rnorm(N, sd = 0.5))
+    s <- nlmixr2est:::.vaeL0Supports(X, y)
+
+    expect_type(s, "list")
+    expect_gt(length(s), 1L)
+    ## every support is an ascending 0-based integer vector inside range
+    for (e in s) {
+      expect_type(e, "integer")
+      expect_false(is.unsorted(e))
+      if (length(e)) {
+        expect_gte(min(e), 0L)
+        expect_lt(max(e), p)
+      }
+    }
+    ## the intercept-only model is always a candidate
+    expect_true(any(vapply(s, length, integer(1)) == 0L))
+    ## deduplicated
+    expect_equal(anyDuplicated(vapply(s, paste, character(1), collapse = ",")), 0L)
+    ## the true support is proposed (0-based)
+    expect_true(any(vapply(s, function(e) identical(e, c(2L, 6L, 9L)), logical(1))))
+  })
+
+  test_that(".vaeL0Supports is deterministic and does not touch the RNG", {
+    skip_if_not_installed("L0Learn")
+    .testSeed(2L)
+    N <- 90L; p <- 8L
+    X <- matrix(rnorm(N * p), N, p)
+    y <- as.numeric(X[, 2] * 2 + rnorm(N))
+    .seedBefore <- .Random.seed
+    a <- nlmixr2est:::.vaeL0Supports(X, y)
+    expect_identical(.Random.seed, .seedBefore)  # no RNG consumption
+    b <- nlmixr2est:::.vaeL0Supports(X, y)
+    expect_identical(a, b)
+  })
+
+  test_that(".vaeL0Supports degrades to the empty support on unusable input", {
+    skip_if_not_installed("L0Learn")
+    .empty <- list(integer(0))
+    expect_identical(nlmixr2est:::.vaeL0Supports(matrix(0, 10, 0), rnorm(10)), .empty)
+    expect_identical(nlmixr2est:::.vaeL0Supports(matrix(1, 2, 3), rnorm(2)), .empty)
+    X <- matrix(rnorm(60), 20, 3); X[1, 1] <- NA_real_
+    expect_identical(nlmixr2est:::.vaeL0Supports(X, rnorm(20)), .empty)
+    X <- matrix(rnorm(60), 20, 3)
+    y <- rnorm(20); y[3] <- Inf
+    expect_identical(nlmixr2est:::.vaeL0Supports(X, y), .empty)
+  })
+
+  test_that(".vaeCovSelectModes resolves the per-eta mode", {
+    ctl <- function(method, maxExact = 25L) {
+      list(covSelectMethod = method, covSelectMaxExact = maxExact)
+    }
+    nCand <- c(30L, 10L, 30L)
+
+    ## explicit "bnb": nothing switches, whatever the size
+    m <- nlmixr2est:::.vaeCovSelectModes(nCand, ctl("bnb"), avail = TRUE)
+    expect_identical(m$mode, c(0L, 0L, 0L))
+    expect_identical(m$used, "bnb")
+    expect_length(m$msg, 0L)
+
+    ## "auto" + available: only the dimensions at/over the threshold switch
+    m <- nlmixr2est:::.vaeCovSelectModes(nCand, ctl("auto"), avail = TRUE)
+    expect_identical(m$mode, c(1L, 0L, 1L))
+    expect_identical(m$used, "mixed")
+    expect_match(m$msg, "not the exact search", all = FALSE)
+
+    ## "auto" below the threshold everywhere: unchanged, silent
+    m <- nlmixr2est:::.vaeCovSelectModes(c(5L, 10L), ctl("auto"), avail = TRUE)
+    expect_identical(m$mode, c(0L, 0L))
+    expect_identical(m$used, "bnb")
+    expect_length(m$msg, 0L)
+
+    ## "auto" over the threshold but L0Learn missing: exact search anyway, warned
+    m <- nlmixr2est:::.vaeCovSelectModes(nCand, ctl("auto"), avail = FALSE)
+    expect_identical(m$mode, c(0L, 0L, 0L))
+    expect_identical(m$used, "bnb")
+    expect_match(m$msg, "install L0Learn", all = FALSE)
+
+    ## explicit "l0learn": every dimension with candidates switches
+    m <- nlmixr2est:::.vaeCovSelectModes(c(3L, 0L), ctl("l0learn"), avail = TRUE)
+    expect_identical(m$mode, c(1L, 0L))
+    expect_identical(m$used, "mixed")
+
+    ## explicit "l0learn" without the package is an error naming it
+    expect_error(nlmixr2est:::.vaeCovSelectModes(nCand, ctl("l0learn"), avail = FALSE),
+                 "L0Learn")
+
+    ## the threshold is honored
+    m <- nlmixr2est:::.vaeCovSelectModes(c(24L, 25L), ctl("auto"), avail = TRUE)
+    expect_identical(m$mode, c(0L, 1L))
+  })
+
+  test_that("every run-time message stays inside the runInfo one-line budget", {
+    ## $runInfo renders one bullet per warning; CLAUDE.md caps these at 75 chars
+    ctl <- list(covSelectMethod = "auto", covSelectMaxExact = 25L)
+    msgs <- c(nlmixr2est:::.vaeCovSelectModes(30L, ctl, avail = TRUE)$msg,
+              nlmixr2est:::.vaeCovSelectModes(30L, ctl, avail = FALSE)$msg)
+    expect_gt(length(msgs), 0L)
+    expect_true(all(nchar(msgs) <= 75L))
+  })
+
+  test_that(".vaeL0Candidates maps reduced supports back to global columns", {
+    skip_if_not_installed("L0Learn")
+    .testSeed(3L)
+    N <- 100L; p <- 10L
+    covMat <- matrix(rnorm(N * p), N, p)
+    y <- cbind(as.numeric(covMat[, 4] * 2 + rnorm(N, sd = 0.3)),
+               as.numeric(covMat[, 9] * -3 + rnorm(N, sd = 0.3)))
+
+    ## dim 1 uses L0Learn, dim 2 stays on the exact search -> NULL
+    cand <- nlmixr2est:::.vaeL0Candidates(y, covMat, mode = c(1L, 0L))
+    expect_length(cand, 2L)
+    expect_null(cand[[2]])
+    expect_true(any(vapply(cand[[1]], function(e) identical(e, 3L), logical(1))))
+
+    ## restricted (pinCovariates) candidate columns: only allowed globals appear
+    allowed <- list(c(3L, 8L), integer(0))
+    cand <- nlmixr2est:::.vaeL0Candidates(y, covMat, mode = c(1L, 1L), allowed = allowed)
+    expect_true(all(unlist(cand[[1]]) %in% c(3L, 8L)))
+    expect_identical(cand[[2]], list(integer(0)))
+  })
+})

--- a/tools/benchVaeCovSelect.R
+++ b/tools/benchVaeCovSelect.R
@@ -1,0 +1,40 @@
+## Wall-clock of one VAE covariate M-step selection, exact branch-and-bound vs
+## L0Learn-proposed candidates + polish, at the neonatal case study's shape
+## (N = 189 subjects).  The M-step runs one of these per latent dimension per
+## training iteration, so the per-call cost below is multiplied by zDim * iters.
+##
+##   Rscript tools/benchVaeCovSelect.R
+##
+## Not a test: it measures, it does not assert.
+
+suppressMessages(devtools::load_all(".", helpers = FALSE, quiet = TRUE))
+if (!requireNamespace("L0Learn", quietly = TRUE)) stop("benchmark needs L0Learn")
+
+N <- 189L
+nCovs <- c(10L, 15L, 20L, 25L, 30L, 35L)
+bnbCap <- 30L                     # above this the exact search is left unmeasured
+set.seed(101)
+
+cat(sprintf("%5s %10s %10s %10s %8s\n", "nCov", "bnb (s)", "l0 (s)", "speedup", "same"))
+for (nCov in nCovs) {
+  X <- matrix(rnorm(N * nCov), N, nCov)
+  sel <- sort(sample.int(nCov, 3L))
+  y <- as.numeric(0.5 + X[, sel, drop = FALSE] %*% c(1.5, -2, 1) + rnorm(N, sd = 1))
+  omega <- 0.4
+  penalty <- log(N)
+
+  t0 <- proc.time()[3]
+  cand <- nlmixr2est:::.vaeL0Supports(X, y)
+  got <- vaeScoreSupports_(y, X, omega, penalty, cand, polish = TRUE)
+  tL <- proc.time()[3] - t0
+
+  if (nCov <= bnbCap) {
+    t0 <- proc.time()[3]
+    ref <- vaeBestSubset_(matrix(y, ncol = 1), X, omega, FALSE, penalty)
+    tB <- proc.time()[3] - t0
+    same <- identical(which(got$selected == 1L), which(ref$selected[1, ] == 1L))
+    cat(sprintf("%5d %10.3f %10.4f %10.1f %8s\n", nCov, tB, tL, tB / tL, same))
+  } else {
+    cat(sprintf("%5d %10s %10.4f %10s %8s\n", nCov, "skipped", tL, "-", "-"))
+  }
+}


### PR DESCRIPTION
## Why

The `est="vae"` covariate M-step solves an exact L0/BIC best-subset problem per
latent dimension per training iteration (`vaeBestSubsetL0`, `src/inner.cpp`):

    score(S) = RSS_S / omega[k] + penalty * |S|

The exact branch-and-bound is fine at the case studies' 5 covariates and blows up
past a few dozen -- **87s for a single 30-covariate dimension**, multiplied by
`zDim * iters`. Rohleff et al. report the same wall in their own implementation and
suggested [L0Learn](https://github.com/hazimehh/L0Learn) at >= 25 covariates.

## What

`vaeControl(covSelectMethod = c("auto", "bnb", "l0learn"))` and
`vaeControl(covSelectMaxExact = 17L)`.

**L0Learn proposes, it never decides.** Supports harvested from its `L0` and `L0L2`
paths are re-scored in C++ with the same exact objective, the same OLS
(`vaeOlsRss`) and the same lexicographic tie-break the branch-and-bound uses, then
improved by an add/drop/swap local search. L0Learn's internal centering, scaling
and lambda grid therefore cannot shift a selection -- they only decide which
subsets get looked at. `omega`, the `covSelectAlpha` penalty ramp, `pinCovariates`
and the `zPop` bound clamp all keep working unchanged.

`"auto"` (the default) switches a latent dimension only when it holds at least
`covSelectMaxExact` candidates, counted **after** `pinCovariates` trimming, so the
threshold is the size of the search actually run. Below it, nothing changes.

L0Learn is a **Suggests**. When the exact search would be impractical but L0Learn
is not installed (`"auto"` at or over the threshold, or an explicit `"l0learn"`),
the fit errors rather than run the slow search silently; `covSelectMaxExact = Inf`
forces the exact branch-and-bound everywhere. Below the threshold a missing
L0Learn is fine -- the exact search runs there regardless.

A fit whose search was approximate says so in `$runInfo` and records
`fit$vae$covSelectMethodUsed`.

## Results

Parity sweep, 200 problems, `nCov` 8..18, half independent and half rho=0.7
correlated: **200/200 exact matches** against the branch-and-bound optimum.

`tools/benchVaeCovSelect.R`, N = 189, one selection call (selection identical at
every measured size):

| nCov | bnb | L0Learn+polish | speedup |
|---|---|---|---|
| 10 | 0.002s | 0.015s | 0.1x |
| 15 | 0.006s | 0.019s | 0.3x |
| 20 | 0.204s | 0.027s | 7.6x |
| 25 | 2.874s | 0.038s | **75.6x** |
| 30 | 87.393s | 0.053s | **1648.9x** |

The wall-clock crossover is near `nCov` 17, so `covSelectMaxExact` defaults to 17
(the authors suggested L0Learn at >= 25; measuring here put the crossover lower).
It is tunable, and `Inf` forces the exact search everywhere.

## Notes for review

- An `Rcpp::Function` cannot be called from inside the M-step's OpenMP loop, so
  candidate generation is **one R crossing per iteration on the main thread**,
  before the loop; scoring and polish still run in parallel.
- Candidates come back indexed into each dimension's reduced design, which is what
  the loop's `Xuse` already is, so the existing `pinCovariates` global mapping is
  reused untouched.
- `vaeBestSubsetL0` / `vaeBestSubset_` are unchanged apart from factoring result
  shaping into a shared `vaeFinishSubset`; the golden MIQP fixtures still pass.
- `src/init.c` prototype and arg count hand-added for the new `vaeScoreSupports_`
  export, per `CLAUDE.md`.

## Verification

- Full essential push/PR subset: **134/134 files, 0 failures**.
- `test-vae-l0learn.R` (essential) green **with** L0Learn (216 pass) and
  **without** it (64 pass / 5 skip).
- `test-vae-l0learn-fit.R` (weekly batch 6) asserts the mechanism --
  `covSelectMethodUsed` and the `$runInfo` note -- not just result agreement.
- Existing `vae-neonatal` / `vae-covariate` / `vae-fit` / `vae-errmodel` /
  `vae-train` / `vae-elbo` unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
