### PR TITLE
docs: document the vae/vi omega handling in vaeControl and emviControl

### DIFF
--- a/R/emviControl.R
+++ b/R/emviControl.R
@@ -113,10 +113,22 @@
 #'   \code{\link{saemControl}()}'s `perNoCor` rule (0.75 there as well); it has no
 #'   effect on a model with no declared off-diagonals.
 #'
-#'    The resolved absolute iteration is stored with the fit and
-#'   reused by `resume=`, so a resumed run releases the correlations at the same
-#'   global iteration a single long run would -- recomputing the fraction from the
-#'   resumed call's `iters` would re-apply a hold the original run had passed.
+#'   Held at ZERO, following saem, not at the `ini()` value: retaining an initial
+#'   covariance while the variances shrink around it can leave the block
+#'   non-positive-definite.  A `fixed()` covariance is exempt -- it is not being
+#'   estimated, so it keeps its value through the hold and out the other side.
+#'   When the correlations are released the off-diagonal gain restarts rather
+#'   than continuing the decayed schedule, so they are still estimable at the
+#'   point they are unfrozen.
+#'
+#'   A value greater than 1 is an ABSOLUTE iteration count rather than a
+#'   fraction, and must be a whole number.  The resolved absolute iteration is
+#'   stored with the fit and reused by `resume=`, so a resumed run releases the
+#'   correlations at the same global iteration a single long run would --
+#'   recomputing the fraction from the resumed call's `iters` would re-apply a
+#'   hold the original run had passed.  Only `est="emvi"` estimates the block at
+#'   all; `est="fbvi"` carries `omega` as per-eta log-variances and errors on a
+#'   correlated model rather than dropping the off-diagonal.
 #' @param tau Stabilizing constant `tau > 0` in the step-size denominator
 #'   (paper Eq 10); the step-size is insensitive to it.
 #' @param alpha Weighting `alpha` in (0, 1) of new vs old gradient information in

--- a/R/emviControl.R
+++ b/R/emviControl.R
@@ -119,7 +119,10 @@
 #'   estimated, so it keeps its value through the hold and out the other side.
 #'   When the correlations are released the off-diagonal gain restarts rather
 #'   than continuing the decayed schedule, so they are still estimable at the
-#'   point they are unfrozen.
+#'   point they are unfrozen.  This is needed here and not in
+#'   \code{\link{vaeControl}()}: there the fraction is of the EM phase, where the
+#'   gain is still 1 at release, whereas this run has no such phase and the
+#'   fraction lands in the decayed schedule.
 #'
 #'   A value greater than 1 is an ABSOLUTE iteration count rather than a
 #'   fraction, and must be a whole number.  The resolved absolute iteration is

--- a/R/vae.R
+++ b/R/vae.R
@@ -245,6 +245,24 @@
 #'   the EMA sufficient statistics and ASSIGNED outright.  `"blend"` is the
 #'   historic behavior, blending the freshly computed `omega` with the previous
 #'   value at the M-step gain (so it is smoothed twice).  Applies to `omega` only.
+#'
+#'   Note this option reaches only ONE of the two omega M-steps.  Which one runs
+#'   is decided by `covariateSelection`: with `TRUE` the covariate M-step runs and
+#'   honors `omegaUpdate`; with `FALSE` the plain closed-form M-step runs, whose
+#'   variances are always raw posterior moments blended at the gain.  A declared
+#'   correlated block's OFF-diagonals always follow whichever estimator that
+#'   branch's diagonal used -- estimating the two halves of one block by different
+#'   estimators need not even give a positive-definite result.
+#'
+#'   The two settings are the SAME update while the gain is 1, which it is
+#'   throughout burn-in and the EM phase (assigning a value and blending it in
+#'   with weight 1 are the same operation); they differ only once `gammaIter`
+#'   decays the gain.  A short run at default settings will show no difference.
+#'
+#'   `mStepObjective` does not enter the omega update at all -- it scores the
+#'   non-mu theta M-step.  Omega has a closed-form EM update from the variational
+#'   posterior either way.
+#'
 #'   The residual error estimate is still EMA-smoothed on the standard-deviation
 #'   scale, where the reference smooths the residual sum of squares and takes the
 #'   root afterwards -- a known remaining difference.  Matching it would need
