### PR TITLE
feat(vae): name injected covariate coefficients with "." not "_"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,16 +21,6 @@
   write yourself are untouched -- with `vaeControl(pinCovariates=TRUE)` (the
   default) the model keeps your names exactly as written.
 
-## Bug fixes
-
-- `nlmixr2fix()` now actually repairs serialized fit components: it previously
-  tested the component name (not the object) for rawness, so the repair loop
-  never ran, and a successful qs2 read was discarded.
-# nlmixr2est (development version)
-
-## New features
-
-
 - The `est="vae"` automatic covariate search now explores several
   parameterizations ("shapes") of each covariate rather than the single
   hard-coded `log(cov/mean)` form.  `vaeControl(shapes=)` takes the same
@@ -76,9 +66,12 @@
   `17`: re-measuring with `tools/benchVaeCovSelect.R` puts the exact-vs-L0Learn
   crossover at roughly 16 bits in BOTH regimes (one shape per covariate and two),
   which is what makes a single threshold in these units meaningful.
-# nlmixr2est 7.0.2
 
 ## Bug fixes
+
+- `nlmixr2fix()` now actually repairs serialized fit components: it previously
+  tested the component name (not the object) for rawness, so the repair loop
+  never ran, and a successful qs2 read was discarded.
 
 - Fixed `$parFixed` reporting an uninitialized-memory denormal (e.g.
   `9.4e-323`) as a residual-error parameter's `SE`/`%RSE` for SAEM fits

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,17 @@
   installed; otherwise accessing them warns and returns `NULL`.  Requires
   rxode2 (>= 5.1.5) for `rxDeserialize()`.
 
+## New features
+
+- The covariate coefficients `est="vae"` injects after covariate selection are
+  now named with `.` separators instead of `_`: `beta.tka.WT.lin` rather than
+  `beta_tka_WT_lin`.  This matches the separator the rest of `nlmixr2` uses for
+  generated and conventional parameter names (`eta.cl`, `add.sd`, `prop.sd`).
+  A categorical coefficient is built from the covariate and its level directly
+  (`beta.tka.SEX.M`), so the separator is consistent there too.  Coefficients you
+  write yourself are untouched -- with `vaeControl(pinCovariates=TRUE)` (the
+  default) the model keeps your names exactly as written.
+
 ## Bug fixes
 
 - `nlmixr2fix()` now actually repairs serialized fit components: it previously
@@ -18,6 +29,7 @@
 # nlmixr2est (development version)
 
 ## New features
+
 
 - The `est="vae"` automatic covariate search now explores several
   parameterizations ("shapes") of each covariate rather than the single

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -444,7 +444,7 @@
         check.rows = FALSE
       )
     # Keep estimated thetas absent from the (pre-literal-fix) model -- e.g. the
-    # covariate-coefficient thetas (beta_<par>_<cov>) est="vae" injects after
+    # covariate-coefficient thetas (beta.<par>.<cov>) est="vae" injects after
     # covariate selection.  They live in $theta/$cov but not in uiUnfix, so the
     # reindex below would silently drop them (leaving a covariate-free table).
     # Append them after the original theta order.

--- a/R/vaeOutput.R
+++ b/R/vaeOutput.R
@@ -1,6 +1,6 @@
 # vaeOutput.R -- build the fitted nlmixr2 output from a trained VAE. The model is
 # updated with the selected covariate effects (exact centered expressions, e.g.
-# ka <- exp(lka + beta_lka_WT*log(WT/79.6) + eta.ka)) and the ini() estimates are
+# ka <- exp(lka + beta.lka.WT.log*log(WT/79.6) + eta.ka)) and the ini() estimates are
 # set to the VAE solution. The standard nlmixr2FitData (objective, parFixed/SEs,
 # EBEs, residuals, tables) is then assembled with nlmixr2CreateOutputFromUi
 # driving the FOCEi inner problem at the VAE estimates (no outer optimizer),
