### PR TITLE
feat(vae): fixCov -- naming a covariate in shapes= limits the covariate search

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Breaking changes
 
+- `est="vae"`: naming a covariate in `vaeControl(shapes=)` now also **limits
+  the search to it**.  The list form gained a `fixCov` element defaulting to
+  `TRUE`, so `shapes = list(WT = "power")` searches `WT` and nothing else,
+  where previously it searched every covariate with `WT` restricted to
+  `"power"`.  Add `fixCov = FALSE` to restore the old meaning.  Excluded
+  covariates are listed in `$runInfo`.  A character vector (`shapes =
+  c("power", "lin")`) names no covariate and is unaffected.
+
 - Dropped the `qs2` dependency (and with it `stringfish`, which no longer
   loads against RcppParallel >= 6.0.0): the focei model disk cache now uses
   RDS files and compressed fit components use base R serialization
@@ -11,6 +19,22 @@
   rxode2 (>= 5.1.5) for `rxDeserialize()`.
 
 ## New features
+
+- `est="vae"`: `vaeControl(shapes=)` list elements are now dispatched
+  individually, so the covariate-named and `list(var=, covar=, shapes=)` forms
+  can be mixed in one list.  A named element is exact shorthand for the
+  covariate-wide rule, and a shape value of `TRUE` means "eligible, default
+  shapes" -- which is how a categorical covariate is named, since it takes no
+  parameterization:
+
+  ```r
+  vaeControl(shapes = list(list(var = "cl", covar = "WT", shapes = "power"),
+                           SEX = TRUE))
+  ```
+
+  This is also how a covariate is restricted to particular parameters without
+  writing the effect into the model: a `var`+`covar` rule makes only that pair
+  eligible.
 
 - The `est="vae"` automatic covariate search gained a `"hockey"` shape, a
   two-armed piecewise-linear relationship knotted at the covariate's centering

--- a/R/vae.R
+++ b/R/vae.R
@@ -62,12 +62,35 @@
 #'   therefore decides how an accepted relationship is written back, and when
 #'   several eligible shapes span the same model the one listed first wins.
 #'   `"hockey"` spans a strictly larger model than the linear shapes and costs
-#'   two coefficients rather than one.  May also be a list
-#'   named by covariate (`list(WT = "power")`) or a list of
-#'   `list(var=, covar=, shapes=)` items to restrict a single
-#'   parameter/covariate pair; anything not named keeps every shape.  Which
-#'   covariates are searched is controlled by `pinCovariates`, not here.
-#'   Categorical covariates always enter as indicators and ignore this setting.
+#'   two coefficients rather than one.
+#'
+#'   May also be a **list**, whose elements are dispatched individually so the
+#'   two forms mix freely: an element named by covariate (`WT = "power"`) is
+#'   shorthand for the covariate-wide rule `list(covar = "WT", shapes =
+#'   "power")`, and a `list(var=, covar=, shapes=)` element restricts one
+#'   parameter/covariate pair.  The most specific rule wins -- `var`+`covar`
+#'   beats `covar`, which beats `var`, which beats a rule naming neither -- and
+#'   ties go to the rule listed last.
+#'
+#'   In the list form, **naming a covariate also puts it in the search**.
+#'   `fixCov = TRUE` (the default, given as an element of the list) fixes the
+#'   searched set to exactly the covariates named, so
+#'   `shapes = list(WT = "power")` searches `WT` and nothing else.  Add
+#'   `fixCov = FALSE` to restrict parameterizations without restricting the
+#'   search, which is what the list form meant previously.  A shape value of
+#'   `TRUE` means "eligible, default shapes", and is how a categorical covariate
+#'   is named (`list(WT = "power", SEX = TRUE)`) since a categorical takes no
+#'   parameterization.  A `var`-only rule makes every covariate eligible on that
+#'   parameter alone; a rule naming neither `var` nor `covar` contradicts
+#'   `fixCov = TRUE` and is an error.  A character vector names no covariate, so
+#'   `fixCov` does not apply and every covariate stays searchable.
+#'
+#'   `fixCov` is ignored when the model itself declares covariate effects: that
+#'   already restricts the search (see `pinCovariates`) and the declaration is
+#'   the more specific statement.  The disagreement is reported in `$runInfo`,
+#'   as is every covariate `fixCov` excludes.  Categorical covariates always
+#'   enter as indicators and take no shape, but `fixCov` still governs whether
+#'   they are searched at all.
 #' @param covCenterType Statistic used to center a continuous covariate,
 #'   `"median"` (default) or `"mean"`, computed over subjects rather than rows.
 #' @param covCenter Named numeric vector of centering values overriding

--- a/R/vaeCovShapes.R
+++ b/R/vaeCovShapes.R
@@ -155,51 +155,154 @@
          stop("unknown covariate shape: ", shape, call. = FALSE))
 }
 
+## The element name that carries the eligibility flag rather than a rule.  Matched
+## EXACTLY and case-sensitively; data columns are upper-cased by the search, so a
+## real `FIXCOV` column is still reachable as a covariate name (the collision is
+## caught in .vaeEligible, where the covariate names are known).
+.vaeFixCovName <- "fixCov"
+
 #' Normalize a user `shapes=` specification into match rules
 #'
-#' Accepts a character vector (one global rule), a list named by covariate, or
-#' a list of `list(var=, covar=, shapes=)` items in nlmixr2scm's `pairsVec`
-#' form.  Covariate names match case-insensitively because the VAE upper-cases
-#' data columns.
+#' Accepts a character vector (one global rule) or a list.  A list element is
+#' dispatched on ITSELF rather than on the whole list, so the two historic forms
+#' may be mixed freely:
+#'
+#'   * a list element -> a `list(var=, covar=, shapes=)` rule (nlmixr2scm's
+#'     `pairsVec` form);
+#'   * a named element -> shorthand for `list(covar = <name>, shapes = <value>)`,
+#'     which is what keeps the named form from needing semantics of its own;
+#'   * the element named `fixCov` -> the eligibility flag, not a rule.
+#'
+#' A shape value of `TRUE` means "eligible, with the default shapes" -- the way
+#' to name a covariate whose parameterization is not up for discussion, i.e. a
+#' categorical, which takes no shape at all.
+#'
+#' Covariate names match case-insensitively because the VAE upper-cases data
+#' columns.
 #' @param spec the `shapes` control value
