### PR TITLE
feat(imp): per-subject proposal adaptation for the importance-sampling EM (t proposal, AUTO, Pareto k-hat)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,7 +84,8 @@ Suggests:
     rmarkdown,
     rlang,
     numDeriv,
-    rstan
+    rstan,
+    loo
 LinkingTo:
     BH,
     n1qn1 (>= 6.0.1-12),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,65 @@
+# nlmixr2est (development version)
+
+## New features
+
+- Importance-sampling EM (`est="imp"` / `"impmap"` / `"qrpem"`): the proposal
+  density is now adapted **per subject** rather than by one global setting, and
+  a diagnostic is reported that can tell when it matters.
+
+    - `fit$env$impPsisK` gives a **Pareto k-hat** per subject -- the tail index
+      of that subject's importance weights.  `k > 0.7` means those weights have
+      infinite variance and that subject's contribution is untrustworthy.  This
+      is worth checking because the two statistics already reported cannot
+      detect the problem: `xi` (NONMEM's `IACCEPT` quantity) and the Kish
+      effective sample size are both means over samples drawn *from* the
+      proposal, so neither sees a tail the proposal rarely visits.  On plain
+      theophylline, two of twelve subjects have k-hat of 2.60 and 1.28 while
+      `xi` reads ~0.97 and the effective-sample fraction ~0.99 for those same
+      subjects.
+
+    - `impmapControl(df=)` switches the proposal from a multivariate normal to
+      a multivariate **t** (NONMEM `DF`).  This is the remedy for a bad k-hat,
+      because it changes the proposal's *tails* rather than its width, and tail
+      weight is what decides whether the weights are well behaved.  More
+      samples does not help -- boosting a failing subject tenfold moved its
+      k-hat from 0.76 to 3.28 -- whereas `df = 20` cleared every failing
+      subject for 0.25% of the effective sample size.
+
+    - `impmapControl(isample=)` additionally accepts one count **per subject**.
+
+    - `impmapControl(gammaMethod=)` selects how the proposal scale is adapted:
+      one shared value, or per subject two-sided toward `iaccept` on that
+      subject's own `xi` (NONMEM's rule).  `"auto"`, the default, uses the
+      per-subject law only for models that are not transformably normal, since
+      `gamma = 1` is already efficient when the individual posterior is close
+      to Gaussian.
+
+    - `impmapControl(auto=)` is NONMEM's `AUTO=1`: choose `df`, `isample` and
+      `iaccept` per subject.  **It defaults to `TRUE`.**  It escalates `df`
+      only for subjects whose k-hat says they need it, leaving the rest on the
+      cheaper Gaussian, and shifts sample budget from data-rich subjects to
+      difficult ones.  Measured on theophylline against a high-accuracy
+      reference, it takes the worst k-hat from 2.44 to 0.49 and improves
+      `Omega` accuracy about 20%, for about 19% more Monte-Carlo noise on the
+      objective; infinite-variance weights are a correctness problem whose
+      error is unbounded in the worst case, while the added noise is bounded
+      and measurable.  Set `auto = FALSE` for the un-adapted behaviour, which
+      is the better choice when `fit$env$impPsisK` is already comfortably below
+      0.7 everywhere and the tightest possible objective is wanted.
+
+  Note NONMEM does not publish the values its `AUTO=1` uses; only the
+  `nobs < neta` trigger and `IACCEPT ~ 0.2` are documented.  The concrete
+  numbers here (`df = 30`, the k-hat thresholds, the sample-budget rule) are
+  nlmixr2's own, tuned on the measurements above.
+
+- Importance-sampling EM: the `covMethod="imp"` covariance is now evaluated at
+  the proposal the fit actually converged on, rather than at the control's
+  initial `gamma` with a Gaussian proposal.
+
+- Importance-sampling EM: `$runInfo` now names which sampling-efficiency
+  statistic a fit is reporting, and states that `xi` and the Kish
+  effective-sample fraction are not comparable with each other.
+
 # nlmixr2est 7.0.2
 
 ## Bug fixes

--- a/R/impPsis.R
+++ b/R/impPsis.R
@@ -1,0 +1,98 @@
+# Tail-sensitive importance-sampling diagnostic: Pareto k-hat (PSIS).
+#
+# The imp family already reports two efficiency statistics -- NONMEM's xi and
+# the Kish effective sample size -- and BOTH are means over samples drawn from
+# the proposal.  That makes them structurally blind to the failure mode that
+# actually matters here: a proposal with lighter tails than the target has
+# importance weights with infinite variance, yet looks perfectly healthy in any
+# finite sample, because the tail responsible is precisely the region the
+# proposal rarely visits.
+#
+# Pareto k-hat estimates the shape parameter of a generalized Pareto fitted to
+# the upper tail of the weights, which is the tail index of the weight
+# distribution itself.  The standard reading (Vehtari, Simpson, Gelman, Yao,
+# Gabry, "Pareto Smoothed Importance Sampling"):
+#
+#   k < 0.5   weight variance finite; importance sampling reliable
+#   0.5-0.7   finite mean, infinite variance; usable but degrading
+#   k > 0.7   unreliable -- the estimate is dominated by a few draws
+#
+# This is the statistic that can tell whether a heavier-tailed (t) proposal is
+# needed, which neither xi nor the Kish ESS can.
+#
+# Implemented here rather than taken from loo:: to avoid a new hard dependency
+# for a diagnostic, but validated against it: on identical weight vectors the
+# two agree to ~0.02, and both recover a known tail index --
+#
+#   true k   0.2    0.5    0.8    1.2
+#   ours     0.209  0.513  0.824  1.241
+#   loo      0.222  0.512  0.807  1.203
+#
+# (means over 5 seeds, S = 4000; per-seed sd ~0.05).  The unit tests re-run
+# that comparison whenever loo is installed.
+
+#' Generalized Pareto fit (Zhang & Stephens 2009 empirical-Bayes estimator)
+#'
+#' @param x Sorted-ascending, strictly positive exceedances over the threshold.
+#' @param minGridPts Grid size floor for the profile-likelihood average.
+#' @return list(k, sigma)
+#' @noRd
+.impGpdFit <- function(x, minGridPts = 30L) {
+  .n <- length(x)
+  if (.n < 5L) return(list(k = NA_real_, sigma = NA_real_))
+  .prior <- 3
+  .m <- minGridPts + floor(sqrt(.n))
+  .jj <- seq_len(.m)
+  # quartile used to set the grid scale
+  .xstar <- x[floor(.n / 4 + 0.5)]
+  if (!is.finite(.xstar) || .xstar <= 0) return(list(k = NA_real_, sigma = NA_real_))
+  .theta <- 1 / x[.n] + (1 - sqrt(.m / (.jj - 0.5))) / .prior / .xstar
+  # profile log-likelihood of theta, up to an additive constant
+  .lx <- vapply(.theta, function(.t) {
+    .k <- mean(log1p(-.t * x))
+    log(-.t / .k) - .k - 1
+  }, numeric(1))
+  .l <- .n * .lx
+  .l[!is.finite(.l)] <- -Inf
+  if (all(!is.finite(.l))) return(list(k = NA_real_, sigma = NA_real_))
+  .w <- exp(.l - max(.l))
+  .w <- .w / sum(.w)
+  .thetaHat <- sum(.theta * .w)
+  .k <- mean(log1p(-.thetaHat * x))
+  .sigma <- -.k / .thetaHat
+  list(k = .k, sigma = .sigma)
+}
+
+#' Pareto k-hat for one subject's importance weights
+#'
+#' @param w Importance weights (any positive scaling; k-hat is scale-invariant).
+#' @return k-hat, or NA if there are too few usable weights.
+#' @noRd
+.impPsisK <- function(w) {
+  .w <- as.numeric(w)
+  .w <- .w[is.finite(.w) & .w > 0]
+  .s <- length(.w)
+  if (.s < 25L) return(NA_real_)
+  # PSIS tail size: min(0.2*S, 3*sqrt(S)), the usual choice
+  .tail <- min(floor(0.2 * .s), floor(3 * sqrt(.s)))
+  if (.tail < 5L) return(NA_real_)
+  .srt <- sort(.w)
+  # threshold is the largest weight NOT in the tail
+  .u <- .srt[.s - .tail]
+  .exc <- .srt[(.s - .tail + 1L):.s] - .u
+  .exc <- .exc[.exc > 0]
+  if (length(.exc) < 5L) return(NA_real_)
+  .impGpdFit(sort(.exc))$k
+}
+
+#' Per-subject Pareto k-hat from a fit's stashed final-iteration weights
+#'
+#' @param env Fit environment holding `impWeights`.
+#' @return numeric vector of k-hat, one per subject (NA where not computable)
+#' @noRd
+.impPsisKAll <- function(env) {
+  .w <- tryCatch(env$impWeights, error = function(e) NULL)
+  if (is.null(.w) || length(.w) == 0L) return(numeric(0))
+  vapply(.w, function(.wi) tryCatch(.impPsisK(.wi), error = function(e) NA_real_),
+         numeric(1), USE.NAMES = FALSE)
+}

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -237,6 +237,9 @@ impmapControl <- function(sigdig=4,
                               .var.name="isample")
   checkmate::assertIntegerish(impSeed, any.missing=FALSE, len=1, .var.name="impSeed")
   .isampleAll <- as.integer(isample)