@@ -257,8 +275,15 @@
 #'   \code{\link{saemControl}()}'s `perNoCor` rule (0.75 there as well); it has no
 #'   effect on a model with no declared off-diagonals.
 #'
-#'    A value greater than 1 is an ABSOLUTE iteration
-#'   count rather than a fraction.
+#'   Held at ZERO, following saem, not at the `ini()` value: retaining an initial
+#'   covariance while the variances shrink around it can leave the block
+#'   non-positive-definite.  A `fixed()` covariance is exempt -- it is not being
+#'   estimated, so it keeps its value through the hold and out the other side.
+#'
+#'   A value greater than 1 is an ABSOLUTE iteration count rather than a fraction,
+#'   and must be a whole number.  Prefer the absolute form whenever a run may be
+#'   resumed or reproduced at a different length: a fraction of a shorter run is a
+#'   different schedule, not the same one truncated.
 #' @param inputScale Which observations the encoder-input centering and scaling
 #'   are computed over.  `"reference"` (default) matches the reference
 #'   implementation, which takes the mean and SD across the whole padded

--- a/R/vae.R
+++ b/R/vae.R
@@ -280,6 +280,13 @@
 #'   non-positive-definite.  A `fixed()` covariance is exempt -- it is not being
 #'   estimated, so it keeps its value through the hold and out the other side.
 #'
+#'   The fraction is of the EM phase, `min(gammaIter, iters)`, not of the whole
+#'   run.  That matters: the gain is 1 for `it <= gammaIter`, so the release
+#'   point falls while the gain is still 1 and the correlations are estimable the
+#'   moment they are unfrozen.  (This is why no gain restart is needed here,
+#'   whereas \code{\link{emviControl}()} -- whose run has no separate unit-gain
+#'   phase -- has to restart the off-diagonal gain at release.)
+#'
 #'   A value greater than 1 is an ABSOLUTE iteration count rather than a fraction,
 #'   and must be a whole number.  Prefer the absolute form whenever a run may be
 #'   resumed or reproduced at a different length: a fraction of a shorter run is a

--- a/man/emviControl.Rd
+++ b/man/emviControl.Rd
@@ -120,10 +120,22 @@ the surrounding method is not; `"adam"` uses Adam.}
   \code{\link{saemControl}()}'s `perNoCor` rule (0.75 there as well); it has no
   effect on a model with no declared off-diagonals.
 
-   The resolved absolute iteration is stored with the fit and
-  reused by `resume=`, so a resumed run releases the correlations at the same
-  global iteration a single long run would -- recomputing the fraction from the
-  resumed call's `iters` would re-apply a hold the original run had passed.}
+  Held at ZERO, following saem, not at the `ini()` value: retaining an initial
+  covariance while the variances shrink around it can leave the block
+  non-positive-definite.  A `fixed()` covariance is exempt -- it is not being
+  estimated, so it keeps its value through the hold and out the other side.
+  When the correlations are released the off-diagonal gain restarts rather
+  than continuing the decayed schedule, so they are still estimable at the
+  point they are unfrozen.
+
+  A value greater than 1 is an ABSOLUTE iteration count rather than a
+  fraction, and must be a whole number.  The resolved absolute iteration is
+  stored with the fit and reused by `resume=`, so a resumed run releases the
+  correlations at the same global iteration a single long run would --
+  recomputing the fraction from the resumed call's `iters` would re-apply a
+  hold the original run had passed.  Only `est="emvi"` estimates the block at
+  all; `est="fbvi"` carries `omega` as per-eta log-variances and errors on a
+  correlated model rather than dropping the off-diagonal.}
 
 \item{etaCandidates}{Candidate step-size scales searched when `adaptEta` is
 `TRUE`.  The default is narrower and smaller-valued than the paper's

--- a/man/emviControl.Rd
+++ b/man/emviControl.Rd
@@ -126,7 +126,10 @@ the surrounding method is not; `"adam"` uses Adam.}
   estimated, so it keeps its value through the hold and out the other side.
   When the correlations are released the off-diagonal gain restarts rather
   than continuing the decayed schedule, so they are still estimable at the