-#' @return data.frame with columns `var`, `cov` (NA meaning "any") and a
-#'   `shapes` list-column
+#' @return list with `rules` (data.frame of `var`, `cov` -- NA meaning "any" --
+#'   and a `shapes` list-column) and `fixCov` (length-one logical)
 #' @noRd
 .vaeResolveShapes <- function(spec) {
   .mk <- function(var, cov, shapes) {
     .d <- data.frame(var = as.character(var), cov = as.character(cov),
                      stringsAsFactors = FALSE)
-    .d$shapes <- list(.vaeAssertContShapes(shapes))
+    ## TRUE == "eligible, default shapes"; anything else must name real shapes
+    if (isTRUE(shapes)) shapes <- .vaeDefaultShapes
+    if (is.logical(shapes)) {
+      stop("shapes value must be TRUE or a shape vector, not ",
+           deparse(shapes), call. = FALSE)
+    }
+    .d$shapes <- list(.vaeAssertContShapes(as.character(shapes)))
     .d
   }
+  .ret <- function(rules, fixCov) list(rules = rules, fixCov = fixCov)
   if (is.null(spec)) spec <- .vaeDefaultShapes
-  if (is.character(spec)) return(.mk(NA_character_, NA_character_, spec))
+  ## a character vector names no covariate, so there is nothing for fixCov to fix
+  if (is.character(spec)) {
+    return(.ret(.mk(NA_character_, NA_character_, spec), FALSE))
+  }
   if (!is.list(spec)) stop("shapes must be a character vector or a list", call. = FALSE)
-  if (length(spec) == 0L) return(.mk(NA_character_, NA_character_, .vaeDefaultShapes))
-  .isPair <- all(vapply(spec, function(e) is.list(e), logical(1)))
-  .out <- list()
-  if (.isPair) {
-    for (.e in spec) {
+  if (length(spec) == 0L) {
+    return(.ret(.mk(NA_character_, NA_character_, .vaeDefaultShapes), FALSE))
+  }
+  .nm <- names(spec)
+  if (is.null(.nm)) .nm <- rep("", length(spec))
+  ## Pull fixCov out BEFORE any rule parsing.  It is not a rule, and a bare
+  ## logical among the elements must not be read as one.
+  .fixCov <- TRUE
+  .fx <- which(.nm == .vaeFixCovName)
+  if (length(.fx) > 1L) stop("fixCov given more than once in shapes", call. = FALSE)
+  if (length(.fx) == 1L) {
+    .fixCov <- spec[[.fx]]
+    checkmate::assertLogical(.fixCov, len = 1, any.missing = FALSE,
+                             .var.name = "fixCov")
+    spec <- spec[-.fx]
+    .nm <- .nm[-.fx]
+  }
+  if (length(spec) == 0L) {
+    ## `shapes = list(fixCov = ...)` restricts nothing and fixes nothing
+    return(.ret(.mk(NA_character_, NA_character_, .vaeDefaultShapes), FALSE))
+  }
+  .out <- vector("list", length(spec))
+  for (.i in seq_along(spec)) {
+    .e <- spec[[.i]]
+    if (is.list(.e)) {
+      ## pair rule; `$` partial-matches, so cov/covar and shape/shapes both work
       .cov <- if (is.null(.e$covar)) .e$cov else .e$covar
       .sh <- if (is.null(.e$shapes)) .e$shape else .e$shapes
       if (is.null(.sh)) .sh <- .vaeDefaultShapes
-      .out[[length(.out) + 1L]] <-
+      .out[[.i]] <-
         .mk(if (is.null(.e$var)) NA_character_ else as.character(.e$var),
             if (is.null(.cov)) NA_character_ else toupper(as.character(.cov)),
-            as.character(.sh))
-    }
-  } else {
-    .nm <- names(spec)
-    if (is.null(.nm) || any(!nzchar(.nm))) {
-      stop("shapes list must be named by covariate, or be list(var=, covar=, shapes=) items",
+            .sh)
+    } else if (nzchar(.nm[.i])) {
+      ## named element: exactly a covar-only pair rule
+      .out[[.i]] <- .mk(NA_character_, toupper(.nm[.i]), .e)
+    } else {
+      stop("shapes list element ", .i,
+           " must be named by covariate, or be a list(var=, covar=, shapes=) item",
            call. = FALSE)
     }
-    for (.i in seq_along(spec)) {
-      .out[[length(.out) + 1L]] <-
-        .mk(NA_character_, toupper(.nm[.i]), as.character(spec[[.i]]))
+  }
+  .ret(do.call(rbind, .out), .fixCov)
+}
+
+#' Which (parameter, covariate) pairs the search may consider
+#'
+#' `fixCov = TRUE` (the default whenever `shapes=` is given as a list) fixes the
+#' searched covariate set to exactly the covariates the rules NAME.  Naming a
+#' covariate is the statement that it belongs in the search, so the common case
+#' -- "search these, and only these" -- costs nothing beyond listing them, with
+#' no per-covariate opt-out for everything left out.
+#'
+#' Eligibility and parameterization are separate passes: this decides WHICH
+#' cells may be searched, `.vaeShapesFor` decides what an eligible cell may look
+#' like.  The specificity ladder is therefore untouched.
+#'
+#' @param rules `$rules` from `.vaeResolveShapes`
+#' @param fixCov `$fixCov` from `.vaeResolveShapes`
+#' @param etaNames per-latent-dim random-effect names
+#' @param thetaForEta per-latent-dim mu-referenced theta names (may be NA)
+#' @param covRaw raw (data column) name per search column
+#' @return logical matrix, `length(etaNames)` by `length(unique(covRaw))`, over
+#'   the RAW covariates in `unique(covRaw)` order
+#' @noRd
+.vaeEligible <- function(rules, fixCov, etaNames, thetaForEta, covRaw) {
+  .raw <- unique(covRaw)
+  .m <- matrix(TRUE, length(etaNames), length(.raw),
+               dimnames = list(NULL, .raw))
+  if (!isTRUE(fixCov) || length(.raw) == 0L) return(.m)
+  ## A rule naming neither a parameter nor a covariate makes everything
+  ## eligible, which is a direct contradiction of fixCov rather than a
+  ## restriction to honor.  Say so instead of silently ignoring one of the two.
+  if (any(is.na(rules$var) & is.na(rules$cov))) {
+    stop("shapes: a rule with neither var= nor covar= makes every covariate ",
+         "eligible, which contradicts fixCov=TRUE\n",
+         "  use fixCov=FALSE to restrict shapes without restricting the search",
+         call. = FALSE)
+  }
+  if (.vaeFixCovName %in% .raw || toupper(.vaeFixCovName) %in% toupper(.raw)) {
+    stop("shapes: a data covariate is named `", .vaeFixCovName,
+         "`, which collides with the eligibility flag", call. = FALSE)
+  }
+  .m[] <- FALSE
+  for (.k in seq_along(etaNames)) {
+    .al <- c(etaNames[.k], thetaForEta[.k], sub("^eta\\.", "", etaNames[.k]))
+    .al <- unique(.al[!is.na(.al)])
+    for (.r in seq_len(nrow(rules))) {
+      .vOk <- is.na(rules$var[.r]) || rules$var[.r] %in% .al
+      if (!.vOk) next
+      if (is.na(rules$cov[.r])) {
+        ## var-only: every covariate, on this parameter alone
+        .m[.k, ] <- TRUE
+      } else {
+        .j <- match(rules$cov[.r], toupper(.raw))
+        if (!is.na(.j)) .m[.k, .j] <- TRUE
+      }
     }
   }
-  do.call(rbind, .out)
+  .m
 }
 
 #' Numeric column a shape's model text evaluates to
@@ -385,23 +488,38 @@
   }, logical(1), USE.NAMES = FALSE)
 }
 
-#' Per-(latent dim, column) mask of shapes the user allows
+#' Per-(latent dim, column) mask of what the user allows
 #'
-#' `shapes=` may restrict a single (parameter, covariate) pair, but the design
-#' matrix is shared across latent dimensions, so the restriction has to be
-#' enforced as a mask rather than by omitting columns.  Categorical columns are
-#' never restricted -- `shapes=` governs continuous parameterizations only.
+#' Two independent restrictions land in the same mask, because the design matrix
+#' is shared across latent dimensions and neither can be enforced by omitting
+#' columns:
+#'
+#'   * ELIGIBILITY (`fixCov`) -- may this parameter carry this covariate at all?
+#'     An ineligible cell has EVERY column of that covariate zeroed, categorical
+#'     columns included.
+#'   * PARAMETERIZATION (`shapes`) -- given that it may, which forms may it take?
+#'     Categorical columns are never restricted this way: `shapes=` governs
+#'     continuous parameterizations only.
+#'
+#' The order matters.  Eligibility is absolute, so it is applied last and
+#' overrides the parameterization pass, including that pass's fallback for a
+#' covariate whose requested family the data cannot support.
 #' @param cov output of `.vaeCovariateSearch`
-#' @param rules output of `.vaeResolveShapes`
+#' @param resolved output of `.vaeResolveShapes` (`$rules` + `$fixCov`); a bare
+#'   rules data.frame is accepted as `fixCov = FALSE` for callers that only ever
+#'   restricted parameterizations
 #' @param etaNames per-latent-dim random-effect names
 #' @keywords internal
 #' @param thetaForEta per-latent-dim mu-referenced theta names (may be NA)
 #' @return integer 0/1 matrix, `length(etaNames)` by `ncol(cov$covMat)`
 #' @noRd
