### PR TITLE
vpcSimExpand: don't merge the whole observed dataset for an unknown extra column (fixes #830)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,15 @@
 
 ## Bug fixes
 
+- `vpcSimExpand()` no longer merges the entire observed dataset into the
+  simulation when a requested `extra` column is missing: a dropped filter
+  result meant an unknown column (e.g. a misspelled `stratify` in
+  `vpcPlot()`) spliced every observed column into the simulation, and valid
+  columns dragged the rest of the observed data along with them (colliding
+  with the simulation's own, e.g. `time.x`/`time.y`).  Only the requested
+  columns are merged now, and a column found in neither the simulation nor
+  the data warns and is ignored (#830).
+
 - FOCEi: the inner eta-reset / eta-nudge machinery could make the objective
   function depend on the optimizer's history rather than on `theta` alone, so
   the same `theta` could return values hundreds of objective-function units

--- a/R/vpc.R
+++ b/R/vpc.R
@@ -283,10 +283,14 @@ vpcSimExpand <- function(object, sim, extra, fullData=NULL) {
   .extra <- .extra[!(.extra %in% names(sim))]
   if (length(.extra) == 0) return(sim)
   .wid <- which(tolower(names(.fullData)) == "id")
-  names(.fullData)[.wid] <- "ID"
   # merge in only the requested columns; other observed columns can
-  # collide with the simulation's own (e.g. time.x/time.y)
-  .fullData <- .fullData[, c("ID", "nlmixrRowNums", .extra), drop=FALSE]
+  # collide with the simulation's own (e.g. time.x/time.y); subset by the
+  # id column's actual name before renaming so an id request cannot
+  # reference a renamed column or duplicate it
+  .keep <- unique(c(names(.fullData)[.wid], "nlmixrRowNums", .extra))
+  .fullData <- .fullData[, .keep, drop=FALSE]
+  .wid <- which(tolower(names(.fullData)) == "id")
+  names(.fullData)[.wid] <- "ID"
   .sim <- sim
   .wid <- which(tolower(names(.sim)) == "id")
   names(.sim)[.wid] <- "ID"

--- a/R/vpc.R
+++ b/R/vpc.R
@@ -274,11 +274,19 @@ vpcSimExpand <- function(object, sim, extra, fullData=NULL) {
     .fullData <- fullData
   }
   .fullData$nlmixrRowNums <- seq_along(.fullData[, 1])
+  .bad <- extra[!(extra %in% c(names(.fullData), names(sim)))]
+  if (length(.bad) > 0) {
+    warning("column(s) not in simulation or data: ",
+            paste(.bad, collapse=", "), call.=FALSE)
+  }
   .extra <- extra[extra %in% names(.fullData)]
-  .extra <- extra[!(extra %in% names(sim))]
+  .extra <- .extra[!(.extra %in% names(sim))]
   if (length(.extra) == 0) return(sim)
   .wid <- which(tolower(names(.fullData)) == "id")
   names(.fullData)[.wid] <- "ID"
+  # merge in only the requested columns; other observed columns can
+  # collide with the simulation's own (e.g. time.x/time.y)
+  .fullData <- .fullData[, c("ID", "nlmixrRowNums", .extra), drop=FALSE]
   .sim <- sim
   .wid <- which(tolower(names(.sim)) == "id")
   names(.sim)[.wid] <- "ID"

--- a/R/vpc.R
+++ b/R/vpc.R
@@ -273,7 +273,7 @@ vpcSimExpand <- function(object, sim, extra, fullData=NULL) {
   } else {
     .fullData <- fullData
   }
-  .fullData$nlmixrRowNums <- seq_along(.fullData[, 1])
+  .fullData$nlmixrRowNums <- seq_len(nrow(.fullData))
   .bad <- extra[!(extra %in% c(names(.fullData), names(sim)))]
   if (length(.bad) > 0) {
     warning("column(s) not in simulation or data: ",

--- a/tests/testthat/test-vpcSim.R
+++ b/tests/testthat/test-vpcSim.R
@@ -74,6 +74,14 @@ nmTest({
 
     expect_equal(tmp$dvid, tmp2$dvid)
 
+    # a valid extra merges in only the requested column (#830)
+    expect_equal(setdiff(names(tmp), c(names(f), "ID", "dvid")), character(0))
+
+    # an unknown extra warns and returns the simulation unchanged (#830)
+    expect_warning(tmp3 <- vpcSimExpand(fitKA1tr1_PDimmemax1_F, f, "NOSUCHCOL"),
+                   "NOSUCHCOL")
+    expect_identical(tmp3, f)
+
   })
 
   test_that("vpcSim works with etas that are set to zero (#341)", {

--- a/tests/testthat/test-vpcSimExpand.R
+++ b/tests/testthat/test-vpcSimExpand.R
@@ -1,0 +1,10 @@
+test_that("vpcSimExpand ignores unknown extra columns (#830)", {
+  sim <- data.frame(id = c(1, 1, 2), time = c(0, 1, 0), sim = c(1, 2, 3))
+  obs <- data.frame(ID = c(1, 2), TIME = c(0, 0), DV = c(1, 3), WT = c(70, 80))
+  # a column in neither frame warns and returns the simulation unchanged
+  expect_warning(out <- vpcSimExpand(NULL, sim, "NOSUCHCOL", obs), "NOSUCHCOL")
+  expect_identical(out, sim)
+  # a column already in the simulation is left alone (no merge, no warning)
+  expect_identical(vpcSimExpand(NULL, sim, "time", obs), sim)
+  expect_identical(vpcSimExpand(NULL, sim, NULL, obs), sim)
+})

--- a/tests/testthat/test-vpcSimExpand.R
+++ b/tests/testthat/test-vpcSimExpand.R
@@ -8,3 +8,31 @@ test_that("vpcSimExpand ignores unknown extra columns (#830)", {
   expect_identical(vpcSimExpand(NULL, sim, "time", obs), sim)
   expect_identical(vpcSimExpand(NULL, sim, NULL, obs), sim)
 })
+
+test_that("vpcSimExpand merges only the requested columns (#830)", {
+  # vpcNameDataCmts needs a real fit; the merge logic does not
+  local_mocked_bindings(vpcNameDataCmts = function(object, data) data)
+  sim <- data.frame(id = c(1, 1, 2), nlmixrRowNums = c(1, 2, 3),
+                    time = c(0, 1, 0), sim = c(1, 2, 3))
+  obs <- data.frame(ID = c(1, 1, 2), time = c(0, 1, 0), DV = c(1, 2, 3),
+                    WT = c(70, 70, 80))
+  out <- vpcSimExpand(NULL, sim, "WT", obs)
+  expect_true("WT" %in% names(out))
+  expect_false("DV" %in% names(out))
+  expect_false(any(grepl("\\.(x|y)$", names(out))))
+  expect_equal(nrow(out), 3L)
+
+  # requesting the id column itself must not crash or duplicate it, even
+  # when its case differs between the simulation and the data
+  simU <- data.frame(ID = c(1, 2), nlmixrRowNums = c(1, 2), sim = c(1, 2))
+  obsL <- data.frame(id = c(1, 2), WT = c(70, 80))
+  out2 <- vpcSimExpand(NULL, simU, c("id", "WT"), obsL)
+  expect_equal(sum(tolower(names(out2)) == "id"), 1L)
+  expect_true("WT" %in% names(out2))
+
+  simL <- data.frame(id = c(1, 2), nlmixrRowNums = c(1, 2), sim = c(1, 2))
+  obsU <- data.frame(ID = c(1, 2), WT = c(70, 80))
+  out3 <- vpcSimExpand(NULL, simL, c("ID", "WT"), obsU)
+  expect_equal(sum(tolower(names(out3)) == "id"), 1L)
+  expect_true("WT" %in% names(out3))
+})


### PR DESCRIPTION
Fixes #830.

## What was wrong

`vpcSimExpand()` filtered the requested `extra` columns twice, but the second
filter reassigned from `extra` instead of narrowing `.extra`, discarding the
in-data filter. A column present in neither the simulation nor the observed
data therefore triggered a full `merge()`, splicing the entire observed dataset
into the simulation (and, via `time.x`/`time.y` collisions, leaving the
simulation with no usable `time` column downstream in `nlmixr2plot`).

## What this does

- Narrows the second filter from the first (`.extra`, not `extra`), so an
  unknown column is a no-op: the simulation is returned unchanged.
- Warns when a requested column exists in neither frame, so a misspelled
  `stratify`/`keep` column fails clearly at the point of the mistake.
- Merges in **only** the requested columns (plus the id key), so valid extras
  no longer drag the rest of the observed data along and collide with the
  simulation's own columns.
- Subsets by the id column's pre-rename name with `unique()`, so requesting the
  id column itself cannot reference a renamed column or duplicate it.
- Uses `seq_len(nrow())` for the merge row numbers (robust to tibble
  `fullData`, where `seq_along(x[, 1])` returns length 1 and recycles).

## Tests

- New always-run unit file `test-vpcSimExpand.R`: unknown-column warning +
  unchanged return, merge path (via mocked `vpcNameDataCmts`) adds only the
  requested columns, id-case edge cases.
- `test-vpcSim.R` (weekly batch): the fit-based test now asserts a valid extra
  adds only itself and an unknown extra warns and returns the simulation
  unchanged.

Each commit was independently reviewed by Antigravity (gemini-3.1-pro-high);
the two real findings (id-case rename crash, duplicate `ID` column) are fixed
in the follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