-  point they are unfrozen.
+  point they are unfrozen.  This is needed here and not in
+  \code{\link{vaeControl}()}: there the fraction is of the EM phase, where the
+  gain is still 1 at release, whereas this run has no such phase and the
+  fraction lands in the decayed schedule.
 
   A value greater than 1 is an ABSOLUTE iteration count rather than a
   fraction, and must be a whole number.  The resolved absolute iteration is

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -286,6 +286,13 @@ which also tightens the structural regression that re-solves per candidate.}
   non-positive-definite.  A `fixed()` covariance is exempt -- it is not being
   estimated, so it keeps its value through the hold and out the other side.
 
+  The fraction is of the EM phase, `min(gammaIter, iters)`, not of the whole
+  run.  That matters: the gain is 1 for `it <= gammaIter`, so the release
+  point falls while the gain is still 1 and the correlations are estimable the
+  moment they are unfrozen.  (This is why no gain restart is needed here,
+  whereas \code{\link{emviControl}()} -- whose run has no separate unit-gain
+  phase -- has to restart the off-diagonal gain at release.)
+
   A value greater than 1 is an ABSOLUTE iteration count rather than a fraction,
   and must be a whole number.  Prefer the absolute form whenever a run may be
   resumed or reproduced at a different length: a fraction of a shorter run is a

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -246,16 +246,34 @@ the ODE frozen, so tightening it is far cheaper than tightening `rhoend`,
 which also tightens the structural regression that re-solves per candidate.}
 
 \item{omegaUpdate}{How the population variances are updated in the covariate
-M-step.  `"suffStat"` (default) follows the reference: `omega` is formed from
-the EMA sufficient statistics and ASSIGNED outright.  `"blend"` is the
-historic behavior, blending the freshly computed `omega` with the previous
-value at the M-step gain (so it is smoothed twice).  Applies to `omega` only.
-The residual error estimate is still EMA-smoothed on the standard-deviation
-scale, where the reference smooths the residual sum of squares and takes the
-root afterwards -- a known remaining difference.  Matching it would need
-per-endpoint sufficient statistics plus an optimizer branch for the error
-models with no closed form (`add + prop`, `add + pow`, Box-Cox /
-Yeo-Johnson), as \code{\link{saemControl}()} does.}
+  M-step.  `"suffStat"` (default) follows the reference: `omega` is formed from
+  the EMA sufficient statistics and ASSIGNED outright.  `"blend"` is the
+  historic behavior, blending the freshly computed `omega` with the previous
+  value at the M-step gain (so it is smoothed twice).  Applies to `omega` only.
+
+  Note this option reaches only ONE of the two omega M-steps.  Which one runs
+  is decided by `covariateSelection`: with `TRUE` the covariate M-step runs and
+  honors `omegaUpdate`; with `FALSE` the plain closed-form M-step runs, whose
+  variances are always raw posterior moments blended at the gain.  A declared
+  correlated block's OFF-diagonals always follow whichever estimator that
+  branch's diagonal used -- estimating the two halves of one block by different
+  estimators need not even give a positive-definite result.
+
+  The two settings are the SAME update while the gain is 1, which it is
+  throughout burn-in and the EM phase (assigning a value and blending it in
+  with weight 1 are the same operation); they differ only once `gammaIter`
+  decays the gain.  A short run at default settings will show no difference.
+
+  `mStepObjective` does not enter the omega update at all -- it scores the
+  non-mu theta M-step.  Omega has a closed-form EM update from the variational
+  posterior either way.
+
+  The residual error estimate is still EMA-smoothed on the standard-deviation
+  scale, where the reference smooths the residual sum of squares and takes the
+  root afterwards -- a known remaining difference.  Matching it would need
+  per-endpoint sufficient statistics plus an optimizer branch for the error
+  models with no closed form (`add + prop`, `add + pow`, Box-Cox /
+  Yeo-Johnson), as \code{\link{saemControl}()} does.}
 
 \item{perNoCor}{Fraction of the EM phase (`gammaIter` iterations) over which a
   declared correlated `omega` block is held at zero correlation, letting the
@@ -263,8 +281,15 @@ Yeo-Johnson), as \code{\link{saemControl}()} does.}
   \code{\link{saemControl}()}'s `perNoCor` rule (0.75 there as well); it has no
   effect on a model with no declared off-diagonals.
 
