### PR TITLE
fix: drop qs2/stringfish dependency for serialization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nlmixr2est
 Title: Nonlinear Mixed Effects Models in Population PK/PD, Estimation Routines
-Version: 7.0.1
+Version: 7.0.2
 Authors@R: c(
     person("Matthew", "Fidler", , "matthew.fidler@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8538-6691")),
     person("Wenping", "Wang", , "wwang8198@gmail.com", role = "aut"),
@@ -57,7 +57,7 @@ Imports:
     nlme,
     Rcpp,
     rex,
-    rxode2 (>= 5.1.3),
+    rxode2 (>= 5.1.5),
     stats,
     symengine,
     utils
@@ -71,7 +71,6 @@ Suggests:
     dplyr (>= 1.1.0),
     generics,
     nloptr,
-    qs2,
     sys,
     testthat,
     tibble,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# nlmixr2est 7.0.2
+
+## Breaking changes
+
+- Dropped the `qs2` dependency (and with it `stringfish`, which no longer
+  loads against RcppParallel >= 6.0.0): the focei model disk cache now uses
+  RDS files and compressed fit components use base R serialization
+  (`rxode2::rxGetDefaultSerialize()`, "bzip2" by default).  Old fits holding
+  qs2-serialized components can still be read when the `qs2` package is
+  installed; otherwise accessing them warns and returns `NULL`.  Requires
+  rxode2 (>= 5.1.5) for `rxDeserialize()`.
+
+## Bug fixes
+
+- `nlmixr2fix()` now actually repairs serialized fit components: it previously
+  tested the component name (not the object) for rawness, so the repair loop
+  never ran, and a successful qs2 read was discarded.
+
 # nlmixr2est 7.0.1
 
 ## New features

