### PR TITLE
Document why generated models must not re-emit splitBolus(); fix nlm/nls/impmap interpolation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,16 @@
   statistic a fit is reporting, and states that `xi` and the Kish
   effective-sample fraction are not comparable with each other.
 
+## Bug fixes
+
+### Estimation
+
+- The nlm family (`est="nlm"`, `"nlminb"`, ...), `est="nls"` and the
+  importance-sampling EM sensitivity model now honor the covariate
+  interpolation declared in the model (`nocb()`, `linear()`, `midpoint()`).
+  Their gradient and prediction models were generated without those lines,
+  so they always used the default `locf()` interpolation.
+
 # nlmixr2est 7.0.2
 
 ## Bug fixes

--- a/R/focei.R
+++ b/R/focei.R
@@ -1307,6 +1307,8 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
 }
 
 .innerInternal <- function(ui, s) {
+  ## Interpolation is carried into the generated models, splitBolus() is not:
+  ## these models solve the pre-split $dataSav (see .foceiPreProcessData()).
   .cmt <-  ui$foceiCmtPreModel
   .interp <- ui$interpLinesStr
   if (.interp != "") {
@@ -2312,6 +2314,10 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   for (.v in c("DV", "TIME")) {
     data[[.v]] <- as.double(data[[.v]])
   }
+  ## The normModel carries splitBolus(), so the etTrans() below splits the doses
+  ## once here and $dataSav holds the split events for every estimation method.
+  ## That is why no generated model re-emits splitBolus() -- a generated model
+  ## that declares it splits the already-split doses a second time.
   .mod <- rxode2::rxModelVars(paste0(ui$mv0$model["normModel"], "\n", .foceiToCmtLinesAndDvid(ui)))
   .strCmpP <- .mod$strCmpParams
   .strCmpPNames <- tolower(names(.strCmpP))

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -1367,6 +1367,8 @@
     .param <- .uiGetThetaEtaParams(ui, TRUE)          # params(THETA[1], .., ETA[1], .., covs)
     .param <- gsub("ETA\\[([0-9]+)\\]", "ETA_\\1_", gsub("THETA\\[([0-9]+)\\]", "THETA_\\1_", .param))
     .modTxt <- paste(.param, .modTxt, sep = "\n")
+    # no splitBolus() in the augmented model -- it translates the already-split
+    # dataSav, so declaring it would split the doses twice (.foceiPreProcessData)
     # eventSens="jump" attaches rxode2's analytic event/dosing-parameter sensitivities
     # (forward variational jumps at dose times) for the sensitivity compartments.  `cols`
     # precomputes solve-output column names/index maps; `cores` carries the fit's rxControl thread

--- a/R/impmapThetaSens.R
+++ b/R/impmapThetaSens.R
@@ -114,8 +114,14 @@ attr(rxUiGet.impmapThetaSens, "rstudio") <- emptyenv()
 .impmapThetaSensModel <- function(ui) {
   .s <- rxUiGet.impmapThetaSens(list(ui))
   if (is.null(.s)) return(NULL)
+  ## Interpolation is carried like the inner model does; splitBolus() is not --
+  ## this model solves the pre-split events, so declaring it would split the
+  ## doses twice (see .foceiPreProcessData())
+  .cmt <- ui$foceiCmtPreModel
+  .interp <- ui$interpLinesStr
+  if (.interp != "") .cmt <- paste0(.cmt, "\n", .interp)
   nlmixr2global$toRxParam <-
-    paste0(.uiGetThetaEtaParams(ui, TRUE), "\n", ui$foceiCmtPreModel, "\n")
+    paste0(.uiGetThetaEtaParams(ui, TRUE), "\n", .cmt, "\n")
   nlmixr2global$toRxDvidCmt <- .foceiToCmtLinesAndDvid(ui)
   .toRx(.s$..thetaSens, "compiling sensitivity model...")
 }

--- a/R/nlm.R
+++ b/R/nlm.R
@@ -583,6 +583,8 @@ rxUiGet.nlmRxModel <- function(x, ...) {
   if (.interp != "") {
     .cmt <-paste0(.cmt, "\n", .interp)
   }
+  ## no splitBolus() here -- this model solves the pre-split events, so
+  ## declaring it would split the doses twice (see .foceiPreProcessData())
   list(predOnly=rxode2::rxode2(paste(c(rxUiGet.nlmParams(x, ...), .cmt,
                                        .ret, .foceiToCmtLinesAndDvid(x[[1]])), collapse="\n")),
        eventTheta=.eventTheta)
@@ -759,11 +761,15 @@ attr(rxUiGet.nlmHdTheta, "rstudio") <- emptyenv()
 #' Finalize nlm rxode2 based on symengine saved info
 #'
 #' @param .s Symengine/rxode2 object
+#' @param interpLines covariate interpolation lines (`locf()`/`nocb()`/...) to
+#'   emit; symengine drops them, so they have to be added back here
 #' @return Nothing
 #' @author Matthew L Fidler
 #' @noRd
 .rxFinalizeNlm <- function(.s, sum.prod = FALSE,
-                           optExpression = TRUE, cores = 0L) {
+                           optExpression = TRUE, cores = 0L,
+                           interpLines = "") {
+  interpLines <- interpLines[interpLines != ""]
   .rxInjectMatExpDdt(.s)
   .prd <- get("rx_pred_", envir = .s)
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))
@@ -791,6 +797,7 @@ attr(rxUiGet.nlmHdTheta, "rstudio") <- emptyenv()
   .s$..nlmS <- paste(c(
     .s$params,
     .s$..stateInfo["state"],
+    interpLines,
     .lhs,
     .ddt,
     .sens,
@@ -814,6 +821,7 @@ attr(rxUiGet.nlmHdTheta, "rstudio") <- emptyenv()
   .s$..pred.nolhs <- paste(c(
     .s$params,
     .s$..stateInfo["state"],
+    interpLines,
     .lhs0,
     .lhs,
     .ddt,
@@ -860,7 +868,8 @@ rxUiGet.nlmEnv <- function(x, ...) {
     .calcSens <- paste0("THETA_", seq_len(.s$..maxTheta), "_")
     .s$..adjSens <- .rxAdjointSensLines(.nlmPrune(x), .calcSens, .adj$stiff)
   }
-  .rxFinalizeNlm(.s, .sumProd, .optExpression, .optExprCores(x[[1]]))
+  .rxFinalizeNlm(.s, .sumProd, .optExpression, .optExprCores(x[[1]]),
+                 interpLines = rxUiGet.interpLinesStr(x, ...))
   .s$..outer <- NULL
   if (exists("..maxTheta", .s)) {
     .eventTheta <- rep(0L, .s$..maxTheta)

--- a/R/nlmeRxUiGet.R
+++ b/R/nlmeRxUiGet.R
@@ -153,6 +153,8 @@ rxUiGet.nlmeRxModelFD <- function(x, ...) {
   if (.interp != "") {
     .cmt <-paste0(.cmt, "\n", .interp)
   }
+  ## no splitBolus() here -- the doses were already split when the data was
+  ## translated (see .foceiPreProcessData())
   paste(c(rxUiGet.saemParams(x, ...), .cmt,
           .ret, .foceiToCmtLinesAndDvid(x[[1]])), collapse="\n")
 }

--- a/R/nls.R
+++ b/R/nls.R
@@ -598,6 +598,8 @@ rxUiGet.nlsRxModel <- function(x, ...) {
   if (.interp != "") {
     .cmt <-paste0(.cmt, "\n", .interp)
   }
+  ## no splitBolus() here -- this model solves the pre-split events, so
+  ## declaring it would split the doses twice (see .foceiPreProcessData())
   list(predOnly =rxode2::rxode2(paste(c(rxUiGet.nlsParams(x, ...), .cmt,
                                         .ret, .foceiToCmtLinesAndDvid(x[[1]])), collapse="\n")),
        eventTheta=.eventTheta)
@@ -665,11 +667,15 @@ attr(rxUiGet.nlsHdTheta, "rstudio") <- emptyenv()
 #' Finalize nls rxode2 based on symengine saved info
 #'
 #' @param .s Symengine/rxode2 object
+#' @param interpLines covariate interpolation lines (`locf()`/`nocb()`/...) to
+#'   emit; symengine drops them, so they have to be added back here
 #' @return Nothing
 #' @author Matthew L Fidler
 #' @noRd
 .rxFinalizeNls <- function(.s, sum.prod = FALSE,
-                           optExpression = TRUE, cores = 0L) {
+                           optExpression = TRUE, cores = 0L,
+                           interpLines = "") {
+  interpLines <- interpLines[interpLines != ""]
   .prd <- get("rx_pred_", envir = .s)
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))
   .yj <- paste(get("rx_yj_", envir = .s))
@@ -687,6 +693,7 @@ attr(rxUiGet.nlsHdTheta, "rstudio") <- emptyenv()
   .s$..nlsS <- paste(c(
     .s$params,
     .s$..stateInfo["state"],
+    interpLines,
     .ddt,
     .sens,
     .yj,
@@ -704,6 +711,7 @@ attr(rxUiGet.nlsHdTheta, "rstudio") <- emptyenv()
   .s$..pred.nolhs <- paste(c(
     .s$params,
     .s$..stateInfo["state"],
+    interpLines,
     .lhs0,
     .ddt,
     .yj,
@@ -736,7 +744,8 @@ rxUiGet.nlsEnv <- function(x, ...) {
   .s$params <- rxUiGet.nlsParams(x, ...)
   .sumProd <- rxode2::rxGetControl(x[[1]], "sumProd", FALSE)
   .optExpression <- rxode2::rxGetControl(x[[1]], "optExpression", TRUE)
-  .rxFinalizeNls(.s, .sumProd, .optExpression, .optExprCores(x[[1]]))
+  .rxFinalizeNls(.s, .sumProd, .optExpression, .optExprCores(x[[1]]),
+                 interpLines = rxUiGet.interpLinesStr(x, ...))
   .s$..outer <- NULL
   if (exists("..maxTheta", .s)) {
     .eventTheta <- rep(0L, .s$..maxTheta)

--- a/R/saemRxUiGetModel.R
+++ b/R/saemRxUiGetModel.R
@@ -387,6 +387,8 @@ rxUiGet.saemModel <- function(x, ...) {
   if (.interp != "") {
     .cmt <-paste0(.cmt, "\n", .interp)
   }
+  ## no splitBolus() here -- saem solves the pre-split $dataSav, so declaring it
+  ## would split the doses twice (see .foceiPreProcessData())
   paste(c(rxUiGet.saemParams(x, ...), .cmt,
           .ret, .foceiToCmtLinesAndDvid(x[[1]])), collapse="\n")
 }
@@ -488,15 +490,9 @@ attr(rxUiGet.interpLinesStr, "rstudio") <- ""
 #' @export
 rxUiGet.saemModelPred <- function(x, ...) {
   .ui0 <- x[[1]]
-  .levels  <- .ui0$levels
-  if (!is.null(.levels)) {
-    .levels <- vapply(seq_along(.levels),
-                      function(i){
-                        deparse1(.levels[[i]])
-                      },
-                      character(1), USE.NAMES=FALSE)
-    .levels <- paste(.levels, collapse="\n")
-  }
+  ## No levels() lines are emitted: .foceiPreProcessData() turns the string
+  ## covariates into factors with the model's level order, so the solve sees
+  ## the numeric codes directly.
   .s <- rxUiGet.loadPruneSaemPred(x, ...)
   .saemModelEnv$symengine <- .s
   .replaceLst <- rxUiGet.saemModelPredReplaceLst(x, ...)
@@ -577,6 +573,8 @@ rxUiGet.saemModelPred <- function(x, ...) {
     .ret2
   ), collapse = "\n")
   .interp <- rxUiGet.interpLinesStr(x, ...)
+  ## as in rxUiGet.saemModel(), splitBolus() is left out: the events this model
+  ## solves have already been split
   .ret <- c(rxUiGet.foceiParams(x, ...),
             rxUiGet.foceiCmtPreModel(x, ...),
             .interp,

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -72,7 +72,7 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   c("focei-wang2007-boxcox-half", "nlm-cens", "issue-429", "issue-470",
     "focei-wang2007-bounded", "saem-loglik", "mu-timevarying", "saem-nearpd",
     "saem-nonmutheta", "saem-sharedinner", "focei-theta-reset-bounds",
-    "saem-cov-analytic", "focei-shi21-bounds"),
+    "saem-cov-analytic", "focei-shi21-bounds", "splitbolus-interp"),
 
   # batch 4
   c("impmap", "matexp", "mfocei", "focei-wang2007-yeojohnson",

--- a/tests/testthat/test-splitbolus-interp.R
+++ b/tests/testthat/test-splitbolus-interp.R
@@ -1,0 +1,78 @@
+nmTest({
+  # splitBolus() is applied once, when .foceiPreProcessData() translates the data
+  # with the user's normModel.  The generated estimation models must therefore NOT
+  # declare splitBolus() themselves, or the already-split doses get split twice.
+  .mkSplit <- function(split) {
+    .bdy <- c("ka <- exp(tka + eta.ka)", "cl <- exp(tcl)", "v <- exp(tv)",
+              "d/dt(depot) <- -ka * depot",
+              "d/dt(central) <- ka * depot - cl / v * central",
+              if (split) "splitBolus(depot, depot, central)",
+              "cp <- central / v", "cp ~ add(add.sd)")
+    eval(parse(text=paste0(
+      "function() {\n ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.ka ~ 0.1; add.sd <- 0.7})\n",
+      " model({\n", paste(.bdy, collapse="\n"), "\n })\n}")))
+  }
+
+  .d <- nlmixr2data::theo_sd
+  .d <- .d[.d$ID <= 3, ]
+  .d$EVID[.d$AMT > 0] <- 1L
+  # equivalent of splitBolus(depot, depot, central): the same bolus into central
+  .dose <- .d[.d$EVID == 1, ]
+  .dose$CMT <- 2
+  .dExpl <- rbind(.d, .dose)
+  .dExpl <- .dExpl[order(.dExpl$ID, .dExpl$TIME, -.dExpl$EVID), ]
+
+  test_that("generated models do not re-emit splitBolus()", {
+    .ui <- .mkSplit(TRUE)()
+    .ui <- rxode2::rxode2(.ui)
+    expect_true(length(rxode2::rxModelVars(.ui)$splitBolus) > 0L)
+    .noSplit <- function(mod) {
+      expect_length(rxode2::rxModelVars(mod)$splitBolus, 0L)
+    }
+    .noSplit(rxUiGet.saemModel(list(.ui)))
+    .noSplit(rxUiGet.saemModelPred(list(.ui))$predOnly)
+    .noSplit(rxUiGet.nlmeRxModelFD(list(.ui)))
+    .fm <- rxUiGet.foceiModel(list(.ui))
+    for (.n in c("inner", "predOnly", "predNoLhs")) .noSplit(.fm[[.n]])
+  })
+
+  test_that("splitBolus() doses are split exactly once during estimation", {
+    .ctl <- foceiControl(maxOuterIterations=0, maxInnerIterations=20, covMethod="",
+                         print=0, calcTables=FALSE)
+    .split <- nlmixr2(.mkSplit(TRUE), .d, est="focei", control=.ctl)
+    .expl <- nlmixr2(.mkSplit(FALSE), .dExpl, est="focei", control=.ctl)
+    .none <- nlmixr2(.mkSplit(FALSE), .d, est="focei", control=.ctl)
+    expect_equal(.split$objf, .expl$objf, tolerance=1e-6)
+    # guard against the split being dropped entirely
+    expect_true(abs(.split$objf - .none$objf) > 1)
+  })
+
+  # est="nlm"/"nls" build their models from symengine parts, which drop the
+  # covariate interpolation declared in the model
+  .mkInterp <- function(interp) {
+    .bdy <- c(if (!is.null(interp)) paste0(interp, "(WT)"),
+              "ka <- exp(tka)", "cl <- exp(tcl + 0.05 * WT)", "v <- exp(tv)",
+              "d/dt(depot) <- -ka * depot",
+              "d/dt(central) <- ka * depot - cl / v * central",
+              "cp <- central / v", "cp ~ add(add.sd)")
+    eval(parse(text=paste0(
+      "function() {\n ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- 0.7})\n",
+      " model({\n", paste(.bdy, collapse="\n"), "\n })\n}")))
+  }
+
+  test_that("nlm/nls honor the model's covariate interpolation", {
+    .di <- .d
+    withr::with_seed(1, .di$WT <- round(runif(nrow(.di), 60, 100), 1))
+    .objf <- function(est, ctl, f) nlmixr2(f, .di, est=est, control=ctl)$objf
+    .nctl <- nlmControl(print=0, calcTables=FALSE, iterlim=1)
+    expect_false(isTRUE(all.equal(.objf("nlm", .nctl, .mkInterp("locf")),
+                                  .objf("nlm", .nctl, .mkInterp("nocb")))))
+    .sctl <- nlsControl(maxiter=1)
+    expect_false(isTRUE(all.equal(.objf("nls", .sctl, .mkInterp("locf")),
+                                  .objf("nls", .sctl, .mkInterp("nocb")))))
+    # the interpolation reaches the compiled gradient model, not just predOnly
+    .ui <- rxode2::rxode2(.mkInterp("nocb"))
+    .interp <- rxode2::rxModelVars(rxUiGet.nlmSensModel(list(.ui))$thetaGrad)$interp
+    expect_true(any(.interp != 0))
+  })
+})


### PR DESCRIPTION
Investigating #637 (add `splitDose()`/`splitBolus()` to the models generated for focei, saem and nlm) showed that the statement is already honored by every estimation method, and that adding it to the generated models actively breaks them. This PR documents that, and fixes two real bugs found while mapping the generation sites.

## splitBolus() is already applied -- once

`.foceiPreProcessData()` translates the data with `ui$mv0$model["normModel"]`, which carries the `splitBolus()` statement, so `$dataSav` already holds the split events and every method solves those.

Carrying `splitBolus()` into the generated models (the literal request in #637) splits the doses a **second** time. Measured against a reference dataset where each bolus is manually duplicated into the target compartment -- which a plain `rxSolve()` confirms reproduces `splitBolus(depot, depot, central)` exactly:

| | main | with splitBolus() carried into the generated models |
|---|---|---|
| focei objf | 1438.4308 (= reference) | 7942.7767 |
| saem objf | 75.019904 (= reference) | 109.91744 |
| nlm objf | 2008.0088 (= reference) | 5974.7282 |
| nls objf | 114.48155 (= reference) | 174.73985 |
| nlme | 73.543761 (= reference) | errors |

FOCEi `PRED` doubles at the dose time. On main, all of focei, focei `fast=TRUE`, foce, posthoc, saem, nlme, imp, nlm, nlminb and nls match the reference exactly -- including the mixture EBE path, whose pruned normalized text legitimately keeps the statement.

So rather than change behavior, each model-generation site now notes that `splitBolus()` is deliberately absent and would double-split, with the reason recorded in `R/focei.R` where the split actually happens.

## Bug fix: nlm/nls/impmap ignored the declared interpolation

`est="nlm"`, `est="nls"` and the impmap theta-sensitivity model are assembled from symengine parts, which drop the model's interpolation lines. A declared `nocb()`, `linear()` or `midpoint()` was silently ignored and the solve fell back to the default `locf()` -- `locf` and `nocb` returned byte-identical objective functions. The interp lines are now carried the way the inner model does. `locf`/default results are unchanged; only the previously-ignored interpolations differ.

## Cleanup: dead levels() code

`rxUiGet.saemModelPred()` computed `levels()` declarations it never used. String covariates are converted to factors on the data side -- a string-covariate saem fit matches its numerically coded equivalent exactly -- so the emitted model does not need them. Removed rather than emitted.

## Verification

- New `tests/testthat/test-splitbolus-interp.R` (12 assertions): generated models carry no `splitBolus`; a split fit matches the manually-split-data fit and differs from the unsplit one; nlm/nls distinguish `locf` from `nocb`; the interpolation reaches the compiled gradient model, not just `predOnly`. At 314s it goes in weekly `.slowBatches` batch 3, not the push/PR subset.
- `test-nlm.R` (24 pass) and `test-nls.R` (5 pass) clean.
- `test-impmap.R` declares no interpolation, so the impmap change is a strict no-op there; verified directly that the generated sensitivity model is unchanged without an interp declaration and picks up `nocb` with one.
- All ten method/reference comparisons above re-run on this branch and identical to main.

Closes #637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)