+  # A per-subject vector must be exactly nsub long.  nsub is not known here, so
+  # the length is checked at fit time in the kernel (it used to fall back to a
+  # uniform max() and ignore a wrong-length vector without a word).
   # the scalar used for sizing / sirSample defaults / reporting is the largest
   .isample <- max(.isampleAll)
   if (is.null(sirSample)) {

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -9,6 +9,7 @@
 # Importance-sampling / EM control names -- stripped when down-converting to a
 # plain foceiControl for the MAP inner problem / output.
 .impmapIsControlNames <- c("isample", "nIter", "mapIter", "gamma",
+                           "gammaMethod",
                            "iscaleMin", "iscaleMax", "iaccept",
                            "ctol", "nConvWindow", "impSeed", "impCov",
                            "qr", "qrShift", "qrRefresh", "sir", "sirSample",
@@ -38,6 +39,28 @@
 #' @param gamma Initial proposal-variance inflation factor (NONMEM ISCALE); the
 #'   proposal covariance is `gamma` times the inverse of the inner information
 #'   matrix at the mode.
+#' @param gammaMethod How the proposal scale `gamma` is adapted during the EM.
+#'
+#'   `"global"` keeps one scale shared by every subject, inflated (never
+#'   relaxed) only when the *mean* Kish effective-sample fraction falls below
+#'   `iaccept`.  It leaves `gamma` at its efficient starting value while
+#'   coverage is healthy, which is the right behaviour when the individual
+#'   posteriors are close to Gaussian.
+#'
+#'   `"individual"` gives every subject its own `gamma_i` and adapts it
+#'   two-sided toward a target on that subject's `xi_i`, clamped to
+#'   `[iscaleMin, iscaleMax]` -- NONMEM's rule (NM7 Technical Guide eq. 1.90 and
+#'   the note after 1.76, where `gamma` is per-subject and is "continually
+#'   adjusted so that xi_i approximates IACCEPT").  Prefer this when the
+#'   individual posteriors are heavy-tailed or the design is heterogeneous:
+#'   a global scale is driven by the mean, so a handful of badly-covered
+#'   subjects never trip it and their likelihood and `Omega` contributions end
+#'   up carried by a few samples.
+#'
+#'   The two modes report *different* efficiency statistics -- `"individual"`
+#'   targets `xi` (the mean normalized importance weight, NONMEM's `IACCEPT`
+#'   quantity) while `"global"` targets the Kish effective-sample fraction.
+#'   These are not comparable; the fit's `$runInfo` says which is in force.
 #' @param iscaleMin,iscaleMax Lower/upper bounds for the adapted `gamma`
 #'   (NONMEM ISCALE_MIN / ISCALE_MAX).
 #' @param iaccept Minimum importance-sampling effective-sample fraction
@@ -94,6 +117,7 @@ impmapControl <- function(sigdig=4,
                           nIter=100L,
                           mapIter=1L,
                           gamma=1.0,
+                          gammaMethod=c("global", "individual"),
                           iscaleMin=0.1,
                           iscaleMax=10.0,
                           iaccept=0.4,
@@ -108,6 +132,7 @@ impmapControl <- function(sigdig=4,
                           sirSample=NULL,
                           muModel=c("lin", "none")) {
   muModel <- match.arg(muModel)
+  gammaMethod <- match.arg(gammaMethod)
   checkmate::assertLogical(qr, any.missing=FALSE, len=1, .var.name="qr")
   checkmate::assertLogical(qrShift, any.missing=FALSE, len=1, .var.name="qrShift")
   checkmate::assertLogical(qrRefresh, any.missing=FALSE, len=1, .var.name="qrRefresh")
@@ -154,6 +179,7 @@ impmapControl <- function(sigdig=4,
   .control$nIter <- as.integer(nIter)
   .control$mapIter <- as.integer(mapIter)
   .control$gamma <- as.double(gamma)
+  .control$gammaMethod <- gammaMethod
   .control$iscaleMin <- as.double(iscaleMin)
   .control$iscaleMax <- as.double(iscaleMax)
   .control$iaccept <- as.double(iaccept)

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -32,7 +32,16 @@
 #' @inheritParams foceiControl
 #' @param ... Parameters used in the default `foceiControl()`
 #' @param isample Number of importance samples drawn per subject per iteration
-#'   (NONMEM ISAMPLE).
+#'   (NONMEM ISAMPLE).  Either a single count used for every subject, or a
+#'   vector of length `nsub` giving a count **per subject**.
+#'
+#'   Per-subject counts are the NM7 Technical Guide's own remedy for poor
+#'   coverage (its derivation is Gaussian throughout and never mentions a t
+#'   proposal): a subject whose weights are badly behaved can be given more
+#'   samples without charging every other subject for them.  Note this treats
+#'   the symptom rather than the cause -- more draws from a proposal whose
+#'   tails are too light still gives weights with infinite variance, which
+#'   `fit$env$impPsisK` will show.  See `df` for the shape-based remedy.
 #' @param nIter Maximum number of importance-sampling EM iterations.
 #' @param mapIter Number of MAP re-centering iterations per EM step; `> 0`
 #'   re-centers the proposal at the MAP mode each iteration.
@@ -170,9 +179,15 @@ impmapControl <- function(sigdig=4,
   checkmate::assertLogical(qrShift, any.missing=FALSE, len=1, .var.name="qrShift")
   checkmate::assertLogical(qrRefresh, any.missing=FALSE, len=1, .var.name="qrRefresh")
   checkmate::assertLogical(sir, any.missing=FALSE, len=1, .var.name="sir")
-  checkmate::assertIntegerish(isample, any.missing=FALSE, len=1, lower=1, .var.name="isample")
+  # isample may be a single count or one count PER SUBJECT (NONMEM's per-subject
+  # ISAMPLE): a badly covered subject can buy more samples without charging
+  # every other subject for them.
+  checkmate::assertIntegerish(isample, any.missing=FALSE, min.len=1, lower=1,
+                              .var.name="isample")
   checkmate::assertIntegerish(impSeed, any.missing=FALSE, len=1, .var.name="impSeed")
-  .isample <- as.integer(isample)
+  .isampleAll <- as.integer(isample)
+  # the scalar used for sizing / sirSample defaults / reporting is the largest
+  .isample <- max(.isampleAll)
   if (is.null(sirSample)) {
     .sirSample <- max(25L, as.integer(ceiling(.isample / 10)))
   } else {
@@ -214,7 +229,7 @@ impmapControl <- function(sigdig=4,
                       c(list(sigdig=sigdig), .dots,
                         list(covMethod=.foceiCovMethod, muModel="lin")))
   .control$impCov <- .impCov
-  .control$isample <- as.integer(isample)
+  .control$isample <- .isampleAll
   .control$nIter <- as.integer(nIter)
   .control$mapIter <- as.integer(mapIter)
   .control$gamma <- as.double(gamma)

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -49,9 +49,12 @@
 #'
 #'   `"individual"` gives every subject its own `gamma_i` and adapts it
 #'   two-sided toward a target on that subject's `xi_i`, clamped to
-#'   `[iscaleMin, iscaleMax]` -- NONMEM's rule (NM7 Technical Guide eq. 1.90 and
-#'   the note after 1.76, where `gamma` is per-subject and is "continually
-#'   adjusted so that xi_i approximates IACCEPT").  Prefer this when the
+#'   `[iscaleMin, iscaleMax]`.  This follows NONMEM's *objective* -- the NM7
+#'   Technical Guide states that `gamma` is per-subject (eq. 1.90) and is
+#'   "continually adjusted so that xi_i approximates IACCEPT" (note after
+#'   eq. 1.76), bounded by `ISCALE_MIN`/`ISCALE_MAX` -- but the guide publishes
+#'   no update formula, so the functional form used here is nlmixr2's own.
+#'   Prefer this when the
 #'   individual posteriors are heavy-tailed or the design is heterogeneous:
 #'   a global scale is driven by the mean, so a handful of badly-covered
 #'   subjects never trip it and their likelihood and `Omega` contributions end

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -9,7 +9,7 @@
 # Importance-sampling / EM control names -- stripped when down-converting to a
 # plain foceiControl for the MAP inner problem / output.
 .impmapIsControlNames <- c("isample", "nIter", "mapIter", "gamma",
-                           "gammaMethod",
+                           "gammaMethod", "gammaMethodUser",
                            "iscaleMin", "iscaleMax", "iaccept",
                            "ctol", "nConvWindow", "impSeed", "impCov",
                            "qr", "qrShift", "qrRefresh", "sir", "sirSample",
@@ -40,6 +40,18 @@
 #'   proposal covariance is `gamma` times the inverse of the inner information
 #'   matrix at the mode.
 #' @param gammaMethod How the proposal scale `gamma` is adapted during the EM.
+#'
+#'   `"auto"` (default) picks per model: `"individual"` when the model is not
+#'   transformably normal -- a general log-likelihood (`ll()`) endpoint, or a
+#'   count/categorical/time-to-event distribution -- and `"global"` otherwise.
+#'   That is the split the hypothesis actually rests on: `gamma = 1` is already
+#'   the efficient proposal when the individual posterior is close to Gaussian,
+#'   so a normal model gains nothing from per-subject adaptation and would only
+#'   pay for it in effective sample size, while a general-likelihood model is
+#'   exactly where the posteriors go non-Gaussian and per-subject coverage
+#'   starts to vary.  The test is `all(ui$predDf$distribution == "norm")`, the
+#'   same line [rxode2::assertRxUiTransformNormal()] draws.  The resolved value
+#'   is reported in the fit's `$runInfo`.
 #'
 #'   `"global"` keeps one scale shared by every subject, inflated (never
 #'   relaxed) only when the *mean* Kish effective-sample fraction falls below
@@ -120,7 +132,7 @@ impmapControl <- function(sigdig=4,
                           nIter=100L,
                           mapIter=1L,
                           gamma=1.0,
-                          gammaMethod=c("global", "individual"),
+                          gammaMethod=c("auto", "global", "individual"),
                           iscaleMin=0.1,
                           iscaleMax=10.0,
                           iaccept=0.4,
@@ -161,6 +173,12 @@ impmapControl <- function(sigdig=4,
   .dots <- list(...)
   .impCov <- isTRUE(.dots$impCov)   # may already be set on a round-tripped control
   .dots$impCov <- NULL              # internal field; do not forward to foceiControl
+  # gammaMethodUser is stamped on the RUNTIME control by .impmapFamilyFit (it
+  # records what the user asked for before "auto" was resolved).  A control that
+  # has been round-tripped therefore carries it; keep it, but do not forward it
+  # to foceiControl, which has no such argument.
+  .gammaMethodUser <- .dots$gammaMethodUser
+  .dots$gammaMethodUser <- NULL
   if (is.character(covMethod)) {
     if (length(covMethod) == 1L && !nzchar(covMethod)) {
       covMethod <- ""
@@ -183,6 +201,7 @@ impmapControl <- function(sigdig=4,
   .control$mapIter <- as.integer(mapIter)
   .control$gamma <- as.double(gamma)
   .control$gammaMethod <- gammaMethod
+  if (!is.null(.gammaMethodUser)) .control$gammaMethodUser <- .gammaMethodUser
   .control$iscaleMin <- as.double(iscaleMin)
   .control$iscaleMax <- as.double(iscaleMax)
   .control$iaccept <- as.double(iaccept)
@@ -265,6 +284,37 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   .impmapControlToFoceiControl(.env, assign=FALSE)
 }
 
+#' Resolve gammaMethod="auto" against the model
+#'
+#' `"individual"` when the model is NOT transformably normal -- a general
+#' log-likelihood (`ll()`) endpoint, or a count / categorical / time-to-event
+#' distribution -- and `"global"` otherwise.
+#'
+#' The rationale is the hypothesis the per-subject controller rests on: the
+#' proposal is the Laplace approximation, so `gamma = 1` is already efficient
+#' when the individual posterior is near-Gaussian.  A normal model therefore
+#' gains nothing from per-subject adaptation and pays for it in effective
+#' sample size (measured on theophylline: ESS 0.95 -> 0.70 for identical
+#' estimates), whereas a general-likelihood model is where the posteriors are
+#' genuinely non-Gaussian and per-subject coverage varies.
+#'
+#' The test is `all(predDf$distribution == "norm")`, the same line
+#' `rxode2::assertRxUiTransformNormal()` draws between transformably-normal and
+#' general likelihoods.
+#'
+#' @param gammaMethod User setting: "auto", "global" or "individual".
+#' @param ui rxode2 ui object
+#' @return "global" or "individual"
+#' @noRd
+.impmapResolveGammaMethod <- function(gammaMethod, ui) {
+  if (!identical(gammaMethod, "auto")) return(gammaMethod)
+  .dist <- tryCatch(ui$predDf$distribution, error=function(e) NULL)
+  # No usable predDf (should not happen for a fittable model): fall back to the
+  # conservative choice, which is the historical behaviour.
+  if (is.null(.dist) || length(.dist) == 0L) return("global")
+  if (all(as.character(.dist) == "norm")) "global" else "individual"
+}
+
 #' Install the impmap control into the ui
 #'
 #' @param env Environment with ui in it
@@ -302,6 +352,10 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   .covMethodUser <- .control$covMethod  # restored on the fit env control below
   .control$maxOuterIterations <- 0L
   .control$covMethod <- 0L
+  # Resolve gammaMethod="auto" here, where the ui (and therefore predDf) is in
+  # scope; the C++ kernel only ever sees a concrete "global"/"individual".
+  .control$gammaMethodUser <- .control$gammaMethod   # kept for $runInfo
+  .control$gammaMethod <- .impmapResolveGammaMethod(.control$gammaMethod, ui)
   # 0-based index maps for the SIMPLE mu-referenced intercepts (theta = population
   # mean of an eta, no covariates): impOuter's M-step shifts each such theta by
   # the mean conditional eta.  Covariate mu-groups are excluded here because they

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -9,7 +9,7 @@
 # Importance-sampling / EM control names -- stripped when down-converting to a
 # plain foceiControl for the MAP inner problem / output.
 .impmapIsControlNames <- c("isample", "nIter", "mapIter", "gamma",
-                           "gammaMethod", "gammaMethodUser", "df",
+                           "gammaMethod", "gammaMethodUser", "df", "auto", "autoNonNormal",
                            "iscaleMin", "iscaleMax", "iaccept",
                            "ctol", "nConvWindow", "impSeed", "impCov",
                            "qr", "qrShift", "qrRefresh", "sir", "sirSample",
@@ -65,6 +65,32 @@
 #'   NONMEM's guidance (Bauer, *NONMEM Tutorial Part II*) is to set a nonzero
 #'   `DF` when there are fewer data points than etas, or for categorical data.
 #'   Small values (3-8) are heavy; large values approach the Gaussian.
+#' @param auto NONMEM `AUTO=1` equivalent: adapt the proposal degrees of
+#'   freedom, the sample count and the acceptance target **per subject** rather
+#'   than applying one global setting to everybody.
+#'
+#'   * **`df`** -- a subject whose observation count is below the number of
+#'     random effects, or any subject when the model is not transformably
+#'     normal, gets a heavy-tailed t proposal.  This is the tutorial's trigger
+#'     ("fewer data points than there are ETAs ... or data are categorical").
+#'   * **`isample`** -- the total sample budget (`isample * nsub`) is
+#'     reallocated toward subjects whose effective-sample fraction is lowest,
+#'     the tutorial's "many ETAs or ... large stochastic fluctuations".  It is
+#'     load-balancing, not a cost increase.  Note sample count is deliberately
+#'     *not* driven by Pareto k-hat: a heavy tail is not repairable by more
+#'     draws (see `df`).
+#'   * **`iaccept`** -- lowered to 0.2 for the same sparse/categorical
+#'     subjects, per the tutorial.
+#'
+#'   The concrete values (`df = 4`, the `nobs < neta` test, the budget
+#'   reallocation rule) are **nlmixr2's choices**.  NONMEM does not publish what
+#'   `AUTO=1` picks internally; only the triggers and `IACCEPT ~ 0.2` are
+#'   documented.  Unlike NONMEM's AUTO, which its own tutorial warns "may result
+#'   in lack of stochastic reproducibility", this remains seeded and
+#'   thread-count independent.
+#'
+#'   Per-subject values are reported in `fit$env$impDfInd`,
+#'   `fit$env$impNsampleInd` and `fit$env$impIacceptInd`.
 #' @param gammaMethod How the proposal scale `gamma` is adapted during the EM.
 #'
 #'   `"auto"` (default) picks per model: `"individual"` when the model is not
@@ -160,6 +186,7 @@ impmapControl <- function(sigdig=4,
                           gamma=1.0,
                           gammaMethod=c("auto", "global", "individual"),
                           df=0,
+                          auto=FALSE,
                           iscaleMin=0.1,
                           iscaleMax=10.0,
                           iaccept=0.4,
@@ -235,6 +262,8 @@ impmapControl <- function(sigdig=4,
   .control$gamma <- as.double(gamma)
   .control$gammaMethod <- gammaMethod
   .control$df <- as.double(df)
+  checkmate::assertLogical(auto, any.missing=FALSE, len=1, .var.name="auto")
+  .control$auto <- auto
   if (!is.null(.gammaMethodUser)) .control$gammaMethodUser <- .gammaMethodUser
   .control$iscaleMin <- as.double(iscaleMin)
   .control$iscaleMax <- as.double(iscaleMax)
@@ -462,6 +491,9 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   if (is.null(.gmUser)) .gmUser <- .control$gammaMethod
   .control$gammaMethodUser <- .gmUser                # kept for $runInfo
   .control$gammaMethod <- .impmapResolveGammaMethod(.gmUser, ui)
+  # AUTO's "or data are categorical" trigger: reuse the same transformably-normal
+  # test the gammaMethod resolution uses, so there is one notion of model class.
+  .control$autoNonNormal <- identical(.impmapResolveGammaMethod("auto", ui), "individual")
   # Say which efficiency statistic this fit's number actually is.  Both are
   # always stashed but they are not the same quantity, and only one drives the
   # adaptation -- warning() here is the established route onto $runInfo

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -478,6 +478,14 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   # only when the counts line up) so vcov()/$cov and the correlation are labelled.
   .impmapNameCov(.fit, ui)
   .impRestoreCovMethod(.fit, .covMethodUser)
+  # Tail-sensitive companion to xi / Kish ESS: computed post-fit from the
+  # stashed final-iteration weights so it costs nothing during the EM.
+  tryCatch({
+    .fenv <- .fit$env
+    if (is.environment(.fenv)) {
+      assign("impPsisK", .impPsisKAll(.fenv), envir=.fenv)
+    }
+  }, error=function(e) NULL)
   .fit
 }
 

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -92,29 +92,30 @@
 #'   Per-subject values are reported in `fit$env$impDfInd`,
 #'   `fit$env$impNsampleInd` and `fit$env$impIacceptInd`.
 #'
-#'   **Measured trade-off -- read this before turning it on.**  `auto = TRUE`
-#'   reliably improves the *tail* behaviour of the importance weights and
-#'   reliably degrades the *accuracy* of the objective.  On theophylline,
-#'   against a reference computed at `isample = 20000` (which agrees to 0.0003
-#'   across Gaussian, `df = 8` and `df = 20` proposals, so it is trustworthy):
+#'   **Measured trade-off.**  `auto = TRUE` (the default) improves the *tail*
+#'   behaviour of the importance weights and the accuracy of `Omega`, at some
+#'   cost in Monte-Carlo noise on the objective.  On theophylline, against a
+#'   reference computed at `isample = 20000` (which agrees to 0.0003 across
+#'   Gaussian, `df = 8` and `df = 20` proposals, so it is trustworthy), over 20
+#'   seeds:
 #'
 #'   \itemize{
-#'     \item `auto = FALSE`: max Pareto k-hat 2.41, 3.3 subjects above 0.7;
-#'       objective bias +0.002, SD 0.029, **RMSE 0.027**
-#'     \item `auto = TRUE`: max Pareto k-hat 0.70, 0.3 subjects above 0.7;
-#'       objective bias -0.025, SD 0.045, **RMSE 0.049**
+#'     \item `auto = FALSE`: max Pareto k-hat 2.44, 2.20 subjects above 0.7;
+#'       objective RMSE 0.0315, `Omega` RMSE 0.00247
+#'     \item `auto = TRUE`: max Pareto k-hat 0.49, 0.05 subjects above 0.7;
+#'       objective RMSE 0.0376, `Omega` RMSE 0.00198
 #'   }
 #'
-#'   So the tail failure k-hat reports is real -- those weights genuinely have
-#'   infinite variance -- but on these fixtures it does not materialise as
-#'   practical error, and heavier-tailed proposals cost roughly twice the RMSE
-#'   to remove it.  `k-hat > 0.7` is a statement about worst-case behaviour;
-#'   over 8-12 seeds the worst case did not occur.
+#'   So `auto` removes the tail failure and estimates `Omega` about 20% more
+#'   accurately, for about 19% more Monte-Carlo noise on the objective.  It is
+#'   on by default because weights with infinite variance are a correctness
+#'   problem -- their error is unbounded in the worst case -- whereas the extra
+#'   noise is a bounded, measurable cost.
 #'
-#'   The default is therefore `FALSE`.  Turn `auto` on when a rare catastrophic
-#'   draw would be worse than a small loss of precision -- a likelihood you
-#'   intend to compare across models, or a model where `fit$env$impPsisK` is
-#'   far above 0.7 rather than marginally above it.
+#'   Set `auto = FALSE` to recover the previous behaviour exactly (that path
+#'   remains bit-identical to earlier versions), which is worth doing when you
+#'   want the tightest possible objective on a model whose `fit$env$impPsisK`
+#'   values are already comfortably below 0.7.
 #' @param gammaMethod How the proposal scale `gamma` is adapted during the EM.
 #'
 #'   `"auto"` (default) picks per model: `"individual"` when the model is not
@@ -210,7 +211,7 @@ impmapControl <- function(sigdig=4,
                           gamma=1.0,
                           gammaMethod=c("auto", "global", "individual"),
                           df=0,
-                          auto=FALSE,
+                          auto=TRUE,
                           iscaleMin=0.1,
                           iscaleMax=10.0,
                           iaccept=0.4,

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -332,6 +332,51 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   if (all(.canon == "dnorm")) "global" else "individual"
 }
 
+#' Build the $runInfo note naming the efficiency statistic in force
+#'
+#' Both statistics are always computed and stashed on the fit -- NONMEM-style
+#' `xi` in `$impXiTrace`/`$impXi` and the Kish effective-sample fraction in
+#' `$impNeffFrac`/`$impNeff` -- but only one of them drives the proposal-scale
+#' adaptation, and they are NOT the same quantity even though both are governed
+#' by `iaccept`.  Measured on theophylline at gamma = 1, mean xi = 1.009 while
+#' the mean Kish fraction = 0.997; at gamma = 4 they read 0.503 and 0.667.
+#' Reading one as if it were the other, or comparing a "global" fit's number
+#' against an "individual" fit's, is a live mistake, so every fit says which is
+#' which.
+#'
+#' @param resolved Resolved gammaMethod: "global" or "individual".
+#' @param user What the user asked for ("auto", "global", "individual").
+#' @param iaccept Target/floor value.
+#' @return A single-line character message.
+#' @noRd
+.impmapGammaRunInfo <- function(resolved, user, iaccept) {
+  .why <- if (identical(user, "auto")) {
+    if (identical(resolved, "individual")) {
+      " (auto: not every endpoint is Gaussian)"
+    } else {
+      " (auto: all endpoints are Gaussian)"
+    }
+  } else {
+    ""
+  }
+  if (identical(resolved, "individual")) {
+    paste0("gammaMethod=\"individual\"", .why,
+           ": the proposal scale is adapted per subject toward xi=", iaccept,
+           " (NONMEM IACCEPT).  Sampling efficiency for this fit is xi",
+           " ($impXi/$impXiTrace); the Kish effective-sample fraction",
+           " ($impNeffFrac) is a DIFFERENT statistic and the two are not",
+           " comparable -- nor is xi comparable across gammaMethod settings.")
+  } else {
+    paste0("gammaMethod=\"global\"", .why,
+           ": one shared proposal scale, adapted only when the mean Kish",
+           " effective-sample fraction falls below ", iaccept,
+           ".  Sampling efficiency for this fit is that fraction",
+           " ($impNeff/$impNeffFrac); NONMEM-style xi ($impXiTrace) is also",
+           " reported but is a DIFFERENT statistic and the two are not",
+           " comparable.")
+  }
+}
+
 #' Install the impmap control into the ui
 #'
 #' @param env Environment with ui in it
@@ -383,6 +428,13 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   if (is.null(.gmUser)) .gmUser <- .control$gammaMethod
   .control$gammaMethodUser <- .gmUser                # kept for $runInfo
   .control$gammaMethod <- .impmapResolveGammaMethod(.gmUser, ui)
+  # Say which efficiency statistic this fit's number actually is.  Both are
+  # always stashed but they are not the same quantity, and only one drives the
+  # adaptation -- warning() here is the established route onto $runInfo
+  # (collected in nlmixr2Est.R and printed under "Information about run").
+  warning(.impmapGammaRunInfo(.control$gammaMethod, .gmUser,
+                              .control$iaccept),
+          call.=FALSE)
   # 0-based index maps for the SIMPLE mu-referenced intercepts (theta = population
   # mean of an eta, no covariates): impOuter's M-step shifts each such theta by
   # the mean conditional eta.  Covariate mu-groups are excluded here because they

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -310,9 +310,26 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   if (!identical(gammaMethod, "auto")) return(gammaMethod)
   .dist <- tryCatch(ui$predDf$distribution, error=function(e) NULL)
   # No usable predDf (should not happen for a fittable model): fall back to the
-  # conservative choice, which is the historical behaviour.
+  # conservative choice, which is the historical behaviour.  Same for an NA
+  # distribution -- `all(NA == "x")` is NA, which would error an `if`.
   if (is.null(.dist) || length(.dist) == 0L) return("global")
-  if (all(as.character(.dist) == "norm")) "global" else "individual"
+  .dist <- as.character(.dist)
+  if (anyNA(.dist)) return("global")
+  # Canonicalize before comparing: rxode2 spells the Gaussian family both
+  # "norm" and "dnorm" and treats them as identical (rxPreferredDistributionName
+  # maps both to "dnorm"), so a literal == "norm" test would send an otherwise
+  # ordinary normal model down the "individual" path.  That matters because
+  # `linCmt() ~ add(add.sd) + dnorm()` -- the exact-likelihood (Laplace) form of
+  # a plain normal endpoint -- reports "dnorm" while having a posterior every
+  # bit as Gaussian as the add() form, so it should not pay for per-subject
+  # adaptation.
+  #
+  # Note lognormal / boxCox / yeoJohnson residuals are carried in
+  # predDf$transform with distribution still "norm", so they canonicalize to
+  # "dnorm" here and correctly count as Gaussian.
+  .canon <- tryCatch(rxode2::rxPreferredDistributionName(.dist),
+                     error=function(e) .dist)
+  if (all(.canon == "dnorm")) "global" else "individual"
 }
 
 #' Install the impmap control into the ui
@@ -354,8 +371,18 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   .control$covMethod <- 0L
   # Resolve gammaMethod="auto" here, where the ui (and therefore predDf) is in
   # scope; the C++ kernel only ever sees a concrete "global"/"individual".
-  .control$gammaMethodUser <- .control$gammaMethod   # kept for $runInfo
-  .control$gammaMethod <- .impmapResolveGammaMethod(.control$gammaMethod, ui)
+  #
+  # Resolve from the USER's original choice, not from whatever this control
+  # currently holds: resolution overwrites gammaMethod in place, so a control
+  # taken off a finished fit (fit$env$impmapControl) and reused on a different
+  # model would otherwise carry the previous model's resolved value and never
+  # re-resolve -- an "auto" control from a log-likelihood fit would silently
+  # pin a normal model to "individual".  Keying off gammaMethodUser makes
+  # resolution idempotent and re-runnable.
+  .gmUser <- .control$gammaMethodUser
+  if (is.null(.gmUser)) .gmUser <- .control$gammaMethod
+  .control$gammaMethodUser <- .gmUser                # kept for $runInfo
+  .control$gammaMethod <- .impmapResolveGammaMethod(.gmUser, ui)
   # 0-based index maps for the SIMPLE mu-referenced intercepts (theta = population
   # mean of an eta, no covariates): impOuter's M-step shifts each such theta by
   # the mean conditional eta.  Covariate mu-groups are excluded here because they

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -91,6 +91,30 @@
 #'
 #'   Per-subject values are reported in `fit$env$impDfInd`,
 #'   `fit$env$impNsampleInd` and `fit$env$impIacceptInd`.
+#'
+#'   **Measured trade-off -- read this before turning it on.**  `auto = TRUE`
+#'   reliably improves the *tail* behaviour of the importance weights and
+#'   reliably degrades the *accuracy* of the objective.  On theophylline,
+#'   against a reference computed at `isample = 20000` (which agrees to 0.0003
+#'   across Gaussian, `df = 8` and `df = 20` proposals, so it is trustworthy):
+#'
+#'   \itemize{
+#'     \item `auto = FALSE`: max Pareto k-hat 2.41, 3.3 subjects above 0.7;
+#'       objective bias +0.002, SD 0.029, **RMSE 0.027**
+#'     \item `auto = TRUE`: max Pareto k-hat 0.70, 0.3 subjects above 0.7;
+#'       objective bias -0.025, SD 0.045, **RMSE 0.049**
+#'   }
+#'
+#'   So the tail failure k-hat reports is real -- those weights genuinely have
+#'   infinite variance -- but on these fixtures it does not materialise as
+#'   practical error, and heavier-tailed proposals cost roughly twice the RMSE
+#'   to remove it.  `k-hat > 0.7` is a statement about worst-case behaviour;
+#'   over 8-12 seeds the worst case did not occur.
+#'
+#'   The default is therefore `FALSE`.  Turn `auto` on when a rare catastrophic
+#'   draw would be worse than a small loss of precision -- a likelihood you
+#'   intend to compare across models, or a model where `fit$env$impPsisK` is
+#'   far above 0.7 rather than marginally above it.
 #' @param gammaMethod How the proposal scale `gamma` is adapted during the EM.
 #'
 #'   `"auto"` (default) picks per model: `"individual"` when the model is not

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -9,7 +9,7 @@
 # Importance-sampling / EM control names -- stripped when down-converting to a
 # plain foceiControl for the MAP inner problem / output.
 .impmapIsControlNames <- c("isample", "nIter", "mapIter", "gamma",
-                           "gammaMethod", "gammaMethodUser",
+                           "gammaMethod", "gammaMethodUser", "df",
                            "iscaleMin", "iscaleMax", "iaccept",
                            "ctol", "nConvWindow", "impSeed", "impCov",
                            "qr", "qrShift", "qrRefresh", "sir", "sirSample",
@@ -39,6 +39,23 @@
 #' @param gamma Initial proposal-variance inflation factor (NONMEM ISCALE); the
 #'   proposal covariance is `gamma` times the inverse of the inner information
 #'   matrix at the mode.
+#' @param df Degrees of freedom of the importance-sampling proposal (NONMEM
+#'   `DF`).  `0` (default) uses a multivariate **normal** proposal; any value
+#'   `> 0` uses a multivariate **t** with that many degrees of freedom.
+#'
+#'   This changes the proposal's SHAPE rather than its width, and that is the
+#'   distinction that matters.  `gamma` can only make a Gaussian proposal
+#'   wider; it cannot give it heavier tails.  When the target posterior has
+#'   heavier tails than the proposal, the importance weights have infinite
+#'   variance -- and neither `xi` nor the Kish effective sample size can detect
+#'   it, because the offending mass lies where the proposal rarely lands.  The
+#'   Pareto k-hat diagnostic (`fit$env$impPsisK`) does detect it: `k > 0.7`
+#'   means that subject's weights are unreliable.  A t proposal has polynomial
+#'   tails that dominate a Gaussian target's, which bounds the weights.
+#'
+#'   NONMEM's guidance (Bauer, *NONMEM Tutorial Part II*) is to set a nonzero
+#'   `DF` when there are fewer data points than etas, or for categorical data.
+#'   Small values (3-8) are heavy; large values approach the Gaussian.
 #' @param gammaMethod How the proposal scale `gamma` is adapted during the EM.
 #'
 #'   `"auto"` (default) picks per model: `"individual"` when the model is not
@@ -133,6 +150,7 @@ impmapControl <- function(sigdig=4,
                           mapIter=1L,
                           gamma=1.0,
                           gammaMethod=c("auto", "global", "individual"),
+                          df=0,
                           iscaleMin=0.1,
                           iscaleMax=10.0,
                           iaccept=0.4,
@@ -201,6 +219,7 @@ impmapControl <- function(sigdig=4,
   .control$mapIter <- as.integer(mapIter)
   .control$gamma <- as.double(gamma)
   .control$gammaMethod <- gammaMethod
+  .control$df <- as.double(df)
   if (!is.null(.gammaMethodUser)) .control$gammaMethodUser <- .gammaMethodUser
   .control$iscaleMin <- as.double(iscaleMin)
   .control$iscaleMax <- as.double(iscaleMax)

--- a/man/impmapControl.Rd
+++ b/man/impmapControl.Rd
@@ -11,6 +11,9 @@ impmapControl(
   nIter = 100L,
   mapIter = 1L,
   gamma = 1,
+  gammaMethod = c("auto", "global", "individual"),
+  df = 0,
+  auto = TRUE,
   iscaleMin = 0.1,
   iscaleMax = 10,
   iaccept = 0.4,
@@ -44,7 +47,16 @@ this is \code{atol = 1e-7}, \code{rtol = 1e-4}.}
 \item{...}{Parameters used in the default `foceiControl()`}
 
 \item{isample}{Number of importance samples drawn per subject per iteration
-(NONMEM ISAMPLE).}
+  (NONMEM ISAMPLE).  Either a single count used for every subject, or a
+  vector of length `nsub` giving a count **per subject**.
+
+  Per-subject counts are the NM7 Technical Guide's own remedy for poor
+  coverage (its derivation is Gaussian throughout and never mentions a t
+  proposal): a subject whose weights are badly behaved can be given more
+  samples without charging every other subject for them.  Note this treats
+  the symptom rather than the cause -- more draws from a proposal whose
+  tails are too light still gives weights with infinite variance, which
+  `fit$env$impPsisK` will show.  See `df` for the shape-based remedy.}
 
 \item{nIter}{Maximum number of importance-sampling EM iterations.}
 
@@ -54,6 +66,114 @@ re-centers the proposal at the MAP mode each iteration.}
 \item{gamma}{Initial proposal-variance inflation factor (NONMEM ISCALE); the
 proposal covariance is `gamma` times the inverse of the inner information
 matrix at the mode.}
+
+\item{gammaMethod}{How the proposal scale `gamma` is adapted during the EM.
+
+  `"auto"` (default) picks per model: `"individual"` when the model is not
+  transformably normal -- a general log-likelihood (`ll()`) endpoint, or a
+  count/categorical/time-to-event distribution -- and `"global"` otherwise.
+  That is the split the hypothesis actually rests on: `gamma = 1` is already
+  the efficient proposal when the individual posterior is close to Gaussian,
+  so a normal model gains nothing from per-subject adaptation and would only
+  pay for it in effective sample size, while a general-likelihood model is
+  exactly where the posteriors go non-Gaussian and per-subject coverage
+  starts to vary.  The test is `all(ui$predDf$distribution == "norm")`, the
+  same line [rxode2::assertRxUiTransformNormal()] draws.  The resolved value
+  is reported in the fit's `$runInfo`.
+
+  `"global"` keeps one scale shared by every subject, inflated (never
+  relaxed) only when the *mean* Kish effective-sample fraction falls below
+  `iaccept`.  It leaves `gamma` at its efficient starting value while
+  coverage is healthy, which is the right behaviour when the individual
+  posteriors are close to Gaussian.
+
+  `"individual"` gives every subject its own `gamma_i` and adapts it
+  two-sided toward a target on that subject's `xi_i`, clamped to
+  `[iscaleMin, iscaleMax]`.  This follows NONMEM's *objective* -- the NM7
+  Technical Guide states that `gamma` is per-subject (eq. 1.90) and is
+  "continually adjusted so that xi_i approximates IACCEPT" (note after
+  eq. 1.76), bounded by `ISCALE_MIN`/`ISCALE_MAX` -- but the guide publishes
+  no update formula, so the functional form used here is nlmixr2's own.
+  Prefer this when the
+  individual posteriors are heavy-tailed or the design is heterogeneous:
+  a global scale is driven by the mean, so a handful of badly-covered
+  subjects never trip it and their likelihood and `Omega` contributions end
+  up carried by a few samples.
+
+  The two modes report *different* efficiency statistics -- `"individual"`
+  targets `xi` (the mean normalized importance weight, NONMEM's `IACCEPT`
+  quantity) while `"global"` targets the Kish effective-sample fraction.
+  These are not comparable; the fit's `$runInfo` says which is in force.}
+
+\item{df}{Degrees of freedom of the importance-sampling proposal (NONMEM
+  `DF`).  `0` (default) uses a multivariate **normal** proposal; any value
+  `> 0` uses a multivariate **t** with that many degrees of freedom.
+
+  This changes the proposal's SHAPE rather than its width, and that is the
+  distinction that matters.  `gamma` can only make a Gaussian proposal
+  wider; it cannot give it heavier tails.  When the target posterior has
+  heavier tails than the proposal, the importance weights have infinite
+  variance -- and neither `xi` nor the Kish effective sample size can detect
+  it, because the offending mass lies where the proposal rarely lands.  The
+  Pareto k-hat diagnostic (`fit$env$impPsisK`) does detect it: `k > 0.7`
+  means that subject's weights are unreliable.  A t proposal has polynomial
+  tails that dominate a Gaussian target's, which bounds the weights.
+
+  NONMEM's guidance (Bauer, *NONMEM Tutorial Part II*) is to set a nonzero
+  `DF` when there are fewer data points than etas, or for categorical data.
+  Small values (3-8) are heavy; large values approach the Gaussian.}
+
+\item{auto}{NONMEM `AUTO=1` equivalent: adapt the proposal degrees of
+  freedom, the sample count and the acceptance target **per subject** rather
+  than applying one global setting to everybody.
+
+  * **`df`** -- a subject whose observation count is below the number of
+    random effects, or any subject when the model is not transformably
+    normal, gets a heavy-tailed t proposal.  This is the tutorial's trigger
+    ("fewer data points than there are ETAs ... or data are categorical").
+  * **`isample`** -- the total sample budget (`isample * nsub`) is
+    reallocated toward subjects whose effective-sample fraction is lowest,
+    the tutorial's "many ETAs or ... large stochastic fluctuations".  It is
+    load-balancing, not a cost increase.  Note sample count is deliberately
+    *not* driven by Pareto k-hat: a heavy tail is not repairable by more
+    draws (see `df`).
+  * **`iaccept`** -- lowered to 0.2 for the same sparse/categorical
+    subjects, per the tutorial.
+
+  The concrete values (`df = 4`, the `nobs < neta` test, the budget
+  reallocation rule) are **nlmixr2's choices**.  NONMEM does not publish what
+  `AUTO=1` picks internally; only the triggers and `IACCEPT ~ 0.2` are
+  documented.  Unlike NONMEM's AUTO, which its own tutorial warns "may result
+  in lack of stochastic reproducibility", this remains seeded and
+  thread-count independent.
+
+  Per-subject values are reported in `fit$env$impDfInd`,
+  `fit$env$impNsampleInd` and `fit$env$impIacceptInd`.
+
+  **Measured trade-off.**  `auto = TRUE` (the default) improves the *tail*
+  behaviour of the importance weights and the accuracy of `Omega`, at some
+  cost in Monte-Carlo noise on the objective.  On theophylline, against a
+  reference computed at `isample = 20000` (which agrees to 0.0003 across
+  Gaussian, `df = 8` and `df = 20` proposals, so it is trustworthy), over 20
+  seeds:
+
+  \itemize{
+    \item `auto = FALSE`: max Pareto k-hat 2.44, 2.20 subjects above 0.7;
+      objective RMSE 0.0315, `Omega` RMSE 0.00247
+    \item `auto = TRUE`: max Pareto k-hat 0.49, 0.05 subjects above 0.7;
+      objective RMSE 0.0376, `Omega` RMSE 0.00198
+  }
+
+  So `auto` removes the tail failure and estimates `Omega` about 20% more
+  accurately, for about 19% more Monte-Carlo noise on the objective.  It is
+  on by default because weights with infinite variance are a correctness
+  problem -- their error is unbounded in the worst case -- whereas the extra
+  noise is a bounded, measurable cost.
+
+  Set `auto = FALSE` to recover the previous behaviour exactly (that path
+  remains bit-identical to earlier versions), which is worth doing when you
+  want the tightest possible objective on a model whose `fit$env$impPsisK`
+  values are already comfortably below 0.7.}
 
 \item{iscaleMin, iscaleMax}{Lower/upper bounds for the adapted `gamma`
 (NONMEM ISCALE_MIN / ISCALE_MAX).}

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -126,6 +126,76 @@ static inline double impCiTCorrection(double df, int p) {
     std::lgamma(0.5 * df) - std::lgamma(0.5 * (df + (double)p));
 }
 
+// ---- Pareto k-hat (PSIS) ----------------------------------------------------
+// In-kernel copy of the Zhang & Stephens (2009) empirical-Bayes GPD fit that
+// R/impPsis.R computes post-fit (validated there against loo::psis).  Needed
+// HERE because AUTO must react to tail failure while the EM is still running,
+// and the cheap in-sample statistics (xi, Kish ESS) are structurally blind to
+// it.  Pure arithmetic on the weight vector; no RNG, no allocation beyond the
+// tail copy, so it is safe inside the parallel E-step.
+static double impPsisKhat(const arma::vec& w) {
+  // Mirrors R/impPsis.R line for line (that version is validated against
+  // loo::psis); the earlier attempt to be clever with Armadillo expressions
+  // silently returned ~0 for weights whose true k-hat was 2.0.
+  std::vector<double> x;
+  x.reserve(w.n_elem);
+  for (arma::uword i = 0; i < w.n_elem; ++i) {
+    double v = w[i];
+    if (R_finite(v) && v > 0.0) x.push_back(v);
+  }
+  int S = (int)x.size();
+  if (S < 25) return NA_REAL;
+  int tail = (int)std::floor(0.2 * S);
+  int t2 = (int)std::floor(3.0 * std::sqrt((double)S));
+  if (t2 < tail) tail = t2;
+  if (tail < 5) return NA_REAL;
+  std::sort(x.begin(), x.end());
+  // threshold = largest weight NOT in the tail (R: .srt[.s - .tail], 1-based)
+  double u = x[S - tail - 1];
+  std::vector<double> exc;
+  exc.reserve(tail);
+  for (int i = S - tail; i < S; ++i) {
+    double e = x[i] - u;
+    if (e > 0.0) exc.push_back(e);
+  }
+  int n = (int)exc.size();
+  if (n < 5) return NA_REAL;
+  std::sort(exc.begin(), exc.end());
+  int m = 30 + (int)std::floor(std::sqrt((double)n));
+  // R: .xstar <- x[floor(.n/4 + 0.5)]  -- 1-based, so subtract 1 here
+  int qi = (int)std::floor((double)n / 4.0 + 0.5) - 1;
+  if (qi < 0) qi = 0;
+  if (qi >= n) qi = n - 1;
+  double xstar = exc[qi];
+  if (!(xstar > 0.0) || !R_finite(xstar)) return NA_REAL;
+  std::vector<double> theta(m), l(m);
+  double lmax = R_NegInf;
+  for (int j = 0; j < m; ++j) {
+    theta[j] = 1.0 / exc[n - 1] +
+      (1.0 - std::sqrt((double)m / ((double)(j + 1) - 0.5))) / 3.0 / xstar;
+    double k = 0.0;
+    for (int i = 0; i < n; ++i) k += std::log1p(-theta[j] * exc[i]);
+    k /= (double)n;
+    double lj = R_NegInf;
+    double a = -theta[j] / k;
+    if (R_finite(k) && k != 0.0 && a > 0.0) lj = (double)n * (std::log(a) - k - 1.0);
+    l[j] = lj;
+    if (lj > lmax) lmax = lj;
+  }
+  if (!R_finite(lmax)) return NA_REAL;
+  double sw = 0.0, tw = 0.0;
+  for (int j = 0; j < m; ++j) {
+    double wj = std::exp(l[j] - lmax);
+    if (!R_finite(wj)) continue;
+    sw += wj; tw += theta[j] * wj;
+  }
+  if (!(sw > 0.0) || !R_finite(sw)) return NA_REAL;
+  double thetaHat = tw / sw;
+  double kh = 0.0;
+  for (int i = 0; i < n; ++i) kh += std::log1p(-thetaHat * exc[i]);
+  return kh / (double)n;
+}
+
 // ---- SIR (sampling-importance-resampling) element ---------------------------
 // Systematic (stratified) resampling: sirN indices drawn with copy counts
 // proportional to the normalized weights (each count is within 1 of
@@ -195,11 +265,11 @@ NumericMatrix impQrPoints_(int isample, int neta, Nullable<NumericVector> shift)
 // throughout and never mentions a t proposal).
 static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
                      const arma::vec& gammaVec,
-                     double df, int cores,
+                     const arma::vec& dfVec, int cores,
                      int iter, double negHalfLogDetOmega, bool isImp,
                      arma::mat& condMean, std::vector<arma::mat>& condVar,
                      arma::vec& Li, arma::vec& Neff, arma::vec& Xi,
-                     arma::vec& XiExpOut,
+                     arma::vec& XiExpOut, arma::vec& KhatExpOut,
                      std::vector<arma::mat>& outS, std::vector<arma::vec>& outZk,
                      arma::mat& aMat, Environment* eStash,
                      uint32_t qrPinSeed) {
@@ -280,6 +350,7 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
   arma::vec LiExp(nExp); LiExp.fill(NA_REAL);
   arma::vec NeffExp(nExp); NeffExp.fill(NA_REAL);
   arma::vec XiExp(nExp); XiExp.fill(NA_REAL);
+  arma::vec KhatExp(nExp); KhatExp.fill(NA_REAL);
   std::vector<char> okExp(nExp, 0);
   outS.assign(nExp, arma::mat());
   outZk.assign(nExp, arma::vec());
@@ -324,7 +395,7 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
       if (!haveL[id]) continue;
       // This subject's own proposal scale (all equal under gammaMethod="global").
       double gammaId = gammaVec[id];
-      double dfId = df;   // proposal degrees of freedom; 0 = Gaussian
+      double dfId = dfVec[id];   // this subject's proposal df; 0 = Gaussian
       int nsId = (int)isampleVec[id];   // this subject's sample count
       arma::mat S(nsId, neta);
       if (qr) {
@@ -409,6 +480,7 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
       NeffExp[id] = 1.0 / arma::accu(arma::square(zk));
       // NONMEM xi: mean weight normalized to the proposal center (see above).
       if (R_finite(qCenter)) XiExp[id] = std::exp(logMeanExp - qCenter);
+      KhatExp[id] = impPsisKhat(zk);   // tail index of this subject's weights
       arma::rowvec pbar = zk.t() * S;
       cmExp.row(id) = pbar;
       arma::mat B(neta, neta, arma::fill::zeros);
@@ -499,6 +571,7 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
   // drives (one gamma_i per expanded subject).  `Xi` above is the
   // responsibility-combined per-base-subject value used for reporting.
   XiExpOut = XiExp;
+  KhatExpOut = KhatExp;
 
   // On the last iteration, stash the per-subject sampler diagnostics (first
   // component for a mixture).
@@ -777,7 +850,7 @@ void impOuter(Environment e) {
   std::vector<arma::mat> condVar;
   std::vector<arma::mat> sampS;
   std::vector<arma::vec> sampZk;
-  arma::vec Li, Neff, Xi, XiExp;
+  arma::vec Li, Neff, Xi, XiExp, KhatExp;
   arma::mat aMat;                 // posterior mixture responsibilities (nsub x Nmix)
   int Nmix = impNmix();
   int nExp = nsub * Nmix;         // expanded pseudo-subjects for the mixture E/M-step
@@ -795,6 +868,12 @@ void impOuter(Environment e) {
   // badly covered subject; holding it as a vector is what lets that happen
   // without charging every other subject for the extra samples.
   arma::ivec isampleVec(nExp); isampleVec.fill(isample);
+  // Per-expanded-subject proposal df and acceptance target.  Uniform unless
+  // AUTO differentiates them.
+  arma::vec dfVec(nExp); dfVec.fill(impDf());
+  arma::vec iacceptVec(nExp); iacceptVec.fill(iaccept);
+  bool autoOn = impAutoEnabled();
+  int isampleBudget = isample * nExp;   // AUTO reallocates within this total
   {
     // A per-subject isample= vector is given per BASE subject; tile it across
     // the mixture's expanded pseudo-subjects so component j of subject i gets
@@ -838,6 +917,48 @@ void impOuter(Environment e) {
   // Initial MAP at the starting parameters.
   impMapPass(e);
 
+  // NB placed AFTER the initial MAP pass on purpose: fInd->nObs is only filled
+  // in during a solve, so reading it before impMapPass() returns 0 for every
+  // subject and makes the whole dataset look sparse (which silently gave every
+  // subject df = 4).
+  // ---- AUTO step 1: proposal df from each subject's data sparsity ----------
+  // Decided once, up front, from nobs/neta: a subject with few observations
+  // relative to the number of random effects has a poorly-determined, often
+  // heavy-tailed conditional density that a normal proposal cannot cover, and
+  // no sample count repairs that (measured: boosting a failing subject 10x
+  // moved its k-hat 0.76 -> 3.28, because extra draws reach further into the
+  // tail the proposal misses).  Heavier tails do repair it, cheaply.
+  //
+  // The trigger is the tutorial's, verbatim: "When there are fewer data points
+  // than there are ETAs to be estimated (sparse data) or data are categorical,
+  // then DF should be set to a nonzero number to use the t-distribution sampler
+  // and/or decrease the acceptance rate IACCEPT from the default value of 0.4
+  // to about 0.2" (Bauer, NONMEM Tutorial Part II, 2019).  So the test is
+  // nobs < neta -- NOT a wider sparsity band -- and categorical/non-normal data
+  // qualifies regardless of how much of it there is.
+  //
+  // On the VALUES: IACCEPT ~ 0.2 is the tutorial's own number.  DF = 4 is NOT
+  // -- the tutorial says only "DF should be set to a nonzero number".  NONMEM
+  // does not publish what AUTO=1 actually picks, so 4 is nlmixr2's choice,
+  // informed by the measurement that even df = 20 cleared every failing
+  // subject on theophylline (max k-hat 1.61 -> -0.58) for 0.25% of the
+  // effective sample size, so a heavier default is safe and cheap.  Any
+  // comparison against NONMEM should treat these numbers as nlmixr2's, not as
+  // a reproduction of NONMEM's internals.
+  if (autoOn) {
+    bool nonNormal = impAutoNonNormal();
+    for (int i = 0; i < nsub; ++i) {
+      bool sparse = impNobs(i) < neta;
+      double dfI = (sparse || nonNormal) ? 4.0 : 0.0;
+      double iaI = (sparse || nonNormal) ? 0.2 : iaccept;
+      for (int j = 0; j < Nmix; ++j) {
+        dfVec[i + j * nsub] = dfI;
+        iacceptVec[i + j * nsub] = iaI;
+      }
+    }
+  }
+
+
   // Fit-constant base seed for the pinned (qrRefresh=FALSE) Cranley-Patterson
   // shift streams; only consumed in that mode so every other path's draw
   // stream is unchanged.
@@ -879,8 +1000,8 @@ void impOuter(Environment e) {
     // controller set at the end of the previous iteration (and the constructor
     // fill for iteration 0), so it must NOT be flattened here.
     if (!gammaInd) gammaVec.fill(gamma);
-    impEStep(nsub, neta, isampleVec, gammaVec, impDf(), cores, iter, impLogDetOmegaInv5(), isImp,
-             condMean, condVar, Li, Neff, Xi, XiExp, sampS, sampZk, aMat, &e, qrPinSeed);
+    impEStep(nsub, neta, isampleVec, gammaVec, dfVec, cores, iter, impLogDetOmegaInv5(), isImp,
+             condMean, condVar, Li, Neff, Xi, XiExp, KhatExp, sampS, sampZk, aMat, &e, qrPinSeed);
     obj = 0.0;
     for (int id = 0; id < nsub; ++id) if (R_finite(Li[id])) obj += 2.0 * Li[id];
     // Mean effective-sample fraction (importance-sampling "acceptance ratio").
@@ -897,6 +1018,57 @@ void impOuter(Environment e) {
     // itself under "global", the mean of the per-subject scales under
     // "individual".  It is what gets traced and reported as impGammaUsed.
     if (gammaInd) gamma = arma::mean(gammaVec);
+    // ---- AUTO step 3: escalate df when k-hat reports tail failure ----------
+    // The tutorial's df trigger (nobs < neta, or categorical) is necessary but
+    // NOT sufficient: measured on plain theophylline -- 11 observations against
+    // 1 eta, transformably normal, so neither condition fires -- four of twelve
+    // subjects still have infinite-variance weights (max k-hat 2.36), which a
+    // t proposal clears completely.  NONMEM has no tail diagnostic to notice
+    // this; we do, so AUTO uses it.
+    //
+    // This is nlmixr2 going BEYOND the documented NONMEM rule, not reproducing
+    // it.  Escalation is one-way and stepwise (Gaussian -> 8 -> 4) so a noisy
+    // k-hat cannot oscillate the proposal shape from iteration to iteration.
+    if (autoOn) {
+      for (int id = 0; id < nExp; ++id) {
+        double kh = KhatExp[id];
+        if (!R_finite(kh) || kh <= 0.7) continue;
+        if (dfVec[id] <= 0.0)      dfVec[id] = 8.0;   // Gaussian -> moderately heavy
+        else if (dfVec[id] > 4.0)  dfVec[id] = 4.0;   // -> heaviest used here
+      }
+    }
+
+    // ---- AUTO step 2: reallocate the sample budget across subjects --------
+    // The tutorial's trigger is "many ETAs or the objective function has large
+    // stochastic fluctuations".  Both show up as a low effective-sample
+    // FRACTION for that subject, so the budget is shifted toward the subjects
+    // whose weights are least effective and away from the ones that are
+    // already cheap to resolve.  The total is held at isample*nExp, so this is
+    // load-balancing rather than a cost increase.
+    //
+    // Deliberately NOT driven by k-hat: a bad tail is not fixable by more
+    // samples (measured: 10x on a failing subject moved k-hat 0.76 -> 3.28),
+    // that is what the df assignment above is for.  Sample count is the right
+    // lever only for ordinary Monte-Carlo noise.
+    if (autoOn && nExp > 1) {
+      arma::vec need(nExp, arma::fill::ones);
+      for (int id = 0; id < nExp; ++id) {
+        double fr = R_finite(Neff[id]) ? Neff[id] / (double)isampleVec[id] : 1.0;
+        if (!(fr > 0.0) || !R_finite(fr)) fr = 1.0;
+        // inverse-efficiency weighting, bounded so no subject starves or hogs
+        double w = 1.0 / std::max(0.05, std::min(1.0, fr));
+        need[id] = std::min(4.0, w);
+      }
+      double tot = arma::accu(need);
+      if (tot > 0.0 && R_finite(tot)) {
+        for (int id = 0; id < nExp; ++id) {
+          int v = (int)std::lround((double)isampleBudget * need[id] / tot);
+          if (v < 25) v = 25;                       // floor: keep PSIS usable
+          if (v > 20 * isample) v = 20 * isample;   // ceiling: bound the cost
+          isampleVec[id] = v;
+        }
+      }
+    }
     objTrace.push_back(obj);
     gammaTrace.push_back(gamma);
     neffTrace.push_back(accFrac);
@@ -1122,7 +1294,7 @@ void impOuter(Environment e) {
         } else if (xiId <= 0.0) {
           fac = capDn;                  // xi = 0: proposal far too wide
         } else {
-          fac = std::pow(xiId / iaccept, pExp);
+          fac = std::pow(xiId / iacceptVec[id], pExp);
           if (fac > capUp) fac = capUp;
           else if (fac < capDn) fac = capDn;
         }
@@ -1180,6 +1352,10 @@ void impOuter(Environment e) {
   e["impGammaUsed"] = gamma;
   e["impNsample"]  = isample;
   e["impNsampleInd"] = wrap(isampleVec);   // per-expanded-subject counts
+  e["impDfInd"]    = wrap(dfVec);           // per-expanded-subject proposal df
+  e["impIacceptInd"] = wrap(iacceptVec);    // per-expanded-subject acceptance target
+  e["impKhatIter"] = wrap(KhatExp);         // last-iteration in-kernel k-hat
+  e["impAuto"]     = autoOn;
   e["impQr"]       = impQrEnabled();
   e["impSir"]      = impSirEnabled();
   e["impSirSample"] = impSirN();

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -617,7 +617,8 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
 // gamma -- wrong whenever the scale adapted during the fit, and badly wrong
 // under gammaMethod="individual" where the scales are per subject.  The
 // covariance must be evaluated with the same proposal the fit converged on.
-void impComputeCov(Environment e, const arma::vec& gammaVec) {
+void impComputeCov(Environment e, const arma::vec& gammaVec,
+                   const arma::vec& dfVec) {
   int nsub = impNsub();
   int neta = impNeta();
   int isample = impNsample();
@@ -691,13 +692,13 @@ void impComputeCov(Environment e, const arma::vec& gammaVec) {
         Z = qrZ0;
       }
       for (int k = 0; k < isample; ++k) {
-        S.row(k) = (modes[id] + Ls[id] * Z.row(k).t()).t();
+        S.row(k) = (modes[id] + Ls[id] * (Z.row(k).t() * impTScale(dfVec[id]))).t();
       }
     } else {
       for (int k = 0; k < isample; ++k) {
         arma::vec z(neta);
         for (int j = 0; j < neta; ++j) z[j] = rxNormEng(0.0, 1.0);
-        S.row(k) = (modes[id] + Ls[id] * z).t();
+        S.row(k) = (modes[id] + Ls[id] * (z * impTScale(dfVec[id]))).t();
       }
     }
     Ss[id] = S;
@@ -741,7 +742,7 @@ void impComputeCov(Environment e, const arma::vec& gammaVec) {
         // This subject's converged proposal scale (all equal under "global").
         // Must use the SAME proposal shape (df) as the E-step or the reweighted
         // objective is not the one the fit converged on.
-        double dfCov = impDf();
+        double dfCov = dfVec[id];
         arma::vec q(isample); int nGood = 0;
         for (int k = 0; k < isample; ++k) {
           arma::vec eta = Ss[id].row(k).t();
@@ -868,6 +869,12 @@ void impOuter(Environment e) {
   // badly covered subject; holding it as a vector is what lets that happen
   // without charging every other subject for the extra samples.
   arma::ivec isampleVec(nExp); isampleVec.fill(isample);
+  // Counts actually USED by the last E-step.  isampleVec is reallocated after
+  // the E-step, so reporting it directly pairs next iteration's counts with
+  // this iteration's Neff and can show an effective-sample FRACTION above 1,
+  // which is impossible.
+  arma::ivec isampleUsed(nExp); isampleUsed.fill(isample);
+  arma::vec dfUsed(nExp); dfUsed.fill(impDf());   // df actually used last E-step
   // Per-expanded-subject proposal df and acceptance target.  Uniform unless
   // AUTO differentiates them.
   arma::vec dfVec(nExp); dfVec.fill(impDf());
@@ -880,6 +887,11 @@ void impOuter(Environment e) {
     // subject i's count.
     std::vector<int> isv;
     impNsampleVecGet(isv);
+    if ((int)isv.size() > 1 && (int)isv.size() != nsub) {
+      Rf_error("'isample' has length %d but there are %d subjects; a per-subject "
+               "isample vector must have one entry per subject",
+               (int)isv.size(), nsub);
+    }
     if ((int)isv.size() == nsub) {
       for (int i = 0; i < nsub; ++i) {
         int v = isv[i] < 1 ? 1 : isv[i];
@@ -954,7 +966,12 @@ void impOuter(Environment e) {
       // the effective sample size, whereas df 4 costs far more Monte-Carlo
       // noise for no extra tail benefit.  The k-hat escalation below drops it
       // further only on evidence.
-      double dfI = (sparse || nonNormal) ? 20.0 : 0.0;
+      // TUNED (df sweep, theophylline, 12 seeds, RMSE vs an isample=20000
+      // reference): df 30 clears the tail failure completely (max k-hat
+      // 2.58 -> -0.02, bad subjects 2.08 -> 0.08) for a 7% RMSE cost
+      // (0.0240 -> 0.0257).  Entering at 20 costs 33% and at 8 costs 3x for no
+      // extra tail benefit, so the earlier ladder was simply mistuned.
+      double dfI = (sparse || nonNormal) ? 30.0 : 0.0;
       // TUNED: iaccept is left alone here.  Lowering it to 0.2 forces gamma
       // wide, and widening a Gaussian is the lever measured NOT to fix tails
       // while costing a lot of ESS -- on a Poisson fixture whose k-hat was
@@ -1011,6 +1028,8 @@ void impOuter(Environment e) {
     // controller set at the end of the previous iteration (and the constructor
     // fill for iteration 0), so it must NOT be flattened here.
     if (!gammaInd) gammaVec.fill(gamma);
+    isampleUsed = isampleVec;
+    dfUsed = dfVec;
     impEStep(nsub, neta, isampleVec, gammaVec, dfVec, cores, iter, impLogDetOmegaInv5(), isImp,
              condMean, condVar, Li, Neff, Xi, XiExp, KhatExp, sampS, sampZk, aMat, &e, qrPinSeed);
     obj = 0.0;
@@ -1018,7 +1037,7 @@ void impOuter(Environment e) {
     // Mean effective-sample fraction (importance-sampling "acceptance ratio").
     double accFrac = 0.0; int nAcc = 0;
     for (int id = 0; id < nsub; ++id)
-      if (R_finite(Neff[id])) { accFrac += Neff[id] / (double)isampleVec[id]; ++nAcc; }
+      if (R_finite(Neff[id])) { accFrac += Neff[id] / (double)isampleUsed[id]; ++nAcc; }
     if (nAcc > 0) accFrac /= (double)nAcc;
     // Mean NONMEM-style xi (a DIFFERENT statistic from accFrac -- see impEStep).
     double xiMean = 0.0; int nXi = 0;
@@ -1041,20 +1060,32 @@ void impOuter(Environment e) {
     // it.  Escalation is one-way and stepwise (Gaussian -> 8 -> 4) so a noisy
     // k-hat cannot oscillate the proposal shape from iteration to iteration.
     if (autoOn) {
+      // Severity-driven, and two-way.  The earlier version walked a fixed
+      // ladder one rung per iteration regardless of HOW bad k-hat was, and
+      // never came back -- so a subject with k-hat 0.75 took the same path as
+      // one at 3.0, and any subject that did not need a t proposal kept paying
+      // for it.  Both waste accuracy, which is what the gate was failing on.
+      //
+      // Mapping comes from the df sweep (theophylline, 12 seeds, RMSE vs an
+      // isample=20000 reference): df 30 already takes max k-hat 2.58 -> -0.02
+      // for a 7% RMSE cost, while df 8 costs 3x for no extra tail benefit.  So
+      // heavier rungs are reserved for k-hat that df 30 has NOT settled.
       for (int id = 0; id < nExp; ++id) {
         double kh = KhatExp[id];
-        if (!R_finite(kh) || kh <= 0.7) continue;
-        // TUNED ladder: Gaussian -> mild -> moderate -> heavy, so each step is
-        // the smallest that might work.  Heavier tails buy tail reliability at
-        // the price of Monte-Carlo noise, so overshooting costs precision.
-        if (dfVec[id] <= 0.0)       dfVec[id] = 20.0;
-        else if (dfVec[id] > 8.0)   dfVec[id] = 8.0;
-        else if (dfVec[id] > 4.0)   dfVec[id] = 4.0;
-        else if (iacceptVec[id] > 0.2) {
-          // tails already as heavy as this ladder goes and still failing: now
-          // fall back to the tutorial's IACCEPT ~ 0.2, which widens gamma
-          iacceptVec[id] = 0.2;
+        if (!R_finite(kh)) continue;              // no usable k-hat: leave alone
+        if (kh > 0.7) {
+          // pick the lightest tail plausibly heavy enough for this severity
+          double want = (kh > 2.0) ? 12.0 : (kh > 1.0 ? 20.0 : 30.0);
+          // only ever go heavier here; escalation must not oscillate
+          if (dfVec[id] <= 0.0 || want < dfVec[id]) dfVec[id] = want;
         }
+        // NOTE deliberately one-way.  Relaxing on a low k-hat is circular: once
+        // a t proposal is in place k-hat drops precisely BECAUSE it is working
+        // (measured -1.3 to -1.9 on subjects that read 2.03 under a Gaussian),
+        // so "safe now" is evidence the fix is needed, not that it is not.
+        // Relaxing on it walks straight back into the failure and oscillates.
+        // Efficiency comes from picking the right rung immediately -- the
+        // severity mapping above -- not from backing off afterwards.
       }
     }
 
@@ -1073,11 +1104,22 @@ void impOuter(Environment e) {
     if (autoOn && nExp > 1) {
       arma::vec need(nExp, arma::fill::ones);
       for (int id = 0; id < nExp; ++id) {
-        double fr = R_finite(Neff[id]) ? Neff[id] / (double)isampleVec[id] : 1.0;
+        double fr = R_finite(Neff[id]) ? Neff[id] / (double)isampleUsed[id] : 1.0;
         if (!(fr > 0.0) || !R_finite(fr)) fr = 1.0;
-        // inverse-efficiency weighting, bounded so no subject starves or hogs
-        double w = 1.0 / std::max(0.05, std::min(1.0, fr));
-        need[id] = std::min(4.0, w);
+        // Only deviate from uniform where the effective-sample fraction is
+        // genuinely deficient.  Reallocating on small differences just adds
+        // per-subject sampling noise for no gain; a subject already above the
+        // acceptance target does not need more draws.
+        // NONMEM's stated behaviour is two-sided: more budget to subjects with
+        // noisy likelihoods or many active random effects, and LESS to
+        // data-rich subjects whose conditional mode is easy to resolve.  A
+        // threshold rule ("boost only below iaccept") captures only the first
+        // half and is completely inert when every subject is above the target,
+        // which is the common case -- so allocate PROPORTIONALLY to inverse
+        // effective-sample fraction instead, normalized to the fixed budget.
+        // Easy subjects then automatically fund the hard ones.
+        double w = 1.0 / std::max(0.02, std::min(1.0, fr));
+        need[id] = std::min(6.0, w);
       }
       double tot = arma::accu(need);
       if (tot > 0.0 && R_finite(tot)) {
@@ -1351,7 +1393,7 @@ void impOuter(Environment e) {
   // Monte-Carlo observed-information covariance (theta block) at the converged
   // estimate, before the inner neqOverride is cleared (the inner solves use it).
   // Selected by impmapControl(covMethod="imp") (the default).
-  if (impCovEnabled()) impComputeCov(e, gammaVec);
+  if (impCovEnabled()) impComputeCov(e, gammaVec, dfVec);
 
   // Clear the multi-endpoint inner neqOverride so it does not leak into a later fit.
   impClearInnerNeqOverride();
@@ -1371,8 +1413,8 @@ void impOuter(Environment e) {
   e["impObj"]      = obj;
   e["impGammaUsed"] = gamma;
   e["impNsample"]  = isample;
-  e["impNsampleInd"] = wrap(isampleVec);   // per-expanded-subject counts
-  e["impDfInd"]    = wrap(dfVec);           // per-expanded-subject proposal df
+  e["impNsampleInd"] = wrap(isampleUsed);  // counts USED by the last E-step
+  e["impDfInd"]    = wrap(dfUsed);          // df USED by the last E-step
   e["impIacceptInd"] = wrap(iacceptVec);    // per-expanded-subject acceptance target
   e["impKhatIter"] = wrap(KhatExp);         // last-iteration in-kernel k-hat
   e["impAuto"]     = autoOn;

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -120,7 +120,7 @@ NumericMatrix impQrPoints_(int isample, int neta, Nullable<NumericVector> shift)
 static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
                      int iter, double negHalfLogDetOmega, bool isImp,
                      arma::mat& condMean, std::vector<arma::mat>& condVar,
-                     arma::vec& Li, arma::vec& Neff,
+                     arma::vec& Li, arma::vec& Neff, arma::vec& Xi,
                      std::vector<arma::mat>& outS, std::vector<arma::vec>& outZk,
                      arma::mat& aMat, Environment* eStash,
                      uint32_t qrPinSeed) {
@@ -200,6 +200,7 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
   std::vector<arma::mat> cvExp(nExp, arma::mat(neta, neta, arma::fill::zeros));
   arma::vec LiExp(nExp); LiExp.fill(NA_REAL);
   arma::vec NeffExp(nExp); NeffExp.fill(NA_REAL);
+  arma::vec XiExp(nExp); XiExp.fill(NA_REAL);
   std::vector<char> okExp(nExp, 0);
   outS.assign(nExp, arma::mat());
   outZk.assign(nExp, arma::vec());
@@ -267,6 +268,24 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
           S.row(k) = (modes[id] + cholL[id] * z).t();
         }
       }
+      // NONMEM-style xi (NM7 eq. 1.73/1.75): the mean importance weight
+      // normalized so the proposal kernel is 1 at its center.  q at the center
+      // is just the log joint density there (the kernel term vanishes at d=0),
+      // so xi = exp(logMeanExp - qCenter) once logMeanExp is formed below.
+      //
+      // xi == 1 exactly when the proposal matches the posterior shape, < 1 when
+      // the proposal is over-dispersed, and > 1 when the posterior has heavier
+      // tails than the Gaussian proposal -- xi is NOT bounded above.  That
+      // heavy-tail signal is what the NONMEM-faithful per-subject gamma
+      // controller targets, and it is a different statistic from the Kish
+      // effective sample size below (they are not comparable).
+      //
+      // Evaluated HERE -- after the draws are complete but before the weight
+      // loop -- deliberately: the sample matrix S is already filled, so this
+      // cannot perturb the sampling stream, and the weight loop still leaves
+      // the subject's eta at S.row(isample-1) exactly as before, preserving
+      // bit-identity with the pre-xi kernel.
+      double qCenter = -impEvalJointLik(modes[id], id);
       // log importance weights.  impEvalJointLik returns the NEGATIVE log joint
       // density (minimized by the inner optimizer), so it enters with a minus;
       // the proposal density is subtracted, contributing +(1/(2 gamma)) d'H d.
@@ -299,6 +318,8 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
         0.5 * logDetH[id];
       LiExp[id] = -(logMeanExp + Ci);          // per-component negative log-likelihood
       NeffExp[id] = 1.0 / arma::accu(arma::square(zk));
+      // NONMEM xi: mean weight normalized to the proposal center (see above).
+      if (R_finite(qCenter)) XiExp[id] = std::exp(logMeanExp - qCenter);
       arma::rowvec pbar = zk.t() * S;
       cmExp.row(id) = pbar;
       arma::mat B(neta, neta, arma::fill::zeros);
@@ -319,6 +340,7 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
   condVar.assign(nsub, arma::mat(neta, neta, arma::fill::zeros));
   Li.set_size(nsub); Li.fill(NA_REAL);
   Neff.set_size(nsub); Neff.fill(NA_REAL);
+  Xi.set_size(nsub); Xi.fill(NA_REAL);
   aMat.set_size(nsub, Nm); aMat.zeros();
   for (int i = 0; i < nsub; ++i) {
     if (Nm == 1) {
@@ -326,6 +348,7 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
       condVar[i] = cvExp[i];
       Li[i] = LiExp[i];
       Neff[i] = NeffExp[i];
+      Xi[i] = XiExp[i];
       aMat(i, 0) = 1.0;
       continue;
     }
@@ -368,6 +391,13 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
       if (a > 0 && R_finite(NeffExp[i + j * nsub])) nf += a * NeffExp[i + j * nsub];
     }
     if (nf > 0) Neff[i] = nf;
+    // Responsibility-weighted xi, matching how Neff is combined above.
+    double xf = 0.0; bool anyXi = false;
+    for (int j = 0; j < Nm; ++j) {
+      double a = aMat(i, j);
+      if (a > 0 && R_finite(XiExp[i + j * nsub])) { xf += a * XiExp[i + j * nsub]; anyXi = true; }
+    }
+    if (anyXi) Xi[i] = xf;
     // Fold the responsibility a_ij into each component's importance weights so the
     // M-step, iterating the expanded subjects, forms the component-weighted score.
     for (int j = 0; j < Nm; ++j) {
@@ -634,7 +664,7 @@ void impOuter(Environment e) {
   std::vector<arma::mat> condVar;
   std::vector<arma::mat> sampS;
   std::vector<arma::vec> sampZk;
-  arma::vec Li, Neff;
+  arma::vec Li, Neff, Xi;
   arma::mat aMat;                 // posterior mixture responsibilities (nsub x Nmix)
   int Nmix = impNmix();
   int nExp = nsub * Nmix;         // expanded pseudo-subjects for the mixture E/M-step
@@ -680,7 +710,7 @@ void impOuter(Environment e) {
   std::vector<int> omFixedEta;
   impGetOmegaFixedEta(omFixedEta);
 
-  std::vector<double> objTrace, gammaTrace, neffTrace;
+  std::vector<double> objTrace, gammaTrace, neffTrace, xiTrace;
   std::vector<arma::vec> parHist;
   bool converged = false;
   int iterRun = 0;
@@ -694,7 +724,7 @@ void impOuter(Environment e) {
     // Stash the E-step diagnostics on every iteration so the fit environment
     // reflects the last iteration actually run (the loop may stop early).
     impEStep(nsub, neta, isample, gamma, cores, iter, impLogDetOmegaInv5(), isImp,
-             condMean, condVar, Li, Neff, sampS, sampZk, aMat, &e, qrPinSeed);
+             condMean, condVar, Li, Neff, Xi, sampS, sampZk, aMat, &e, qrPinSeed);
     obj = 0.0;
     for (int id = 0; id < nsub; ++id) if (R_finite(Li[id])) obj += 2.0 * Li[id];
     // Mean effective-sample fraction (importance-sampling "acceptance ratio").
@@ -702,9 +732,15 @@ void impOuter(Environment e) {
     for (int id = 0; id < nsub; ++id)
       if (R_finite(Neff[id])) { accFrac += Neff[id] / (double)isample; ++nAcc; }
     if (nAcc > 0) accFrac /= (double)nAcc;
+    // Mean NONMEM-style xi (a DIFFERENT statistic from accFrac -- see impEStep).
+    double xiMean = 0.0; int nXi = 0;
+    for (int id = 0; id < nsub; ++id)
+      if (R_finite(Xi[id])) { xiMean += Xi[id]; ++nXi; }
+    if (nXi > 0) xiMean /= (double)nXi; else xiMean = NA_REAL;
     objTrace.push_back(obj);
     gammaTrace.push_back(gamma);
     neffTrace.push_back(accFrac);
+    xiTrace.push_back(xiMean);
     iterRun = iter + 1;
 
     // M-step.  First a Newton step on the non-mu structural thetas from the
@@ -916,6 +952,7 @@ void impOuter(Environment e) {
   e["impCondVar"]  = condVarList;
   e["impLi"]       = wrap(Li);
   e["impNeff"]     = wrap(Neff);
+  e["impXi"]       = wrap(Xi);
   e["impObj"]      = obj;
   e["impGammaUsed"] = gamma;
   e["impNsample"]  = isample;
@@ -928,6 +965,7 @@ void impOuter(Environment e) {
   e["impObjTrace"] = wrap(objTrace);
   e["impGammaTrace"] = wrap(gammaTrace);
   e["impNeffFrac"] = wrap(neffTrace);
+  e["impXiTrace"]  = wrap(xiTrace);
   e["impMuGroupN"] = impMuGroupN();
 
   // Restore the solve core count if it was forced serial for the mixture EM.

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -966,10 +966,26 @@ void impOuter(Environment e) {
       // xi_i below target means it is needlessly over-dispersed and gamma_i
       // shrinks.  Two-sided, so a bad early iteration is not paid for forever.
       //
-      // The sqrt damps the step (xi is not linear in gamma) and the symmetric
-      // 1.25x cap keeps one noisy iteration from slamming a subject into a
-      // bound.  Weights correct for gamma, so this moves variance, not the
-      // estimates.
+      // The damping exponent MUST scale with the number of random effects.
+      // For a Gaussian posterior matched by H_i the statistic is
+      // xi = gamma^(-neta/2), so the update gamma' = gamma * (xi/iaccept)^p
+      // linearizes (in log gamma) to an error multiplier
+      //
+      //   lambda = 1 - p * neta / 2
+      //
+      // A FIXED p (e.g. the natural-looking sqrt, p = 1/2) is therefore only
+      // stable for neta < 8: at neta = 8 lambda = -1 and the controller enters
+      // a period-2 limit cycle that never settles, so the fit can never meet
+      // the gamma-stability gate.  That is not a hypothetical -- an 8-eta model
+      // oscillates gamma 1.32/1.24/1.30/1.23... and xi 0.36/0.45/0.37/0.46...
+      // indefinitely.  Models with 8+ random effects are ordinary here.
+      //
+      // p = 2/neta gives lambda = 0: the Newton step for the Gaussian case,
+      // stable for every dimension, and one-step convergent when the posterior
+      // really is Gaussian.  The symmetric 1.25x cap still bounds a single
+      // noisy iteration.  Weights correct for gamma, so this moves variance,
+      // not the estimates.
+      const double pExp = 2.0 / std::max(1.0, (double)neta);
       const double capUp = 1.25, capDn = 1.0 / 1.25;
       double maxStep = 0.0;
       for (int id = 0; id < nExp; ++id) {
@@ -981,7 +997,7 @@ void impOuter(Environment e) {
         } else if (xiId <= 0.0) {
           fac = capDn;                  // xi = 0: proposal far too wide
         } else {
-          fac = std::sqrt(xiId / iaccept);
+          fac = std::pow(xiId / iaccept, pExp);
           if (fac > capUp) fac = capUp;
           else if (fac < capDn) fac = capDn;
         }

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -285,8 +285,8 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
       // xi == 1 exactly when the proposal matches the posterior shape, < 1 when
       // the proposal is over-dispersed, and > 1 when the posterior has heavier
       // tails than the Gaussian proposal -- xi is NOT bounded above.  That
-      // heavy-tail signal is what the NONMEM-faithful per-subject gamma
-      // controller targets, and it is a different statistic from the Kish
+      // heavy-tail signal is what the per-subject gamma controller
+      // targets, and it is a different statistic from the Kish
       // effective sample size below (they are not comparable).
       //
       // Evaluated HERE -- after the draws are complete but before the weight
@@ -448,12 +448,16 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
 // behaved.  The observed information is 0.5 * d2(-2LL)/dpar2 and the covariance
 // is its inverse.  (mu-referenced thetas still need mode tracking -- a later
 // increment -- since the fixed samples do not follow the mode shift.)
-void impComputeCov(Environment e) {
+// gammaVec carries the CONVERGED proposal scales from the EM (one per expanded
+// subject; the first nsub entries are component 0, which is the indexing this
+// function uses).  It previously read impGammaProp(), the control's *initial*
+// gamma -- wrong whenever the scale adapted during the fit, and badly wrong
+// under gammaMethod="individual" where the scales are per subject.  The
+// covariance must be evaluated with the same proposal the fit converged on.
+void impComputeCov(Environment e, const arma::vec& gammaVec) {
   int nsub = impNsub();
   int neta = impNeta();
   int isample = impNsample();
-  double gamma = impGammaProp();
-  double invGamma2 = 1.0 / (2.0 * gamma);
   // Parallelize the reweighted-objective subject loop (each subject contributes an
   // independent scalar to the -2LL) when the inner solves are thread-safe: no
   // mixture (expanded pseudo-subjects share solve rows) and no multi-endpoint
@@ -489,7 +493,7 @@ void impComputeCov(Environment e) {
       H = 0.5 * (H + H.t()); // guard against tiny numerical asymmetry
       arma::mat Sigma; double ldv, lds;
       if (arma::inv_sympd(Sigma, H) && arma::log_det(ldv, lds, H) && lds > 0) {
-        Sigma *= gamma;
+        Sigma *= gammaVec[id];
         arma::mat L;
         if (arma::chol(L, Sigma, "lower")) {
           Hs[id] = H; Ls[id] = L; logDetH[id] = ldv; ok[id] = 1;
@@ -571,6 +575,8 @@ void impComputeCov(Environment e) {
 #endif
       if (ok[id]) {
         impForceResolve(id);
+        // This subject's converged proposal scale (all equal under "global").
+        double invGamma2 = 1.0 / (2.0 * gammaVec[id]);
         arma::vec q(isample); int nGood = 0;
         for (int k = 0; k < isample; ++k) {
           arma::vec eta = Ss[id].row(k).t();
@@ -583,7 +589,7 @@ void impComputeCov(Environment e) {
           double qmax = q.max();
           double sumw = arma::accu(arma::exp(q - qmax));
           double logMeanExp = qmax + std::log(sumw / (double)isample);
-          double Ci = negHalfLogDetOmega + 0.5 * neta * std::log(gamma) - 0.5 * logDetH[id];
+          double Ci = negHalfLogDetOmega + 0.5 * neta * std::log(gammaVec[id]) - 0.5 * logDetH[id];
           objBuf[id] = -2.0 * (logMeanExp + Ci);
         }
       }
@@ -692,10 +698,17 @@ void impOuter(Environment e) {
   // holding it as a vector is what lets a per-subject controller drive the
   // elements apart without touching the E-step again.
   arma::vec gammaVec(nExp); gammaVec.fill(gamma);
-  // gammaMethod="individual": NONMEM's per-subject rule (NM7 eq. 1.90 and the
-  // note after 1.76) -- each subject's gamma_i is adapted two-sided so that its
-  // own xi_i approaches iaccept.  Otherwise the legacy global rule drives one
-  // shared scale off the MEAN Kish effective-sample fraction.
+  // gammaMethod="individual": each subject's gamma_i is adapted two-sided so
+  // that its own xi_i approaches iaccept.  Otherwise the legacy global rule
+  // drives one shared scale off the MEAN Kish effective-sample fraction.
+  //
+  // NONMEM specifies the OBJECTIVE of this loop but not its update law.  The
+  // NM7 Technical Guide gives the target ("gamma is continually adjusted so
+  // that xi_i approximates IACCEPT", note after eq. 1.76), the per-subject
+  // granularity (gamma_i in eq. 1.90; "adjusted for each subject" at 1.474),
+  // and the [ISCALE_MIN, ISCALE_MAX] bounds -- and nothing further.  The
+  // functional form below (multiplicative, exponent 2/neta, symmetric cap) is
+  // ours; the guide publishes no formula to copy.
   bool gammaInd = impGammaIndividual();
   // Largest relative per-step change the controller applied last iteration;
   // starts large so convergence cannot trip before the controller has run.
@@ -960,7 +973,7 @@ void impOuter(Environment e) {
     // per-step cap and clamped to [iscaleMin, iscaleMax].  The importance weights
     // correct for gamma, so this changes only the variance, not the estimates.
     if (gammaInd) {
-      // NONMEM's per-subject rule.  xi_i falls monotonically as the proposal
+      // xi_i falls monotonically as the proposal
       // widens, so xi_i ABOVE the target means subject i's proposal is too
       // narrow for its posterior (the heavy-tail case) and gamma_i must grow;
       // xi_i below target means it is needlessly over-dispersed and gamma_i
@@ -980,11 +993,12 @@ void impOuter(Environment e) {
       // oscillates gamma 1.32/1.24/1.30/1.23... and xi 0.36/0.45/0.37/0.46...
       // indefinitely.  Models with 8+ random effects are ordinary here.
       //
-      // p = 2/neta gives lambda = 0: the Newton step for the Gaussian case,
-      // stable for every dimension, and one-step convergent when the posterior
-      // really is Gaussian.  The symmetric 1.25x cap still bounds a single
-      // noisy iteration.  Weights correct for gamma, so this moves variance,
-      // not the estimates.
+      // p = 2/neta gives lambda = 0 at every dimension.  This is not tuned
+      // damping: xi = gamma^(-neta/2) inverts exactly, so
+      // gamma * (xi/target)^(2/neta) IS the analytic solve for the gamma that
+      // hits the target -- a FIXED exponent is the thing that needs justifying.
+      // The symmetric 1.25x cap still bounds a single noisy iteration.  Weights
+      // correct for gamma, so this moves variance, not the estimates.
       const double pExp = 2.0 / std::max(1.0, (double)neta);
       const double capUp = 1.25, capDn = 1.0 / 1.25;
       double maxStep = 0.0;
@@ -1034,7 +1048,7 @@ void impOuter(Environment e) {
   // Monte-Carlo observed-information covariance (theta block) at the converged
   // estimate, before the inner neqOverride is cleared (the inner solves use it).
   // Selected by impmapControl(covMethod="imp") (the default).
-  if (impCovEnabled()) impComputeCov(e);
+  if (impCovEnabled()) impComputeCov(e, gammaVec);
 
   // Clear the multi-endpoint inner neqOverride so it does not leak into a later fit.
   impClearInnerNeqOverride();

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -126,6 +126,7 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
                      int iter, double negHalfLogDetOmega, bool isImp,
                      arma::mat& condMean, std::vector<arma::mat>& condVar,
                      arma::vec& Li, arma::vec& Neff, arma::vec& Xi,
+                     arma::vec& XiExpOut,
                      std::vector<arma::mat>& outS, std::vector<arma::vec>& outZk,
                      arma::mat& aMat, Environment* eStash,
                      uint32_t qrPinSeed) {
@@ -414,6 +415,11 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
     }
   }
 
+  // Per-EXPANDED-subject xi, which is what the individual-gamma controller
+  // drives (one gamma_i per expanded subject).  `Xi` above is the
+  // responsibility-combined per-base-subject value used for reporting.
+  XiExpOut = XiExp;
+
   // On the last iteration, stash the per-subject sampler diagnostics (first
   // component for a mixture).
   if (eStash != nullptr) {
@@ -672,7 +678,7 @@ void impOuter(Environment e) {
   std::vector<arma::mat> condVar;
   std::vector<arma::mat> sampS;
   std::vector<arma::vec> sampZk;
-  arma::vec Li, Neff, Xi;
+  arma::vec Li, Neff, Xi, XiExp;
   arma::mat aMat;                 // posterior mixture responsibilities (nsub x Nmix)
   int Nmix = impNmix();
   int nExp = nsub * Nmix;         // expanded pseudo-subjects for the mixture E/M-step
@@ -686,6 +692,14 @@ void impOuter(Environment e) {
   // holding it as a vector is what lets a per-subject controller drive the
   // elements apart without touching the E-step again.
   arma::vec gammaVec(nExp); gammaVec.fill(gamma);
+  // gammaMethod="individual": NONMEM's per-subject rule (NM7 eq. 1.90 and the
+  // note after 1.76) -- each subject's gamma_i is adapted two-sided so that its
+  // own xi_i approaches iaccept.  Otherwise the legacy global rule drives one
+  // shared scale off the MEAN Kish effective-sample fraction.
+  bool gammaInd = impGammaIndividual();
+  // Largest relative per-step change the controller applied last iteration;
+  // starts large so convergence cannot trip before the controller has run.
+  double gammaStepPrev = R_PosInf;
 
   // Force the EM serial when the per-subject inner solves are not thread-safe:
   //  (a) mixtures -- the expanded pseudo-subjects' per-component solves race and
@@ -736,11 +750,13 @@ void impOuter(Environment e) {
     if (iter > 0 && !isImp) impReMap();
     // Stash the E-step diagnostics on every iteration so the fit environment
     // reflects the last iteration actually run (the loop may stop early).
-    // Global rule: every expanded subject shares the scalar scale.  (The
-    // per-subject controller replaces this fill with its own per-element update.)
-    gammaVec.fill(gamma);
+    // Global rule: every expanded subject shares the scalar scale.  Under
+    // "individual" gammaVec already carries the per-subject scales the
+    // controller set at the end of the previous iteration (and the constructor
+    // fill for iteration 0), so it must NOT be flattened here.
+    if (!gammaInd) gammaVec.fill(gamma);
     impEStep(nsub, neta, isample, gammaVec, cores, iter, impLogDetOmegaInv5(), isImp,
-             condMean, condVar, Li, Neff, Xi, sampS, sampZk, aMat, &e, qrPinSeed);
+             condMean, condVar, Li, Neff, Xi, XiExp, sampS, sampZk, aMat, &e, qrPinSeed);
     obj = 0.0;
     for (int id = 0; id < nsub; ++id) if (R_finite(Li[id])) obj += 2.0 * Li[id];
     // Mean effective-sample fraction (importance-sampling "acceptance ratio").
@@ -753,6 +769,10 @@ void impOuter(Environment e) {
     for (int id = 0; id < nsub; ++id)
       if (R_finite(Xi[id])) { xiMean += Xi[id]; ++nXi; }
     if (nXi > 0) xiMean /= (double)nXi; else xiMean = NA_REAL;
+    // `gamma` is the scalar summary of the scale actually used this iteration:
+    // itself under "global", the mean of the per-subject scales under
+    // "individual".  It is what gets traced and reported as impGammaUsed.
+    if (gammaInd) gamma = arma::mean(gammaVec);
     objTrace.push_back(obj);
     gammaTrace.push_back(gamma);
     neffTrace.push_back(accFrac);
@@ -920,7 +940,13 @@ void impOuter(Environment e) {
       // not a precision requirement (the objMetric gate carries the precision).
       double parTol = 0.02;
       double gWin0 = gammaTrace[n - nConvWindow - 1];
-      bool gammaStable = std::fabs(gamma - gWin0) <= 1e-3 * std::max(1.0, gWin0);
+      // Under "individual" the traced scalar is a MEAN, so offsetting moves
+      // across subjects could look settled while individual scales are still
+      // swinging.  Gate on the largest per-subject step the controller actually
+      // applied instead, which cannot be masked that way.
+      bool gammaStable = gammaInd
+        ? (gammaStepPrev <= 1e-3)
+        : (std::fabs(gamma - gWin0) <= 1e-3 * std::max(1.0, gWin0));
       if (gammaStable && objMetric < ctol && parMetric < parTol) { converged = true; break; }
     }
 
@@ -933,7 +959,43 @@ void impOuter(Environment e) {
     // drops below the floor (heavy-tailed/skewed posterior), with a gentle
     // per-step cap and clamped to [iscaleMin, iscaleMax].  The importance weights
     // correct for gamma, so this changes only the variance, not the estimates.
-    if (iaccept > 0 && accFrac > 0 && accFrac < iaccept) {
+    if (gammaInd) {
+      // NONMEM's per-subject rule.  xi_i falls monotonically as the proposal
+      // widens, so xi_i ABOVE the target means subject i's proposal is too
+      // narrow for its posterior (the heavy-tail case) and gamma_i must grow;
+      // xi_i below target means it is needlessly over-dispersed and gamma_i
+      // shrinks.  Two-sided, so a bad early iteration is not paid for forever.
+      //
+      // The sqrt damps the step (xi is not linear in gamma) and the symmetric
+      // 1.25x cap keeps one noisy iteration from slamming a subject into a
+      // bound.  Weights correct for gamma, so this moves variance, not the
+      // estimates.
+      const double capUp = 1.25, capDn = 1.0 / 1.25;
+      double maxStep = 0.0;
+      for (int id = 0; id < nExp; ++id) {
+        double xiId = XiExp[id];
+        if (ISNAN(xiId)) continue;      // no usable xi (dead subject): leave alone
+        double fac;
+        if (!R_finite(xiId)) {
+          fac = capUp;                  // xi = +Inf: as under-dispersed as it gets
+        } else if (xiId <= 0.0) {
+          fac = capDn;                  // xi = 0: proposal far too wide
+        } else {
+          fac = std::sqrt(xiId / iaccept);
+          if (fac > capUp) fac = capUp;
+          else if (fac < capDn) fac = capDn;
+        }
+        double g = gammaVec[id] * fac;
+        if (g < iscaleMin) g = iscaleMin;
+        if (g > iscaleMax) g = iscaleMax;
+        // Measure the step actually taken (after clamping) so a subject pinned
+        // at a bound reads as settled rather than as perpetually moving.
+        double applied = (gammaVec[id] > 0.0) ? std::fabs(g / gammaVec[id] - 1.0) : 0.0;
+        if (applied > maxStep) maxStep = applied;
+        gammaVec[id] = g;
+      }
+      gammaStepPrev = maxStep;
+    } else if (iaccept > 0 && accFrac > 0 && accFrac < iaccept) {
       double fac = std::sqrt(iaccept / accFrac);
       if (fac > 1.25) fac = 1.25;
       gamma *= fac;
@@ -969,6 +1031,10 @@ void impOuter(Environment e) {
   e["impLi"]       = wrap(Li);
   e["impNeff"]     = wrap(Neff);
   e["impXi"]       = wrap(Xi);
+  // Per-expanded-subject proposal scales actually used, and which controller
+  // produced them.  Under "global" every element equals impGammaUsed.
+  e["impGammaInd"] = wrap(gammaVec);
+  e["impGammaMethod"] = gammaInd ? "individual" : "global";
   e["impObj"]      = obj;
   e["impGammaUsed"] = gamma;
   e["impNsample"]  = isample;

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -187,7 +187,14 @@ NumericMatrix impQrPoints_(int isample, int neta, Nullable<NumericVector> shift)
 // a mixture's components each get their own scale.  Under gammaMethod="global"
 // every element holds the same value and this is arithmetically identical to the
 // previous scalar gamma; the per-subject controller is what makes them diverge.
-static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
+// isampleVec carries one sample count per EXPANDED subject.  Under the classic
+// (scalar) setting every entry is the same and this is arithmetically identical
+// to the previous fixed-count E-step; per-subject counts let a badly covered
+// subject buy more samples without charging every other subject for them, which
+// is the NM7 Technical Guide's own mechanism (its derivation is Gaussian
+// throughout and never mentions a t proposal).
+static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
+                     const arma::vec& gammaVec,
                      double df, int cores,
                      int iter, double negHalfLogDetOmega, bool isImp,
                      arma::mat& condMean, std::vector<arma::mat>& condVar,
@@ -293,7 +300,7 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
   bool qrRefresh = impQrRefreshEnabled();
   arma::mat qrU0, qrZ0;
   if (qr) {
-    qrU0 = impSobolU0(isample, neta);
+    qrU0 = impSobolU0((int)isampleVec.max(), neta);
     if (!qrShift) qrZ0 = impQrZ(qrU0, nullptr);
   }
   // Parallelize over base subjects, iterating a subject's mixture components
@@ -318,7 +325,8 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
       // This subject's own proposal scale (all equal under gammaMethod="global").
       double gammaId = gammaVec[id];
       double dfId = df;   // proposal degrees of freedom; 0 = Gaussian
-      arma::mat S(isample, neta);
+      int nsId = (int)isampleVec[id];   // this subject's sample count
+      arma::mat S(nsId, neta);
       if (qr) {
         // Sobol points -> N(0,I) -> proposal.  With qrShift the shift comes
         // from this subject's seeded stream; qrRefresh=FALSE instead uses the
@@ -333,7 +341,7 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
         } else {
           Z = qrZ0;
         }
-        for (int k = 0; k < isample; ++k) {
+        for (int k = 0; k < nsId; ++k) {
           // Quasi-random t: the Sobol point supplies the Gaussian direction and
           // a fresh uniform supplies the chi-square scale.  (A fully
           // quasi-random t would need an extra Sobol coordinate; this keeps the
@@ -342,7 +350,7 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
           S.row(k) = (modes[id] + cholL[id] * (Z.row(k).t() * ts)).t();
         }
       } else {
-        for (int k = 0; k < isample; ++k) {
+        for (int k = 0; k < nsId; ++k) {
           arma::vec z(neta);
           for (int jj = 0; jj < neta; ++jj) z[jj] = rxNormEng(0.0, 1.0);
           double ts = impTScale(dfId);
@@ -370,9 +378,9 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
       // log importance weights.  impEvalJointLik returns the NEGATIVE log joint
       // density (minimized by the inner optimizer), so it enters with a minus;
       // the proposal density is subtracted, contributing +(1/(2 gamma)) d'H d.
-      arma::vec q(isample);
+      arma::vec q(nsId);
       int nGood = 0;
-      for (int k = 0; k < isample; ++k) {
+      for (int k = 0; k < nsId; ++k) {
         arma::vec eta = S.row(k).t();
         arma::vec d = eta - modes[id];
         double qk = -impEvalJointLik(eta, id) +
@@ -394,7 +402,7 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
       outS[id] = S;
       outZk[id] = zk;
       okExp[id] = 1;
-      double logMeanExp = qmax + std::log(sumw / (double)isample);
+      double logMeanExp = qmax + std::log(sumw / (double)nsId);
       double Ci = negHalfLogDetOmega + 0.5 * neta * std::log(gammaId) -
         0.5 * logDetH[id] + impCiTCorrection(dfId, neta);
       LiExp[id] = -(logMeanExp + Ci);          // per-component negative log-likelihood
@@ -404,7 +412,7 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
       arma::rowvec pbar = zk.t() * S;
       cmExp.row(id) = pbar;
       arma::mat B(neta, neta, arma::fill::zeros);
-      for (int k = 0; k < isample; ++k) {
+      for (int k = 0; k < nsId; ++k) {
         arma::rowvec dr = S.row(k) - pbar;
         B += zk[k] * (dr.t() * dr);
       }
@@ -783,6 +791,23 @@ void impOuter(Environment e) {
   // holding it as a vector is what lets a per-subject controller drive the
   // elements apart without touching the E-step again.
   arma::vec gammaVec(nExp); gammaVec.fill(gamma);
+  // Per-expanded-subject sample count.  Uniform unless AUTO raises it for a
+  // badly covered subject; holding it as a vector is what lets that happen
+  // without charging every other subject for the extra samples.
+  arma::ivec isampleVec(nExp); isampleVec.fill(isample);
+  {
+    // A per-subject isample= vector is given per BASE subject; tile it across
+    // the mixture's expanded pseudo-subjects so component j of subject i gets
+    // subject i's count.
+    std::vector<int> isv;
+    impNsampleVecGet(isv);
+    if ((int)isv.size() == nsub) {
+      for (int i = 0; i < nsub; ++i) {
+        int v = isv[i] < 1 ? 1 : isv[i];
+        for (int j = 0; j < Nmix; ++j) isampleVec[i + j * nsub] = v;
+      }
+    }
+  }
   // gammaMethod="individual": each subject's gamma_i is adapted two-sided so
   // that its own xi_i approaches iaccept.  Otherwise the legacy global rule
   // drives one shared scale off the MEAN Kish effective-sample fraction.
@@ -820,7 +845,8 @@ void impOuter(Environment e) {
   uint32_t qrPinSeed = (uint32_t)impBaseSeed() + 0x9E3779B1u;
   // Salted base for the SIR stratified offsets; SIR only engages when it can
   // shrink the sample (sirN < isample) so every other path is unchanged.
-  bool sir = impSirEnabled() && impSirN() < isample;
+  // SIR only engages where it actually shrinks that subject's sample.
+  bool sir = impSirEnabled();
   int sirN = impSirN();
   uint32_t sirSeed = (uint32_t)impBaseSeed() + 0x7F4A7C15u;
 
@@ -853,14 +879,14 @@ void impOuter(Environment e) {
     // controller set at the end of the previous iteration (and the constructor
     // fill for iteration 0), so it must NOT be flattened here.
     if (!gammaInd) gammaVec.fill(gamma);
-    impEStep(nsub, neta, isample, gammaVec, impDf(), cores, iter, impLogDetOmegaInv5(), isImp,
+    impEStep(nsub, neta, isampleVec, gammaVec, impDf(), cores, iter, impLogDetOmegaInv5(), isImp,
              condMean, condVar, Li, Neff, Xi, XiExp, sampS, sampZk, aMat, &e, qrPinSeed);
     obj = 0.0;
     for (int id = 0; id < nsub; ++id) if (R_finite(Li[id])) obj += 2.0 * Li[id];
     // Mean effective-sample fraction (importance-sampling "acceptance ratio").
     double accFrac = 0.0; int nAcc = 0;
     for (int id = 0; id < nsub; ++id)
-      if (R_finite(Neff[id])) { accFrac += Neff[id] / (double)isample; ++nAcc; }
+      if (R_finite(Neff[id])) { accFrac += Neff[id] / (double)isampleVec[id]; ++nAcc; }
     if (nAcc > 0) accFrac /= (double)nAcc;
     // Mean NONMEM-style xi (a DIFFERENT statistic from accFrac -- see impEStep).
     double xiMean = 0.0; int nXi = 0;
@@ -1153,6 +1179,7 @@ void impOuter(Environment e) {
   e["impObj"]      = obj;
   e["impGammaUsed"] = gamma;
   e["impNsample"]  = isample;
+  e["impNsampleInd"] = wrap(isampleVec);   // per-expanded-subject counts
   e["impQr"]       = impQrEnabled();
   e["impSir"]      = impSirEnabled();
   e["impSirSample"] = impSirN();

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -879,6 +879,7 @@ void impOuter(Environment e) {
   // for the next iteration, so anything consuming "the converged proposal" must
   // read the snapshot rather than the live vector -- including impComputeCov.
   arma::vec gammaUsed(nExp); gammaUsed.fill(gamma);
+  double gammaScalarUsed = gamma;   // scalar counterpart of gammaUsed
   // Per-expanded-subject proposal df and acceptance target.  Uniform unless
   // AUTO differentiates them.
   arma::vec dfVec(nExp); dfVec.fill(impDf());
@@ -1035,6 +1036,7 @@ void impOuter(Environment e) {
     isampleUsed = isampleVec;
     dfUsed = dfVec;
     gammaUsed = gammaVec;
+    gammaScalarUsed = gamma;
     impEStep(nsub, neta, isampleVec, gammaVec, dfVec, cores, iter, impLogDetOmegaInv5(), isImp,
              condMean, condVar, Li, Neff, Xi, XiExp, KhatExp, sampS, sampZk, aMat, &e, qrPinSeed);
     obj = 0.0;
@@ -1420,7 +1422,11 @@ void impOuter(Environment e) {
   e["impGammaInd"] = wrap(gammaUsed);
   e["impGammaMethod"] = gammaInd ? "individual" : "global";
   e["impObj"]      = obj;
-  e["impGammaUsed"] = gamma;
+  // Snapshot, so the scalar cannot disagree with the impGammaInd vector: under
+  // gammaMethod="global" the scalar gamma is adapted at the END of the loop for
+  // an iteration that never runs, which would report gamma_start*fac here
+  // against gamma_start in the vector.
+  e["impGammaUsed"] = gammaScalarUsed;
   e["impNsample"]  = isample;
   e["impNsampleInd"] = wrap(isampleUsed);  // counts USED by the last E-step
   e["impDfInd"]    = wrap(dfUsed);          // df USED by the last E-step

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -424,15 +424,25 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
   // component for a mixture).
   if (eStash != nullptr) {
     arma::mat modeMat(nsub, neta);
-    List hessList(nsub), samplesList(nsub);
+    List hessList(nsub), samplesList(nsub), weightList(nsub);
     for (int id = 0; id < nsub; ++id) {
       modeMat.row(id) = modes[id].t();
       hessList[id] = haveL[id] ? wrap(Hs[id]) : R_NilValue;
       samplesList[id] = wrap(outS[id]);
+      // Normalized importance weights, kept so a TAIL-sensitive diagnostic
+      // (Pareto k-hat) can be computed post-fit.  xi and the Kish ESS are both
+      // means over samples drawn FROM the proposal, so both are structurally
+      // blind to tails the proposal never visits -- which is the failure mode a
+      // heavier-tailed (t) proposal exists to prevent.  k-hat estimates the
+      // tail index of the weight distribution and does see it.  Pareto k-hat is
+      // scale-invariant, so the mixture responsibility folded into these
+      // weights above does not affect it.
+      weightList[id] = wrap(outZk[id]);
     }
     (*eStash)["impEtaMode"] = wrap(modeMat);
     (*eStash)["impEtaHess"] = hessList;
     (*eStash)["impSamples"] = samplesList;
+    (*eStash)["impWeights"] = weightList;
   }
 }
 

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -949,8 +949,19 @@ void impOuter(Environment e) {
     bool nonNormal = impAutoNonNormal();
     for (int i = 0; i < nsub; ++i) {
       bool sparse = impNobs(i) < neta;
-      double dfI = (sparse || nonNormal) ? 4.0 : 0.0;
-      double iaI = (sparse || nonNormal) ? 0.2 : iaccept;
+      // TUNED: start at a MILD t (df 20) rather than the heaviest.  df 20 was
+      // measured to clear every failing subject on theophylline for 0.25% of
+      // the effective sample size, whereas df 4 costs far more Monte-Carlo
+      // noise for no extra tail benefit.  The k-hat escalation below drops it
+      // further only on evidence.
+      double dfI = (sparse || nonNormal) ? 20.0 : 0.0;
+      // TUNED: iaccept is left alone here.  Lowering it to 0.2 forces gamma
+      // wide, and widening a Gaussian is the lever measured NOT to fix tails
+      // while costing a lot of ESS -- on a Poisson fixture whose k-hat was
+      // already -1.33 (no failure at all) it cut ESS 0.549 -> 0.412 and
+      // doubled the objective noise for nothing.  It is now applied only where
+      // k-hat says the proposal is genuinely struggling (below).
+      double iaI = iaccept;
       for (int j = 0; j < Nmix; ++j) {
         dfVec[i + j * nsub] = dfI;
         iacceptVec[i + j * nsub] = iaI;
@@ -1033,8 +1044,17 @@ void impOuter(Environment e) {
       for (int id = 0; id < nExp; ++id) {
         double kh = KhatExp[id];
         if (!R_finite(kh) || kh <= 0.7) continue;
-        if (dfVec[id] <= 0.0)      dfVec[id] = 8.0;   // Gaussian -> moderately heavy
-        else if (dfVec[id] > 4.0)  dfVec[id] = 4.0;   // -> heaviest used here
+        // TUNED ladder: Gaussian -> mild -> moderate -> heavy, so each step is
+        // the smallest that might work.  Heavier tails buy tail reliability at
+        // the price of Monte-Carlo noise, so overshooting costs precision.
+        if (dfVec[id] <= 0.0)       dfVec[id] = 20.0;
+        else if (dfVec[id] > 8.0)   dfVec[id] = 8.0;
+        else if (dfVec[id] > 4.0)   dfVec[id] = 4.0;
+        else if (iacceptVec[id] > 0.2) {
+          // tails already as heavy as this ladder goes and still failing: now
+          // fall back to the tutorial's IACCEPT ~ 0.2, which widens gamma
+          iacceptVec[id] = 0.2;
+        }
       }
     }
 

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -16,6 +16,7 @@
 #include <RcppArmadillo.h>
 #include <rxode2ptr.h>
 #include <boost/random/sobol.hpp>
+#include <boost/math/distributions/chi_squared.hpp>
 #include <ctime>
 #include "nmMcmcRng.h"
 #include "imp.h"
@@ -58,6 +59,71 @@ static arma::mat impQrZ(const arma::mat& U0, const arma::vec* shift) {
     }
   }
   return Z;
+}
+
+// ---- multivariate-t proposal (NONMEM DF) -----------------------------------
+// A Gaussian proposal scaled by gamma can only be made WIDER, never
+// heavier-tailed, and importance weights blow up (infinite variance) when the
+// proposal's tails are lighter than the target's -- a failure Pareto k-hat
+// detects and xi/Kish ESS cannot.  Switching the proposal to a multivariate t
+// with `df` degrees of freedom fixes the SHAPE: t tails are polynomial, so for
+// small df they dominate any Gaussian target tail.  df = 0 means "Gaussian",
+// the historical path.
+//
+// Only rxNormEng/rxUnifEng are available on the thread-safe engine, so the
+// chi-square is drawn by INVERSE CDF from a single uniform, using boost's
+// quantile function.  Inverse CDF rather than a rejection sampler
+// (Marsaglia-Tsang) on purpose: a rejection loop consumes a VARIABLE number of
+// draws, so the stream position would depend on the accept/reject history and
+// the fit would stop being reproducible under any change that shifts it.  One
+// uniform in, one chi-square out, and it works for any real df > 0.  It also
+// makes the quasi-random path natural -- a Sobol coordinate can feed it
+// directly.
+static inline double impChisqQuantile(double u, double df) {
+  if (u <= 0.0) u = 1e-12;
+  if (u >= 1.0) u = 1.0 - 1e-12;
+  return boost::math::quantile(boost::math::chi_squared_distribution<double>(df), u);
+}
+
+// Scale factor turning a standard normal vector into a multivariate-t one:
+// t = z * sqrt(df / chisq_df).  df <= 0 -> 1 (Gaussian: no scaling and NO
+// uniform drawn, so the Gaussian path consumes exactly the stream it always
+// did and stays bit-identical).
+static inline double impTScale(double df) {
+  if (df <= 0.0) return 1.0;
+  double w = impChisqQuantile(rxUnifEng(0.0, 1.0), df);
+  if (!(w > 0.0) || !R_finite(w)) return 1.0;
+  return std::sqrt(df / w);
+}
+
+// Same, but from a supplied uniform (quasi-random path).
+static inline double impTScaleU(double u, double df) {
+  if (df <= 0.0) return 1.0;
+  double w = impChisqQuantile(u, df);
+  if (!(w > 0.0) || !R_finite(w)) return 1.0;
+  return std::sqrt(df / w);
+}
+
+// Log of the peak-normalized proposal kernel's RECIPROCAL, i.e. the term that
+// enters the log importance weight q_k.  Gaussian: d'Hd/(2 gamma).
+// t: ((df+p)/2) * log1p(d'Hd/(gamma*df)).  Both are 0 at d = 0.
+static inline double impLogKernelRecip(double quad, double gammaId, double df, int p) {
+  // NB the Gaussian branch reproduces the original operation order exactly --
+  // (1/(2*gamma)) * quad, not quad/(2*gamma).  They differ in the last bits,
+  // and est="imp" (whose quadratic form has a different magnitude) shows the
+  // reassociation as ~1e-10 drift, which would break the bit-identity contract
+  // this branch has held to at every step.
+  if (df <= 0.0) return (1.0 / (2.0 * gammaId)) * quad;
+  return 0.5 * (df + (double)p) * std::log1p(quad / (gammaId * df));
+}
+
+// Additive correction to the Gaussian normalizer Ci when a t proposal is used:
+//   (p/2) log(df/2) + lgamma(df/2) - lgamma((df+p)/2)
+// -> 0 as df -> Inf (Gamma(x+a)/Gamma(x) ~ x^a), recovering the Gaussian.
+static inline double impCiTCorrection(double df, int p) {
+  if (df <= 0.0) return 0.0;
+  return 0.5 * (double)p * std::log(0.5 * df) +
+    std::lgamma(0.5 * df) - std::lgamma(0.5 * (df + (double)p));
 }
 
 // ---- SIR (sampling-importance-resampling) element ---------------------------
@@ -122,7 +188,7 @@ NumericMatrix impQrPoints_(int isample, int neta, Nullable<NumericVector> shift)
 // every element holds the same value and this is arithmetically identical to the
 // previous scalar gamma; the per-subject controller is what makes them diverge.
 static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
-                     int cores,
+                     double df, int cores,
                      int iter, double negHalfLogDetOmega, bool isImp,
                      arma::mat& condMean, std::vector<arma::mat>& condVar,
                      arma::vec& Li, arma::vec& Neff, arma::vec& Xi,
@@ -251,7 +317,7 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
       if (!haveL[id]) continue;
       // This subject's own proposal scale (all equal under gammaMethod="global").
       double gammaId = gammaVec[id];
-      double invGamma2 = 1.0 / (2.0 * gammaId);
+      double dfId = df;   // proposal degrees of freedom; 0 = Gaussian
       arma::mat S(isample, neta);
       if (qr) {
         // Sobol points -> N(0,I) -> proposal.  With qrShift the shift comes
@@ -268,13 +334,19 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
           Z = qrZ0;
         }
         for (int k = 0; k < isample; ++k) {
-          S.row(k) = (modes[id] + cholL[id] * Z.row(k).t()).t();
+          // Quasi-random t: the Sobol point supplies the Gaussian direction and
+          // a fresh uniform supplies the chi-square scale.  (A fully
+          // quasi-random t would need an extra Sobol coordinate; this keeps the
+          // low-discrepancy structure where it does the most good.)
+          double ts = impTScale(dfId);
+          S.row(k) = (modes[id] + cholL[id] * (Z.row(k).t() * ts)).t();
         }
       } else {
         for (int k = 0; k < isample; ++k) {
           arma::vec z(neta);
           for (int jj = 0; jj < neta; ++jj) z[jj] = rxNormEng(0.0, 1.0);
-          S.row(k) = (modes[id] + cholL[id] * z).t();
+          double ts = impTScale(dfId);
+          S.row(k) = (modes[id] + cholL[id] * (z * ts)).t();
         }
       }
       // NONMEM-style xi (NM7 eq. 1.73/1.75): the mean importance weight
@@ -304,7 +376,7 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
         arma::vec eta = S.row(k).t();
         arma::vec d = eta - modes[id];
         double qk = -impEvalJointLik(eta, id) +
-          invGamma2 * arma::as_scalar(d.t() * Hs[id] * d);
+          impLogKernelRecip(arma::as_scalar(d.t() * Hs[id] * d), gammaId, dfId, neta);
         // A proposal sample whose inner solve fails (NA/NaN, even after the
         // FOCEI tolerance-relaxation retry) is dropped from the weighted mean by
         // giving it -Inf log-weight (weight 0).
@@ -324,7 +396,7 @@ static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
       okExp[id] = 1;
       double logMeanExp = qmax + std::log(sumw / (double)isample);
       double Ci = negHalfLogDetOmega + 0.5 * neta * std::log(gammaId) -
-        0.5 * logDetH[id];
+        0.5 * logDetH[id] + impCiTCorrection(dfId, neta);
       LiExp[id] = -(logMeanExp + Ci);          // per-component negative log-likelihood
       NeffExp[id] = 1.0 / arma::accu(arma::square(zk));
       // NONMEM xi: mean weight normalized to the proposal center (see above).
@@ -586,20 +658,23 @@ void impComputeCov(Environment e, const arma::vec& gammaVec) {
       if (ok[id]) {
         impForceResolve(id);
         // This subject's converged proposal scale (all equal under "global").
-        double invGamma2 = 1.0 / (2.0 * gammaVec[id]);
+        // Must use the SAME proposal shape (df) as the E-step or the reweighted
+        // objective is not the one the fit converged on.
+        double dfCov = impDf();
         arma::vec q(isample); int nGood = 0;
         for (int k = 0; k < isample; ++k) {
           arma::vec eta = Ss[id].row(k).t();
           arma::vec d = eta - modes[id];
           double qk = -impEvalJointLik(eta, id) +
-            invGamma2 * arma::as_scalar(d.t() * Hs[id] * d);
+            impLogKernelRecip(arma::as_scalar(d.t() * Hs[id] * d), gammaVec[id], dfCov, neta);
           if (R_finite(qk)) { q[k] = qk; ++nGood; } else q[k] = R_NegInf;
         }
         if (nGood != 0) {
           double qmax = q.max();
           double sumw = arma::accu(arma::exp(q - qmax));
           double logMeanExp = qmax + std::log(sumw / (double)isample);
-          double Ci = negHalfLogDetOmega + 0.5 * neta * std::log(gammaVec[id]) - 0.5 * logDetH[id];
+          double Ci = negHalfLogDetOmega + 0.5 * neta * std::log(gammaVec[id]) - 0.5 * logDetH[id]
+            + impCiTCorrection(dfCov, neta);
           objBuf[id] = -2.0 * (logMeanExp + Ci);
         }
       }
@@ -778,7 +853,7 @@ void impOuter(Environment e) {
     // controller set at the end of the previous iteration (and the constructor
     // fill for iteration 0), so it must NOT be flattened here.
     if (!gammaInd) gammaVec.fill(gamma);
-    impEStep(nsub, neta, isample, gammaVec, cores, iter, impLogDetOmegaInv5(), isImp,
+    impEStep(nsub, neta, isample, gammaVec, impDf(), cores, iter, impLogDetOmegaInv5(), isImp,
              condMean, condVar, Li, Neff, Xi, XiExp, sampS, sampZk, aMat, &e, qrPinSeed);
     obj = 0.0;
     for (int id = 0; id < nsub; ++id) if (R_finite(Li[id])) obj += 2.0 * Li[id];

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -117,14 +117,18 @@ NumericMatrix impQrPoints_(int isample, int neta, Nullable<NumericVector> shift)
 // conditional mean, variance, objective contribution, and effective sample
 // size.  `iter` shifts the per-subject RNG stream so successive iterations use
 // fresh (still thread-count-independent) samples.
-static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
+// gammaVec carries ONE proposal scale per EXPANDED subject (id = i + j*nsub), so
+// a mixture's components each get their own scale.  Under gammaMethod="global"
+// every element holds the same value and this is arithmetically identical to the
+// previous scalar gamma; the per-subject controller is what makes them diverge.
+static void impEStep(int nsub, int neta, int isample, const arma::vec& gammaVec,
+                     int cores,
                      int iter, double negHalfLogDetOmega, bool isImp,
                      arma::mat& condMean, std::vector<arma::mat>& condVar,
                      arma::vec& Li, arma::vec& Neff, arma::vec& Xi,
                      std::vector<arma::mat>& outS, std::vector<arma::vec>& outZk,
                      arma::mat& aMat, Environment* eStash,
                      uint32_t qrPinSeed) {
-  double invGamma2 = 1.0 / (2.0 * gamma);
   int Nm = impNmix();
   int nExp = nsub * Nm; // expanded pseudo-subjects: component j (1-based) is i + (j-1)*nsub
 
@@ -154,6 +158,7 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
 #ifdef _OPENMP
     if (doParProp) setRxThreadId(omp_get_thread_num());
 #endif
+    double gammaId = gammaVec[id];
     if (isImp) {
       arma::vec eta(neta);
       impGetEta(id, eta);
@@ -169,7 +174,7 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
       double ldv, lds;
       if (arma::inv_sympd(Hi, Sig) && arma::log_det(ldv, lds, Hi) && lds > 0) {
         arma::mat L;
-        if (arma::chol(L, gamma * Sig, "lower")) {
+        if (arma::chol(L, gammaId * Sig, "lower")) {
           Hs[id] = Hi; logDetH[id] = ldv; cholL[id] = L; haveL[id] = 1;
         }
       }
@@ -184,7 +189,7 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
         if (arma::inv_sympd(Sigma, H) && arma::log_det(ldv, lds, H) && lds > 0) {
           Hs[id] = H;
           logDetH[id] = ldv;
-          Sigma *= gamma;
+          Sigma *= gammaId;
           arma::mat L;
           if (arma::chol(L, Sigma, "lower")) { cholL[id] = L; haveL[id] = 1; }
         }
@@ -243,6 +248,9 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
       nmSetSeedEng1(seed0 + (uint32_t)((iter * nExp + id) * 2));
       cmExp.row(id) = modes[id].t();
       if (!haveL[id]) continue;
+      // This subject's own proposal scale (all equal under gammaMethod="global").
+      double gammaId = gammaVec[id];
+      double invGamma2 = 1.0 / (2.0 * gammaId);
       arma::mat S(isample, neta);
       if (qr) {
         // Sobol points -> N(0,I) -> proposal.  With qrShift the shift comes
@@ -314,7 +322,7 @@ static void impEStep(int nsub, int neta, int isample, double gamma, int cores,
       outZk[id] = zk;
       okExp[id] = 1;
       double logMeanExp = qmax + std::log(sumw / (double)isample);
-      double Ci = negHalfLogDetOmega + 0.5 * neta * std::log(gamma) -
+      double Ci = negHalfLogDetOmega + 0.5 * neta * std::log(gammaId) -
         0.5 * logDetH[id];
       LiExp[id] = -(logMeanExp + Ci);          // per-component negative log-likelihood
       NeffExp[id] = 1.0 / arma::accu(arma::square(zk));
@@ -673,6 +681,11 @@ void impOuter(Environment e) {
   // est="imp": skip the per-iteration MAP search; the E-step proposal is centered
   // at the running conditional mean with covariance gamma*Omega.
   bool isImp = impIsImp();
+  // Per-expanded-subject proposal scale.  Under the current (global) rule every
+  // element tracks the scalar `gamma`, so the E-step arithmetic is unchanged;
+  // holding it as a vector is what lets a per-subject controller drive the
+  // elements apart without touching the E-step again.
+  arma::vec gammaVec(nExp); gammaVec.fill(gamma);
 
   // Force the EM serial when the per-subject inner solves are not thread-safe:
   //  (a) mixtures -- the expanded pseudo-subjects' per-component solves race and
@@ -723,7 +736,10 @@ void impOuter(Environment e) {
     if (iter > 0 && !isImp) impReMap();
     // Stash the E-step diagnostics on every iteration so the fit environment
     // reflects the last iteration actually run (the loop may stop early).
-    impEStep(nsub, neta, isample, gamma, cores, iter, impLogDetOmegaInv5(), isImp,
+    // Global rule: every expanded subject shares the scalar scale.  (The
+    // per-subject controller replaces this fill with its own per-element update.)
+    gammaVec.fill(gamma);
+    impEStep(nsub, neta, isample, gammaVec, cores, iter, impLogDetOmegaInv5(), isImp,
              condMean, condVar, Li, Neff, Xi, sampS, sampZk, aMat, &e, qrPinSeed);
     obj = 0.0;
     for (int id = 0; id < nsub; ++id) if (R_finite(Li[id])) obj += 2.0 * Li[id];

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -875,6 +875,10 @@ void impOuter(Environment e) {
   // which is impossible.
   arma::ivec isampleUsed(nExp); isampleUsed.fill(isample);
   arma::vec dfUsed(nExp); dfUsed.fill(impDf());   // df actually used last E-step
+  // Same for gamma.  The controllers all mutate their vectors AFTER the E-step,
+  // for the next iteration, so anything consuming "the converged proposal" must
+  // read the snapshot rather than the live vector -- including impComputeCov.
+  arma::vec gammaUsed(nExp); gammaUsed.fill(gamma);
   // Per-expanded-subject proposal df and acceptance target.  Uniform unless
   // AUTO differentiates them.
   arma::vec dfVec(nExp); dfVec.fill(impDf());
@@ -1030,6 +1034,7 @@ void impOuter(Environment e) {
     if (!gammaInd) gammaVec.fill(gamma);
     isampleUsed = isampleVec;
     dfUsed = dfVec;
+    gammaUsed = gammaVec;
     impEStep(nsub, neta, isampleVec, gammaVec, dfVec, cores, iter, impLogDetOmegaInv5(), isImp,
              condMean, condVar, Li, Neff, Xi, XiExp, KhatExp, sampS, sampZk, aMat, &e, qrPinSeed);
     obj = 0.0;
@@ -1393,7 +1398,11 @@ void impOuter(Environment e) {
   // Monte-Carlo observed-information covariance (theta block) at the converged
   // estimate, before the inner neqOverride is cleared (the inner solves use it).
   // Selected by impmapControl(covMethod="imp") (the default).
-  if (impCovEnabled()) impComputeCov(e, gammaVec, dfVec);
+  // Snapshots, not the live vectors: the adaptation steps have already moved
+  // gammaVec/dfVec on for an iteration that never ran, so passing them would
+  // evaluate the covariance at a proposal the fit never actually used (and
+  // disagree with the reported impDfInd / impGammaInd).
+  if (impCovEnabled()) impComputeCov(e, gammaUsed, dfUsed);
 
   // Clear the multi-endpoint inner neqOverride so it does not leak into a later fit.
   impClearInnerNeqOverride();
@@ -1408,7 +1417,7 @@ void impOuter(Environment e) {
   e["impXi"]       = wrap(Xi);
   // Per-expanded-subject proposal scales actually used, and which controller
   // produced them.  Under "global" every element equals impGammaUsed.
-  e["impGammaInd"] = wrap(gammaVec);
+  e["impGammaInd"] = wrap(gammaUsed);
   e["impGammaMethod"] = gammaInd ? "individual" : "global";
   e["impObj"]      = obj;
   e["impGammaUsed"] = gamma;

--- a/src/imp.h
+++ b/src/imp.h
@@ -165,7 +165,8 @@ void impUpdateStructThetas(const arma::vec& step);
 // Monte-Carlo observed-information covariance for the estimated thetas: FD
 // Hessian of the importance-sampling -2LL over fixed (common-random-number)
 // samples.  Stashes impCovTheta / impSeTheta / impCovThetaIdx on `e`.
-void impComputeCov(Rcpp::Environment e, const arma::vec& gammaVec);
+void impComputeCov(Rcpp::Environment e, const arma::vec& gammaVec,
+                   const arma::vec& dfVec);
 bool impCovProgress();                             // draw the cov-step progress bar?
 
 // Importance-sampling EM driver; called from foceiFitCpp_ when est=="impmap"

--- a/src/imp.h
+++ b/src/imp.h
@@ -36,6 +36,7 @@ std::string impDiagXform();
 
 // Convergence controller / proposal-scale adaptation controls (from impmapControl):
 double impIaccept();      // target effective-sample fraction that gamma adapts toward
+double impDf();           // proposal degrees of freedom (NONMEM DF); 0 = Gaussian
 bool impGammaIndividual();// TRUE for gammaMethod="individual" (per-subject NONMEM gamma_i)
 double impIscaleMin();    // lower bound for the adapted gamma
 double impIscaleMax();    // upper bound for the adapted gamma

--- a/src/imp.h
+++ b/src/imp.h
@@ -37,6 +37,7 @@ std::string impDiagXform();
 // Convergence controller / proposal-scale adaptation controls (from impmapControl):
 double impIaccept();      // target effective-sample fraction that gamma adapts toward
 double impDf();           // proposal degrees of freedom (NONMEM DF); 0 = Gaussian
+void impNsampleVecGet(std::vector<int>& out); // per-subject ISAMPLE (empty = use the scalar)
 bool impGammaIndividual();// TRUE for gammaMethod="individual" (per-subject NONMEM gamma_i)
 double impIscaleMin();    // lower bound for the adapted gamma
 double impIscaleMax();    // upper bound for the adapted gamma

--- a/src/imp.h
+++ b/src/imp.h
@@ -160,7 +160,7 @@ void impUpdateStructThetas(const arma::vec& step);
 // Monte-Carlo observed-information covariance for the estimated thetas: FD
 // Hessian of the importance-sampling -2LL over fixed (common-random-number)
 // samples.  Stashes impCovTheta / impSeTheta / impCovThetaIdx on `e`.
-void impComputeCov(Rcpp::Environment e);
+void impComputeCov(Rcpp::Environment e, const arma::vec& gammaVec);
 bool impCovProgress();                             // draw the cov-step progress bar?
 
 // Importance-sampling EM driver; called from foceiFitCpp_ when est=="impmap"

--- a/src/imp.h
+++ b/src/imp.h
@@ -38,6 +38,9 @@ std::string impDiagXform();
 double impIaccept();      // target effective-sample fraction that gamma adapts toward
 double impDf();           // proposal degrees of freedom (NONMEM DF); 0 = Gaussian
 void impNsampleVecGet(std::vector<int>& out); // per-subject ISAMPLE (empty = use the scalar)
+int impNobs(int id);      // observation count for subject id (AUTO's sparsity test)
+bool impAutoEnabled();    // AUTO=1 equivalent: per-subject df / isample / iaccept
+bool impAutoNonNormal();  // model not transformably normal (tutorial's "categorical" trigger)
 bool impGammaIndividual();// TRUE for gammaMethod="individual" (per-subject NONMEM gamma_i)
 double impIscaleMin();    // lower bound for the adapted gamma
 double impIscaleMax();    // upper bound for the adapted gamma

--- a/src/imp.h
+++ b/src/imp.h
@@ -36,6 +36,7 @@ std::string impDiagXform();
 
 // Convergence controller / proposal-scale adaptation controls (from impmapControl):
 double impIaccept();      // target effective-sample fraction that gamma adapts toward
+bool impGammaIndividual();// TRUE for gammaMethod="individual" (per-subject NONMEM gamma_i)
 double impIscaleMin();    // lower bound for the adapted gamma
 double impIscaleMax();    // upper bound for the adapted gamma
 int impNconvWindow();     // trailing-iteration window for the convergence check

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -510,6 +510,8 @@ struct focei_options {
   // Optional per-subject sample counts (NONMEM's per-subject ISAMPLE).  Empty
   // means "use the scalar impNsample for everyone".
   std::vector<int> impNsampleVec;
+  bool impAuto = false;      // AUTO=1: adapt df / isample / iaccept per subject
+  bool impAutoNonNormal = false; // model is not transformably normal (categorical etc.)
   // "global" (one shared gamma, inflate-only on the mean Kish ESS fraction) or
   // "individual" (per-subject gamma_i, two-sided on that subject's xi -- NONMEM)
   std::string impGammaMethod = "global";
@@ -5225,6 +5227,9 @@ NumericVector foceiSetup_(const RObject &obj,
     if (foceiO.containsElementNamed("nIter")) op_focei.impNiter = as<int>(foceiO["nIter"]);
     if (foceiO.containsElementNamed("iaccept")) op_focei.impIaccept = as<double>(foceiO["iaccept"]);
     if (foceiO.containsElementNamed("df")) op_focei.impDf = as<double>(foceiO["df"]);
+    if (foceiO.containsElementNamed("auto")) op_focei.impAuto = as<bool>(foceiO["auto"]);
+    if (foceiO.containsElementNamed("autoNonNormal"))
+      op_focei.impAutoNonNormal = as<bool>(foceiO["autoNonNormal"]);
     if (foceiO.containsElementNamed("isample")) {
       IntegerVector isv = as<IntegerVector>(foceiO["isample"]);
       op_focei.impNsampleVec.clear();
@@ -9086,7 +9091,16 @@ std::string impDiagXform() {
 
 double impIaccept() { return op_focei.impIaccept; }
 double impDf() { return op_focei.impDf; }
+bool impAutoEnabled() { return op_focei.impAuto; }
+bool impAutoNonNormal() { return op_focei.impAutoNonNormal; }
 void impNsampleVecGet(std::vector<int>& out) { out = op_focei.impNsampleVec; }
+
+// Observation count for subject id -- AUTO uses nobs/neta to decide whether a
+// subject's data is sparse enough to need a heavy-tailed (t) proposal.
+int impNobs(int id) {
+  focei_ind *fInd = &(inds_focei[id]);
+  return (int)fInd->nObs;
+}
 // TRUE when the per-subject (NONMEM) gamma controller is selected.  Queried once
 // per EM iteration, not in the sampling loop, so the string compare is free.
 bool impGammaIndividual() { return op_focei.impGammaMethod == "individual"; }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -504,6 +504,9 @@ struct focei_options {
   double impGamma = 1.0; // proposal-variance inflation factor: cov = gamma * H^-1
   int impNiter = 100;    // maximum EM iterations
   double impIaccept = 0.4;   // target importance-sampling effective-sample fraction (adapts gamma)
+  // Proposal degrees of freedom (NONMEM DF).  0 = multivariate normal; >0 uses a
+  // multivariate t, whose polynomial tails dominate a Gaussian target's.
+  double impDf = 0.0;
   // "global" (one shared gamma, inflate-only on the mean Kish ESS fraction) or
   // "individual" (per-subject gamma_i, two-sided on that subject's xi -- NONMEM)
   std::string impGammaMethod = "global";
@@ -5211,6 +5214,7 @@ NumericVector foceiSetup_(const RObject &obj,
     if (foceiO.containsElementNamed("gamma")) op_focei.impGamma = as<double>(foceiO["gamma"]);
     if (foceiO.containsElementNamed("nIter")) op_focei.impNiter = as<int>(foceiO["nIter"]);
     if (foceiO.containsElementNamed("iaccept")) op_focei.impIaccept = as<double>(foceiO["iaccept"]);
+    if (foceiO.containsElementNamed("df")) op_focei.impDf = as<double>(foceiO["df"]);
     if (foceiO.containsElementNamed("gammaMethod") && TYPEOF(foceiO["gammaMethod"]) == STRSXP)
       op_focei.impGammaMethod = as<std::string>(foceiO["gammaMethod"]);
     if (foceiO.containsElementNamed("iscaleMin")) op_focei.impIscaleMin = as<double>(foceiO["iscaleMin"]);
@@ -9064,6 +9068,7 @@ std::string impDiagXform() {
 }
 
 double impIaccept() { return op_focei.impIaccept; }
+double impDf() { return op_focei.impDf; }
 // TRUE when the per-subject (NONMEM) gamma controller is selected.  Queried once
 // per EM iteration, not in the sampling loop, so the string compare is free.
 bool impGammaIndividual() { return op_focei.impGammaMethod == "individual"; }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -507,6 +507,9 @@ struct focei_options {
   // Proposal degrees of freedom (NONMEM DF).  0 = multivariate normal; >0 uses a
   // multivariate t, whose polynomial tails dominate a Gaussian target's.
   double impDf = 0.0;
+  // Optional per-subject sample counts (NONMEM's per-subject ISAMPLE).  Empty
+  // means "use the scalar impNsample for everyone".
+  std::vector<int> impNsampleVec;
   // "global" (one shared gamma, inflate-only on the mean Kish ESS fraction) or
   // "individual" (per-subject gamma_i, two-sided on that subject's xi -- NONMEM)
   std::string impGammaMethod = "global";
@@ -5210,11 +5213,25 @@ NumericVector foceiSetup_(const RObject &obj,
     op_focei.isNpb = false;
   }
   if (op_focei.isImpmap) {
-    if (foceiO.containsElementNamed("isample")) op_focei.impIsample = as<int>(foceiO["isample"]);
+    // isample may be a per-subject vector; the scalar is the largest requested
+    // count (used for sizing, the SIR default and reporting).
+    if (foceiO.containsElementNamed("isample")) {
+      IntegerVector isv0 = as<IntegerVector>(foceiO["isample"]);
+      int mx = 1;
+      for (int i = 0; i < isv0.size(); ++i) if (isv0[i] > mx) mx = isv0[i];
+      op_focei.impIsample = mx;
+    }
     if (foceiO.containsElementNamed("gamma")) op_focei.impGamma = as<double>(foceiO["gamma"]);
     if (foceiO.containsElementNamed("nIter")) op_focei.impNiter = as<int>(foceiO["nIter"]);
     if (foceiO.containsElementNamed("iaccept")) op_focei.impIaccept = as<double>(foceiO["iaccept"]);
     if (foceiO.containsElementNamed("df")) op_focei.impDf = as<double>(foceiO["df"]);
+    if (foceiO.containsElementNamed("isample")) {
+      IntegerVector isv = as<IntegerVector>(foceiO["isample"]);
+      op_focei.impNsampleVec.clear();
+      if (isv.size() > 1) {
+        for (int i = 0; i < isv.size(); ++i) op_focei.impNsampleVec.push_back(isv[i]);
+      }
+    }
     if (foceiO.containsElementNamed("gammaMethod") && TYPEOF(foceiO["gammaMethod"]) == STRSXP)
       op_focei.impGammaMethod = as<std::string>(foceiO["gammaMethod"]);
     if (foceiO.containsElementNamed("iscaleMin")) op_focei.impIscaleMin = as<double>(foceiO["iscaleMin"]);
@@ -9069,6 +9086,7 @@ std::string impDiagXform() {
 
 double impIaccept() { return op_focei.impIaccept; }
 double impDf() { return op_focei.impDf; }
+void impNsampleVecGet(std::vector<int>& out) { out = op_focei.impNsampleVec; }
 // TRUE when the per-subject (NONMEM) gamma controller is selected.  Queried once
 // per EM iteration, not in the sampling loop, so the string compare is free.
 bool impGammaIndividual() { return op_focei.impGammaMethod == "individual"; }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -504,6 +504,9 @@ struct focei_options {
   double impGamma = 1.0; // proposal-variance inflation factor: cov = gamma * H^-1
   int impNiter = 100;    // maximum EM iterations
   double impIaccept = 0.4;   // target importance-sampling effective-sample fraction (adapts gamma)
+  // "global" (one shared gamma, inflate-only on the mean Kish ESS fraction) or
+  // "individual" (per-subject gamma_i, two-sided on that subject's xi -- NONMEM)
+  std::string impGammaMethod = "global";
   double impIscaleMin = 0.1; // lower bound for adapted gamma
   double impIscaleMax = 10.0;// upper bound for adapted gamma
   double impCtol = -1.0;     // windowed-convergence tolerance on the objective (<0: derive from sigdig)
@@ -5208,6 +5211,8 @@ NumericVector foceiSetup_(const RObject &obj,
     if (foceiO.containsElementNamed("gamma")) op_focei.impGamma = as<double>(foceiO["gamma"]);
     if (foceiO.containsElementNamed("nIter")) op_focei.impNiter = as<int>(foceiO["nIter"]);
     if (foceiO.containsElementNamed("iaccept")) op_focei.impIaccept = as<double>(foceiO["iaccept"]);
+    if (foceiO.containsElementNamed("gammaMethod") && TYPEOF(foceiO["gammaMethod"]) == STRSXP)
+      op_focei.impGammaMethod = as<std::string>(foceiO["gammaMethod"]);
     if (foceiO.containsElementNamed("iscaleMin")) op_focei.impIscaleMin = as<double>(foceiO["iscaleMin"]);
     if (foceiO.containsElementNamed("iscaleMax")) op_focei.impIscaleMax = as<double>(foceiO["iscaleMax"]);
     if (foceiO.containsElementNamed("ctol") && !Rf_isNull(foceiO["ctol"]))
@@ -9059,6 +9064,9 @@ std::string impDiagXform() {
 }
 
 double impIaccept() { return op_focei.impIaccept; }
+// TRUE when the per-subject (NONMEM) gamma controller is selected.  Queried once
+// per EM iteration, not in the sampling loop, so the string compare is free.
+bool impGammaIndividual() { return op_focei.impGammaMethod == "individual"; }
 double impIscaleMin() { return op_focei.impIscaleMin; }
 double impIscaleMax() { return op_focei.impIscaleMax; }
 int impNconvWindow() { return op_focei.impNconvWindow; }

--- a/tests/testthat/test-imp-auto.R
+++ b/tests/testthat/test-imp-auto.R
@@ -84,7 +84,13 @@ nmTest({
                                    impmapControl(print = 0L, nIter = 8L, isample = 300L,
                                                  covMethod = "", auto = TRUE)))
     expect_true(all(.f$env$impDfInd > 0))          # every subject gets a t proposal
-    expect_true(all(.f$env$impIacceptInd == 0.2))  # and the tutorial's target
+    # iaccept is NOT dropped to 0.2 up front any more.  Lowering it forces gamma
+    # wide, and widening a Gaussian was measured not to fix tails while costing
+    # a lot of ESS -- on this very fixture (k-hat already -1.33, i.e. no failure
+    # at all) the blanket 0.2 cut ESS 0.549 -> 0.412 and doubled the objective
+    # noise for nothing.  It is now held in reserve for subjects whose k-hat is
+    # still failing after the df ladder is exhausted.
+    expect_true(all(.f$env$impIacceptInd == 0.4))
   })
 
   test_that("auto reallocates the sample budget without inflating it", {

--- a/tests/testthat/test-imp-auto.R
+++ b/tests/testthat/test-imp-auto.R
@@ -1,0 +1,99 @@
+# AUTO: per-subject df / isample / iaccept (NONMEM AUTO=1 equivalent).
+#
+# The tutorial's documented triggers are implemented verbatim (nobs < neta, or
+# non-normal data -> nonzero DF and IACCEPT ~ 0.2), but they are NECESSARY not
+# SUFFICIENT: on plain theophylline neither fires and subjects still have
+# infinite-variance weights.  AUTO therefore also escalates df from the Pareto
+# k-hat diagnostic, which NONMEM has no equivalent of.  That escalation is
+# nlmixr2's, not a reproduction of NONMEM.
+nmTest({
+
+  .pk <- function() {
+    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+    model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+           linCmt() ~ add(add.sd)})
+  }
+  .fitAuto <- function(auto, nIter = 12L) {
+    suppressWarnings(nlmixr2(.pk, nlmixr2data::theo_sd, "impmap",
+                             impmapControl(print = 0L, nIter = nIter, isample = 300L,
+                                           covMethod = "", auto = auto)))
+  }
+
+  test_that("auto control round-trips and defaults off", {
+    expect_false(impmapControl()$auto)
+    expect_true(impmapControl(auto = TRUE)$auto)
+    expect_true(do.call(impmapControl, impmapControl(auto = TRUE))$auto)
+    expect_error(impmapControl(auto = "yes"))
+    expect_true(all(c("auto", "autoNonNormal") %in% .impmapIsControlNames))
+  })
+
+  test_that("the in-kernel k-hat matches the validated R implementation", {
+    # AUTO reacts to k-hat DURING the EM, so the kernel needs its own copy.  It
+    # must agree with R/impPsis.R, which is the version validated against
+    # loo::psis -- otherwise AUTO would be steering on a different number than
+    # the one reported.
+    .f <- .fitAuto(FALSE)
+    .k <- .f$env$impKhatIter
+    .r <- .f$env$impPsisK
+    .ok <- is.finite(.k) & is.finite(.r)
+    expect_gt(sum(.ok), 5L)
+    expect_equal(.k[.ok], .r[.ok], tolerance = 1e-6)
+  })
+
+  test_that("auto=FALSE changes nothing", {
+    .a <- .fitAuto(FALSE)
+    expect_true(all(.a$env$impDfInd == 0))
+    expect_true(all(.a$env$impIacceptInd == 0.4))
+    expect_equal(length(unique(as.integer(.a$env$impNsampleInd))), 1L)
+  })
+
+  test_that("auto escalates df only for the subjects that need it", {
+    # The discriminating test: theophylline is data-rich (11 obs, 1 eta) and
+    # transformably normal, so the TUTORIAL's trigger does not fire at all.
+    # Escalation must come from k-hat, and must be selective -- healthy
+    # subjects keep the cheaper Gaussian proposal.
+    skip_on_cran()
+    .off <- .fitAuto(FALSE)
+    .on <- .fitAuto(TRUE)
+    .k0 <- .off$env$impPsisK
+    expect_gt(sum(.k0 > 0.7), 0L)                      # premise
+    # some subjects got a t proposal, but NOT all of them
+    expect_gt(sum(.on$env$impDfInd > 0), 0L)
+    expect_gt(sum(.on$env$impDfInd == 0), 0L)
+    # and the tail failure is cleared
+    expect_lt(max(.on$env$impPsisK), 0.7)
+    expect_lt(max(.on$env$impPsisK), max(.k0))
+    # without moving the answer
+    expect_equal(.on$objf, .off$objf, tolerance = 0.5)
+  })
+
+  test_that("auto applies the tutorial's trigger for non-normal data", {
+    # "or data are categorical" -> nonzero DF and IACCEPT ~ 0.2, for every
+    # subject, regardless of how much data each has.
+    skip_on_cran()
+    .testSeed(202); rxode2::rxSetSeed(202)
+    .d <- do.call(rbind, lapply(1:20, function(id) {
+      .el <- stats::rnorm(1, 0, 0.7)
+      data.frame(id = id, time = 1:10, dv = stats::rpois(10, exp(1 + .el)), evid = 0)
+    }))
+    .m <- function() {
+      ini({tl <- 1; eta.l ~ 0.7})
+      model({lam <- exp(tl + eta.l); dv ~ pois(lam)})
+    }
+    .f <- suppressWarnings(nlmixr2(.m, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 8L, isample = 300L,
+                                                 covMethod = "", auto = TRUE)))
+    expect_true(all(.f$env$impDfInd > 0))          # every subject gets a t proposal
+    expect_true(all(.f$env$impIacceptInd == 0.2))  # and the tutorial's target
+  })
+
+  test_that("auto reallocates the sample budget without inflating it", {
+    skip_on_cran()
+    .on <- .fitAuto(TRUE)
+    .n <- length(.on$env$impNsampleInd)
+    # load-balancing, not a cost increase: the total stays near isample*nsub
+    expect_lt(abs(sum(.on$env$impNsampleInd) - 300 * .n), 0.25 * 300 * .n)
+    expect_true(all(.on$env$impNsampleInd >= 25))   # floor keeps PSIS usable
+  })
+
+})

--- a/tests/testthat/test-imp-auto.R
+++ b/tests/testthat/test-imp-auto.R
@@ -20,7 +20,8 @@ nmTest({
   }
 
   test_that("auto control round-trips and defaults off", {
-    expect_false(impmapControl()$auto)
+    expect_true(impmapControl()$auto)
+    expect_false(impmapControl(auto = FALSE)$auto)
     expect_true(impmapControl(auto = TRUE)$auto)
     expect_true(do.call(impmapControl, impmapControl(auto = TRUE))$auto)
     expect_error(impmapControl(auto = "yes"))

--- a/tests/testthat/test-imp-psis.R
+++ b/tests/testthat/test-imp-psis.R
@@ -1,0 +1,132 @@
+# Pareto k-hat: the tail-sensitive importance-sampling diagnostic.
+#
+# xi and the Kish effective sample size are both means over samples drawn FROM
+# the proposal, so neither can see a tail the proposal does not visit.  k-hat
+# estimates the tail index of the weight distribution and can.  These tests pin
+# that the estimator actually recovers a known tail index, because a biased
+# diagnostic is worse than no diagnostic.
+nmTest({
+
+  .rgpd <- function(n, k) ((1 - stats::runif(n))^(-k) - 1) / k
+
+  test_that("k-hat recovers a known generalized-Pareto tail index", {
+    .est <- function(k, seeds = 1:5) {
+      vapply(seeds, function(s) {
+        set.seed(100 + s)
+        .impPsisK(.rgpd(4000, k))
+      }, numeric(1))
+    }
+    for (.k in c(0.2, 0.5, 0.8, 1.2)) {
+      .m <- mean(.est(.k))
+      expect_true(is.finite(.m))
+      # within 0.15 of truth: comfortably tighter than the 0.5/0.7 decision
+      # thresholds the statistic is actually used against
+      expect_lt(abs(.m - .k), 0.15)
+    }
+  })
+
+  test_that("k-hat separates light from heavy tails", {
+    set.seed(11)
+    # exponential weights: tail index 0
+    expect_lt(.impPsisK(stats::rexp(4000)), 0.3)
+    # heavy: k = 1 has infinite variance AND infinite mean
+    expect_gt(mean(vapply(1:3, function(s) {
+      set.seed(200 + s); .impPsisK(.rgpd(4000, 1.0))
+    }, numeric(1))), 0.7)
+  })
+
+  test_that("k-hat is scale invariant and degrades gracefully", {
+    set.seed(5)
+    .w <- .rgpd(2000, 0.6)
+    # scale invariance matters: the stored weights carry a per-subject mixture
+    # responsibility factor that must not shift the diagnostic
+    expect_equal(.impPsisK(.w), .impPsisK(.w * 1e6), tolerance = 1e-8)
+    expect_equal(.impPsisK(.w), .impPsisK(.w * 1e-6), tolerance = 1e-8)
+    # too few weights to fit a tail -> NA rather than a wrong number
+    expect_true(is.na(.impPsisK(.w[1:10])))
+    expect_true(is.na(.impPsisK(numeric(0))))
+    # non-finite and non-positive weights are dropped, not propagated
+    expect_true(is.finite(.impPsisK(c(.w, NA, Inf, 0, -1))))
+  })
+
+  test_that("k-hat agrees with the loo reference implementation", {
+    skip_if_not_installed("loo")
+    for (.k in c(0.3, 0.7, 1.1)) {
+      set.seed(321)
+      .w <- .rgpd(4000, .k)
+      .mine <- .impPsisK(.w)
+      .ref <- suppressWarnings(
+        loo::psis(matrix(log(.w), ncol = 1), r_eff = NA)$diagnostics$pareto_k)
+      expect_lt(abs(.mine - .ref), 0.1)
+    }
+  })
+
+  test_that("a fit exposes per-subject k-hat alongside xi and the Kish ESS", {
+    .m <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+             linCmt() ~ add(add.sd)})
+    }
+    .d <- nlmixr2data::theo_sd
+    .f <- suppressWarnings(nlmixr2(.m, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 6L,
+                                                 isample = 300L, covMethod = "")))
+    .E <- .f$env
+    expect_equal(length(.E$impPsisK), length(unique(.d$ID)))
+    # all three diagnostics are present and per-subject
+    expect_equal(length(.E$impXi), length(.E$impPsisK))
+    expect_equal(length(.E$impNeff), length(.E$impPsisK))
+    expect_true(all(is.finite(.E$impPsisK)))
+  })
+
+  test_that("k-hat sees tail failure that xi and the Kish ESS cannot", {
+    # THE MOTIVATING MEASUREMENT.  On plain theophylline with a Gaussian
+    # (Laplace) proposal, some subjects have importance weights with infinite
+    # variance -- k-hat well above the 0.7 reliability threshold -- while xi
+    # sits at ~1.0 and the Kish effective-sample fraction at ~0.99 for those
+    # SAME subjects.  Neither in-sample statistic can see it, because the
+    # offending mass is in a tail the proposal rarely visits and no single
+    # drawn weight dominates.
+    #
+    # This is the premise for the t-distribution proposal (NONMEM's DF): the
+    # fix has to make the proposal's tails HEAVIER than the target's, which
+    # widening a Gaussian by gamma cannot do.
+    .m <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+             linCmt() ~ add(add.sd)})
+    }
+    .f <- suppressWarnings(nlmixr2(.m, nlmixr2data::theo_sd, "impmap",
+                                   impmapControl(print = 0L, nIter = 6L,
+                                                 isample = 300L, covMethod = "")))
+    .E <- .f$env
+    .bad <- which(.E$impPsisK > 0.7)
+    # at least one subject is in the unreliable regime
+    expect_gt(length(.bad), 0L)
+    # ... and for those subjects the two in-sample statistics look FINE, which
+    # is precisely why they could not be used to justify (or refute) the fix
+    expect_true(all(abs(.E$impXi[.bad] - 1) < 0.15))
+    expect_true(all((.E$impNeff / .E$impNsample)[.bad] > 0.9))
+  })
+
+  test_that("the k-hat alarm persists as isample grows (not a small-tail artifact)", {
+    # A genuinely heavy tail is revealed MORE by extra samples; small-sample
+    # noise would wash out.  Measured: max k-hat 2.49 (isample 300) -> 3.31
+    # (1000) -> 3.76 (4000).
+    skip_on_cran()
+    .m <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+             linCmt() ~ add(add.sd)})
+    }
+    .maxK <- function(ns) {
+      .f <- suppressWarnings(nlmixr2(.m, nlmixr2data::theo_sd, "impmap",
+                                     impmapControl(print = 0L, nIter = 5L,
+                                                   isample = ns, covMethod = "")))
+      max(.f$env$impPsisK)
+    }
+    expect_gt(.maxK(300L), 1.0)
+    expect_gt(.maxK(2000L), 1.0)
+  })
+
+})

--- a/tests/testthat/test-imp-tprop.R
+++ b/tests/testthat/test-imp-tprop.R
@@ -96,3 +96,72 @@ nmTest({
   })
 
 })
+
+# Per-subject ISAMPLE (the NM7 Technical Guide's own remedy) vs the t proposal.
+nmTest({
+
+  .isModel <- function() {
+    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+    model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+           linCmt() ~ add(add.sd)})
+  }
+
+  test_that("isample accepts a per-subject vector and uses it", {
+    expect_equal(impmapControl(isample = 300L)$isample, 300L)
+    expect_equal(impmapControl(isample = c(100L, 200L))$isample, c(100L, 200L))
+    expect_error(impmapControl(isample = 0L))
+    .d <- nlmixr2data::theo_sd
+    .n <- length(unique(.d$ID))
+    .iv <- rep(300L, .n); .iv[c(1L, 3L)] <- 900L
+    .f <- suppressWarnings(nlmixr2(.isModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 5L,
+                                                 isample = .iv, covMethod = "")))
+    expect_equal(as.integer(.f$env$impNsampleInd), .iv)
+  })
+
+  test_that("a uniform isample vector matches the equivalent scalar", {
+    .d <- nlmixr2data::theo_sd
+    .n <- length(unique(.d$ID))
+    .a <- suppressWarnings(nlmixr2(.isModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 5L,
+                                                 isample = 300L, covMethod = "")))
+    .b <- suppressWarnings(nlmixr2(.isModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 5L,
+                                                 isample = rep(300L, .n),
+                                                 covMethod = "")))
+    expect_equal(.b$objf, .a$objf, tolerance = 1e-10)
+    expect_equal(unname(.b$theta), unname(.a$theta), tolerance = 1e-10)
+  })
+
+  test_that("more samples does NOT repair tail failure -- only a heavier tail does", {
+    # The guide's remedy treats the symptom; the tutorial's treats the cause.
+    # Infinite weight variance is a property of the proposal/target TAIL RATIO,
+    # so extra draws from a too-light proposal simply reach further into the
+    # region that breaks the estimator and can make k-hat WORSE.  Measured:
+    #
+    #   Gaussian, uniform 300              max k-hat 1.611, 4 subjects bad
+    #   Gaussian, bad subjects at 3000     max k-hat 3.276, 1 subject bad
+    #   t proposal df=20, uniform 300      max k-hat -0.577, 0 bad
+    skip_on_cran()
+    .d <- nlmixr2data::theo_sd
+    .n <- length(unique(.d$ID))
+    .g <- suppressWarnings(nlmixr2(.isModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 8L,
+                                                 isample = 300L, covMethod = "")))
+    .k0 <- .g$env$impPsisK
+    expect_gt(sum(.k0 > 0.7), 0L)                     # premise
+    .iv <- rep(300L, .n); .iv[.k0 > 0.7] <- 3000L
+    .boost <- suppressWarnings(nlmixr2(.isModel, .d, "impmap",
+                                       impmapControl(print = 0L, nIter = 8L,
+                                                     isample = .iv, covMethod = "")))
+    .t <- suppressWarnings(nlmixr2(.isModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 8L,
+                                                 isample = 300L, covMethod = "",
+                                                 df = 20)))
+    # 10x the samples does not clear the unreliable regime ...
+    expect_gt(max(.boost$env$impPsisK), 0.7)
+    # ... while a heavier-tailed proposal does, at the ORIGINAL sample count
+    expect_lt(max(.t$env$impPsisK), 0.7)
+  })
+
+})

--- a/tests/testthat/test-imp-tprop.R
+++ b/tests/testthat/test-imp-tprop.R
@@ -1,0 +1,98 @@
+# Multivariate-t importance-sampling proposal (NONMEM DF).
+#
+# gamma can only make a Gaussian proposal WIDER; it cannot give it heavier
+# tails.  When the target posterior's tails are heavier than the proposal's the
+# importance weights have infinite variance -- detectable by Pareto k-hat and
+# invisible to xi and the Kish ESS.  A t proposal has polynomial tails that
+# dominate a Gaussian target's, which bounds the weights.
+nmTest({
+
+  .tModel <- function() {
+    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+    model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+           linCmt() ~ add(add.sd)})
+  }
+
+  .fitDf <- function(df, nIter = 8L, isample = 300L) {
+    suppressWarnings(nlmixr2(.tModel, nlmixr2data::theo_sd, "impmap",
+                             impmapControl(print = 0L, nIter = nIter,
+                                           isample = isample, covMethod = "",
+                                           df = df)))
+  }
+
+  test_that("df control round-trips and defaults to the Gaussian proposal", {
+    expect_equal(impmapControl()$df, 0)
+    expect_equal(impmapControl(df = 5)$df, 5)
+    expect_equal(do.call(impmapControl, impmapControl(df = 7))$df, 7)
+    expect_true("df" %in% .impmapIsControlNames)
+  })
+
+  test_that("a t proposal removes the tail failure a Gaussian one has", {
+    # THE POINT OF THE FEATURE.  On plain theophylline the Gaussian proposal
+    # leaves several subjects with infinite-variance weights (k-hat > 0.7); a t
+    # proposal bounds them.  Measured max k-hat: 1.61 (Gaussian) vs -0.58
+    # (df=20), -0.86 (df=5).
+    .g <- .fitDf(0)
+    .t <- .fitDf(20)
+    expect_gt(max(.g$env$impPsisK), 0.7)      # premise: the Gaussian fails
+    expect_gt(sum(.g$env$impPsisK > 0.7), 0L)
+    expect_lt(max(.t$env$impPsisK), 0.7)      # and the t proposal fixes it
+    expect_equal(sum(.t$env$impPsisK > 0.7), 0L)
+  })
+
+  test_that("the fix is cheap -- it barely costs effective sample size", {
+    # The competing mechanism (widening a Gaussian via gamma) cost ESS
+    # 0.95 -> 0.70 on this model.  df = 20 costs well under a percent, because
+    # it changes the proposal's SHAPE rather than inflating its width.
+    .g <- .fitDf(0)
+    .t <- .fitDf(20)
+    .essG <- mean(.g$env$impNeff / .g$env$impNsample)
+    .essT <- mean(.t$env$impNeff / .t$env$impNsample)
+    expect_gt(.essT, 0.95 * .essG)
+  })
+
+  test_that("df does not move the estimates, only the weights' behaviour", {
+    # The importance weights divide by the proposal density, so changing the
+    # proposal shape must not change what the EM converges to.
+    .g <- .fitDf(0, nIter = 12L)
+    .t <- .fitDf(5, nIter = 12L)
+    expect_equal(unname(.t$theta), unname(.g$theta), tolerance = 0.02)
+    expect_equal(.t$objf, .g$objf, tolerance = 0.5)
+  })
+
+  test_that("large df recovers the Gaussian normalizer", {
+    # Ci gains (p/2)log(df/2) + lgamma(df/2) - lgamma((df+p)/2), which -> 0 as
+    # df -> Inf.  If that correction were wrong (or omitted) the objective would
+    # be offset by a constant, so agreement at large df is a direct check of the
+    # normalizer rather than of the sampler.
+    .g <- .fitDf(0, nIter = 5L, isample = 1000L)
+    .t <- .fitDf(2000, nIter = 5L, isample = 1000L)
+    expect_equal(.t$env$impObj, .g$env$impObj, tolerance = 0.15)
+  })
+
+  test_that("the t proposal composes with qrpem and with individual gamma", {
+    .q <- suppressWarnings(nlmixr2(.tModel, nlmixr2data::theo_sd, "qrpem",
+                                   qrpemControl(print = 0L, nIter = 6L,
+                                                covMethod = "", df = 10)))
+    expect_true(inherits(.q, "nlmixr2FitCore"))
+    expect_true(all(is.finite(.q$env$impPsisK)))
+    .i <- suppressWarnings(nlmixr2(.tModel, nlmixr2data::theo_sd, "impmap",
+                                   impmapControl(print = 0L, nIter = 6L,
+                                                 covMethod = "", df = 10,
+                                                 gammaMethod = "individual")))
+    expect_equal(.i$env$impGammaMethod, "individual")
+    expect_true(all(is.finite(.i$env$impGammaInd)))
+  })
+
+  test_that("covMethod='imp' works under a t proposal", {
+    # The covariance step builds its own proposal and must use the SAME df, or
+    # the reweighted objective is not the one the fit converged on.
+    .f <- suppressWarnings(nlmixr2(.tModel, nlmixr2data::theo_sd, "impmap",
+                                   impmapControl(print = 0L, nIter = 8L,
+                                                 covMethod = "imp", df = 10)))
+    .cv <- as.matrix(.f$env$cov)
+    expect_true(all(is.finite(.cv)))
+    expect_true(all(diag(.cv) > 0))
+  })
+
+})

--- a/tests/testthat/test-imp-xi-gamma.R
+++ b/tests/testthat/test-imp-xi-gamma.R
@@ -119,6 +119,45 @@ nmTest({
     expect_equal(.impmapResolveGammaMethod("auto", rxode2::rxode2(.lnm)), "global")
   })
 
+  test_that("gammaMethod='auto' requires EVERY endpoint to be Gaussian", {
+    # predDf has one row per endpoint, so the decision is an all() over rows:
+    # a model is only "global" if every endpoint is Gaussian.  One non-normal
+    # endpoint alongside normal ones makes the joint posterior non-Gaussian and
+    # must select "individual".
+    .m2n <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; teff <- 1
+           eta.cl ~ 0.1; add.sd <- 0.7; eff.sd <- 0.5})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+             d/dt(depot) <- -ka * depot
+             d/dt(cen) <- ka * depot - cl / v * cen
+             cp <- cen / v
+             eff <- teff * cp
+             cp ~ add(add.sd)
+             eff ~ add(eff.sd)})
+    }
+    .mMix <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; tl <- 1; eta.cl ~ 0.1; add.sd <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+             d/dt(depot) <- -ka * depot
+             d/dt(cen) <- ka * depot - cl / v * cen
+             cp <- cen / v
+             lam <- exp(tl)
+             cp ~ add(add.sd)
+             eff ~ pois(lam)})
+    }
+    .u2n <- rxode2::rxode2(.m2n)
+    .uMix <- rxode2::rxode2(.mMix)
+    expect_equal(nrow(.u2n$predDf), 2L)     # premise: multiple rows
+    expect_equal(nrow(.uMix$predDf), 2L)
+    # all endpoints Gaussian -> global
+    expect_equal(.impmapResolveGammaMethod("auto", .u2n), "global")
+    # ONE non-Gaussian endpoint is enough to select individual
+    expect_equal(.impmapResolveGammaMethod("auto", .uMix), "individual")
+    # and the canonicalizer must vectorize across rows rather than collapse
+    expect_equal(unname(rxode2::rxPreferredDistributionName(
+      as.character(.uMix$predDf$distribution))), c("dnorm", "pois"))
+  })
+
   test_that("gammaMethod='auto' re-resolves when a control is reused", {
     # Resolution overwrites gammaMethod in place.  A control lifted off a
     # finished fit and reused on a different model must re-resolve from the

--- a/tests/testthat/test-imp-xi-gamma.R
+++ b/tests/testthat/test-imp-xi-gamma.R
@@ -196,6 +196,46 @@ nmTest({
     expect_gt(length(unique(round(.fl$env$impGammaInd, 8))), 1L)
   })
 
+  test_that("$runInfo names which efficiency statistic the fit is reporting", {
+    # xi and the Kish effective-sample fraction are both always stashed, are
+    # both governed by iaccept, and are NOT the same quantity.  Every fit has to
+    # say which one its number is, or the two get read interchangeably.
+    .msgG <- .impmapGammaRunInfo("global", "auto", 0.4)
+    .msgI <- .impmapGammaRunInfo("individual", "auto", 0.4)
+    # each names its own statistic ...
+    expect_match(.msgG, "Kish effective-sample fraction")
+    expect_match(.msgG, "impNeffFrac", fixed = TRUE)
+    expect_match(.msgI, "xi")
+    expect_match(.msgI, "impXiTrace", fixed = TRUE)
+    # ... and both state plainly that the two cannot be compared
+    expect_match(.msgG, "not\\s+comparable")
+    expect_match(.msgI, "not\\s+comparable")
+    # auto explains itself; an explicit choice does not editorialize
+    expect_match(.msgI, "auto", fixed = TRUE)
+    expect_false(grepl("auto", .impmapGammaRunInfo("individual", "individual", 0.4), fixed = TRUE))
+    # the target value is reported, not hardcoded in the prose
+    expect_match(.impmapGammaRunInfo("individual", "auto", 0.25), "0.25", fixed = TRUE)
+  })
+
+  test_that("$runInfo note reaches the fit on both paths", {
+    .d <- nlmixr2data::theo_sd
+    .fn <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                    impmapControl(print = 0L, nIter = 5L, covMethod = "")))
+    .ri <- .fn$runInfo
+    expect_true(any(grepl("gammaMethod=\"global\"", .ri, fixed = TRUE)))
+    expect_true(any(grepl("not comparable", .ri, fixed = TRUE)))
+    .ll <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; sd1 <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv); cp <- linCmt()
+             ll(cp) ~ -0.5 * log(2 * pi) - log(sd1) - 0.5 * ((DV - cp) / sd1)^2})
+    }
+    .fl <- suppressWarnings(nlmixr2(.ll, .d, "impmap",
+                                    impmapControl(print = 0L, nIter = 5L, covMethod = "")))
+    .ril <- .fl$runInfo
+    expect_true(any(grepl("gammaMethod=\"individual\"", .ril, fixed = TRUE)))
+    expect_true(any(grepl("not comparable", .ril, fixed = TRUE)))
+  })
+
   test_that("gammaMethod='global' keeps one shared scale", {
     .d <- nlmixr2data::theo_sd
     .f <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",

--- a/tests/testthat/test-imp-xi-gamma.R
+++ b/tests/testthat/test-imp-xi-gamma.R
@@ -63,8 +63,9 @@ nmTest({
     expect_true(all(diff(.xi1) < 0))
   })
 
-  test_that("gammaMethod: control accepts both modes and defaults to global", {
-    expect_equal(impmapControl()$gammaMethod, "global")
+  test_that("gammaMethod: control accepts all three modes and defaults to auto", {
+    expect_equal(impmapControl()$gammaMethod, "auto")
+    expect_equal(impmapControl(gammaMethod = "global")$gammaMethod, "global")
     expect_equal(impmapControl(gammaMethod = "individual")$gammaMethod, "individual")
     expect_error(impmapControl(gammaMethod = "nonsense"))
     # round-trips through the control constructor (do.call re-entry)
@@ -72,6 +73,45 @@ nmTest({
     expect_equal(do.call(impmapControl, .c)$gammaMethod, "individual")
     # stripped when down-converting to a plain foceiControl
     expect_true("gammaMethod" %in% .impmapIsControlNames)
+  })
+
+  test_that("gammaMethod='auto' resolves on the model's distribution", {
+    # The unit of the decision: transformably-normal -> "global" (gamma = 1 is
+    # already the efficient proposal), anything else -> "individual".
+    .norm <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+             linCmt() ~ add(add.sd)})
+    }
+    .ll <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; sd1 <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv); cp <- linCmt()
+             ll(cp) ~ -0.5 * log(2 * pi) - log(sd1) - 0.5 * ((DV - cp) / sd1)^2})
+    }
+    expect_equal(.impmapResolveGammaMethod("auto", rxode2::rxode2(.norm)), "global")
+    expect_equal(.impmapResolveGammaMethod("auto", rxode2::rxode2(.ll)), "individual")
+    # an explicit choice is never overridden
+    expect_equal(.impmapResolveGammaMethod("global", rxode2::rxode2(.ll)), "global")
+    expect_equal(.impmapResolveGammaMethod("individual", rxode2::rxode2(.norm)), "individual")
+    # a ui with no usable predDf falls back to the historical behaviour
+    expect_equal(.impmapResolveGammaMethod("auto", list()), "global")
+  })
+
+  test_that("gammaMethod='auto' end-to-end: normal stays global, ll goes individual", {
+    .d <- nlmixr2data::theo_sd
+    .fn <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                    impmapControl(print = 0L, nIter = 10L, covMethod = "")))
+    expect_equal(.fn$env$impGammaMethod, "global")
+    expect_equal(length(unique(round(.fn$env$impGammaInd, 8))), 1L)
+    .ll <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; sd1 <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv); cp <- linCmt()
+             ll(cp) ~ -0.5 * log(2 * pi) - log(sd1) - 0.5 * ((DV - cp) / sd1)^2})
+    }
+    .fl <- suppressWarnings(nlmixr2(.ll, .d, "impmap",
+                                    impmapControl(print = 0L, nIter = 10L, covMethod = "")))
+    expect_equal(.fl$env$impGammaMethod, "individual")
+    expect_gt(length(unique(round(.fl$env$impGammaInd, 8))), 1L)
   })
 
   test_that("gammaMethod='global' keeps one shared scale", {

--- a/tests/testthat/test-imp-xi-gamma.R
+++ b/tests/testthat/test-imp-xi-gamma.R
@@ -135,6 +135,30 @@ nmTest({
     expect_gt(max(.f$env$impGammaInd), 1.0)
   })
 
+  test_that("covMethod='imp' uses the converged scales under individual gamma", {
+    # impComputeCov used to read impGammaProp() -- the control's INITIAL gamma --
+    # so with gammaMethod="individual" it evaluated the covariance with a single
+    # scale of 1.0 while the fit had converged near 1.8 per subject.  The
+    # importance weights correct for gamma, so that was consistent rather than
+    # biased, but it sampled from a proposal the fit had already rejected as
+    # poorly matched, which inflates Monte-Carlo noise in the FD Hessian.  This
+    # pins that the covariance is built and stays well-formed on that path.
+    .d <- nlmixr2data::theo_sd
+    .f <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 15L,
+                                                 covMethod = "imp",
+                                                 gammaMethod = "individual")))
+    .E <- .f$env
+    # the scales really did move away from the control's initial gamma = 1
+    expect_gt(min(.E$impGammaInd), 1.05)
+    .cv <- as.matrix(.E$cov)
+    expect_true(all(is.finite(.cv)))
+    expect_equal(.cv, t(.cv), tolerance = 1e-8)          # symmetric
+    expect_true(all(diag(.cv) > 0))                       # positive diagonal
+    expect_true(all(is.finite(.E$impSeTheta)))
+    expect_true(all(.E$impSeTheta > 0))
+  })
+
   test_that("individual gamma is stable at high eta dimension (no limit cycle)", {
     # The damping exponent has to scale with neta.  For a Gaussian posterior
     # xi = gamma^(-neta/2), so gamma' = gamma*(xi/iaccept)^p linearizes to an

--- a/tests/testthat/test-imp-xi-gamma.R
+++ b/tests/testthat/test-imp-xi-gamma.R
@@ -95,6 +95,49 @@ nmTest({
     expect_equal(.impmapResolveGammaMethod("individual", rxode2::rxode2(.norm)), "individual")
     # a ui with no usable predDf falls back to the historical behaviour
     expect_equal(.impmapResolveGammaMethod("auto", list()), "global")
+    # ... as does an NA distribution (all(NA == "x") is NA, which would error an if)
+    expect_equal(.impmapResolveGammaMethod(
+      "auto", list(predDf = data.frame(distribution = c("norm", NA)))), "global")
+    # "norm" and "dnorm" are rxode2 ALIASES for the same Gaussian family, so the
+    # exact-likelihood (Laplace) form of a plain normal endpoint must still
+    # resolve to "global" -- its posterior is as Gaussian as the add() form
+    .dn <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+             linCmt() ~ add(add.sd) + dnorm()})
+    }
+    .udn <- rxode2::rxode2(.dn)
+    expect_equal(as.character(.udn$predDf$distribution), "dnorm")   # premise
+    expect_equal(.impmapResolveGammaMethod("auto", .udn), "global")
+    # lognormal residuals ride predDf$transform with distribution "norm", so
+    # they are Gaussian for this purpose too
+    .lnm <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+             linCmt() ~ lnorm(add.sd)})
+    }
+    expect_equal(.impmapResolveGammaMethod("auto", rxode2::rxode2(.lnm)), "global")
+  })
+
+  test_that("gammaMethod='auto' re-resolves when a control is reused", {
+    # Resolution overwrites gammaMethod in place.  A control lifted off a
+    # finished fit and reused on a different model must re-resolve from the
+    # user's original "auto" rather than carry the previous model's answer.
+    .norm <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+             linCmt() ~ add(add.sd)})
+    }
+    .uNorm <- rxode2::rxode2(.norm)
+    # simulate a control already resolved to "individual" by an earlier ll fit
+    .ctl <- impmapControl()
+    .ctl$gammaMethodUser <- "auto"
+    .ctl$gammaMethod <- "individual"
+    .gm <- .ctl$gammaMethodUser
+    expect_equal(.impmapResolveGammaMethod(.gm, .uNorm), "global")
+    # whereas an explicitly-set control keeps the user's choice on reuse
+    .ctl2 <- impmapControl(gammaMethod = "individual")
+    expect_equal(.impmapResolveGammaMethod(.ctl2$gammaMethod, .uNorm), "individual")
   })
 
   test_that("gammaMethod='auto' end-to-end: normal stays global, ll goes individual", {

--- a/tests/testthat/test-imp-xi-gamma.R
+++ b/tests/testthat/test-imp-xi-gamma.R
@@ -1,0 +1,81 @@
+# Tests for the NONMEM-style per-subject xi statistic and the individual-gamma
+# controller built on it.
+#
+# xi (NM7 Technical Guide eq. 1.73/1.75) is the mean importance weight normalized
+# so the proposal kernel is 1 at its center:
+#
+#   xi_i = (1/r) sum_k [pi(eta_k) / pi(center)] / e(eta_k)
+#
+# It equals 1 when the proposal matches the posterior shape, is < 1 when the
+# proposal is over-dispersed, and is > 1 when the posterior has heavier tails
+# than the Gaussian proposal.  It is a DIFFERENT statistic from the Kish
+# effective sample size (impNeffFrac) and the two are not comparable.
+nmTest({
+
+  .xiModel <- function() {
+    ini({
+      tka <- 0.45; tcl <- 1; tv <- 3.45
+      eta.cl ~ 0.1
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  test_that("xi: per-subject xi and its trace are exposed and well-formed", {
+    .d <- nlmixr2data::theo_sd
+    .f <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 5L,
+                                                 isample = 300L, covMethod = "")))
+    .E <- .f$env
+    # one xi per subject, all finite and strictly positive
+    expect_false(is.null(.E$impXi))
+    expect_length(.E$impXi, length(unique(.d$ID)))
+    expect_true(all(is.finite(.E$impXi)))
+    expect_true(all(.E$impXi > 0))
+    # the trace has one entry per EM iteration actually run, alongside the
+    # Kish-ESS trace it must not be confused with
+    expect_length(.E$impXiTrace, .E$impIter)
+    expect_length(.E$impNeffFrac, .E$impIter)
+    expect_true(all(is.finite(.E$impXiTrace)))
+    # xi and the Kish ESS fraction are different statistics: on a real fit they
+    # must not coincide, which is exactly why $runInfo has to name which is which
+    expect_false(isTRUE(all.equal(.E$impXiTrace, .E$impNeffFrac)))
+  })
+
+  test_that("xi decreases monotonically as the proposal is widened (gamma)", {
+    # This is the property that makes xi targetable by the individual-gamma
+    # controller: widening the proposal must lower xi, monotonically.  Compared
+    # at iteration 1 across fits so every run sees identical starting parameters.
+    .d <- nlmixr2data::theo_sd
+    .xi1 <- vapply(c(1.0, 2.0, 4.0), function(g) {
+      .f <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                     impmapControl(print = 0L, nIter = 1L,
+                                                   isample = 500L, gamma = g,
+                                                   covMethod = "")))
+      .f$env$impXiTrace[1]
+    }, numeric(1))
+    expect_true(all(is.finite(.xi1)))
+    expect_true(all(diff(.xi1) < 0))
+  })
+
+  test_that("xi is near 1 for a well-matched proposal on a near-Gaussian model", {
+    # gamma = 1 makes the proposal the Laplace approximation itself, so on a
+    # model whose individual posterior is close to Gaussian xi should sit near 1.
+    # Deliberately a loose band -- this pins the scale/orientation of the
+    # statistic (a sign error or a missing normalizer would blow it out by
+    # orders of magnitude), not its precise value.
+    .d <- nlmixr2data::theo_sd
+    .f <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 1L,
+                                                 isample = 500L, gamma = 1.0,
+                                                 covMethod = "")))
+    expect_true(.f$env$impXiTrace[1] > 0.5)
+    expect_true(.f$env$impXiTrace[1] < 2.0)
+  })
+
+})

--- a/tests/testthat/test-imp-xi-gamma.R
+++ b/tests/testthat/test-imp-xi-gamma.R
@@ -63,6 +63,78 @@ nmTest({
     expect_true(all(diff(.xi1) < 0))
   })
 
+  test_that("gammaMethod: control accepts both modes and defaults to global", {
+    expect_equal(impmapControl()$gammaMethod, "global")
+    expect_equal(impmapControl(gammaMethod = "individual")$gammaMethod, "individual")
+    expect_error(impmapControl(gammaMethod = "nonsense"))
+    # round-trips through the control constructor (do.call re-entry)
+    .c <- impmapControl(gammaMethod = "individual")
+    expect_equal(do.call(impmapControl, .c)$gammaMethod, "individual")
+    # stripped when down-converting to a plain foceiControl
+    expect_true("gammaMethod" %in% .impmapIsControlNames)
+  })
+
+  test_that("gammaMethod='global' keeps one shared scale", {
+    .d <- nlmixr2data::theo_sd
+    .f <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 10L,
+                                                 covMethod = "",
+                                                 gammaMethod = "global")))
+    .E <- .f$env
+    expect_equal(.E$impGammaMethod, "global")
+    # every subject on the same scale, equal to the reported scalar
+    expect_equal(length(unique(round(.E$impGammaInd, 12))), 1L)
+    expect_equal(unname(.E$impGammaInd[1]), unname(.E$impGammaUsed), tolerance = 1e-10)
+  })
+
+  test_that("gammaMethod='individual' gives per-subject scales that target iaccept", {
+    .d <- nlmixr2data::theo_sd
+    .f <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 30L,
+                                                 covMethod = "",
+                                                 gammaMethod = "individual")))
+    .E <- .f$env
+    expect_equal(.E$impGammaMethod, "individual")
+    # subjects genuinely diverge -- this is the whole point of the mode
+    expect_gt(length(unique(round(.E$impGammaInd, 8))), 1L)
+    # every scale respects the ISCALE bounds
+    expect_true(all(.E$impGammaInd >= 0.1 - 1e-8))
+    expect_true(all(.E$impGammaInd <= 10 + 1e-8))
+    expect_true(all(is.finite(.E$impGammaInd)))
+    # the controller drives mean xi onto the iaccept target (default 0.4).  The
+    # global rule leaves it near 1 on this near-Gaussian model, so this is a
+    # genuine discriminator between the two laws, not a tautology.
+    expect_equal(tail(.E$impXiTrace, 1), 0.4, tolerance = 0.1)
+  })
+
+  test_that("gammaMethod does not move the estimates, only the variance", {
+    # The importance weights correct for gamma, so both laws must agree on the
+    # parameters even though they sample at very different proposal widths.
+    .d <- nlmixr2data::theo_sd
+    .g <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 25L, covMethod = "",
+                                                 gammaMethod = "global")))
+    .i <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 25L, covMethod = "",
+                                                 gammaMethod = "individual")))
+    # the two ran at materially different scales ...
+    expect_gt(.i$env$impGammaUsed, 1.2 * .g$env$impGammaUsed)
+    # ... but agree on the fixed effects and the objective
+    expect_equal(unname(.i$theta), unname(.g$theta), tolerance = 0.02)
+    expect_equal(.i$env$impObj, .g$env$impObj, tolerance = 0.5)
+  })
+
+  test_that("individual gamma respects a tightened iscaleMax clamp", {
+    .d <- nlmixr2data::theo_sd
+    .f <- suppressWarnings(nlmixr2(.xiModel, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 20L, covMethod = "",
+                                                 gammaMethod = "individual",
+                                                 iscaleMax = 1.2)))
+    # the unclamped controller wants gamma ~ 1.8 here, so 1.2 must bind
+    expect_true(all(.f$env$impGammaInd <= 1.2 + 1e-8))
+    expect_gt(max(.f$env$impGammaInd), 1.0)
+  })
+
   test_that("xi is near 1 for a well-matched proposal on a near-Gaussian model", {
     # gamma = 1 makes the proposal the Laplace approximation itself, so on a
     # model whose individual posterior is close to Gaussian xi should sit near 1.

--- a/tests/testthat/test-imp-xi-gamma.R
+++ b/tests/testthat/test-imp-xi-gamma.R
@@ -135,6 +135,58 @@ nmTest({
     expect_gt(max(.f$env$impGammaInd), 1.0)
   })
 
+  test_that("individual gamma is stable at high eta dimension (no limit cycle)", {
+    # The damping exponent has to scale with neta.  For a Gaussian posterior
+    # xi = gamma^(-neta/2), so gamma' = gamma*(xi/iaccept)^p linearizes to an
+    # error multiplier lambda = 1 - p*neta/2.  A FIXED p = 1/2 gives
+    # lambda = -1 at neta = 8, i.e. a period-2 limit cycle that never settles
+    # (observed: gamma 1.32/1.24/1.30/1.23..., xi 0.36/0.45/0.37/0.46...).
+    # p = 2/neta gives lambda = 0 for every dimension.  This test fails on the
+    # fixed-exponent controller and passes on the dimension-aware one.
+    skip_on_cran()
+    .testSeed(7); rxode2::rxSetSeed(7)
+    .mk <- function() {
+      tt <- c(0.25, 1, 2, 4, 8, 16, 24)
+      do.call(rbind, lapply(1:12, function(id) {
+        ka <- exp(0.4 + stats::rnorm(1, 0, .3)); cl <- exp(1 + stats::rnorm(1, 0, .3))
+        v <- exp(3.4 + stats::rnorm(1, 0, .3))
+        cp <- 100 * ka / (v * (ka - cl / v)) * (exp(-cl / v * tt) - exp(-ka * tt))
+        cp <- pmax(cp, 1e-3) * exp(stats::rnorm(length(tt), 0, .1))
+        rbind(data.frame(id = id, time = 0, dv = NA_real_, amt = 100, evid = 1, cmt = "depot"),
+              data.frame(id = id, time = tt, dv = cp, amt = 0, evid = 0, cmt = "cen"))
+      }))
+    }
+    .d <- .mk(); .d <- .d[order(.d$id, .d$time, -.d$evid), ]
+    m8 <- function() {
+      ini({
+        tka <- 0.4; tcl <- 1; tv <- 3.4; tq <- 0.8; tv2 <- 3; tf <- 0; tlag <- -2; tke0 <- -1
+        eta.ka ~ .3; eta.cl ~ .3; eta.v ~ .3; eta.q ~ .3
+        eta.v2 ~ .3; eta.f ~ .2; eta.lag ~ .2; eta.ke0 ~ .2
+        add.sd <- 0.3
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        q <- exp(tq + eta.q); v2 <- exp(tv2 + eta.v2); f <- exp(tf + eta.f)
+        lag <- exp(tlag + eta.lag); ke0 <- exp(tke0 + eta.ke0)
+        d/dt(depot) <- -ka * depot
+        d/dt(cen) <- ka * depot - cl / v * cen - q / v * cen + q / v2 * peri + 0 * lag + 0 * ke0
+        d/dt(peri) <- q / v * cen - q / v2 * peri
+        cp <- f * cen / v
+        cp ~ add(add.sd)
+      })
+    }
+    .f <- suppressWarnings(nlmixr2(m8, .d, "impmap",
+                                   impmapControl(print = 0L, nIter = 18L, isample = 200L,
+                                                 covMethod = "", gammaMethod = "individual")))
+    expect_equal(nrow(.f$omega), 8L)
+    .tail <- tail(.f$env$impXiTrace, 10)
+    # a period-2 limit cycle has lag-1 autocorrelation ~ -1; a settled trace
+    # with Monte-Carlo noise sits well above that
+    expect_gt(stats::cor(head(.tail, -1), .tail[-1]), -0.8)
+    # and the swing must be small relative to the target it is holding
+    expect_lt(diff(range(.tail)), 0.15)
+  })
+
   test_that("xi is near 1 for a well-matched proposal on a near-Gaussian model", {
     # gamma = 1 makes the proposal the Laplace approximation itself, so on a
     # model whose individual posterior is close to Gaussian xi should sit near 1.

--- a/tests/testthat/test-qrpem-slow.R
+++ b/tests/testthat/test-qrpem-slow.R
@@ -75,10 +75,14 @@ nmTest({
   })
 
   test_that("Q3: qrRefresh pins or redraws the per-subject shift across iterations", {
+    # auto=FALSE: this pins the Sobol shift STREAM, and a t proposal consumes an
+    # extra uniform per draw for the chi-square scale, so letting auto assign df
+    # would shift the stream and the pin/redraw comparison would compare
+    # different things.
     .zLast <- function(nIter, qrRefresh, i = 1L) {
       .f <- suppressWarnings(
         nlmixr2(.oneCmt, nlmixr2data::theo_sd, "impmap",
-                impmapControl(print=0L, nIter=nIter, isample=128L, qr=TRUE,
+                impmapControl(print=0L, nIter=nIter, isample=128L, qr=TRUE, auto=FALSE,
                               qrRefresh=qrRefresh)))
       .zPoints(.f$env, i)
     }
@@ -90,7 +94,7 @@ nmTest({
     # even with a fixed shift, different subjects get different shifts
     .f <- suppressWarnings(
       nlmixr2(.oneCmt, nlmixr2data::theo_sd, "impmap",
-              impmapControl(print=0L, nIter=1L, isample=128L, qr=TRUE,
+              impmapControl(print=0L, nIter=1L, isample=128L, qr=TRUE, auto=FALSE,
                             qrRefresh=FALSE)))
     expect_gt(max(abs(.zPoints(.f$env, 1L) - .zPoints(.f$env, 2L))), 0.01)
   })
@@ -154,11 +158,15 @@ nmTest({
     # the SIR branch only engages when sirN < isample; at equality the fit is
     # bit-identical to sir=FALSE (the SIR plumbing is a strict superset)
     .run <- function(sir, sirSample = NULL) {
+      # auto=FALSE: the SIR branch engages on sirN < that subject's isample, and
+      # auto reallocates isample per subject, so "sirSample == isample" is no
+      # longer a single condition holding for everybody.  This test is about the
+      # SIR plumbing, so it pins a uniform sample count.
       .ctl <- if (sir) {
         impmapControl(print=0L, nIter=2L, isample=100L, sir=TRUE,
-                      sirSample=sirSample)
+                      sirSample=sirSample, auto=FALSE)
       } else {
-        impmapControl(print=0L, nIter=2L, isample=100L)
+        impmapControl(print=0L, nIter=2L, isample=100L, auto=FALSE)
       }
       suppressWarnings(nlmixr2(.oneCmt, nlmixr2data::theo_sd, "impmap", .ctl))
     }
@@ -234,10 +242,15 @@ nmTest({
   })
 
   test_that("Q1: default (qr/sir off) fit is unchanged vs the pre-QRPEM baseline", {
+    # auto=FALSE explicitly: this baseline was recorded before per-subject
+    # adaptation existed, and `auto` now defaults to TRUE, so the DEFAULT fit is
+    # deliberately no longer identical to it.  What this test still guards is
+    # that the un-adapted path is untouched -- which is the contract auto=FALSE
+    # carries.
     .ref <- readRDS(test_path("baselines", "qrpem-baseline-ref.rds"))
     .f <- suppressWarnings(
       nlmixr2(.oneCmt, nlmixr2data::theo_sd, "impmap",
-              impmapControl(print=0L, nIter=5L, isample=100L)))
+              impmapControl(print=0L, nIter=5L, isample=100L, auto=FALSE)))
     expect_equal(fixef(.f), .ref$fixef, tolerance=1e-8)
     expect_equal(.f$omega, .ref$omega, tolerance=1e-8)
     expect_equal(.f$env$impObj, .ref$obj, tolerance=1e-8)


### PR DESCRIPTION
## What this is

Per-subject adaptation of the importance-sampling proposal in `imp`/`impmap`/`qrpem`, plus the diagnostic that shows why it is needed.

## The finding that drove it

`xi` (NONMEM's `IACCEPT` quantity) and the Kish effective sample size are both **means over samples drawn from the proposal**, so neither can detect a tail the proposal rarely visits. On plain theophylline — transformably normal, 11 observations per subject — two of twelve subjects have importance weights with **infinite variance**:

| subject | Pareto k-hat | `xi` | ESS frac | verdict |
|---|---|---|---|---|
| 1 | **2.60** | 0.98 | 1.00 | unreliable |
| 5 | 0.68 | 0.96 | 0.99 | degrading |
| 10 | **1.28** | 0.96 | 0.99 | unreliable |

Not a small-sample artifact: max k-hat *grows* with more draws (2.49 → 3.31 → 3.76 at `isample` 300 → 1000 → 4000).

Three remedies, same fixture:

| approach | max k-hat | subjects k>0.7 | cost |
|---|---|---|---|
| Gaussian, `isample = 300` | 1.61 | 4 | baseline |
| Gaussian, failing subjects at `isample = 3000` | **3.28** | 1 | 10× samples |
| **t proposal, `df = 20`** | **−0.58** | **0** | 0.25% of ESS |

More samples treats the symptom and can make it worse — extra draws reach further into the tail the proposal misses. Only a heavier tail treats the cause.

## What landed

- [x] `fit$env$impXi` — NONMEM-style `xi`, exposed (no behaviour change)
- [x] Per-subject proposal-scale state (bit-identical refactor)
- [x] `gammaMethod` — NONMEM's two-sided per-subject `gamma` controller, with dimension-aware damping (`p = 2/neta`; a fixed exponent gives a period-2 limit cycle at `neta ≥ 8`)
- [x] IS covariance evaluated at the proposal the fit actually converged on
- [x] `gammaMethod="auto"` — `individual` only for non-transformably-normal models
- [x] `$runInfo` names which efficiency statistic is in force, and that the two are not comparable
- [x] `fit$env$impPsisK` — Pareto k-hat (validated against `loo::psis`)
- [x] `df` — multivariate-t proposal (NONMEM `DF`)
- [x] Per-subject `isample` (NONMEM per-subject `ISAMPLE`)
- [x] `auto` — per-subject `df`/`isample`/`iaccept` (NONMEM `AUTO=1`), **on by default**
- [x] Acceptance gate, tuned and re-run
- [x] Vignette (nlmixr2#404)

## Default change

`auto = TRUE` is the new default. Measured on theophylline against an `isample = 20000` reference (Gaussian, `df=8` and `df=20` references agree to 0.0003), 20 seeds:

| | objective RMSE | max k-hat | subjects k>0.7 | `Omega` RMSE |
|---|---|---|---|---|
| `auto = FALSE` | 0.0315 | 2.44 | 2.20 | 0.00247 |
| `auto = TRUE` | 0.0376 | **0.49** | **0.05** | **0.00198** |

Rationale: infinite-variance weights are a correctness problem whose error is unbounded in the worst case; the extra objective noise is bounded and measurable. `auto = FALSE` recovers the previous behaviour **bit-identically**.

## What is NONMEM's and what is ours

The NM7 Technical Guide's importance-sampling derivation is Gaussian throughout and never mentions `DF`. Bauer's *Tutorial Part II* documents the t sampler, `IACCEPT ≈ 0.2`, per-subject `ISAMPLE` and `AUTO=1`.

**Neither publishes the numbers.** Only the `nobs < neta` trigger and `IACCEPT ≈ 0.2` appear anywhere. So `df = 30`, the k-hat thresholds, the budget rule, the `2/neta` exponent and the 1.25× cap are **nlmixr2's own choices**, tuned on the measurements above — not reproductions of NONMEM internals. Unlike NONMEM's `AUTO`, which its tutorial warns "may result in lack of stochastic reproducibility", this stays seeded and thread-count independent.

## Verification

Every commit bit-identity checked against `main` on the `auto=FALSE`/`gammaMethod="global"` path — `identical()` on objf, theta, omega, impObj, impNeff, impCondMean, impLi and the full traces, not tolerances. Every commit independently reviewed (Antigravity/Gemini); that review caught four real defects, including the covariance step drawing Gaussian samples while weighting them as t.

**Not yet ready to merge:** the full `test-impmap.R` regression run under the new default is still outstanding. See the checklist comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX55hh6MDrfoMQHGk1pbwh