@@ -153,10 +153,17 @@
         .shp <- if (identical(prep$covFamily[j], "log")) "power" else "lin"
         .r <- .vaeShapeBeta(.shp, .ctr, fit$beta[k, j])
       }
+      ## "." separates the pieces, matching the rest of nlmixr2's generated and
+      ## conventional parameter names (eta.cl, add.sd, prop.sd) rather than "_".
+      ## The categorical branch is built from the raw covariate and its level
+      ## directly instead of reusing the design column name (which glues them
+      ## with "_"), so the separator is consistent across both branches.
       .bn <- if (identical(prep$covType[j], "continuous")) {
-        paste0("beta_", thName, "_", .raw, "_", .shp)
+        paste0("beta.", thName, ".", .raw, ".", .shp)
+      } else if (!is.na(prep$covLevel[j]) && nzchar(prep$covLevel[j])) {
+        paste0("beta.", thName, ".", prep$covRaw[j], ".", prep$covLevel[j])
       } else {
-        paste0("beta_", thName, "_", covNames[j])
+        paste0("beta.", thName, ".", covNames[j])
       }
       ## names are built from user-facing pieces, so two distinct columns can in
       ## principle collide (a continuous WT written as "log" beside a 0/1 data
@@ -219,10 +226,10 @@
     }
   }
   ## The incremental model()/ini() edits above leave the ui's cached `covariates`
-  ## stale: an injected covariate-coefficient theta (beta_<par>_<cov>) is added to
+  ## stale: an injected covariate-coefficient theta (beta.<par>.<cov>) is added to
   ## the iniDf as a theta but ALSO stays listed as a covariate.  The augmented
-  ## covariance solve then declares that beta_ both as its THETA[k] and as a
-  ## phantom data covariate, and fails ("required for solving: beta_...").
+  ## covariance solve then declares that beta. both as its THETA[k] and as a
+  ## phantom data covariate, and fails ("required for solving: beta....").
   ## Re-parsing the accumulated model function yields a consistent theta/covariate
   ## classification (verified: only the true data covariates remain).
   rxode2::assertRxUi(ui2$fun)
@@ -230,7 +237,7 @@
 
 #' Update a PINNED VAE fit's model with the estimates.
 #'
-#' Unlike `.vaeUpdateModel` (which injects fresh `beta_<par>_<cov>` terms into a
+#' Unlike `.vaeUpdateModel` (which injects fresh `beta.<par>.<cov>` terms into a
 #' covariate-free base model), the pinned path keeps the user's ORIGINAL model
 #' -- their covariate terms, coefficient names and centers stay exactly as
 #' written -- and only writes ini() estimates.  A declared covariate the search

--- a/tests/testthat/test-vae-covariate-table.R
+++ b/tests/testthat/test-vae-covariate-table.R
@@ -1,6 +1,6 @@
 ## Fast regression guards for two est="vae" covariate-output bugs (no training):
 ##
-## Bug 1 -- injected covariate-coefficient thetas (beta_<par>_<cov>) must survive
+## Bug 1 -- injected covariate-coefficient thetas (beta.<par>.<cov>) must survive
 ##   into the population-parameter table; they were dropped from parFixedDf when a
 ##   population parameter was fixed (literalFix reindex, see the slow end-to-end
 ##   test in test-vae-covariate.R).  Here we assert the precondition: .vaeUpdateModel
