### PR TITLE
ci: rebuild qs2/stringfish from source for RcppParallel 6.0.0 (oneTBB)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,6 +54,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # cache-version 2: drop caches holding qs2/stringfish binaries built
+          # against RcppParallel < 6.0.0 (pre-oneTBB); those fail to load with
+          # undefined tbb::internal symbols.  qs2/stringfish are forced to
+          # source so they always link the installed RcppParallel.
+          cache-version: 2
           extra-packages: |
             any::rcmdcheck
             nlmixr2/lbfgsb3c
@@ -64,6 +69,8 @@ jobs:
             nlmixr2/rxode2
             nlmixr2/PreciseSums
             qs=?ignore
+            qs2=?source
+            stringfish=?source
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          cache-version: 2
           extra-packages: |
             any::pkgdown
             nlmixr2/n1qn1c
@@ -43,6 +45,8 @@ jobs:
             nlmixr2/rxode2
             nlmixr2/PreciseSums
             qs=?ignore
+            qs2=?source
+            stringfish=?source
             local::.
           needs: website
 

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -60,7 +60,11 @@ jobs:
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-          extra-packages: nlmixr2/rxode2
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          extra-packages: |
+            nlmixr2/rxode2
+            qs2=?source
+            stringfish=?source
       - uses: r-hub/actions/run-check@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
@@ -97,7 +101,11 @@ jobs:
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-          extra-packages: nlmixr2/rxode2
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          extra-packages: |
+            nlmixr2/rxode2
+            qs2=?source
+            stringfish=?source
       - uses: r-hub/actions/run-check@v1
         with:
           job-config: ${{ matrix.config.job-config }}

--- a/.github/workflows/runtime-benchmarks.yaml
+++ b/.github/workflows/runtime-benchmarks.yaml
@@ -36,6 +36,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          cache-version: 2
           extra-packages: |
             any::rcmdcheck
             nlmixr2/lbfgsb3c
@@ -46,6 +48,8 @@ jobs:
             nlmixr2/rxode2
             nlmixr2/PreciseSums
             qs=?ignore
+            qs2=?source
+            stringfish=?source
           needs: check
 
       - name: Install package

--- a/.github/workflows/slow-tests.yaml
+++ b/.github/workflows/slow-tests.yaml
@@ -49,6 +49,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          cache-version: 2
           extra-packages: |
             any::rcmdcheck
             nlmixr2/lbfgsb3c
@@ -59,6 +61,8 @@ jobs:
             nlmixr2/rxode2
             nlmixr2/PreciseSums
             qs=?ignore
+            qs2=?source
+            stringfish=?source
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # See R-CMD-check.yaml: qs2/stringfish must link RcppParallel >= 6.0.0
+          cache-version: 2
           extra-packages: |
             any::covr
             any::xml2
@@ -35,6 +37,8 @@ jobs:
             nlmixr2/rxode2
             nlmixr2/PreciseSums
             qs=?ignore
+            qs2=?source
+            stringfish=?source
           needs: coverage
 
       - name: Test coverage


### PR DESCRIPTION
## Summary

RcppParallel 6.0.0 (the oneTBB switch) broke CI on every platform:

- **Linux/macOS**: cached/prebuilt `stringfish`/`qs2` binaries were compiled against RcppParallel 5.x and fail to load with `undefined symbol: _ZN3tbb8internal25concurrent_vector_base_v3...`. This kills examples and `helper-zzz-fits.R` (rxode2's model cache saves/loads via qs2, and the fixture cache uses qs2).
- **Windows**: `rxode2.dll` failed to load after building against RcppParallel 6.0.0; fixed upstream in rxode2#1162 (already merged), so it heals on re-run since CI installs `nlmixr2/rxode2` from GitHub.

## Fix

In all four workflows (R-CMD-check, test-coverage, slow-tests, pkgdown):
- Force `qs2=?source` and `stringfish=?source` so they always link the installed RcppParallel.
- Bump `cache-version` to 2 to drop caches holding the stale 5.x-era binaries.

This is what broke the checks on #819 (and main) -- the failures are unrelated to that PR's content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)