### PR TITLE
fix: parFixed SE for residual-error parameters read uninitialized memory (#816)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,6 +54,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # cache-version 2: drop caches holding qs2/stringfish binaries built
+          # against RcppParallel < 6.0.0 (pre-oneTBB); those fail to load with
+          # undefined tbb::internal symbols.  qs2/stringfish are forced to
+          # source so they always link the installed RcppParallel.
+          cache-version: 2
           extra-packages: |
             any::rcmdcheck
             nlmixr2/lbfgsb3c
@@ -64,6 +69,8 @@ jobs:
             nlmixr2/rxode2
             nlmixr2/PreciseSums
             qs=?ignore
+            qs2=?source
+            stringfish=?source
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          cache-version: 2
           extra-packages: |
             any::pkgdown
             nlmixr2/n1qn1c
@@ -43,6 +45,8 @@ jobs:
             nlmixr2/rxode2
             nlmixr2/PreciseSums
             qs=?ignore
+            qs2=?source
+            stringfish=?source
             local::.
           needs: website
 

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -60,7 +60,11 @@ jobs:
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-          extra-packages: nlmixr2/rxode2
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          extra-packages: |
+            nlmixr2/rxode2
+            qs2=?source
+            stringfish=?source
       - uses: r-hub/actions/run-check@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
@@ -97,7 +101,11 @@ jobs:
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-          extra-packages: nlmixr2/rxode2
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          extra-packages: |
+            nlmixr2/rxode2
+            qs2=?source
+            stringfish=?source
       - uses: r-hub/actions/run-check@v1
         with:
           job-config: ${{ matrix.config.job-config }}

--- a/.github/workflows/runtime-benchmarks.yaml
+++ b/.github/workflows/runtime-benchmarks.yaml
@@ -36,6 +36,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          cache-version: 2
           extra-packages: |
             any::rcmdcheck
             nlmixr2/lbfgsb3c
@@ -46,6 +48,8 @@ jobs:
             nlmixr2/rxode2
             nlmixr2/PreciseSums
             qs=?ignore
+            qs2=?source
+            stringfish=?source
           needs: check
 
       - name: Install package

--- a/.github/workflows/slow-tests.yaml
+++ b/.github/workflows/slow-tests.yaml
@@ -49,6 +49,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          cache-version: 2
           extra-packages: |
             any::rcmdcheck
             nlmixr2/lbfgsb3c
@@ -59,6 +61,8 @@ jobs:
             nlmixr2/rxode2
             nlmixr2/PreciseSums
             qs=?ignore
+            qs2=?source
+            stringfish=?source
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          cache-version: 2
           extra-packages: |
             any::covr
             any::xml2
@@ -35,6 +37,8 @@ jobs:
             nlmixr2/rxode2
             nlmixr2/PreciseSums
             qs=?ignore
+            qs2=?source
+            stringfish=?source
           needs: coverage
 
       - name: Test coverage

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nlmixr2est
 Title: Nonlinear Mixed Effects Models in Population PK/PD, Estimation Routines
-Version: 7.0.1
+Version: 7.0.2
 Authors@R: c(
     person("Matthew", "Fidler", , "matthew.fidler@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8538-6691")),
     person("Wenping", "Wang", , "wwang8198@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# nlmixr2est 7.0.2
+
+## Bug fixes
+
+- Fixed `$parFixed` reporting an uninitialized-memory denormal (e.g.
+  `9.4e-323`) as a residual-error parameter's `SE`/`%RSE` for SAEM fits
+  (#816).  The finalization filled theta SEs positionally from a covariance
+  that does not span the residual thetas, reading past the end of its
+  diagonal; the SE fill now maps by the covariance dimnames.  Post-fit
+  covariance installs also refresh the displayed `$parFixed` (previously only
+  `$parFixedDf` was updated), so the residual `SE`, `%RSE`, and confidence
+  interval now carry `sqrt(diag(fit$cov))`; a theta with no covariance row
+  gets a blank `SE` instead of garbage.
+
 # nlmixr2est 7.0.1
 
 ## New features

--- a/R/covRecompute.R
+++ b/R/covRecompute.R
@@ -142,28 +142,7 @@
   assign("cov", .cov, envir = env)
   assign("covMethod", r$covMethod, envir = env)
   # refresh SE/%RSE/CI on the fit's own parameter table from the new covariance
-  if (exists("parFixedDf", envir = env, inherits = FALSE)) {
-    .pf <- env$parFixedDf
-    .se <- sqrt(diag(.cov))
-    .ci <- tryCatch(as.numeric(rxode2::rxGetControl(env$ui, "ci", 0.95)),
-                    error = function(e) 0.95)
-    .qn <- stats::qnorm(1 - (1 - .ci) / 2)
-    for (.n in rownames(.pf)) {
-      if (.n %in% names(.se) && "SE" %in% names(.pf)) {
-        .s <- .se[[.n]]; .e <- .pf[.n, "Estimate"]
-        .pf[.n, "SE"] <- .s
-        if ("%RSE" %in% names(.pf)) {
-          .pf[.n, "%RSE"] <- if (is.finite(.e) && .e != 0) abs(.s / .e) * 100 else NA_real_
-        }
-        if (all(c("CI Lower", "CI Upper", "Back-transformed") %in% names(.pf)) &&
-              isTRUE(all.equal(unname(.pf[.n, "Back-transformed"]), unname(.e)))) {
-          .pf[.n, "CI Lower"] <- .e - .qn * .s
-          .pf[.n, "CI Upper"] <- .e + .qn * .s
-        }
-      }
-    }
-    env$parFixedDf <- .pf
-  }
+  .updateParFixedRefreshSeFromCov(env, .cov)
   .nlmixr2CovConditionUpdate(env)
   invisible(TRUE)
 }

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -365,10 +365,18 @@
     if ("%RSE" %in% names(.pf)) {
       .pf[.n, "%RSE"] <- if (is.finite(.e) && .e != 0) abs(.s / .e) * 100 else NA_real_
     }
-    if (all(c("CI Lower", "CI Upper", "Back-transformed") %in% names(.pf)) &&
-          isTRUE(all.equal(unname(.pf[.n, "Back-transformed"]), unname(.e)))) {
-      .pf[.n, "CI Lower"] <- .e - .qn * .s
-      .pf[.n, "CI Upper"] <- .e + .qn * .s
+    if (all(c("CI Lower", "CI Upper", "Back-transformed") %in% names(.pf))) {
+      # recompute the CI when the default back-transform (identity/exp/expit/
+      # probitInv) reproduces the stored back-transformed value; rows with a
+      # manual backTransform keep their existing CI
+      .btf <- function(.v) {
+        tryCatch(.updateParFixedBackTransformFixed(env$ui, .n, .v),
+                 error = function(e) .v)
+      }
+      if (isTRUE(all.equal(unname(.pf[.n, "Back-transformed"]), unname(.btf(.e))))) {
+        .pf[.n, "CI Lower"] <- .btf(.e - .qn * .s)
+        .pf[.n, "CI Upper"] <- .btf(.e + .qn * .s)
+      }
     }
     .changed <- TRUE
   }

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -327,6 +327,82 @@
   ret
 }
 
+#' Refresh a fit's parameter-table SEs from an installed covariance
+#'
+#' Updates the numeric `$parFixedDf` and regenerates the formatted `$parFixed`
+#' so both carry `sqrt(diag(cov))` for every theta row named in `cov`
+#' (issue #816: a post-fit covariance install updated only `$parFixedDf`,
+#' leaving the displayed table stale).
+#'
+#' @param env fit environment carrying `$parFixedDf`, `$parFixed`, `$ui`
+#' @param cov named covariance matrix
+#' @param onlyMissing when `TRUE` update only rows whose SE is missing or
+#'   non-finite (used when `cov` adds rows -- e.g. residual thetas -- to a
+#'   table whose structural SEs are already correct)
+#' @return invisibly, called for side effects on `env`
+#' @noRd
+.updateParFixedRefreshSeFromCov <- function(env, cov, onlyMissing = FALSE) {
+  if (!exists("parFixedDf", envir = env, inherits = FALSE)) return(invisible())
+  .pf <- env$parFixedDf
+  if (!is.matrix(cov) || is.null(rownames(cov)) ||
+        !is.data.frame(.pf) || !("SE" %in% names(.pf))) {
+    return(invisible())
+  }
+  .se <- sqrt(diag(cov))
+  .ci <- tryCatch(as.numeric(rxode2::rxGetControl(env$ui, "ci", 0.95)),
+                  error = function(e) 0.95)
+  .qn <- stats::qnorm(1 - (1 - .ci) / 2)
+  .changed <- FALSE
+  for (.n in intersect(rownames(.pf), names(.se))) {
+    if (onlyMissing) {
+      .cur <- .pf[.n, "SE"]
+      # denormal garbage from a pre-fix finalization also counts as missing
+      if (!(is.na(.cur) || !is.finite(.cur) || .cur < 1e-100)) next
+    }
+    .s <- .se[[.n]]
+    .e <- .pf[.n, "Estimate"]
+    .pf[.n, "SE"] <- .s
+    if ("%RSE" %in% names(.pf)) {
+      .pf[.n, "%RSE"] <- if (is.finite(.e) && .e != 0) abs(.s / .e) * 100 else NA_real_
+    }
+    if (all(c("CI Lower", "CI Upper", "Back-transformed") %in% names(.pf)) &&
+          isTRUE(all.equal(unname(.pf[.n, "Back-transformed"]), unname(.e)))) {
+      .pf[.n, "CI Lower"] <- .e - .qn * .s
+      .pf[.n, "CI Upper"] <- .e + .qn * .s
+    }
+    .changed <- TRUE
+  }
+  if (!.changed) return(invisible())
+  env$parFixedDf <- .pf
+  # regenerate the formatted table; the FIXED / fix(...) decorations are
+  # re-derived from the existing formatted table (the numeric one lacks them)
+  if (exists("parFixed", envir = env, inherits = FALSE) &&
+        is.data.frame(env$parFixed)) {
+    .old <- env$parFixed
+    .fixedNames <- rownames(.old)[which(.old[["SE"]] == "FIXED")]
+    .bsvCol <- which(startsWith(names(.old), "BSV("))
+    .bsvFixedNames <- if (length(.bsvCol) == 1L) {
+      rownames(.old)[startsWith(as.character(.old[[.bsvCol]]), "fix(")]
+    } else {
+      character()
+    }
+    .digits <- tryCatch({
+      .v <- env$control[["sigdigTable"]]
+      if (length(.v) == 1L && is.finite(.v)) {
+        .v
+      } else {
+        rxode2::rxGetControl(env$ui, "sigdigTable", 3L)
+      }
+    }, error = function(e) 3L)
+    .new <- .updateParFixedApplySig(.pf, digits = .digits, ci = .ci,
+                                    fixedNames = .fixedNames,
+                                    bsvFixedNames = .bsvFixedNames)
+    class(.new) <- class(.old)
+    env$parFixed <- .new
+  }
+  invisible()
+}
+
 #' Create the parFixed dataset
 #'
 #' @param .ret focei style environment

--- a/R/saem.R
+++ b/R/saem.R
@@ -1068,26 +1068,7 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
   # surface the residual (error-model theta) SEs in the parameter table from the full
   # cov -- these are theta rows with a missing SE (Omega variances are reported as BSV,
   # with their SEs available in $cov).
-  if (exists("parFixedDf", envir = .env, inherits = FALSE)) {
-    .pf <- .env$parFixedDf
-    .se <- sqrt(diag(.full))
-    .ci <- tryCatch(as.numeric(rxode2::rxGetControl(.env$ui, "ci", 0.95)), error = function(e) 0.95)
-    .qn <- stats::qnorm(1 - (1 - .ci) / 2)
-    for (.n in rownames(.pf)) {
-      if (.n %in% names(.se) && "SE" %in% names(.pf) &&
-            (is.na(.pf[.n, "SE"]) || !is.finite(.pf[.n, "SE"]) || .pf[.n, "SE"] < 1e-100)) {
-        .s <- .se[[.n]]; .e <- .pf[.n, "Estimate"]
-        .pf[.n, "SE"] <- .s
-        if ("%RSE" %in% names(.pf)) .pf[.n, "%RSE"] <- abs(.s / .e) * 100
-        if (all(c("CI Lower", "CI Upper", "Back-transformed") %in% names(.pf)) &&
-              isTRUE(all.equal(unname(.pf[.n, "Back-transformed"]), unname(.e)))) {
-          .pf[.n, "CI Lower"] <- .e - .qn * .s
-          .pf[.n, "CI Upper"] <- .e + .qn * .s
-        }
-      }
-    }
-    .env$parFixedDf <- .pf
-  }
+  .updateParFixedRefreshSeFromCov(.env, .full, onlyMissing = TRUE)
   invisible()
 }
 