-   A value greater than 1 is an ABSOLUTE iteration
-  count rather than a fraction.}
+  Held at ZERO, following saem, not at the `ini()` value: retaining an initial
+  covariance while the variances shrink around it can leave the block
+  non-positive-definite.  A `fixed()` covariance is exempt -- it is not being
+  estimated, so it keeps its value through the hold and out the other side.
+
+  A value greater than 1 is an ABSOLUTE iteration count rather than a fraction,
+  and must be a whole number.  Prefer the absolute form whenever a run may be
+  resumed or reproduced at a different length: a fraction of a shorter run is a
+  different schedule, not the same one truncated.}
 
 \item{inputScale}{Which observations the encoder-input centering and scaling
 are computed over.  `"reference"` (default) matches the reference


### PR DESCRIPTION
Follow-up to #822 (now merged). Documentation only; no code change.

Companion to nlmixr2/nlmixr2#402, which does the same for the VAE article.

## Why

`vaeControl(omegaUpdate=)` documented *what* it does without saying *which*
omega M-step it reaches -- and there are two. The reference docs also didn't say
what the `perNoCor` hold actually holds the correlations *at*.

## What the docs now say

**`vaeControl(omegaUpdate=)`** applies to the **covariate** M-step only.
`covariateSelection = FALSE` runs the plain closed-form M-step instead, whose
variances are always raw posterior moments blended at the gain and which has no
switch. A declared block's off-diagonals always follow whichever estimator that
branch's diagonal used -- taking the two halves of one block from different
estimators need not even give a positive-definite result.

Two points added because both are easy to assume wrongly, and I checked both by
fitting rather than by reading:

- The two `omegaUpdate` settings are the **same update while the gain is 1**,
  which it is throughout burn-in and the EM phase -- assigning a value and
  blending it in with weight 1 are the same operation. A short run at default
  `gammaIter = 250` shows *no* difference between them (agreement to ~1e-13,
  separating to ~1e-5 only once the gain decays). Anyone A/B-testing the option
  at defaults would reasonably conclude it does nothing.
- **`mStepObjective` does not enter the omega update at all.** It scores the
  non-mu theta M-step and gates `nonMuTheta="grad"`. Omega has a closed-form EM
  update from the variational posterior either way, so an ELBO-only fit and an
  outer-objective fit use identical omega machinery. I verified all four
  `mStepObjective` x `omegaUpdate` combinations: omega is unchanged across the
  `mStepObjective` axis.

**`perNoCor=`** (both `vaeControl` and `emviControl`) now says the hold is at
**zero**, not at the `ini()` value -- following saem, because retaining an
initial covariance while the variances shrink around it can leave the block
non-positive-definite. A `fixed()` covariance is exempt: it is not being
estimated, so it survives the hold unchanged. A value `> 1` is an absolute
whole-number iteration count, and is the form to prefer whenever a run may be
resumed, since a fraction of a shorter run is a *different schedule* rather than
the same one truncated.

`emviControl()` additionally records the off-diagonal gain restart at release
(without it the correlations are unfrozen at a gain too small to estimate them --
that was a real defect found in #822) and that `est="fbvi"` errors on a
correlated model rather than silently dropping the off-diagonal.

## Verification

`man/vaeControl.Rd`, `man/emviControl.Rd` and `man/fbviControl.Rd` regenerated
and parsed. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMZpj6ywLmjmB9p3fzMpoQ