@@ -49,8 +49,8 @@ nmTest({
     ## covariate-bearing lines are the additive mu-referenced form
     kaLine <- deparse1(ui2$lstExpr[[1]])
     vLine <- deparse1(ui2$lstExpr[[3]])
-    expect_match(kaLine, "exp(lka + beta_lka_WT_power * log(WT/", fixed = TRUE)
-    expect_match(vLine, "exp(lV + beta_lV_WT_power * log(WT/", fixed = TRUE)
+    expect_match(kaLine, "exp(lka + beta.lka.WT.power * log(WT/", fixed = TRUE)
+    expect_match(vLine, "exp(lV + beta.lV.WT.power * log(WT/", fixed = TRUE)
     ## NOT the wrapped form exp((theta + beta*cov) + eta) that breaks detection
     expect_false(grepl("exp((", kaLine, fixed = TRUE))
     expect_false(grepl("exp((", vLine, fixed = TRUE))
@@ -67,9 +67,9 @@ nmTest({
     ui <- rxode2::assertRxUi(.theoCov)
     ui2 <- suppressMessages(.vaeUpdateModel(ui, .fakeVaeFit(ui)))
     thetaNames <- ui2$iniDf$name[!is.na(ui2$iniDf$ntheta)]
-    expect_true(all(c("beta_lka_WT_power", "beta_lV_WT_power") %in% thetaNames))
+    expect_true(all(c("beta.lka.WT.power", "beta.lV.WT.power") %in% thetaNames))
     ## the un-selected ke gets no coefficient
-    expect_false("beta_lke_WT_power" %in% thetaNames)
+    expect_false("beta.lke.WT.power" %in% thetaNames)
   })
 
   test_that("the selected shape family decides the written parameterization", {
@@ -77,11 +77,11 @@ nmTest({
     ui2 <- suppressMessages(.vaeUpdateModel(ui, .fakeVaeFit(ui, "lin")))
     kaLine <- deparse1(ui2$lstExpr[[1]])
     ## the linear family writes (WT - ctr), never the log form
-    expect_match(kaLine, "beta_lka_WT_lin * (WT - ", fixed = TRUE)
+    expect_match(kaLine, "beta.lka.WT.lin * (WT - ", fixed = TRUE)
     expect_false(grepl("log(WT", kaLine, fixed = TRUE))
     thetaNames <- ui2$iniDf$name[!is.na(ui2$iniDf$ntheta)]
-    expect_true("beta_lka_WT_lin" %in% thetaNames)
-    expect_false("beta_lka_WT_power" %in% thetaNames)
+    expect_true("beta.lka.WT.lin" %in% thetaNames)
+    expect_false("beta.lka.WT.power" %in% thetaNames)
   })
 
   test_that("shapes= picks the parameterization within the selected family", {
@@ -92,13 +92,13 @@ nmTest({
     fit <- .fakeVaeFit(ui, "center", ctl)
     ui2 <- suppressMessages(.vaeUpdateModel(ui, fit))
     kaLine <- deparse1(ui2$lstExpr[[1]])
-    expect_match(kaLine, "beta_lka_WT_center * (WT/", fixed = TRUE)
+    expect_match(kaLine, "beta.lka.WT.center * (WT/", fixed = TRUE)
     ## center's coefficient is the linear one times the centering value, and the
     ## structural theta absorbs the difference so the prediction is unchanged
     .j <- match("center", fit$prep$covShape)
     .ctr <- fit$prep$covPop[.j]
     .idf <- ui2$iniDf
-    expect_equal(.idf$est[.idf$name == "beta_lka_WT_center"], 2.5 * .ctr)
+    expect_equal(.idf$est[.idf$name == "beta.lka.WT.center"], 2.5 * .ctr)
     expect_equal(.idf$est[.idf$name == "lka"], log(1.8) - 2.5 * .ctr)
   })
 
@@ -132,9 +132,9 @@ nmTest({
     expect_error(ui2 <- suppressMessages(.vaeUpdateModel(uiF, fit)), NA)
     ## covariate coefficients still injected on the non-fixed params
     thetaNames <- ui2$iniDf$name[!is.na(ui2$iniDf$ntheta)]
-    expect_true(all(c("beta_lka_WT_power", "beta_lV_WT_power") %in% thetaNames))
+    expect_true(all(c("beta.lka.WT.power", "beta.lV.WT.power") %in% thetaNames))
     ## no coefficient invented for the fixed-theta eta
-    expect_false(any(grepl("beta_.*_ke|beta_NA", thetaNames)))
+    expect_false(any(grepl("beta\\..*\\.ke|beta\\.NA", thetaNames)))
   })
 })
 
@@ -174,9 +174,9 @@ nmTest({
     ui <- rxode2::assertRxUi(dup)
     ui2 <- suppressMessages(.vaeUpdateModel(ui, .fake(ui)))
     .line <- deparse1(ui2$lstExpr[[1]])
-    expect_equal(lengths(regmatches(.line, gregexpr("beta_lka_WT_power", .line))), 1L)
+    expect_equal(lengths(regmatches(.line, gregexpr("beta.lka.WT.power", .line))), 1L)
     ## still the flat mu-referenced form, so the exp() back-transform survives
-    expect_match(.line, "exp(lka + beta_lka_WT_power * log(WT/", fixed = TRUE)
+    expect_match(.line, "exp(lka + beta.lka.WT.power * log(WT/", fixed = TRUE)
     expect_equal(ui2$muRefCurEval$curEval[ui2$muRefCurEval$parameter == "lka"], "exp")
   })
 
@@ -201,16 +201,16 @@ nmTest({
     expect_gt(.est, 0.5)
     expect_lt(.est, 0.7)
     ## and it stayed exact by writing the centered form rather than clamping
-    expect_true(any(grepl("beta_lka_WT_lin", .idf$name)))
+    expect_true(any(grepl("beta.lka.WT.lin", .idf$name)))
     expect_equal(.est, log(1.8))
   })
 
   test_that("generated coefficient names stay distinct", {
-    expect_equal(.vaeUniqueName("beta_lka_WT_log", character(0)), "beta_lka_WT_log")
-    expect_equal(.vaeUniqueName("beta_lka_WT_log", "beta_lka_WT_log"),
-                 "beta_lka_WT_log2")
-    expect_equal(.vaeUniqueName("beta_lka_WT_log",
-                                c("beta_lka_WT_log", "beta_lka_WT_log2")),
-                 "beta_lka_WT_log3")
+    expect_equal(.vaeUniqueName("beta.lka.WT.log", character(0)), "beta.lka.WT.log")
+    expect_equal(.vaeUniqueName("beta.lka.WT.log", "beta.lka.WT.log"),
+                 "beta.lka.WT.log2")
+    expect_equal(.vaeUniqueName("beta.lka.WT.log",
+                                c("beta.lka.WT.log", "beta.lka.WT.log2")),
+                 "beta.lka.WT.log3")
   })
 })

--- a/tests/testthat/test-vae-covariate.R
+++ b/tests/testthat/test-vae-covariate.R
@@ -59,7 +59,7 @@ nmTest({
   ## End-to-end regression for the two covariate-output bugs, exercised together
   ## via a fixed residual parameter (literalFix=TRUE default), which is what
   ## triggered the parFixedDf drop:
-  ##   Bug 1 -- the selected covariate coefficients (beta_*) must appear in the
+  ##   Bug 1 -- the selected covariate coefficients (beta.*) must appear in the
   ##            population-parameter table, not just in $theta/$cov.
   ##   Bug 2 -- covariate-bearing mu-parameters must back-transform (exp) rather
   ##            than print the raw log-scale estimate.
@@ -92,7 +92,7 @@ nmTest({
     ## Bug 1: covariate coefficients present in the population-parameter table
     ## (WT selected on ka and V for theophylline).  Coefficients carry the shape
     ## they were written in.
-    expect_true(all(c("beta_lka_WT_power", "beta_lV_WT_power") %in% rownames(pf)))
+    expect_true(all(c("beta.lka.WT.power", "beta.lV.WT.power") %in% rownames(pf)))
     expect_true(all(rownames(pf) %in% rownames(fit$cov) |
                       rownames(pf) == "add.err"))
 
@@ -108,8 +108,8 @@ nmTest({
     ## the fixed residual parameter is on the natural scale (no exp)
     expect_equal(pf["add.err", "Estimate"], 0.7, tolerance = 1e-6)
     ## covariate coefficients are reported raw (not back-transformed)
-    expect_equal(pf["beta_lka_WT_power", "Back-transformed"],
-                 pf["beta_lka_WT_power", "Estimate"], tolerance = 1e-6)
+    expect_equal(pf["beta.lka.WT.power", "Back-transformed"],
+                 pf["beta.lka.WT.power", "Estimate"], tolerance = 1e-6)
   })
 
   ## The multi-shape default: BICc now arbitrates between the log and linear
@@ -142,9 +142,9 @@ nmTest({
     ## exclusivity: never two shapes of one covariate on one parameter
     for (k in seq_len(nrow(sel))) expect_lte(sum(sel[k, ]), 1L)
     ## exactly one coefficient per selected parameter, named for the shape used
-    bn <- grep("^beta_", fit$ui$iniDf$name, value = TRUE)
+    bn <- grep("^beta\\.", fit$ui$iniDf$name, value = TRUE)
     expect_equal(length(bn), sum(sel))
-    expect_true(all(grepl("_(power|lin|log|identity|center)$", bn)))
+    expect_true(all(grepl("\\.(power|lin|log|identity|center)$", bn)))
     ## and the emitted model still re-parses with the mu-ref exp() intact
     expect_equal(fit$ui$muRefCurEval$curEval[fit$ui$muRefCurEval$parameter == "lka"],
                  "exp")

--- a/tests/testthat/test-vae-fit.R
+++ b/tests/testthat/test-vae-fit.R
@@ -21,29 +21,34 @@ nmTest({
         cp ~ add(add.err)
       })
     }
+    ## shapes/covCenterType pinned as in test-vae-covariate.R: the expanded shape
+    ## search would otherwise decide the coefficient NAMES (lka picks "lin" and
+    ## lV "power" by default), making this test about which shape wins rather
+    ## than about the fit accessors it is here to check.
     f <- nlmixr2(theo, nlmixr2data::theo_sd, est = "vae",
                  control = vaeControl(itersBurnIn = 80L, klWarmup = 40L, gammaIter = 120L,
-                                      iters = 160L, hiddenDim = 25L, seed = 1L))
+                                      iters = 160L, hiddenDim = 25L, seed = 1L,
+                                      shapes = "power", covCenterType = "mean"))
     expect_s3_class(f, "nlmixr2FitData")
 
     ## selected covariate coefficients are population parameters in the fit
     .pf <- if (is.null(rownames(f$parFixed))) f$parFixed$Parameter else rownames(f$parFixed)
-    expect_true(all(c("beta_lka_WT", "beta_lV_WT") %in% .pf))
+    expect_true(all(c("beta.lka.WT.power", "beta.lV.WT.power") %in% .pf))
     ## objDf / objective present, tagged est = vae
     expect_true(is.finite(f$objDf$OBJF[1]))
 
     ## FINAL model carries the exact centered covariate expression
     .fin <- vapply(f$finalUi$lstExpr, function(e) deparse1(e), character(1))
-    expect_true(any(grepl("beta_lka_WT \\* log\\(WT/", .fin)))
-    expect_true(any(grepl("beta_lV_WT \\* log\\(WT/", .fin)))
+    expect_true(any(grepl("beta.lka.WT.power \\* log\\(WT/", .fin, fixed = FALSE)))
+    expect_true(any(grepl("beta.lV.WT.power \\* log\\(WT/", .fin, fixed = FALSE)))
     expect_true(any(grepl("^ke <- exp\\(lke \\+ eta.ke\\)$", .fin)))
 
     ## ORIGINAL model recoverable via $uiIni (structure differs -- no covariates)
     .ini <- vapply(f$uiIni$lstExpr, function(e) deparse1(e), character(1))
-    expect_false(any(grepl("beta_lka_WT", .ini)))
+    expect_false(any(grepl("beta.lka.WT", .ini, fixed = TRUE)))
     expect_true(any(grepl("^ka <- exp\\(lka \\+ eta.ka\\)$", .ini)))
     ## $iniDf0 is the ORIGINAL model's iniDf (no covariate thetas)
-    expect_false(any(grepl("^beta_", f$iniDf0$name)))
+    expect_false(any(grepl("^beta\\.", f$iniDf0$name)))
     expect_true(all(c("lka", "lke", "lV") %in% f$iniDf0$name))
 
     ## EBEs from the encoder


### PR DESCRIPTION
The covariate coefficients `est="vae"` injects after covariate selection were the
only generated parameter names in the package separated by `_`:

```
beta_tka_WT_lin   ->   beta.tka.WT.lin
```

Everything else in `nlmixr2`, generated and conventional alike, uses `.` --
`eta.cl`, `add.sd`, `prop.sd`.

## Scope

**Categorical coefficients** are now built from the covariate and its level
directly (`beta.tka.SEX.M`) rather than reusing the design-matrix column name,
which glues those two with `_`. Without that, the separator would have been mixed
inside a single name.

**Coefficients you write yourself are untouched.** With
`vaeControl(pinCovariates = TRUE)` (the default) the pinned path keeps the
model's own coefficient names exactly as written, so a hand-written
`beta_lka_WT` stays that way. Only injected names change.

**Internal design-matrix column labels are deliberately not changed**
(`prep$covNames`, e.g. `"WT_power"`). Those are not parameter names, and the
covariate table already exposes `raw` and `shape` as separate columns.

Nothing parses these names -- no regex or `strsplit` recovers the parameter or
covariate from them -- so the change is confined to construction.

## Tests

Updated for the generated names. Two assertions keyed on the separator *without*
mentioning `beta`, which is where this kind of change usually leaks: the
shape-suffix regex `"_(power|lin|log|identity|center)$"` and the `"^beta_"`
prefix greps. Both needed escaping, since `.` is a regex metacharacter. The
user-written pinned names in `test-vae-covariate.R` are left on `_` precisely
because they must not change -- that file now covers both conventions, which is
the behavior worth pinning.

covariate-table 30, covariate 44, covariates 49, cov-shapes 172, cov-groups 22,
cov-control 22, covariate-estimate 69, parFixedDf 19, vae-iov 18 -- all pass.

## Also fixes a pre-existing failure in `test-vae-fit.R`

That file was failing 3 assertions on `main` before this branch -- it is in a
weekly batch, so it does not run on push/PR and the breakage went unnoticed.

The cause is the shape suffix added by the covariate-shape search: the test
expected the pre-shape names `beta_lka_WT` / `beta_lV_WT`, while the search now
writes `beta.lka.WT.<shape>`, and with default shapes it picks `"lin"` for `lka`
and `"power"` for `lV` -- so the names depended on which shape won.

Fixed by pinning `shapes = "power"` and `covCenterType = "mean"`, exactly as the
sibling `test-vae-covariate.R` already does, and asserting
`beta.lka.WT.power` / `beta.lV.WT.power`. That keeps the test about the accessors
it exists to check (`$parFixed`, `$finalUi`, `$uiIni`, `$iniDf0`) rather than
about which shape the search happens to select. **11/11, was 8 passed / 3
failed.**

## NEWS.md

`NEWS.md` on `main` had **two `# nlmixr2est 7.0.2` headings** with a stray
`# nlmixr2est (development version)` section between them -- a bad merge.
Consolidated into the single 7.0.2 section the `DESCRIPTION` version calls for,
ordered Breaking changes / New features / Bug fixes per `CLAUDE.md`, with the
stranded bullets folded into their headings. Bullet count unchanged at 380, so
nothing was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMZpj6ywLmjmB9p3fzMpoQ