@@ -1135,26 +1116,7 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
   .env$covMethod <- "analytic"
   assign(".covAnalytic", .r, envir = .env)                 # getVarCov()/$cov reuse it
   # overwrite the parameter-table SEs from the analytic covariance
-  if (exists("parFixedDf", envir = .env, inherits = FALSE)) {
-    .pf <- .env$parFixedDf
-    .se <- sqrt(diag(.cov))
-    .ci <- tryCatch(as.numeric(rxode2::rxGetControl(.env$ui, "ci", 0.95)),
-                    error = function(e) 0.95)
-    .qn <- stats::qnorm(1 - (1 - .ci) / 2)
-    for (.n in rownames(.pf)) {
-      if (.n %in% names(.se) && "SE" %in% names(.pf)) {
-        .s <- .se[[.n]]; .e <- .pf[.n, "Estimate"]
-        .pf[.n, "SE"] <- .s
-        if ("%RSE" %in% names(.pf)) .pf[.n, "%RSE"] <- abs(.s / .e) * 100
-        if (all(c("CI Lower", "CI Upper", "Back-transformed") %in% names(.pf)) &&
-              isTRUE(all.equal(unname(.pf[.n, "Back-transformed"]), unname(.e)))) {
-          .pf[.n, "CI Lower"] <- .e - .qn * .s
-          .pf[.n, "CI Upper"] <- .e + .qn * .s
-        }
-      }
-    }
-    .env$parFixedDf <- .pf
-  }
+  .updateParFixedRefreshSeFromCov(.env, .cov)
   .nlmixr2CovConditionUpdate(.env)
   invisible()
 }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -8477,11 +8477,42 @@ void foceiFinalizeTables(Environment e){
   std::fill_n(&cv[0], theta.size(), NA_REAL);
   int j=0, k=0, l=0;
   if (covExists){
-    for (int k = 0; k < se.size(); k++){
-      if (k >= skipCov.size()) break;
-      if (!skipCov[k]){
-        se[k] = se1[j++];
-        cv[k] = std::fabs(se[k]/theta[k])*100;
+    // The cov may not span every non-skipped theta (e.g. SAEM installs a
+    // structural-theta block here; the full theta+Omega+residual matrix is
+    // swapped in after the fit is built).  When the cov carries dimnames, map
+    // SEs by name; otherwise fill positionally without reading past the end of
+    // the diagonal (issue #816: the overrun surfaced uninitialized memory as
+    // the residual-error SE).
+    CharacterVector covNames;
+    bool covHasNames = false;
+    RObject covDimnames = as<RObject>(e["cov"]).attr("dimnames");
+    if (!covDimnames.isNULL()) {
+      List dn = as<List>(covDimnames);
+      if (dn.size() == 2 && !Rf_isNull(dn[0])) {
+        covNames = as<CharacterVector>(dn[0]);
+        covHasNames = true;
+      }
+    }
+    if (covHasNames) {
+      for (int k = 0; k < se.size(); k++){
+        if (k >= skipCov.size() || k >= thetaNames.size()) break;
+        if (skipCov[k]) continue;
+        for (int m = 0; m < covNames.size(); m++){
+          if (!strcmp(CHAR(STRING_ELT(covNames, m)), CHAR(STRING_ELT(thetaNames, k)))) {
+            se[k] = se1[m];
+            cv[k] = std::fabs(se[k]/theta[k])*100;
+            break;
+          }
+        }
+      }
+    } else {
+      for (int k = 0; k < se.size(); k++){
+        if (k >= skipCov.size()) break;
+        if (j >= (int)se1.n_elem) break;
+        if (!skipCov[k]){
+          se[k] = se1[j++];
+          cv[k] = std::fabs(se[k]/theta[k])*100;
+        }
       }
     }
   }
@@ -8668,8 +8699,12 @@ void foceiFinalizeTables(Environment e){
       }
     }
     List thetaDim = List::create(thetaCovN,thetaCovN);
-    tmpNM.attr("dimnames") = thetaDim;
-    e["cov"]=tmpNM;
+    // an R-side cov (e.g. SAEM) already carries correct dimnames; only stamp
+    // positional theta names on the native (unnamed) C++ cov
+    if (Rf_isNull(tmpNM.attr("dimnames"))) {
+      tmpNM.attr("dimnames") = thetaDim;
+      e["cov"]=tmpNM;
+    }
     if (e.exists("Rinv") && rxode2::rxIs(e["Rinv"], "matrix")){
       tmpNM = as<NumericMatrix>(e["Rinv"]);
       tmpNM.attr("dimnames") = thetaDim;

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -119,6 +119,14 @@ nmTest({
     fit <- suppressMessages(suppressWarnings(setCov(fit, "analytic")))
     expect_identical(fit$covMethod, "analytic")
     expect_true(all(is.finite(sqrt(diag(fit$cov)))))
+    # issue #816: the displayed $parFixed must track the installed covariance,
+    # not just the numeric $parFixedDf
+    expect_equal(unname(fit$parFixedDf["add.sd", "SE"]),
+                 unname(sqrt(diag(fit$cov))["add.sd"]))
+    .seNum <- suppressWarnings(as.numeric(fit$parFixed["add.sd", "SE"]))
+    expect_true(is.finite(.seNum))
+    expect_equal(.seNum, signif(unname(fit$parFixedDf["add.sd", "SE"]), 3),
+                 tolerance = 1e-2)
   })
 
   test_that("finite-difference covMethod='r,s' covFull=TRUE installs the true full FD sandwich", {

--- a/tests/testthat/test-cov-decouple-saimp.R
+++ b/tests/testthat/test-cov-decouple-saimp.R
@@ -37,6 +37,17 @@ nmTest({
     expect_true(.isPdFinite(.fi$cov))
   })
 
+  # the formatted $parFixed must track the installed cov (issue #816: only
+  # $parFixedDf was refreshed, leaving the displayed SE stale)
+  .expectParFixedTracksCov <- function(.f, .n = "add.sd") {
+    expect_equal(unname(.f$parFixedDf[.n, "SE"]),
+                 unname(sqrt(diag(.f$cov))[.n]))
+    .seNum <- suppressWarnings(as.numeric(.f$parFixed[.n, "SE"]))
+    expect_true(is.finite(.seNum))
+    expect_equal(.seNum, signif(unname(.f$parFixedDf[.n, "SE"]), 3),
+                 tolerance = 1e-2)
+  }
+
   test_that("setCov() switches any completed fit to sa/imp", {
     .f <- suppressWarnings(nlmixr2(.lc, .d, est = "focei",
                                    control = foceiControl(print = 0L)))
@@ -44,8 +55,10 @@ nmTest({
     suppressMessages(setCov(.f, "sa"))
     expect_equal(.f$covMethod, "sa")
     expect_true(.isPdFinite(.f$cov))
+    .expectParFixedTracksCov(.f)
     suppressMessages(setCov(.f, "imp"))
     expect_equal(.f$covMethod, "imp")
+    .expectParFixedTracksCov(.f)
     # the original r,s covariance stays recoverable from the cache
     suppressMessages(setCov(.f, "r,s"))
     expect_equal(.f$covMethod, "r,s")

--- a/tests/testthat/test-parFixedDf.R
+++ b/tests/testthat/test-parFixedDf.R
@@ -35,6 +35,19 @@ nmTest({
   })
 
   test_that(".updateParFixedRefreshSeFromCov updates parFixedDf and the formatted parFixed (#816)", {
+    .uiMod816 <- function() {
+      ini({
+        tcl <- 1; tfix <- fix(2); add.sd <- 0.7
+        eta.cl ~ 0.3
+      })
+      model({
+        cl <- exp(tcl + eta.cl)
+        v <- tfix
+        d/dt(center) <- -cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
     .pf <- data.frame(
       Parameter = c("", "", ""),
       Estimate = c(1, 2, 0.7),
@@ -46,6 +59,7 @@ nmTest({
       check.names = FALSE,
       row.names = c("tcl", "tfix", "add.sd"))
     env <- new.env(parent = emptyenv())
+    env$ui <- rxode2::assertRxUi(.uiMod816)
     env$parFixedDf <- .pf
     env$parFixed <- .updateParFixedApplySig(.pf, 3L, 0.95, "tfix")
     class(env$parFixed) <- c("nlmixr2ParFixed", "data.frame")
@@ -65,10 +79,15 @@ nmTest({
     expect_equal(as.numeric(env$parFixed["add.sd", "SE"]), 0.05)
     expect_equal(env$parFixed["tfix", "SE"], "FIXED")
 
-    # onlyMissing = FALSE overwrites the structural SE from the cov
+    # onlyMissing = FALSE overwrites the structural SE from the cov, and the
+    # CI of a log-scale theta is recomputed through its default back-transform
     .updateParFixedRefreshSeFromCov(env, .cov)
     expect_equal(unname(env$parFixedDf["tcl", "SE"]), 0.2)
     expect_equal(as.numeric(env$parFixed["tcl", "SE"]), 0.2)
+    expect_equal(unname(env$parFixedDf["tcl", "CI Lower"]),
+                 exp(1 - qnorm(0.975) * 0.2))
+    expect_equal(unname(env$parFixedDf["tcl", "CI Upper"]),
+                 exp(1 + qnorm(0.975) * 0.2))
 
     # a denormal (uninitialized-memory signature) counts as missing
     env$parFixedDf["add.sd", "SE"] <- 9.39e-323

--- a/tests/testthat/test-parFixedDf.R
+++ b/tests/testthat/test-parFixedDf.R
@@ -34,6 +34,48 @@ nmTest({
                  signif(sqrt(fit$omega[1, 1]), foceiControl()$sigdig))
   })
 
+  test_that(".updateParFixedRefreshSeFromCov updates parFixedDf and the formatted parFixed (#816)", {
+    .pf <- data.frame(
+      Parameter = c("", "", ""),
+      Estimate = c(1, 2, 0.7),
+      SE = c(0.1, NA_real_, NA_real_),
+      "%RSE" = c(10, NA_real_, NA_real_),
+      "Back-transformed" = c(exp(1), 2, 0.7),
+      "CI Lower" = c(exp(1 - qnorm(0.975) * 0.1), NA_real_, NA_real_),
+      "CI Upper" = c(exp(1 + qnorm(0.975) * 0.1), NA_real_, NA_real_),
+      check.names = FALSE,
+      row.names = c("tcl", "tfix", "add.sd"))
+    env <- new.env(parent = emptyenv())
+    env$parFixedDf <- .pf
+    env$parFixed <- .updateParFixedApplySig(.pf, 3L, 0.95, "tfix")
+    class(env$parFixed) <- c("nlmixr2ParFixed", "data.frame")
+    .cov <- matrix(c(0.04, 0, 0, 0.0025), 2, 2,
+                   dimnames = list(c("tcl", "add.sd"), c("tcl", "add.sd")))
+
+    .updateParFixedRefreshSeFromCov(env, .cov, onlyMissing = TRUE)
+
+    # add.sd filled from sqrt(diag(cov)); tcl kept (onlyMissing = TRUE)
+    expect_equal(unname(env$parFixedDf["add.sd", "SE"]), 0.05)
+    expect_equal(unname(env$parFixedDf["add.sd", "%RSE"]), 0.05 / 0.7 * 100)
+    expect_equal(unname(env$parFixedDf["tcl", "SE"]), 0.1)
+    # CI recomputed on the natural scale (Back-transformed == Estimate)
+    expect_equal(unname(env$parFixedDf["add.sd", "CI Lower"]),
+                 0.7 - qnorm(0.975) * 0.05)
+    # formatted table regenerated; FIXED decoration preserved
+    expect_equal(as.numeric(env$parFixed["add.sd", "SE"]), 0.05)
+    expect_equal(env$parFixed["tfix", "SE"], "FIXED")
+
+    # onlyMissing = FALSE overwrites the structural SE from the cov
+    .updateParFixedRefreshSeFromCov(env, .cov)
+    expect_equal(unname(env$parFixedDf["tcl", "SE"]), 0.2)
+    expect_equal(as.numeric(env$parFixed["tcl", "SE"]), 0.2)
+
+    # a denormal (uninitialized-memory signature) counts as missing
+    env$parFixedDf["add.sd", "SE"] <- 9.39e-323
+    .updateParFixedRefreshSeFromCov(env, .cov, onlyMissing = TRUE)
+    expect_equal(unname(env$parFixedDf["add.sd", "SE"]), 0.05)
+  })
+
   ## Literally-fixed thetas are re-inserted into $popDf after the C++ step, so
   ## the default (exp/expit/probitInv) back-transform must be applied in R;
   ## previously they printed on the raw (log/logit) scale.

--- a/tests/testthat/test-saem-cov-sa.R
+++ b/tests/testthat/test-saem-cov-sa.R
@@ -45,6 +45,27 @@ nmTest({
     # residual SE surfaced in the parameter table
     expect_true(is.finite(fS$parFixedDf["add.sd", "SE"]))
     expect_gt(fS$parFixedDf["add.sd", "SE"], 0)
+
+    # issue #816: the FORMATTED $parFixed must carry the same residual SE as
+    # $parFixedDf / sqrt(diag($cov)) -- it previously printed uninitialized
+    # memory (a denormal like 9.4e-323).  A theta with no covariance row must
+    # be blank, never garbage.
+    for (.f in list(fS, fL)) {
+      if ("add.sd" %in% rownames(.f$cov)) {
+        expect_equal(unname(.f$parFixedDf["add.sd", "SE"]),
+                     unname(sqrt(diag(.f$cov))["add.sd"]))
+        .seNum <- suppressWarnings(as.numeric(.f$parFixed["add.sd", "SE"]))
+        expect_true(is.finite(.seNum))
+        expect_gt(.seNum, 1e-100)
+        expect_equal(.seNum, signif(unname(.f$parFixedDf["add.sd", "SE"]), 3),
+                     tolerance = 1e-2)
+        .rseNum <- suppressWarnings(as.numeric(.f$parFixed["add.sd", "%RSE"]))
+        expect_true(is.finite(.rseNum))
+        expect_gt(.rseNum, 1e-100)
+      } else {
+        expect_identical(unname(.f$parFixed["add.sd", "SE"]), "")
+      }
+    }
   })
 
   test_that("SAEM covMethod='fim' inverts the (mu-block-corrected) estimation-phase FIM", {


### PR DESCRIPTION
## Summary

Fixes #816: for SAEM fits, `fit$parFixed` reported the residual-error
parameter's `SE` as an uninitialized-memory denormal (e.g. `9.39e-323`,
varying between identical seeded runs) while the correct value was already
sitting in `fit$cov`.

## Root cause

Two layers:

1. **Out-of-bounds read in `foceiFinalizeTables` (`src/inner.cpp`).**  The
   per-theta SE vector was filled positionally from `sqrt(diag(cov))` over the
   non-skipped thetas.  SAEM installs a *structural-theta* covariance block for
   finalization (error thetas excluded; the full theta+Omega+residual matrix is
   swapped in after the fit object is built), while `foceiSkipCov` does not skip
   error thetas -- so the fill loop indexed one past the end of the diagonal and
   surfaced uninitialized memory as the residual SE (and `%RSE`).
2. **Stale formatted table.**  The post-fit covariance installs
   (`.saemInstallFullCov`, `.saemInstallAnalyticCov`, `.covInstallResult`)
   patched only the numeric `$parFixedDf`; the displayed `$parFixed` was never
   refreshed, so the garbage stayed visible even after the correct SE had been
   computed.

## Fix

- `src/inner.cpp`: the SE fill now maps by the covariance dimnames when they
  are present (an R-side cov is always named), and the positional fallback for
  the native unnamed C++ cov is bounds-guarded.  A theta with no covariance row
  gets `NA` (blank in the table) instead of garbage.  The dimnames stamping no
  longer overwrites an already-named covariance.
- `R/nlmixr2output.R`: new shared `.updateParFixedRefreshSeFromCov()` updates
  `$parFixedDf` *and* regenerates the formatted `$parFixed` from it, so the
  displayed residual `SE`, `%RSE`, and CI carry `sqrt(diag(fit$cov))`.  The CI
  is recomputed through the parameter's default back-transform
  (identity/exp/expit/probitInv); manual `backTransform` rows keep their
  existing CI.  The three install sites now share this helper instead of three
  divergent hand-patches.

## Result

```
       Parameter  Est.     SE %RSE Back-transformed(95%CI) BSV(CV%)
tka           Ka 0.456  0.189 41.5       1.58 (1.09, 2.29)     70.4
tcl           Cl  1.01 0.0822 8.11       2.76 (2.35, 3.24)     27.2
tv             V  3.45 0.0432 1.25       31.6 (29.0, 34.4)     13.3
add.sd           0.697 0.0471 6.75    0.697 (0.605, 0.789)
```

(previously `add.sd` printed `SE 9.39e-323`, `%RSE 1.33e-320`, and a
degenerate CI)

## Tests

- `test-parFixedDf.R`: unit test of the refresh helper (fill-missing,
  full-overwrite, denormal-counts-as-missing, log-scale CI recompute, FIXED
  decoration preserved).
- `test-saem-cov-sa.R`: the formatted `$parFixed` residual SE/%RSE must match
  `sqrt(diag($cov))` for both the `sa` and `linFim` covariances, and must be
  blank (never garbage) when the covariance has no row for the theta.
- `test-cov-decouple-saimp.R`, `test-cov-analytic.R`: the displayed table
  tracks the installed covariance after `setCov(fit, "sa"/"imp"/"analytic")`.

Independent reviews run before submission: GitHub Copilot (GPT family; two
test-coverage suggestions, both adopted) and Antigravity (Gemini family; one
real finding -- stale CIs for back-transformed thetas on covariance refresh --
fixed, one finding rejected as unreachable because `.foceiSetupSkipCov`
normalizes `skipCov` to theta length).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