-.vaeShapeAllowMask <- function(cov, rules, etaNames, thetaForEta) {
+.vaeShapeAllowMask <- function(cov, resolved, etaNames, thetaForEta) {
   .nCov <- length(cov$covNames)
   .m <- matrix(1L, length(etaNames), .nCov)
-  if (.nCov == 0L || is.null(rules)) return(.m)
+  if (.nCov == 0L || is.null(resolved)) return(.m)
+  if (is.data.frame(resolved)) resolved <- list(rules = resolved, fixCov = FALSE)
+  rules <- resolved$rules
+  if (is.null(rules)) return(.m)
   for (.k in seq_along(etaNames)) {
     .al <- c(etaNames[.k], thetaForEta[.k], sub("^eta\\.", "", etaNames[.k]))
     .al <- unique(.al[!is.na(.al)])
@@ -417,6 +535,15 @@
       .have <- setdiff(unique(cov$covFamily[cov$covRaw == cov$covRaw[.j]]), "cat")
       if (length(intersect(.want, .have)) == 0L) next
       if (!(cov$covFamily[.j] %in% .want)) .m[.k, .j] <- 0L
+    }
+  }
+  ## Eligibility last, and unconditionally: an ineligible covariate is out of the
+  ## search whatever the loop above decided, including via the fallback `next`.
+  .el <- .vaeEligible(rules, resolved$fixCov, etaNames, thetaForEta, cov$covRaw)
+  if (!all(.el)) {
+    .col <- match(cov$covRaw, colnames(.el))
+    for (.k in seq_along(etaNames)) {
+      .m[.k, !.el[.k, .col]] <- 0L
     }
   }
   .m

--- a/R/vaeCovShapes.R
+++ b/R/vaeCovShapes.R
@@ -221,7 +221,15 @@
     .nm <- .nm[-.fx]
   }
   if (length(spec) == 0L) {
-    ## `shapes = list(fixCov = ...)` restricts nothing and fixes nothing
+    ## `shapes = list(fixCov = TRUE)` asks to fix the searched set to the
+    ## covariates named, and names none.  Silently reading that as FALSE would
+    ## override an explicit flag; silently reading it as TRUE would search
+    ## nothing.  Neither is what was meant, so say so.
+    if (isTRUE(.fixCov) && length(.fx) == 1L) {
+      stop("shapes: fixCov=TRUE but no covariate is named\n",
+           "  name the covariates to search, or use covariateSelection=FALSE ",
+           "to turn the search off", call. = FALSE)
+    }
     return(.ret(.mk(NA_character_, NA_character_, .vaeDefaultShapes), FALSE))
   }
   .out <- vector("list", length(spec))
@@ -297,8 +305,12 @@
         ## var-only: every covariate, on this parameter alone
         .m[.k, ] <- TRUE
       } else {
-        .j <- match(rules$cov[.r], toupper(.raw))
-        if (!is.na(.j)) .m[.k, .j] <- TRUE
+        ## `which`, not `match`: match() takes only the FIRST hit, which would
+        ## leave a second same-named-up-to-case covariate ineligible.  Both entry
+        ## points upper-case the data columns before the search, so that cannot
+        ## arise today -- this keeps the function correct without relying on it.
+        .j <- which(toupper(.raw) == rules$cov[.r])
+        if (length(.j) > 0L) .m[.k, .j] <- TRUE
       }
     }
   }

--- a/R/vaeData.R
+++ b/R/vaeData.R
@@ -1019,10 +1019,15 @@ vaeCovariates <- function(data, warn = TRUE,
              "  use covariateSelection=FALSE to turn the search off outright",
              call. = FALSE)
       }
-      .fxDrop <- .cov$covRaw[colSums(.shapeMask) == 0L]
+      ## Grouped by RAW covariate, not by column.  A covariate restricted to one
+      ## shape has its other columns masked to zero while the covariate itself is
+      ## still searched through the column that survived, so a per-column test
+      ## could name it as excluded when it was not.
+      .fxBy <- tapply(colSums(.shapeMask), .cov$covRaw, sum)
+      .fxDrop <- names(.fxBy)[.fxBy == 0]
       if (length(.fxDrop) > 0L) {
         .fxPre <- "fixCov=TRUE, covariate(s) not searched: "
-        warning(.fxPre, .vaeTruncList(unique(.fxDrop), prefix = .fxPre),
+        warning(.fxPre, .vaeTruncList(.fxDrop, prefix = .fxPre),
                 call. = FALSE)
       }
     }