--- a/R/compat.R
+++ b/R/compat.R
@@ -28,15 +28,37 @@ nlmixr2fix <- function(fit) {
   .ui <- suppressMessages(.ui())
   assign("ui", .ui, envir = fit$env)
   for (.v in ls(fit$env, all.names=TRUE)) {
-    if (inherits(.v, "raw")) {
-      ## Try reading in with qs2 if it doesn't work try with qs
-      .c <- try(qs2::qs_deserialize(get(.v, envir=fit$env)))
-      if (inherits(.c, "try-error")) {
-        rxode2::rxReq("qs")
-        .c <- rxode2::rxOldQsDes(get(.v, envir=fit$env))
+    .raw <- get(.v, envir=fit$env)
+    if (inherits(.raw, "raw")) {
+      .type <- rxode2::rxGetSerialType_(.raw)
+      .c <- if (.type == "qs2") {
+        try(.legacyQs2(.raw, "qs_deserialize"), silent=TRUE)
+      } else if (.type == "qdata") {
+        try(.legacyQs2(.raw, "qd_deserialize"), silent=TRUE)
+      } else {
+        try(rxode2::rxDeserialize(.raw), silent=TRUE)
+      }
+      if (!inherits(.c, "try-error")) {
         assign(.v, .c, envir=fit$env)
       }
     }
   }
   fit
+}
+
+#' Deserialize a legacy qs2/qdata blob from an old fit
+#'
+#' Fits saved by nlmixr2est <= 7.0.1 may hold qs2- or qdata-serialized
+#' objects; qs2 is no longer a dependency, so look it up dynamically.
+#'
+#' @param raw raw vector to deserialize
+#' @param fun qs2 function name to use
+#' @return the deserialized object
+#' @noRd
+.legacyQs2 <- function(raw, fun) {
+  if (!requireNamespace("qs2", quietly=TRUE)) {
+    stop("this object was saved with 'qs2'; install qs2 to read it",
+         call.=FALSE)
+  }
+  getExportedValue("qs2", fun)(raw)
 }

--- a/R/compat.R
+++ b/R/compat.R
@@ -24,41 +24,52 @@ nlmixr2fix <- function(fit) {
   print(fit$env$sessioninfo)
   message("\n")
   message("# If all else fails you can try to install the version of nlmixr2 used to create the fit\n")
-  .ui <- fit$env$ui$fun
-  .ui <- suppressMessages(.ui())
-  assign("ui", .ui, envir = fit$env)
+  # repair raw slots first; `ui` itself may be serialized in an old fit
   for (.v in ls(fit$env, all.names=TRUE)) {
     .raw <- get(.v, envir=fit$env)
     if (inherits(.raw, "raw")) {
-      .type <- rxode2::rxGetSerialType_(.raw)
-      .c <- if (.type == "qs2") {
-        try(.legacyQs2(.raw, "qs_deserialize"), silent=TRUE)
-      } else if (.type == "qdata") {
-        try(.legacyQs2(.raw, "qd_deserialize"), silent=TRUE)
-      } else {
-        try(rxode2::rxDeserialize(.raw), silent=TRUE)
-      }
+      .c <- try(.deserializeRaw(.raw), silent=TRUE)
       if (!inherits(.c, "try-error")) {
         assign(.v, .c, envir=fit$env)
       }
     }
   }
+  .ui <- fit$env$ui$fun
+  .ui <- suppressMessages(.ui())
+  assign("ui", .ui, envir = fit$env)
   fit
 }
 
-#' Deserialize a legacy qs2/qdata blob from an old fit
+#' Deserialize a raw fit component by its serialization tag
 #'
-#' Fits saved by nlmixr2est <= 7.0.1 may hold qs2- or qdata-serialized
-#' objects; qs2 is no longer a dependency, so look it up dynamically.
+#' Fits saved by nlmixr2est <= 7.0.1 may hold qs2-, qdata- or qs-serialized
+#' objects; neither qs2 nor qs is a dependency any more, so look them up
+#' dynamically when installed.
 #'
 #' @param raw raw vector to deserialize
-#' @param fun qs2 function name to use
-#' @return the deserialized object
+#' @param type serialization tag (from `rxode2::rxGetSerialType_()`)
+#' @return the deserialized object; errors when the format needs a package
+#'   that is not installed
 #' @noRd
-.legacyQs2 <- function(raw, fun) {
-  if (!requireNamespace("qs2", quietly=TRUE)) {
-    stop("this object was saved with 'qs2'; install qs2 to read it",
-         call.=FALSE)
+.deserializeRaw <- function(raw, type=rxode2::rxGetSerialType_(raw)) {
+  switch(type,
+         qs2 = .legacyQsFn("qs2", "qs_deserialize")(raw),
+         qdata = .legacyQsFn("qs2", "qd_deserialize")(raw),
+         qs = .legacyQsFn("qs", "qdeserialize")(raw),
+         xz = unserialize(memDecompress(raw, type="xz")),
+         bzip2 = unserialize(memDecompress(raw, type="bzip2")),
+         base = unserialize(raw),
+         stop("unknown serialization type '", type, "'", call.=FALSE))
+}
+
+#' @param pkg legacy serialization package ("qs2" or "qs")
+#' @param fun function name to look up in `pkg`
+#' @return the function, when `pkg` is installed
+#' @noRd
+.legacyQsFn <- function(pkg, fun) {
+  if (!requireNamespace(pkg, quietly=TRUE)) {
+    stop("this object was saved with '", pkg, "'; install ", pkg,
+         " to read it", call.=FALSE)
   }
-  getExportedValue("qs2", fun)(raw)
+  getExportedValue(pkg, fun)
 }

--- a/R/focei.R
+++ b/R/focei.R
@@ -1412,11 +1412,11 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
                            "compiling EBE model..."))
   }
   # Augmented outer-gradient model (fast=TRUE): built here, once, with the compiled
-  # rxode2 model at top level (`outer`) so rxUiGet.foceiModel's qs2 rxLoad reloads
+  # rxode2 model at top level (`outer`) so rxUiGet.foceiModel's rxLoad reloads
   # it; the direction metadata travels separately in `outerMeta`.
   .outerAm <- tryCatch(rxUiGet.foceiOuter(list(ui)), error = function(e) NULL)
   # AGQ (nAGQ>1) only: the 1st-order model the nodes solve on, built here so it rides in the
-  # qs2 cache next to `outer` rather than re-paying the symengine+gcc pass each session.
+  # disk cache next to `outer` rather than re-paying the symengine+gcc pass each session.
   .nodeAm <- tryCatch(rxUiGet.foceiOuterNode(list(ui)), error = function(e) NULL)
   .ret <- list(
     inner = inner,
@@ -1430,7 +1430,7 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
     # subset breaks the live gradient (E$R/E$aR never filled)
     outerMeta = if (is.null(.outerAm)) NULL else .outerAm[setdiff(names(.outerAm), "augMod")],
     # AGQ node model (1st order), NULL for nAGQ<=1.  Same split as outer/outerMeta: model at
-    # top level so the qs2 rxLoad reloads it, metadata separately.
+    # top level so the rxLoad reloads it, metadata separately.
     outerNode = if (is.null(.nodeAm)) NULL else .nodeAm$augMod,
     outerNodeMeta = if (is.null(.nodeAm)) NULL else .nodeAm[setdiff(names(.nodeAm), "augMod")],
     predNoLhs = .toRx(pred.opt, ifelse(.getRxPredLlikOption(),
@@ -1568,7 +1568,7 @@ rxUiGet.foceiModelDigest <- function(x, ...) {
   ## The augmented outer model (foceiModelList$outer) also depends on which covariates
   ## are subject-constant (analytic covariate-coefficient reuse scales those out of the
   ## symbolic sensitivity build) and on the sigma-skip toggle -- both change the outer model
-  ## text, so they must key the persisted (qs2) cache too, else two fits of the same model
+  ## text, so they must key the persisted cache too, else two fits of the same model
   ## whose datasets differ only in covariate-constancy would collide.
   .constCovs <- paste(sort(rxode2::rxGetControl(.ui, "foceiConstCovs", NULL)), collapse=",")
   digest::digest(c(all(is.na(.iniDf$neta1)),
@@ -1586,7 +1586,7 @@ attr(rxUiGet.foceiModelDigest, "rstudio") <- "hash"
 #' @export
 rxUiGet.foceiModelCache <- function(x, ...) {
   file.path(rxode2::rxTempDir(),
-            paste0("focei-", rxUiGet.foceiModelDigest(x, ...), ".qs2"))
+            paste0("focei-", rxUiGet.foceiModelDigest(x, ...), ".rds"))
 }
 #attr(rxUiGet.foceiModelCache, "desc") <- "Get the focei cache file for a model"
 attr(rxUiGet.foceiModelCache, "rstudio") <- "file"
@@ -1595,7 +1595,7 @@ attr(rxUiGet.foceiModelCache, "rstudio") <- "file"
 rxUiGet.foceiModel <- function(x, ...) {
   .cacheFile <- rxUiGet.foceiModelCache(x, ...)
   if (file.exists(.cacheFile)) {
-    .ret <- qs2::qs_read(.cacheFile)
+    .ret <- readRDS(.cacheFile)
     lapply(seq_along(.ret), function(i) {
       if (inherits(.ret[[i]], "rxode2")) {
         rxode2::rxLoad(.ret[[i]])
@@ -1614,7 +1614,7 @@ rxUiGet.foceiModel <- function(x, ...) {
       .ret <- rxUiGet.foce(x, ...)
     }
   }
-  qs2::qs_save(.ret, .cacheFile)
+  saveRDS(.ret, .cacheFile)
   .ret
 }
 # attr(rxUiGet.foceiModel, "desc") <- "Get focei model object"
@@ -3066,13 +3066,10 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
           .obj <- get(.item, envir=.env)
           .size <- utils::object.size(.obj)
           .type <- rxode2::rxGetDefaultSerialize()
+          # older rxode2 could return qs2/qdata here; those formats are no
+          # longer written (stringfish/qs2 dependency dropped)
+          if (!(.type %in% c("base", "bzip2", "xz"))) .type <- "bzip2"
           .objC <- switch(.type,
-                 qs2 = {
-                   qs2::qs_serialize(.obj)
-                 },
-                 qdata = {
-                   qs2::qd_serialize(.obj)
-                 },
                  bzip2 = {
                    memCompress(serialize(.obj, NULL), type="bzip2")
                  },
@@ -3081,9 +3078,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
                  },
                  base = {
                    serialize(.obj, NULL)
-                 },
-                 stop("unknown serialization type") # nocov
-                 )
+                 })
           .size2 <- utils::object.size(.objC)
           if (.size2 < .size) {
             .size0 <- (.size - .size2)

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -673,7 +673,7 @@
     # 26 ODE states -> 8.  They are nAGQ^neta solves per gradient and dominate once the
     # grid grows, so this is worth 1.07x-1.91x on the gradient.
     #
-    # Prefer the `outerNode` sibling built at model setup and qs2-cached in foceiModel
+    # Prefer the `outerNode` sibling built at model setup and disk-cached in foceiModel
     # (same treatment as `outer`); fall back to building it.  Cached on the fit env either
     # way, with a FALSE sentinel so a model that cannot build one does not re-attempt the
     # symengine pass every gradient call.
@@ -1193,7 +1193,7 @@
     data <- get("dataSav", e)
     # censored obs handled in .foceiAnalyticGradCore (FOCE-censored gates to FD there)
     # The augmented model is the persistent `..outer` sibling of the inner model.
-    # Prefer the copy built at model-setup time and qs2-cached in foceiModel$outer
+    # Prefer the copy built at model-setup time and disk-cached in foceiModel$outer
     # (reconstruct am from the top-level compiled model + outerMeta); fall back to
     # building it via rxUiGet.foceiOuter.  Cached on the fit env either way.
     am <- if (exists(".foceiGradAug", e, inherits = FALSE)) get(".foceiGradAug", e) else NULL
@@ -1329,7 +1329,7 @@
 # `P2`) for a UI.  This is the persistent `..outer` sibling of the inner model:
 # it depends only on the model + direction set (NOT theta/eta/omega), so it is
 # built once during model setup (via `rxUiGet.foceiModel`/`foceModel`, which
-# qs2-cache the whole model list) and reused across every outer-gradient call.
+# disk-cache the whole model list) and reused across every outer-gradient call.
 # Callable independently as `ui$foceiOuter`.  `NULL` when out of analytic scope
 # (the gradient then falls back to finite differences).
 #' @export
@@ -1365,7 +1365,7 @@ attr(rxUiGet.foceiOuter, "rstudio") <- emptyenv()
 #' to 1.91x (neta=5, nAGQ=3) on the whole gradient.
 #'
 #' Only built for nAGQ > 1; every other fast fit gets NULL and pays no extra build.  Like
-#' `foceiOuter` this rides in the qs2-cached `foceiModel` list, so the extra symengine+gcc
+#' `foceiOuter` this rides in the disk-cached `foceiModel` list, so the extra symengine+gcc
 #' pass is paid once per model, not once per session.
 #' @noRd
 #' @export

--- a/R/nmObjGet.R
+++ b/R/nmObjGet.R
@@ -216,30 +216,22 @@ nmObjGet.default <- function(x, ...) {
     if (inherits(.ret, "raw")) {
       .type <- rxode2::rxGetSerialType_(.ret)
       if (.type == "qs2") {
-        .ret <- try(qs2::qs_deserialize(.ret), silent=TRUE)
+        .ret <- try(.legacyQs2(.ret, "qs_deserialize"), silent=TRUE)
         if (inherits(.ret, "try-error")) {
           warning("cannot deserialize object '", .arg, "' (qs2)", call.=FALSE)
           .ret <- NULL
         }
       } else if (.type == "qdata") {
-        .ret <- try({
-          rxode2::rxReq("qs2")
-          qs2::qd_deserialize(.ret)
-        })
+        .ret <- try(.legacyQs2(.ret, "qd_deserialize"), silent=TRUE)
         if (inherits(.ret, "try-error")) {
           warning("cannot deserialize object '", .arg, "' (qdata)", call.=FALSE)
           .ret <- NULL
         }
       } else if (.type == "qs") {
-        .ret <- try(rxode2::rxOldQsDes(.ret), silent=TRUE)
+        .ret <- try(rxode2::rxDeserialize(.ret), silent=TRUE)
         if (inherits(.ret, "try-error")) {
-          .ret <- try({
-            rxode2::rxOldQsDes(get(.arg, envir = .env))
-          })
-          if (inherits(.ret, "try-error")) {
-            warning("cannot deserialize object '", .arg, "' (qs)", call.=FALSE)
-            .ret <- NULL
-          }
+          warning("cannot deserialize object '", .arg, "' (qs)", call.=FALSE)
+          .ret <- NULL
         }
       } else if (.type == "xz") {
         .ret <- try(unserialize(memDecompress(.ret, type="xz")), silent=TRUE)

--- a/R/nmObjGet.R
+++ b/R/nmObjGet.R
@@ -215,42 +215,11 @@ nmObjGet.default <- function(x, ...) {
     .ret <- get(.arg, envir = .env)
     if (inherits(.ret, "raw")) {
       .type <- rxode2::rxGetSerialType_(.ret)
-      if (.type == "qs2") {
-        .ret <- try(.legacyQs2(.ret, "qs_deserialize"), silent=TRUE)
-        if (inherits(.ret, "try-error")) {
-          warning("cannot deserialize object '", .arg, "' (qs2)", call.=FALSE)
-          .ret <- NULL
-        }
-      } else if (.type == "qdata") {
-        .ret <- try(.legacyQs2(.ret, "qd_deserialize"), silent=TRUE)
-        if (inherits(.ret, "try-error")) {
-          warning("cannot deserialize object '", .arg, "' (qdata)", call.=FALSE)
-          .ret <- NULL
-        }
-      } else if (.type == "qs") {
-        .ret <- try(rxode2::rxDeserialize(.ret), silent=TRUE)
-        if (inherits(.ret, "try-error")) {
-          warning("cannot deserialize object '", .arg, "' (qs)", call.=FALSE)
-          .ret <- NULL
-        }
-      } else if (.type == "xz") {
-        .ret <- try(unserialize(memDecompress(.ret, type="xz")), silent=TRUE)
-        if (inherits(.ret, "try-error")) {
-          warning("cannot deserialize object '", .arg, "' (xz)", call.=FALSE)
-          .ret <- NULL
-        }
-      } else if (.type == "bzip2") {
-        .ret <- try(unserialize(memDecompress(.ret, type="bzip2")), silent=TRUE)
-        if (inherits(.ret, "try-error")) {
-          warning("cannot deserialize object '", .arg, "' (bzip2)", call.=FALSE)
-          .ret <- NULL
-        }
-      } else if (.type == "base") {
-        .ret <- try(unserialize(.ret), silent=TRUE)
-        if (inherits(.ret, "try-error")) {
-          warning("cannot deserialize object '", .arg, "' (base)", call.=FALSE)
-          .ret <- NULL
-        }
+      .ret <- try(.deserializeRaw(.ret, .type), silent=TRUE)
+      if (inherits(.ret, "try-error")) {
+        warning("cannot deserialize object '", .arg, "' (", .type, ")",
+                call.=FALSE)
+        .ret <- NULL
       }
     }
     return(.ret)


### PR DESCRIPTION
## Summary

RcppParallel 6.0.0 (oneTBB) breaks `stringfish` at load time (undefined `tbb::internal` symbols), which breaks any `qs2` use and blocks the CRAN submission. GitHub-runner workarounds (#820, closed) cannot fix CRAN, so this removes qs2/stringfish from the dependency chain entirely, matching what rxode2 >= 5.1.5 already did.

## Changes

- focei model disk cache: `.qs2`/`qs_read`/`qs_save` -> `.rds`/`readRDS`/`saveRDS`.
- Compressed fit components (`origData`, `parHistData`, `phiM`): base R serialization via `rxode2::rxGetDefaultSerialize()` (bzip2 default); qs2/qdata are never written, with a fallback if an older rxode2 returns them.
- New internal `.deserializeRaw()` dispatches on the serialization tag: inline base/bzip2/xz, dynamic optional lookup for legacy qs2/qdata/qs blobs (package name passed as a variable, so `R CMD check`'s dependency scan stays quiet -- verified: `checking dependencies in R code ... OK`). `rxode2::rxDeserialize()` is deliberately not used for fit components: its class validation rejects the `phiM` matrix / `saem0` list (review finding).
- `nlmixr2fix()`: repairs raw slots before touching `fit$env$ui` and fixes two pre-existing bugs (tested the name instead of the object for rawness; discarded successful qs2 reads).
- DESCRIPTION: drop `qs2` from Suggests; require rxode2 >= 5.1.5 (for `rxDeserialize()`); version 7.0.2.

## Verification

- Smoke: focei fit end-to-end, `.rds` cache written, no `.qs2`, qs2/stringfish never load, `parHistData`/`origData` round-trip.
- `.deserializeRaw()` round-trips base/bzip2/xz matrices; unknown tag errors cleanly.
- Legacy qs-era fixture (`inst/testfit_nlmixr3.rds`) without `qs` installed: `nlmixr2fix()` errors with an install-qs message (parity with old behavior); `fit$phiM` warns and returns NULL instead of hard-erroring.
- Reviews per commit: Copilot + Antigravity on commit 1 (both flagged the `rxDeserialize` class-validation regression -- fixed in commit 2); Antigravity clean on commit 2 (Copilot quota exhausted for that round).

Closes the CI breakage seen on #819 once merged (that branch will be updated to drop its interim workflow edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)