--- a/R/vaeData.R
+++ b/R/vaeData.R
@@ -1010,7 +1010,12 @@ vaeCovariates <- function(data, warn = TRUE,
   if (!.searchOff && !.pinActive && length(.cov$covNames) > 0L) {
     .shapeMask <- .vaeShapeAllowMask(.cov, .resolvedShapes, .etaNames,
                                      .foceiEtaThetaMap(ui)$thetaForEta)
-    if (isTRUE(.resolvedShapes$fixCov)) {
+    ## Only when a search is actually going to run.  With
+    ## covariateSelection=FALSE there is nothing for fixCov to narrow, so the
+    ## error below would fire against a user who had ALREADY done what it tells
+    ## them to do, and the note would blame fixCov for a search that was off
+    ## regardless.
+    if (isTRUE(.resolvedShapes$fixCov) && isTRUE(control$covariateSelection)) {
       ## fixCov=TRUE with nothing left to search is a contradiction the user
       ## almost certainly did not intend; covariateSelection=FALSE is the way to
       ## ask for no search at all.

--- a/R/vaeData.R
+++ b/R/vaeData.R
@@ -148,7 +148,7 @@
                                 covCenterType = c("median", "mean"),
                                 covCenter = NULL, catCutoff = 0.05) {
   covCenterType <- match.arg(covCenterType)
-  if (is.null(shapeRules)) shapeRules <- .vaeResolveShapes(NULL)
+  if (is.null(shapeRules)) shapeRules <- .vaeResolveShapes(NULL)$rules
   N <- length(ids)
   ## auto-discover subject-level covariate candidates (constant within ID),
   ## excluding reserved data columns
@@ -446,7 +446,7 @@ vaeCovariates <- function(data, warn = TRUE,
   if (is.null(d$ID)) {
     stop("'data' must contain an ID column", call. = FALSE)
   }
-  .cov <- .vaeCovariateSearch(d, unique(d$ID), .vaeResolveShapes(shapes),
+  .cov <- .vaeCovariateSearch(d, unique(d$ID), .vaeResolveShapes(shapes)$rules,
                               match.arg(covCenterType), covCenter, catCutoff)
   if (warn && length(.cov$tvExcl) > 0L) {
     warning("time-varying covariate(s) were excluded from automatic covariate search: ",
@@ -851,7 +851,8 @@ vaeCovariates <- function(data, warn = TRUE,
   .cct <- if (is.null(control$covCenterType)) "mean" else control$covCenterType
   .cco <- if (is.null(control$catCutoff)) 0.05 else control$catCutoff
   .csh <- if (is.null(control$shapes)) "power" else control$shapes
-  .cov <- .vaeCovariateSearch(d, .ids, .vaeResolveShapes(.csh), .cct,
+  .resolvedShapes <- .vaeResolveShapes(.csh)
+  .cov <- .vaeCovariateSearch(d, .ids, .resolvedShapes$rules, .cct,
                               control$covCenter, .cco)
   if (length(.cov$tvExcl) > 0L) {
     ## keep the $runInfo note single-line even with many covariates
@@ -1004,10 +1005,31 @@ vaeCovariates <- function(data, warn = TRUE,
   ## that is then neither searched nor regressed, and so written back as exactly
   ## 0, silently deleting it.  Under pinning the declaration wins; a declared
   ## shape with no column to pin to already falls back to the regress M-step.
+  ## The same holds for fixCov: the declaration is the more specific statement,
+  ## so it wins, and the disagreement is reported rather than acted on.
   if (!.searchOff && !.pinActive && length(.cov$covNames) > 0L) {
-    .shapeMask <- .vaeShapeAllowMask(.cov, .vaeResolveShapes(.csh), .etaNames,
+    .shapeMask <- .vaeShapeAllowMask(.cov, .resolvedShapes, .etaNames,
                                      .foceiEtaThetaMap(ui)$thetaForEta)
+    if (isTRUE(.resolvedShapes$fixCov)) {
+      ## fixCov=TRUE with nothing left to search is a contradiction the user
+      ## almost certainly did not intend; covariateSelection=FALSE is the way to
+      ## ask for no search at all.
+      if (all(.shapeMask == 0L)) {
+        stop("shapes: fixCov=TRUE leaves no covariate searchable on any parameter\n",
+             "  use covariateSelection=FALSE to turn the search off outright",
+             call. = FALSE)
+      }
+      .fxDrop <- .cov$covRaw[colSums(.shapeMask) == 0L]
+      if (length(.fxDrop) > 0L) {
+        .fxPre <- "fixCov=TRUE, covariate(s) not searched: "
+        warning(.fxPre, .vaeTruncList(unique(.fxDrop), prefix = .fxPre),
+                call. = FALSE)
+      }
+    }
     if (any(.shapeMask == 0L)) .covAllow <- .shapeMask
+  } else if (isTRUE(.resolvedShapes$fixCov) && .pinActive) {
+    warning("fixCov=TRUE ignored: the model declares covariates, which pins the search",
+            call. = FALSE)
   }
 
   ## Fixed-effect thetas estimated directly by a bounded bobyqa regression in the
@@ -1246,7 +1268,7 @@ vaeCovariates <- function(data, warn = TRUE,
        covFamily = .cov$covFamily, covLevel = .cov$covLevel,
        covGroup = .cov$covGroup, covBlock = .cov$covBlock,
        covExpr = .cov$covExpr,
-       covCanon = .cov$covCanon, shapeRules = .vaeResolveShapes(.csh),
+       covCanon = .cov$covCanon, shapeRules = .resolvedShapes$rules,
        pinActive = .pinActive, pinPairs = .pinPairs, covAllow = .covAllow,
        tMax = .tMax, dvMean = .dvMean, dvSd = .dvSd, Nobs = length(.allDv))
 }

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -123,26 +123,49 @@ VAE covariate search never re-centers it.  The original expression is
 restored in the reported model.}
 
 \item{shapes}{Which parameterizations ("shapes") of a continuous covariate
-the automatic search may consider, using the same vocabulary as
-`nlmixr2scm::runSCM()`: `"power"` (`beta*log(COV/ctr)`), `"lin"`
-(`beta*(COV - ctr)`), `"log"` (`beta*log(COV)`), `"identity"` (`beta*COV`)
-and `"center"` (`beta*(COV/ctr)`).  `"hockey"` is a two-armed piecewise
-linear relationship knotted at the centering value, written as
-`beta.low*(COV < ctr)*(COV - ctr) + beta.hi*(COV >= ctr)*(COV - ctr)`; both
-arms enter or neither does, and it is skipped for a covariate with fewer
-than `catCutoff` of the subjects on one side of the knot.  At most one shape
-of a covariate may enter a given parameter.  Because the selection objective
-is an ordinary least squares fit with a free intercept, `"power"`/`"log"`
-span the same model, as do `"lin"`/`"identity"`/`"center"`; the shape
-therefore decides how an accepted relationship is written back, and when
-several eligible shapes span the same model the one listed first wins.
-`"hockey"` spans a strictly larger model than the linear shapes and costs
-two coefficients rather than one.  May also be a list
-named by covariate (`list(WT = "power")`) or a list of
-`list(var=, covar=, shapes=)` items to restrict a single
-parameter/covariate pair; anything not named keeps every shape.  Which
-covariates are searched is controlled by `pinCovariates`, not here.
-Categorical covariates always enter as indicators and ignore this setting.}
+  the automatic search may consider, using the same vocabulary as
+  `nlmixr2scm::runSCM()`: `"power"` (`beta*log(COV/ctr)`), `"lin"`
+  (`beta*(COV - ctr)`), `"log"` (`beta*log(COV)`), `"identity"` (`beta*COV`)
+  and `"center"` (`beta*(COV/ctr)`).  `"hockey"` is a two-armed piecewise
+  linear relationship knotted at the centering value, written as
+  `beta.low*(COV < ctr)*(COV - ctr) + beta.hi*(COV >= ctr)*(COV - ctr)`; both
+  arms enter or neither does, and it is skipped for a covariate with fewer
+  than `catCutoff` of the subjects on one side of the knot.  At most one shape
+  of a covariate may enter a given parameter.  Because the selection objective
+  is an ordinary least squares fit with a free intercept, `"power"`/`"log"`
+  span the same model, as do `"lin"`/`"identity"`/`"center"`; the shape
+  therefore decides how an accepted relationship is written back, and when
+  several eligible shapes span the same model the one listed first wins.
+  `"hockey"` spans a strictly larger model than the linear shapes and costs
+  two coefficients rather than one.
+
+  May also be a **list**, whose elements are dispatched individually so the
+  two forms mix freely: an element named by covariate (`WT = "power"`) is
+  shorthand for the covariate-wide rule `list(covar = "WT", shapes =
+  "power")`, and a `list(var=, covar=, shapes=)` element restricts one
+  parameter/covariate pair.  The most specific rule wins -- `var`+`covar`
+  beats `covar`, which beats `var`, which beats a rule naming neither -- and
+  ties go to the rule listed last.
+
+  In the list form, **naming a covariate also puts it in the search**.
+  `fixCov = TRUE` (the default, given as an element of the list) fixes the
+  searched set to exactly the covariates named, so
+  `shapes = list(WT = "power")` searches `WT` and nothing else.  Add
+  `fixCov = FALSE` to restrict parameterizations without restricting the
+  search, which is what the list form meant previously.  A shape value of
+  `TRUE` means "eligible, default shapes", and is how a categorical covariate
+  is named (`list(WT = "power", SEX = TRUE)`) since a categorical takes no
+  parameterization.  A `var`-only rule makes every covariate eligible on that
+  parameter alone; a rule naming neither `var` nor `covar` contradicts
+  `fixCov = TRUE` and is an error.  A character vector names no covariate, so
+  `fixCov` does not apply and every covariate stays searchable.
+
+  `fixCov` is ignored when the model itself declares covariate effects: that
+  already restricts the search (see `pinCovariates`) and the declaration is
+  the more specific statement.  The disagreement is reported in `$runInfo`,
+  as is every covariate `fixCov` excludes.  Categorical covariates always
+  enter as indicators and take no shape, but `fixCov` still governs whether
+  they are searched at all.}
 
 \item{covCenterType}{Statistic used to center a continuous covariate,
 `"median"` (default) or `"mean"`, computed over subjects rather than rows.}
@@ -498,16 +521,42 @@ function.  By default this is \code{TRUE}}
 \item{ci}{Confidence level for some tables.  By default this is
 0.95 or 95\% confidence.}
 
-\item{sigdig}{Specifies the "significant digits" that the ode
-solving requests.  When specified this controls the relative and
-absolute tolerances of the ODE solvers.  By default the tolerance
-is \code{0.5*10^(-sigdig-2)} for regular ODEs. For the
-sensitivity equations the default is \verb{0.5*10\\^(-sigdig-1.5)}
-(sensitivity changes only applicable for liblsoda).  This also
-controls the \code{atol}/\code{rtol} of the steady state solutions. The
-\code{ssAtol}/\code{ssRtol} is \verb{0.5*10\\^(-sigdig)} and for the sensitivities
-\verb{0.5*10\\^(-sigdig+0.625)}.  By default
-this is unspecified (\code{NULL}) and uses the standard \code{atol}/\code{rtol}.}
+\item{sigdig}{Specifies the "significant digits" that the ODE
+solving requests.  This is \code{NULL} by default, and while it is
+\code{NULL} it has no effect at all: \code{rxSolve()} uses the standard
+\code{atol}/\code{rtol} (and the standard sensitivity and steady-state
+tolerances).  \code{sigdig} only changes a tolerance when you ask for
+it explicitly.
+
+When it is supplied, the tolerances are derived with one
+solver-independent formula -- the same for stiff, non-stiff and
+auto-switching solvers.  The \code{rtol} exponent IS \code{sigdig} and
+\code{atol} sits three orders below it:
+\itemize{
+\item \code{rtol = 10^(-sigdig)}, \code{atol = 10^(-sigdig-3)}
+\item the sensitivity tolerances match the main solve, so
+\code{rtolSens = rtol} and \code{atolSens = atol} (gradients and
+covariances are built from them)
+\item the steady-state tolerances run one order looser than the
+corresponding main tolerance, so \code{ssRtol = ssRtolSens = 10*rtol}
+and \code{ssAtol = ssAtolSens = 10*atol}
+}
+
+Each of these is set only when you did not pass that tolerance
+yourself; a tolerance you supply always wins.  Because they are
+resolved independently, an explicit \code{atol}/\code{rtol} overrides the
+main solve but does \emph{not} propagate to the sensitivity or
+steady-state tolerances -- set those directly if you need them
+changed too.
+
+This mapping matches how \code{nlmixr2est} derives solver tolerances
+from its optimization \code{sigdig}, so a \code{sigdig} used for estimation
+and the same \code{sigdig} used for a plain \code{rxSolve()} mean the same
+thing.  Note it is keyed to \code{sigdig} as a request for that many
+significant digits, and is looser than the \code{atol}/\code{rtol} defaults
+for small \code{sigdig} -- at \code{sigdig = 4} it gives \code{rtol = 1e-4}
+against a default \code{rtol = 1e-6}.  Raise \code{sigdig}, or set
+\code{atol}/\code{rtol} directly, when you want a tighter solve.}
 
 \item{sigdigTable}{Significant digits in the final output table.
 If not specified, then it matches the significant digits in the

--- a/plans/vae-shapes-limit-search.md
+++ b/plans/vae-shapes-limit-search.md
@@ -1,0 +1,223 @@
+# Limiting the VAE covariate search with `shapes=`
+
+Lets `shapes=` say that a covariate may take **no** shape on a parameter, which
+removes that (parameter, covariate) pair from the automatic search. Today
+`shapes=` can only choose among parameterizations; there is no way to tell the
+search "consider `GA` and `Mage`, nothing else" or "search `GA` only on `lW0`"
+without writing the effects into the model.
+
+## Why the current answer is not enough
+
+The only existing way to restrict which pairs are searched is `pinCovariates`,
+and it is driven by the model rather than by the control:
+
+```r
+neonatalPin <- neonatalModel |>
+  model(W0 <- exp(lW0 + beta.lW0.GA.power * log(GA / 40) + eta.W0)) |>
+  ini(beta.lW0.GA.power <- 1)
+```
+
+That works, but it makes the user commit to three things at once to express one:
+
+1. **A shape.** A pinned pair is allowed only the column matching the shape it
+   was written in (`.vaeData.R` `.vaePinColumn`), so pinning `GA` on `lW0` also
+   decides it is a `power`. There is no way to say "search `GA` on `lW0`, any
+   shape".
+2. **A starting value.** The coefficient has to be promoted in `ini()`, or the
+   symbol is read as a data covariate and *nothing* is pinned -- a silent
+   fall-through to the full search.
+3. **All-or-nothing scope.** Declaring one effect pins the search to the
+   declared set. There is no way to narrow one parameter while leaving the rest
+   of the search alone.
+
+`shapes=` already resolves per (parameter, covariate) with a specificity ladder,
+aliases and case-insensitive covariate names. Exclusion is the one thing that
+ladder cannot express, and it is the thing users ask for.
+
+## Proposed surface: `fixCov`
+
+Naming a covariate in `shapes=` **is** the statement that it belongs in the
+search. `fixCov = TRUE` -- the default -- fixes the searched covariate set to
+exactly the ones `shapes=` names; `fixCov = FALSE` restores today's behavior,
+where `shapes=` restricts parameterizations only and every other covariate is
+still searched with the default shapes.
+
+```r
+## search GA and Mage, nothing else -- fixCov = TRUE is the default
+vaeControl(shapes = list(GA   = c("power", "hockey"),
+                         Mage = "lin"))
+
+## restrict GA's shapes, but keep searching every other covariate
+## (this is what the same call means today)
+vaeControl(shapes = list(GA = c("power", "hockey"),
+                         fixCov = FALSE))
+
+## per-pair: search GA only on lW0, and Mage only on lkin
+vaeControl(shapes = list(
+  list(var = "lW0",  covar = "GA",   shapes = "power"),
+  list(var = "lkin", covar = "Mage", shapes = "lin")
+))
+```
+
+The point is that the common case costs nothing. A modeler who knows the
+covariates they care about lists them and is done -- there is no per-covariate
+opt-out to write for the ones they left out, and no deny-then-allow preamble.
+The escape hatch (`fixCov = FALSE`) is one element, written once, for the less
+common case of "restrict these parameterizations, keep looking at the rest".
+
+`fixCov` is an element of the `shapes` list, so it travels with the rules it
+governs rather than as a second control argument that could disagree with them.
+
+### Interaction with the rules
+
+`fixCov` decides which pairs are **eligible**; the existing ladder
+(`var`+`covar` > `covar` > `var` > global, ties to the last rule listed) then
+decides which shapes an eligible pair may take. The two are separate passes,
+which keeps the ladder untouched.
+
+### Why not `"none"`
+
+An earlier draft reserved a `"none"` shape token and had the user deny
+per-covariate, or write a global deny rule and then allow back. Both put the
+burden on the common case: an explicit covariate list is what modelers
+actually write, so that should be the default reading, not an idiom assembled
+out of exclusions.
+
+### Backward compatibility
+
+This changes what an existing `shapes = list(...)` call means. Today
+`list(GA = "power")` searches every covariate with `GA` restricted to `power`;
+under the new default it searches `GA` alone. Any user who was restricting
+shapes and relying on the rest of the search continuing has to add
+`fixCov = FALSE`. See decision 3.
+
+## Decisions (confirmed with the user before implementation)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Pair rules under `fixCov=TRUE` | a `var`+`covar` rule makes only that PAIR eligible; a `covar`-only rule makes it eligible on every parameter |
+| 2 | Naming a categorical | `Sex = TRUE` -- "eligible, shapes not applicable". `TRUE` works for a continuous covariate too, meaning "eligible with the default shapes" |
+| 2b | **Mixed list forms must work** | `list(list(var=, covar=, shapes=), Sex = TRUE)` -- named entries and pair entries in ONE list. This is new; today mixing is an error |
+| 3 | Backward compatibility | no separate warning: report it through `$runInfo`, following the conventions already used there |
+| 4 | Where `fixCov` lives | element of the `shapes` list only; NOT a `vaeControl()` argument, so it cannot disagree with the rules it governs |
+| 5 | `shapes` as a character vector | names no covariate, so `fixCov` has nothing to fix: every covariate stays searched. `fixCov` alongside a character vector is an error |
+| 6 | Global rule under `fixCov=TRUE` | a rule with neither `var` nor `covar` makes everything eligible, negating `fixCov`; error rather than a silent contradiction |
+| 7 | `var`-only rule under `fixCov=TRUE` | every covariate eligible on that parameter, and only that parameter |
+| 8 | A data column named `fixCov` | matched exactly and case-sensitively as a control element; covariates are upper-cased, so a real `FIXCOV` column is still reachable. Error on collision |
+| 9 | Nothing eligible | error, naming `covariateSelection = FALSE` as the intended spelling |
+| 10 | Interaction with pinning | a model that declares covariates already pins; declaration wins, and `$runInfo` says so when `fixCov` would have disagreed |
+| 11 | Reporting | the eligible set, and every covariate `fixCov` excluded, in `$runInfo` (this subsumes decision 3) |
+
+### Decision 2b is the invasive one
+
+`.vaeResolveShapes` currently decides the form with
+`all(vapply(spec, is.list, logical(1)))` -- every element a list means the pair
+form, otherwise the named form, and anything mixed dies on "shapes list must be
+named by covariate". Supporting `list(list(...), Sex = TRUE)` means replacing
+that whole-list test with a **per-element** one:
+
+- element is a list -> a pair rule (`var`/`covar`/`shapes`)
+- element is named -> shorthand for `list(covar = <name>, shapes = <value>)`,
+  where `<value>` may be a shape vector or `TRUE`
+- element is named `fixCov` -> the control flag, not a rule
+
+A named entry becoming exact shorthand for a `covar`-only pair rule is what
+keeps this from adding a second set of semantics: after parsing there is one
+rule table, and the existing specificity ladder is untouched.
+
+Note that this makes the "the two forms cannot be mixed" paragraph in the
+`vaeNeonatal` vignette wrong once shipped; the article needs updating in the
+same PR that lands this.
+
+## Implementation
+
+Two separable pieces: parsing `fixCov` out of the `shapes` list, and turning an
+eligibility set into mask zeros. The mask machinery already exists and already
+propagates.
+
+1. **`R/vaeCovShapes.R`**
+   - `.vaeResolveShapes`: replace the whole-list form detection with the
+     per-element dispatch of decision 2b, and pull `fixCov` out before any of
+     it. Ordering matters -- a bare `fixCov = FALSE` is not a list, so leaving
+     it in would flip the old whole-list test on its own. Return
+     `list(rules =, fixCov =)` rather than an attribute; there are three call
+     sites and the explicit shape reads better at all of them.
+   - `TRUE` as a shape value (decision 2) resolves to "eligible, default
+     shapes" -- for a categorical it means eligible with no parameterization to
+     choose, which is already how a `cat` column behaves.
+   - New `.vaeEligible(rules, fixCov, etaNames, thetaForEta, cov)` returning an
+     (eta x raw covariate) logical matrix, following decisions 1, 6 and 7. With
+     `fixCov = FALSE` it is all-TRUE and nothing downstream changes.
+   - `.vaeShapesFor`: unchanged. Eligibility and parameterization stay separate
+     passes so the specificity ladder is untouched.
+   - `.vaeShapeAllowMask`: zero every column of an ineligible cell. Both
+     existing guards need care -- the `cat` skip and the "requested family
+     unavailable -> leave selectable" fallback each protect a covariate from
+     being masked out entirely, which is right for a parameterization
+     restriction and wrong for an eligibility one.
+   - `.vaeAssertContShapes` gains no token, which is the main simplification
+     over the `"none"` draft.
+2. **`R/vaeData.R`**
+   - `.vaeDataPrep` (~line 1007): the mask is built only when
+     `!.searchOff && !.pinActive`. Under pinning, resolve `fixCov` far enough
+     to emit the decision-10 warning, then discard it.
+   - `.vaeCovariateSearch` builds the candidate columns; a covariate ineligible
+     on every parameter can be dropped there rather than masked, which is
+     cheaper -- but only if that does not disturb `covGroup`/`covBlock`
+     numbering. Masking is the safe default; measure before optimizing.
+   - Line ~1218 (`.sel <- which(colSums(.covAllow) > 0L)`) already drops a
+     column allowed for no dimension, so an excluded covariate leaves the
+     design matrix with no extra work.
+   - `$runInfo` note (decision 11), next to the existing
+     `catDropped`/`logDrop`/`hockeyDrop` warnings; decision 9's error.
+3. **`R/vaeFit.R`** -- nothing. `.nCand` is computed from `prepC$covAllow`
+   (~line 271), so an exclusion shrinks the bit count that picks
+   `bnb`/`l0learn` automatically. Worth a test rather than a change.
+4. **`R/vae.R`** -- `shapes=` roxygen: `fixCov`, the default, the
+   backward-compatibility note, and that pinning overrides it.
+5. **`NEWS.md`** -- decision 3 makes this a user-visible behavior change and it
+   needs an entry whatever we choose.
+
+## Tests
+
+- `shapes = list(GA = "power")` searches `GA` and nothing else (assert on the
+  `covAllow` mask -- cheap and exact -- and on a fit outcome once).
+- The same call with `fixCov = FALSE` reproduces today's mask exactly. This is
+  the regression guard for decision 3.
+- Pair rules: `list(list(var = "lW0", covar = "GA", shapes = "power"))` makes
+  `GA` eligible on `lW0` only (decision 1).
+- `fixCov` in a pair-form list does not break form detection -- the specific
+  failure the strip-first ordering exists to prevent.
+- Mixed forms (decision 2b): `list(list(var=, covar=, shapes=), Sex = TRUE)`
+  parses, and a named entry resolves identically to the `covar`-only pair rule
+  it is shorthand for.
+- `TRUE` as a shape value on a continuous covariate means "eligible, default
+  shapes"; on a categorical it means eligible.
+- A categorical covariate named in the list is searched; one not named is not
+  (decision 2, spelling TBD).
+- Nothing eligible raises the decision-9 error.
+- A pinned model with a disagreeing `fixCov` warns, and the declaration wins
+  (decision 10).
+- `covSelectMethod`: excluding covariates moves a dimension from `l0learn` back
+  to `bnb`.
+
+## Working agreement
+
+- **Isolated worktree.** Implement on a branch stacked on `feat/vae-hockey`, in
+  its own worktree (the repo already keeps one per line of work, e.g.
+  `~/src/nlmixr2est-vae-hockey`), so the shapes work never lands on whatever
+  branch the main checkout happens to be on.
+- **Commit often.** One commit per numbered implementation step above, not one
+  commit at the end -- the parse change, the eligibility matrix, the mask
+  change, the `runInfo`/error handling, the docs and the NEWS entry are each
+  independently reviewable and independently revertable.
+- **Review with antigravity.** Run the `antigravity-code-review` skill on the
+  branch diff before the work is considered done, and again after any
+  non-trivial round of fixes. A Gemini-family reviewer is genuinely independent
+  of the reading that produced the code, which is the point.
+
+## Note on branches
+
+The code above is on `feat/vae-hockey` (`.vaeDefaultShapes`, `.vaeHockeyArms`,
+the block-aware `.bitsOf`), not on `main`. This plan is written against that
+branch and should be implemented on top of it or on a branch stacked on it.

--- a/tests/testthat/test-vae-cov-shapes.R
+++ b/tests/testthat/test-vae-cov-shapes.R
@@ -729,3 +729,93 @@ nmTest({
                  "named by covariate")
   })
 })
+
+## fixCov end to end: the mask .vaeShapeAllowMask actually produces, and the
+## three .vaeDataPrep paths (exclusion note, nothing-searchable error, and the
+## declaring model that overrides the flag).
+nmTest({
+  .d <- nlmixr2data::theo_sd
+  .d$WT <- rep(c(60, 70, 80), length.out = length(unique(.d$ID)))[
+    match(.d$ID, unique(.d$ID))]
+  .d$AGE <- rep(c(30, 40, 50), length.out = length(unique(.d$ID)))[
+    match(.d$ID, unique(.d$ID))]
+  names(.d) <- toupper(names(.d))
+
+  ## built as text like the pinning tests above: model()/ini() piping inside
+  ## test_that() resolves the covariate symbol in the wrong environment
+  .mk <- function(term = NULL) {
+    .ini <- if (is.null(term)) "" else " b1 <- 0.1;"
+    .cl <- if (is.null(term)) "exp(tcl + eta.cl)"
+           else paste0("exp(tcl + b1 * ", term, " + eta.cl)")
+    eval(parse(text = paste0(
+      "function() {\n",
+      "  ini({ tka <- 0.45; tcl <- 1; tv <- 3.45;", .ini, " add.sd <- 0.7\n",
+      "        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1 })\n",
+      "  model({ ka <- exp(tka + eta.ka)\n",
+      "    cl <- ", .cl, "\n",
+      "    v <- exp(tv + eta.v)\n",
+      "    d/dt(depot) <- -ka * depot\n",
+      "    d/dt(center) <- ka * depot - cl / v * center\n",
+      "    cp <- center / v; cp ~ add(add.sd) })\n}")))
+  }
+
+  test_that("fixCov masks whole covariates in .vaeShapeAllowMask", {
+    r <- .vaeResolveShapes(list(wt = "power"))
+    cov <- .vaeCovariateSearch(.d, unique(.d$ID), r$rules)
+    m <- .vaeShapeAllowMask(cov, r, c("eta.ka", "eta.cl"), c("tka", "tcl"))
+    ## every WT column stays selectable, every AGE column is masked out
+    expect_true(all(m[, cov$covRaw == "WT"] == 1L))
+    expect_true(all(m[, cov$covRaw == "AGE"] == 0L))
+    ## fixCov=FALSE leaves AGE alone
+    r2 <- .vaeResolveShapes(list(wt = "power", fixCov = FALSE))
+    m2 <- .vaeShapeAllowMask(cov, r2, c("eta.ka", "eta.cl"), c("tka", "tcl"))
+    expect_true(all(m2[, cov$covRaw == "AGE"] == 1L))
+  })
+
+  ## .vaeDataPrep emits several warnings and their order is not part of the
+  ## contract, so collect them all rather than relying on which one comes first
+  .warns <- function(expr) {
+    .w <- character(0)
+    withCallingHandlers(invisible(force(expr)),
+                        warning = function(cond) {
+                          .w <<- c(.w, conditionMessage(cond))
+                          invokeRestart("muffleWarning")
+                        })
+    .w
+  }
+
+  test_that("a covariate restricted to one shape is not reported as excluded", {
+    ## the false positive an independent review predicted: WT's non-power
+    ## columns are masked, but WT itself is still searched through WT_power
+    .w <- .warns(.vaeDataPrep(rxode2::assertRxUi(.mk()), .d,
+                              vaeControl(shapes = list(wt = "power"),
+                                         muRefCovAlg = FALSE)))
+    .fx <- grep("fixCov=TRUE, covariate", .w, value = TRUE)
+    expect_length(.fx, 1L)
+    expect_match(.fx, "AGE")
+    expect_false(grepl("WT", .fx))
+  })
+
+  test_that("fixCov=TRUE with nothing searchable is an error", {
+    expect_error(
+      .vaeDataPrep(rxode2::assertRxUi(.mk()), .d,
+                   vaeControl(shapes = list(noSuchCov = "power"),
+                              muRefCovAlg = FALSE)),
+      "leaves no covariate searchable")
+  })
+
+  test_that("a declaring model overrides fixCov", {
+    .w <- .warns(.vaeDataPrep(rxode2::assertRxUi(.mk("log(WT/70)")), .d,
+                              vaeControl(shapes = list(age = "power"),
+                                         muRefCovAlg = FALSE)))
+    expect_true(any(grepl("fixCov=TRUE ignored", .w)))
+    ## the declaration is what actually restricts the search
+    expect_true(any(grepl("pinned to model-specified covariates", .w)))
+  })
+
+  test_that("fixCov=TRUE naming no covariate is rejected outright", {
+    expect_error(.vaeResolveShapes(list(fixCov = TRUE)), "no covariate is named")
+    ## ... while an explicit FALSE with no rules is simply unrestricted
+    expect_false(.vaeResolveShapes(list(fixCov = FALSE))$fixCov)
+  })
+})

--- a/tests/testthat/test-vae-cov-shapes.R
+++ b/tests/testthat/test-vae-cov-shapes.R
@@ -804,6 +804,24 @@ nmTest({
       "leaves no covariate searchable")
   })
 
+  test_that("covariateSelection=FALSE has nothing for fixCov to narrow", {
+    ## the error above told the user to set covariateSelection=FALSE, so it must
+    ## not fire at someone who already has -- there is no search to restrict
+    expect_error(
+      suppressWarnings(
+        .vaeDataPrep(rxode2::assertRxUi(.mk()), .d,
+                     vaeControl(covariateSelection = FALSE,
+                                shapes = list(noSuchCov = "power"),
+                                muRefCovAlg = FALSE))),
+      NA)
+    ## nor may it blame fixCov for a search that was off regardless
+    .w <- .warns(.vaeDataPrep(rxode2::assertRxUi(.mk()), .d,
+                              vaeControl(covariateSelection = FALSE,
+                                         shapes = list(wt = "power"),
+                                         muRefCovAlg = FALSE)))
+    expect_false(any(grepl("fixCov=TRUE, covariate", .w)))
+  })
+
   test_that("a declaring model overrides fixCov", {
     .w <- .warns(.vaeDataPrep(rxode2::assertRxUi(.mk("log(WT/70)")), .d,
                               vaeControl(shapes = list(age = "power"),

--- a/tests/testthat/test-vae-cov-shapes.R
+++ b/tests/testthat/test-vae-cov-shapes.R
@@ -143,17 +143,17 @@ nmTest({
   })
 
   test_that("a character shapes= vector is one global rule", {
-    r <- .vaeResolveShapes(c("power", "lin"))
+    r <- .vaeResolveShapes(c("power", "lin"))$rules
     expect_equal(nrow(r), 1L)
     expect_true(is.na(r$var) && is.na(r$cov))
     expect_equal(.vaeShapesFor(r, "cl", "WT"), c("power", "lin"))
     ## NULL means the default shapes
-    expect_equal(.vaeShapesFor(.vaeResolveShapes(NULL), "cl", "WT"),
+    expect_equal(.vaeShapesFor(.vaeResolveShapes(NULL)$rules, "cl", "WT"),
                  .vaeDefaultShapes)
   })
 
   test_that("a covariate-named list restricts that covariate only", {
-    r <- .vaeResolveShapes(list(wt = "power"))
+    r <- .vaeResolveShapes(list(wt = "power"))$rules
     ## matching is case-insensitive because the VAE upper-cases data columns
     expect_equal(.vaeShapesFor(r, "cl", "WT"), "power")
     ## an unmatched covariate stays free
@@ -163,7 +163,7 @@ nmTest({
   test_that("a pairsVec list restricts one parameter/covariate pair", {
     r <- .vaeResolveShapes(list(
       list(var = "cl", covar = "wt", shapes = "power"),
-      list(var = "v", covar = "wt", shapes = c("lin", "identity"))))
+      list(var = "v", covar = "wt", shapes = c("lin", "identity"))))$rules
     expect_equal(.vaeShapesFor(r, "cl", "WT"), "power")
     expect_equal(.vaeShapesFor(r, "v", "WT"), c("lin", "identity"))
     ## shapes= restricts parameterizations only -- a pair no rule mentions is
@@ -175,13 +175,13 @@ nmTest({
   test_that("the most specific rule wins", {
     r <- .vaeResolveShapes(list(
       list(covar = "wt", shapes = "lin"),
-      list(var = "cl", covar = "wt", shapes = "power")))
+      list(var = "cl", covar = "wt", shapes = "power")))$rules
     expect_equal(.vaeShapesFor(r, "cl", "WT"), "power")
     expect_equal(.vaeShapesFor(r, "v", "WT"), "lin")
   })
 
   test_that("a parameter matches any of its aliases", {
-    r <- .vaeResolveShapes(list(list(var = "tcl", covar = "wt", shapes = "lin")))
+    r <- .vaeResolveShapes(list(list(var = "tcl", covar = "wt", shapes = "lin")))$rules
     expect_equal(.vaeShapesFor(r, c("eta.cl", "tcl", "cl"), "WT"), "lin")
     ## a different parameter is unaffected by the rule
     expect_equal(.vaeShapesFor(r, c("eta.v", "tv", "v"), "WT"), .vaeDefaultShapes)
@@ -629,5 +629,103 @@ nmTest({
       ## and it round-trips: the level reads back exactly as written
       expect_equal(.vaeDetectShape(.e, "GRP")$level, .l, info = .l)
     }
+  })
+})
+
+## fixCov: naming a covariate in shapes= is the statement that it belongs in the
+## search.  Eligibility is asserted on the matrix rather than on a fit outcome --
+## exact, and it does not need a converged model to be meaningful.
+nmTest({
+  .etas <- c("eta.cl", "eta.v", "eta.ka")
+  .thetas <- c("tcl", "tv", "tka")
+  .raw <- c("WT", "WT", "AGE", "AGE", "SEX")
+  .el <- function(spec) {
+    r <- .vaeResolveShapes(spec)
+    .vaeEligible(r$rules, r$fixCov, .etas, .thetas, .raw)
+  }
+
+  test_that("fixCov=TRUE is the default and fixes the searched set", {
+    m <- .el(list(wt = "power"))
+    expect_true(all(m[, "WT"]))
+    expect_false(any(m[, "AGE"]))
+    expect_false(any(m[, "SEX"]))
+    ## the default only applies to the list form -- a character vector names no
+    ## covariate, so there is nothing to fix
+    expect_true(all(.el(c("power", "lin"))))
+    expect_true(all(.el(NULL)))
+  })
+
+  test_that("fixCov=FALSE reproduces the parameterization-only behavior", {
+    expect_true(all(.el(list(wt = "power", fixCov = FALSE))))
+    ## and it leaves the shape restriction itself intact
+    r <- .vaeResolveShapes(list(wt = "power", fixCov = FALSE))
+    expect_false(r$fixCov)
+    expect_equal(.vaeShapesFor(r$rules, "cl", "WT"), "power")
+  })
+
+  test_that("a pair rule makes only that pair eligible", {
+    m <- .el(list(list(var = "cl", covar = "wt", shapes = "power")))
+    expect_true(m[1L, "WT"])
+    expect_false(any(m[-1L, "WT"]))
+    ## covar-only: that covariate on every parameter
+    m2 <- .el(list(list(covar = "wt", shapes = "power")))
+    expect_true(all(m2[, "WT"]))
+    expect_false(any(m2[, "AGE"]))
+    ## var-only: every covariate, on that parameter alone
+    m3 <- .el(list(list(var = "v", shapes = "power")))
+    expect_true(all(m3[2L, ]))
+    expect_false(any(m3[-2L, ]))
+  })
+
+  test_that("named and pair entries mix in one list", {
+    r <- .vaeResolveShapes(list(list(var = "cl", covar = "wt", shapes = "power"),
+                                sex = TRUE))
+    expect_equal(nrow(r$rules), 2L)
+    ## a named entry is exactly the covar-only rule it is shorthand for
+    expect_equal(.vaeShapesFor(r$rules, "cl", "WT"), "power")
+    expect_equal(.vaeShapesFor(r$rules, "ka", "SEX"), .vaeDefaultShapes)
+    m <- .vaeEligible(r$rules, r$fixCov, .etas, .thetas, .raw)
+    expect_true(m[1L, "WT"])
+    expect_false(any(m[-1L, "WT"]))
+    expect_true(all(m[, "SEX"]))
+    expect_false(any(m[, "AGE"]))
+  })
+
+  test_that("fixCov survives the pair form it is mixed into", {
+    ## the regression this ordering exists to prevent: a bare logical element is
+    ## not a list, so leaving it in would flip the per-element dispatch
+    r <- .vaeResolveShapes(list(list(var = "cl", covar = "wt", shapes = "power"),
+                                fixCov = FALSE))
+    expect_false(r$fixCov)
+    expect_equal(nrow(r$rules), 1L)
+    expect_true(all(.el(list(list(var = "cl", covar = "wt", shapes = "power"),
+                             fixCov = FALSE))))
+  })
+
+  test_that("TRUE means eligible with the default shapes", {
+    r <- .vaeResolveShapes(list(wt = TRUE))
+    expect_equal(.vaeShapesFor(r$rules, "cl", "WT"), .vaeDefaultShapes)
+    expect_true(all(.el(list(wt = TRUE))[, "WT"]))
+  })
+
+  test_that("contradictory fixCov specifications are rejected", {
+    ## a rule naming neither var nor covar makes everything eligible
+    expect_error(.el(list(list(shapes = "lin"), wt = "power")),
+                 "contradicts fixCov")
+    expect_error(.vaeResolveShapes(list(wt = FALSE)),
+                 "TRUE or a shape vector")
+    expect_error(.vaeResolveShapes(list(wt = "power", fixCov = TRUE, fixCov = FALSE)),
+                 "more than once")
+    expect_error(.vaeResolveShapes(list(wt = "power", fixCov = "yes")), "fixCov")
+    ## a data column colliding with the flag name
+    expect_error(.vaeEligible(.vaeResolveShapes(list(wt = "power"))$rules, TRUE,
+                              .etas, .thetas, c("WT", "FIXCOV")),
+                 "collides with the eligibility flag")
+  })
+
+  test_that("an unnamed non-list element is still an error", {
+    expect_error(.vaeResolveShapes(list("power")), "named by covariate")
+    expect_error(.vaeResolveShapes(list(list(covar = "wt", shapes = "lin"), "power")),
+                 "named by covariate")
   })
 })

--- a/tests/testthat/test-vae-covariates.R
+++ b/tests/testthat/test-vae-covariates.R
@@ -53,7 +53,7 @@ nmTest({
 
   test_that("the arms partition the subjects and sum to the lin column", {
     d <- hkData()
-    s <- .vaeCovariateSearch(d, unique(d$ID), .vaeResolveShapes(c("lin", "hockey")))
+    s <- .vaeCovariateSearch(d, unique(d$ID), .vaeResolveShapes(c("lin", "hockey"))$rules)
     m <- s$covMat
     expect_equal(unname(m[, "WT_hockeyLow"] + m[, "WT_hockeyHi"]),
                  unname(m[, "WT_lin"]))
@@ -145,7 +145,7 @@ nmTest({
     ## $runInfo renders one bullet per warning; CLAUDE.md caps these at 75 chars
     d <- hkData()
     .cov <- .vaeCovariateSearch(d, unique(d$ID),
-                                .vaeResolveShapes(c("lin", "hockey")),
+                                .vaeResolveShapes(c("lin", "hockey"))$rules,
                                 covCenter = c(WT = 200))
     expect_equal(.cov$hockeyDrop, "WT")
     .pre <- "<5% of subjects one side of knot, hockey skipped: "


### PR DESCRIPTION
Builds on the hockey-shape work from #827, which merged while this was in progress. Branched from `feat/vae-hockey` at e833503, so the diff here is six commits; `main` has since moved ahead of that point.

## The problem

`vaeControl(shapes=)` could only choose among *parameterizations*. Restricting **which** (parameter, covariate) pairs the VAE search considers meant writing the effects into the model and letting `pinCovariates` trim to them — which forces three commitments to express one:

1. **a shape**, since a pinned pair is allowed only the column matching the form it was written in;
2. **a starting value**, since a symbol not promoted in `ini()` is read as a *data covariate*, so nothing pins and the full search silently runs;
3. **all-or-nothing scope** — declaring one effect pins the whole search.

There was no way to say "search `GA` and `Mage`, nothing else", or "search `GA` only on `lW0`, any shape".

## The change

Naming a covariate in `shapes=` is now the statement that it belongs in the search.

```r
## searches GA and Mage; Sex, DelM and Para2 are not considered
vaeControl(shapes = list(GA = c("power", "hockey"), Mage = "lin"))

## restrict parameterizations only -- what this call meant before
vaeControl(shapes = list(GA = c("power", "hockey"), fixCov = FALSE))

## GA on lW0 alone, any shape it likes; Sex eligible everywhere
vaeControl(shapes = list(list(var = "lW0", covar = "GA", shapes = "power"),
                         Sex = TRUE))
```

- **`fixCov`** is an element of the `shapes` list (not a separate `vaeControl()` argument, so it cannot disagree with the rules it governs). `TRUE` is the default for the list form.
- **The two list forms now mix.** `.vaeResolveShapes` dispatches per *element* rather than testing the whole list, so a named entry and a pair rule can sit side by side. A named entry is exact shorthand for the `covar`-only pair rule, which is what kept the specificity ladder untouched.
- **`TRUE` as a shape value** means "eligible, default shapes" — how you name a categorical, which takes no parameterization.
- **A `var`+`covar` rule makes only that pair eligible**; `covar`-only means everywhere; `var`-only means every covariate on that parameter alone; a rule naming neither contradicts `fixCov=TRUE` and errors.

Eligibility and parameterization are separate passes. In `.vaeShapeAllowMask` eligibility is applied **last and unconditionally**, so it overrides the parameterization pass including its fallback for a covariate whose requested family the data cannot support.

`R/vaeFit.R` needed no change: `.nCand` already derives from `prep$covAllow`, so an exclusion shrinks the bit count that picks `bnb` vs `l0learn` for free.

## Breaking change

`shapes = list(WT = "power")` previously searched every covariate with `WT` restricted to `power`; it now searches `WT` alone. `fixCov = FALSE` restores the old meaning. Excluded covariates are named in `$runInfo`, so a narrowed search is never silent. A character vector (`shapes = c("power", "lin")`) names no covariate and is unaffected.

## Verification

End-to-end on `nlmixr2data::neonatal_wt`:

| `shapes=` | selected coefficients |
|---|---|
| `list(GA = "power")` | `beta.lW0.GA.power` only; `$runInfo`: *not searched: SEX, DELM, MAGE, PARA2* |
| `+ fixCov = FALSE` | the full 14-coefficient unrestricted search |
| `list(list(var="lW0", covar="GA", shapes="power"), Sex=TRUE)` | `GA` on `lW0` only; `SEX` on all five parameters |

338 assertions pass across `test-vae-cov-shapes.R` and `test-vae-covariates.R`.

## Independent review

Three rounds with Antigravity (`gemini-3.1-pro-high`), triaged rather than applied wholesale:

- **Round 1, confirmed:** `shapes = list(fixCov = TRUE)` hit the empty-spec branch and returned a hardcoded `FALSE`, silently overriding an explicit flag — now an error. Missing integration coverage for the mask and the three `.vaeDataPrep` paths — added.
- **Round 1, rejected but hardened:** a predicted false-positive exclusion warning (unreachable — `.vaeCovariateSearch` does not build columns for unrequested shapes) and a `match()` case-collision (unreachable — both entry points upper-case column names first). Both changed anyway, since the safer form costs nothing.
- **Round 2:** no findings. It asserted the `covariateSelection = FALSE` interaction was side-effect free, which was **wrong** — reproducing that path directly showed the "leaves no covariate searchable" error firing at users who had *already* set `covariateSelection = FALSE`. Fixed in `42c3fc8`; both the error and the note are now gated on the search actually running.
- **Round 3:** clean — no findings, and it independently walked the `covariateSelection = FALSE` and `pinCovariates = FALSE` (`.searchOff`) paths, the `covSelectMethod` bit count, hockey's two-arm grouping and the non-positive-covariate log fallback.

Worth knowing for future tests here: `model()`/`ini()` piping **inside `test_that()`** resolves the covariate symbol in the wrong environment and silently yields an undeclared model. The new tests build models as text, matching the pinning tests above them.

## Docs

`plans/vae-shapes-limit-search.md` records the design and the eleven decisions. `NEWS.md` carries the breaking change and the mixed-form feature. The `vaeNeonatal` article in nlmixr2 is updated to match (nlmixr2#404) — that PR and this one need to land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxQN2MqG4BGGk1rEGfaS5a
