### PR TITLE
fix(cov): analytic covariance ignored covSolveTol and ran single-threaded

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,13 @@
   as a result -- measured at about 4% of that step, which is inside its
   run-to-run noise; set `covSolveTol` to trade accuracy back for speed.
 
+- `covMethod="analytic"` solves in parallel again.  The pooled covariance solve
+  coerced `rxControl(cores = 0)` -- the default, which means "use rxode2's thread
+  setting" -- to a literal 1, so it ran **single-threaded over subjects** while the
+  `rxSolve` route it replaced honoured the 0 and ran threaded.  The shared pool's
+  parallelism was therefore off by default here.  A 5-ETA 2-compartment covariance
+  goes from 1.04s to 0.71s, and from slower than the unpooled route to faster.
+
 - Fixed the objective function for a model that has a **general-likelihood
   endpoint (`ll()`, `pois()`, `binom()`, ...) alongside any other endpoint**.
   Each observation's distribution was read one row before the model had been

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,13 @@
   at the default `sigdig`).  Both routes now agree exactly.  Set `covSolveTol` to
   trade accuracy back for the slightly larger covariance step.
 
+- Fixed a subject whose pooled augmented solve failed being scored into
+  `covMethod="analytic"` as zeros -- no prediction and no sensitivity -- instead
+  of sending the covariance to its fallback.  The zero fill was written for the
+  R outer gradient, which replaced such a subject's column by a finite
+  difference; that gradient is gone, and zeros are finite, so nothing downstream
+  noticed.  Such a population now falls back to the unpooled solve.
+
 - Fixed the pooled `covMethod="analytic"` solve running single-threaded.  It
   coerced `rxControl(cores = 0)` -- the default, meaning "use rxode2's thread
   setting" -- to a literal 1, so its loop over subjects never went parallel,

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,20 @@
 
 ### Estimation
 
+- `covMethod="analytic"` now solves at the tolerance it asks for.  The augmented
+  solves behind the analytic R matrix are central-differenced twice and Richardson
+  extrapolated to recover a 3rd-order tensor, so they are run at
+  `foceiControl(covSolveTol=)` -- or, unset, a value tightened from `sigdig`.
+  Whenever the shared ODE solve pool was available that tolerance was dropped and
+  the fit's own, much looser, tolerance was used instead.  Two consequences, both
+  gone: standard errors carried the fit's solve error rather than the
+  covariance's (1.7e-2 relative on a 5-ETA 2-compartment model at the default
+  `sigdig`), and since the pool is only available with `fast = TRUE`,
+  **`foceiControl(fast=)` changed the standard errors**.  The pooled and
+  unpooled routes now agree exactly.  The covariance step does slightly more work
+  as a result -- measured at about 4% of that step, which is inside its
+  run-to-run noise; set `covSolveTol` to trade accuracy back for speed.
+
 - Fixed the objective function for a model that has a **general-likelihood
   endpoint (`ll()`, `pois()`, `binom()`, ...) alongside any other endpoint**.
   Each observation's distribution was read one row before the model had been

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,26 +12,21 @@
 
 ### Estimation
 
-- `covMethod="analytic"` now solves at the tolerance it asks for.  The augmented
-  solves behind the analytic R matrix are central-differenced twice and Richardson
-  extrapolated to recover a 3rd-order tensor, so they are run at
-  `foceiControl(covSolveTol=)` -- or, unset, a value tightened from `sigdig`.
-  Whenever the shared ODE solve pool was available that tolerance was dropped and
-  the fit's own, much looser, tolerance was used instead.  Two consequences, both
-  gone: standard errors carried the fit's solve error rather than the
-  covariance's (1.7e-2 relative on a 5-ETA 2-compartment model at the default
-  `sigdig`), and since the pool is only available with `fast = TRUE`,
-  **`foceiControl(fast=)` changed the standard errors**.  The pooled and
-  unpooled routes now agree exactly.  The covariance step does slightly more work
-  as a result -- measured at about 4% of that step, which is inside its
-  run-to-run noise; set `covSolveTol` to trade accuracy back for speed.
+- Fixed `covMethod="analytic"` ignoring its own solve tolerance whenever the
+  shared ODE solve pool was available, solving at the fit's much looser tolerance
+  instead of `foceiControl(covSolveTol=)` (or, unset, a value tightened from
+  `sigdig`).  The augmented solves are differenced twice to recover a 3rd-order
+  tensor, so their error is the standard errors' error: they carried the fit's
+  instead, and because the pool needs `fast = TRUE`, **`foceiControl(fast=)`
+  changed the standard errors** (1.7e-2 relative on a 5-ETA 2-compartment model
+  at the default `sigdig`).  Both routes now agree exactly.  Set `covSolveTol` to
+  trade accuracy back for the slightly larger covariance step.
 
-- `covMethod="analytic"` solves in parallel again.  The pooled covariance solve
-  coerced `rxControl(cores = 0)` -- the default, which means "use rxode2's thread
-  setting" -- to a literal 1, so it ran **single-threaded over subjects** while the
-  `rxSolve` route it replaced honoured the 0 and ran threaded.  The shared pool's
-  parallelism was therefore off by default here.  A 5-ETA 2-compartment covariance
-  goes from 1.04s to 0.71s, and from slower than the unpooled route to faster.
+- Fixed the pooled `covMethod="analytic"` solve running single-threaded.  It
+  coerced `rxControl(cores = 0)` -- the default, meaning "use rxode2's thread
+  setting" -- to a literal 1, so its loop over subjects never went parallel,
+  while the `rxSolve` route it replaced passed the 0 through and did.  A 5-ETA
+  2-compartment covariance goes from 1.04s to 0.71s.
 
 - Fixed the objective function for a model that has a **general-likelihood
   endpoint (`ll()`, `pois()`, `binom()`, ...) alongside any other endpoint**.

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,12 @@
   at the default `sigdig`).  Both routes now agree exactly.  Set `covSolveTol` to
   trade accuracy back for the slightly larger covariance step.
 
+- Fixed `foceiControl(covSolveTol=)` being dropped part-way through the
+  covariance step.  Once the analytic route had restored the fit's ODE solve --
+  which it does whether it succeeded or declined -- the finite-difference
+  covariance work after that point ran at the fit's tolerance again, because
+  rebuilding the solve resets the tolerances along with it.
+
 - Fixed a subject whose pooled augmented solve failed being scored into
   `covMethod="analytic"` as zeros -- no prediction and no sensitivity -- instead
   of sending the covariance to its fallback.  The zero fill was written for the

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -245,8 +245,8 @@ foceiOuterFdInd_ <- function(ids0, analyticRef) {
     .Call(`_nlmixr2est_foceiOuterFdInd_`, ids0, analyticRef)
 }
 
-vaeOuterSolve_ <- function(thVals, ebes, cols, cores) {
-    .Call(`_nlmixr2est_vaeOuterSolve_`, thVals, ebes, cols, cores)
+vaeOuterSolve_ <- function(thVals, ebes, cols, cores, tol = NA_real_) {
+    .Call(`_nlmixr2est_vaeOuterSolve_`, thVals, ebes, cols, cores, tol)
 }
 
 #' Analytic outer gradient at a caller-supplied theta / eta / omega

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -1570,7 +1570,7 @@
 #' batched Ath reproduces the per-subject adaptive-Shi Ath (the FOCEI-vs-FOCE analytic-R agreement,
 #' not just the SEs).  Returns the per-subject E-list with `Ath` attached, or NULL (-> per-subject).
 #' @noRd
-.foceiAnalyticSolveAllFD3 <- function(am, thv, ebes, ids, data, obsTimes, tol = 1e-10,
+.foceiAnalyticSolveAllFD3 <- function(am, thv, ebes, ids, data, obsTimes, tol,
                                       fdEps = 1e-3, withR = FALSE, sigSel = NULL) {
   dirs <- am$dirs; nd <- length(dirs); neta <- ncol(ebes)
   E0 <- .foceiAnalyticSolveAll(am, thv, ebes, ids, data, obsTimes, tol)

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -581,7 +581,11 @@
   ## Solve the augmented model IN THE SHARED FOCEi pool (which it sized) and take
   ## the per-subject E structures straight from C++, instead of routing through
   ## rxode2::rxSolve, which frees and rebuilds the global solve on every call.
-  ## Used by BOTH est="vae"'s M-step and focei's own fast gradient.
+  ##
+  ## `tol` is the tolerance to solve at, and applies to BOTH routes; pass NA to solve
+  ## at the fit's instead.  A covariance caller wants its own (covSolveTol, else
+  ## tightened from sigdig) because it differences these solves; a gradient caller
+  ## wants the fit's, so that it differentiates the objective being minimized.
   ##
   ## No session flag guards this any more.  vaeOuterSolve_ refuses unless the
   ## augmented model is registered AND the pool is at least its size
@@ -601,23 +605,17 @@
   {
     .cols <- tryCatch(.vaeOuterCols(am), error = function(e) NULL)
     if (!is.null(.cols)) {
-      ## cores = 0 is rxControl's default and MEANS "use rxode2's thread setting" -- the
-      ## rxSolve fallback below passes the 0 through and gets a threaded solve.  Coercing
-      ## it to 1 here made the pooled route single-threaded over subjects
-      ## (outerSolveFill: doParallel = cores > 1), i.e. the pool's whole reason for
-      ## existing was off by default.  Resolve 0 the same way rxSolve does; C++ still
-      ## caps it with min2(cores, getOpCores(op)).
+      ## cores = 0 is rxControl's default and means "use rxode2's thread setting", which
+      ## the rxSolve fallback below passes through.  Coercing it to 1 here left the
+      ## pooled route single-threaded over subjects (outerSolveFill: doParallel =
+      ## cores > 1).  Resolve it the same way rxSolve does; C++ still caps the result
+      ## with min2(cores, getOpCores(op)).
       .nc <- tryCatch({ .c <- am$cores
-        if (is.null(.c) || is.na(.c) || .c < 1L) as.integer(rxode2::rxCores()) else as.integer(.c) },
+        if (is.null(.c) || is.na(.c) || .c < 1L) as.integer(rxode2::getRxThreads()) else as.integer(.c) },
         error = function(e) 1L)
-      ## `tol` reaches the pooled solve too, not just the rxSolve fallback below.  It
-      ## used to be dropped here, so the pooled route silently ran at the FIT's
-      ## tolerance -- right for a gradient, wrong for the covariance, which is every
-      ## caller of this function (the gradient has been all-C++ since the R core was
-      ## deleted).  Pass NA to ask for the fit's tolerance; see vaeOuterSolve_.
-      ## min(): the guard sets atol and rtol together, while the rxSolve fallback below
-      ## reads a 2-vector as (atol, rtol).  Every caller passes a scalar, so this only
-      ## decides an unused corner -- take the tighter one rather than half the request.
+      ## The pooled solve takes one tolerance for atol and rtol both, while the rxSolve
+      ## fallback below reads a 2-vector as (atol, rtol).  Every caller passes a scalar;
+      ## take the tighter of a pair rather than half the request.
       .tolP <- suppressWarnings(min(as.numeric(tol)))
       .Ec <- tryCatch(vaeOuterSolve_(as.numeric(thv), as.matrix(ebes), .cols, .nc,
                                      if (length(.tolP) != 1L || !is.finite(.tolP)) NA_real_ else .tolP),

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -620,37 +620,20 @@
       .Ec <- tryCatch(vaeOuterSolve_(as.numeric(thv), as.matrix(ebes), .cols, .nc,
                                      if (length(.tolP) != 1L || !is.finite(.tolP)) NA_real_ else .tolP),
                       error = function(e) NULL)
-      ## vaeOuterSolve_ now flags failed subjects per individual (attr "ok") rather
-      ## than discarding the whole gradient.  Until the Phase 8D2 finite-difference
-      ## phase consumes those flags, a flagged subject still falls through to the
-      ## rxSolve route, i.e. behaviour is unchanged -- but the flags are here.
+      ## vaeOuterSolve_ flags failed subjects per individual (attr "ok") rather than
+      ## discarding the whole population.  Nothing here consumes the flags yet, so a
+      ## flagged subject falls THROUGH to the rxSolve route below -- all or nothing.
+      ##
+      ## This branch used to zero-fill a flagged subject's E and return it, on the
+      ## grounds that its column is replaced wholesale by the per-individual finite
+      ## difference in foceiGradAllFR_.  That was the R gradient, which is gone; every
+      ## caller now reads the E structures as they stand, so the zeros went straight
+      ## into the covariance as a subject with no prediction and no sensitivity -- and
+      ## a zero E is FINITE, so it did not even trip the callers' is.finite guards.
       if (!is.null(.Ec) && length(.Ec) > 0L) {
         .ok <- attr(.Ec, "ok")
-        if (is.null(.ok) || all(.ok == 1L)) {
-          .foceiOuterFlagged$ids <- integer(0)
-          return(.Ec)
-        }
-        ## A flagged subject has no E.  Give it a zero-filled one of the right shape so
-        ## the assembly below keeps working; its gradient column is replaced wholesale in
-        ## foceiGradAllFR_ by the per-individual finite difference, so these zeros never
-        ## reach the result.
-        .good <- which(.ok == 1L)
-        if (length(.good) > 0L) {
-          .tmpl <- .Ec[[.good[1L]]]
-          for (.i in which(.ok == 0L)) {
-            .nobsI <- length(obsTimes[[.i]])
-            .z <- lapply(.tmpl, function(.x) {
-              if (is.null(dim(.x))) numeric(.nobsI)
-              else array(0, c(.nobsI, dim(.x)[-1]))
-            })
-            .z <- .z[names(.tmpl)]
-            if (!is.null(.tmpl$trans)) .z$trans <- .tmpl$trans
-            .Ec[[.i]] <- .z
-          }
-          .foceiOuterFlagged$ids <- which(.ok == 0L)
-          attr(.Ec, "ok") <- .ok
-          return(.Ec)
-        }
+        .foceiOuterFlagged$ids <- if (is.null(.ok)) integer(0) else which(.ok == 0L)
+        if (length(.foceiOuterFlagged$ids) == 0L) return(.Ec)
       }
     }
   }

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -604,11 +604,17 @@
       .nc <- tryCatch({ .c <- am$cores
         if (is.null(.c) || is.na(.c) || .c < 1L) 1L else as.integer(.c) },
         error = function(e) 1L)
-      ## No tolerance argument: the pooled solve runs at the FIT's tolerance (C++
-      ## OdeFitTolGuard resets to it), because the gradient must be the gradient of the
-      ## objective the optimizer is minimizing.  `tol` below still tunes the rxSolve
-      ## fallback and the covariance path.
-      .Ec <- tryCatch(vaeOuterSolve_(as.numeric(thv), as.matrix(ebes), .cols, .nc),
+      ## `tol` reaches the pooled solve too, not just the rxSolve fallback below.  It
+      ## used to be dropped here, so the pooled route silently ran at the FIT's
+      ## tolerance -- right for a gradient, wrong for the covariance, which is every
+      ## caller of this function (the gradient has been all-C++ since the R core was
+      ## deleted).  Pass NA to ask for the fit's tolerance; see vaeOuterSolve_.
+      ## min(): the guard sets atol and rtol together, while the rxSolve fallback below
+      ## reads a 2-vector as (atol, rtol).  Every caller passes a scalar, so this only
+      ## decides an unused corner -- take the tighter one rather than half the request.
+      .tolP <- suppressWarnings(min(as.numeric(tol)))
+      .Ec <- tryCatch(vaeOuterSolve_(as.numeric(thv), as.matrix(ebes), .cols, .nc,
+                                     if (length(.tolP) != 1L || !is.finite(.tolP)) NA_real_ else .tolP),
                       error = function(e) NULL)
       ## vaeOuterSolve_ now flags failed subjects per individual (attr "ok") rather
       ## than discarding the whole gradient.  Until the Phase 8D2 finite-difference

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -597,15 +597,17 @@
   }, error = function(e) 1L)
 }
 
-.foceiAnalyticSolveAll <- function(am, thv, ebes, ids, data, obsTimes, tol = 1e-10) {
+.foceiAnalyticSolveAll <- function(am, thv, ebes, ids, data, obsTimes, tol) {
   ## Solve the augmented model IN THE SHARED FOCEi pool (which it sized) and take
   ## the per-subject E structures straight from C++, instead of routing through
   ## rxode2::rxSolve, which frees and rebuilds the global solve on every call.
   ##
-  ## `tol` is the tolerance to solve at, and applies to BOTH routes; pass NA to solve
-  ## at the fit's instead.  A covariance caller wants its own (covSolveTol, else
-  ## tightened from sigdig) because it differences these solves; a gradient caller
-  ## wants the fit's, so that it differentiates the objective being minimized.
+  ## `tol` is the tolerance to solve at and applies to BOTH routes; pass NA to solve at
+  ## the fit's instead.  A covariance caller wants its own (covSolveTol, else tightened
+  ## from sigdig) because it differences these solves; a gradient caller wants the fit's,
+  ## so that it differentiates the objective being minimized.  It has NO DEFAULT on
+  ## purpose -- the two answers are different numbers and there is no value that is right
+  ## for both, so the choice is the caller's to state.
   ##
   ## No session flag guards this any more.  vaeOuterSolve_ refuses unless the
   ## augmented model is registered AND the pool is at least its size

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -573,9 +573,29 @@
 #' Recorded here rather than acted on in the solve loop: that loop runs inside
 #' OdeSwapEsBatch(odeSlotOuter), and the finite difference needs the INNER problem's
 #' event sensitivities, which can only be installed at a batch boundary.
+#'
+#' `n` counts pooled solves abandoned because of a flag, and only ever grows.  A test
+#' that wants to prove the POOLED result was used, rather than merely attempted, has to
+#' check this too: `pooledSolveN` counts the attempt and rises either way.
 #' @noRd
 .foceiOuterFlagged <- new.env(parent = emptyenv())
 .foceiOuterFlagged$ids <- integer(0)
+.foceiOuterFlagged$n <- 0L
+
+#' Threads for the pooled augmented solve, from the fit's `rxControl(cores=)`.
+#'
+#' `0` (rxControl's default) and `NA` mean "use rxode2's thread setting", the same
+#' reading `rxSolve` gives them; anything >= 1 is taken literally.  Resolving 0 to a
+#' literal 1 is what left the pooled route serial.  C++ still caps the result with
+#' min2(cores, getOpCores(op)).
+#' @noRd
+.foceiPoolCores <- function(cores) {
+  tryCatch({
+    .c <- suppressWarnings(as.integer(cores)[1L])       # a NULL/character cores -> NA
+    if (is.na(.c)) return(as.integer(rxode2::getRxThreads()))
+    if (.c < 1L) as.integer(rxode2::getRxThreads()) else .c
+  }, error = function(e) 1L)
+}
 
 .foceiAnalyticSolveAll <- function(am, thv, ebes, ids, data, obsTimes, tol = 1e-10) {
   ## Solve the augmented model IN THE SHARED FOCEi pool (which it sized) and take
@@ -605,14 +625,7 @@
   {
     .cols <- tryCatch(.vaeOuterCols(am), error = function(e) NULL)
     if (!is.null(.cols)) {
-      ## cores = 0 is rxControl's default and means "use rxode2's thread setting", which
-      ## the rxSolve fallback below passes through.  Coercing it to 1 here left the
-      ## pooled route single-threaded over subjects (outerSolveFill: doParallel =
-      ## cores > 1).  Resolve it the same way rxSolve does; C++ still caps the result
-      ## with min2(cores, getOpCores(op)).
-      .nc <- tryCatch({ .c <- am$cores
-        if (is.null(.c) || is.na(.c) || .c < 1L) as.integer(rxode2::getRxThreads()) else as.integer(.c) },
-        error = function(e) 1L)
+      .nc <- .foceiPoolCores(am$cores)   # 0 means rxode2's threads, not one
       ## The pooled solve takes one tolerance for atol and rtol both, while the rxSolve
       ## fallback below reads a 2-vector as (atol, rtol).  Every caller passes a scalar;
       ## take the tighter of a pair rather than half the request.
@@ -634,6 +647,7 @@
         .ok <- attr(.Ec, "ok")
         .foceiOuterFlagged$ids <- if (is.null(.ok)) integer(0) else which(.ok == 0L)
         if (length(.foceiOuterFlagged$ids) == 0L) return(.Ec)
+        .foceiOuterFlagged$n <- .foceiOuterFlagged$n + 1L
       }
     }
   }

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -601,8 +601,14 @@
   {
     .cols <- tryCatch(.vaeOuterCols(am), error = function(e) NULL)
     if (!is.null(.cols)) {
+      ## cores = 0 is rxControl's default and MEANS "use rxode2's thread setting" -- the
+      ## rxSolve fallback below passes the 0 through and gets a threaded solve.  Coercing
+      ## it to 1 here made the pooled route single-threaded over subjects
+      ## (outerSolveFill: doParallel = cores > 1), i.e. the pool's whole reason for
+      ## existing was off by default.  Resolve 0 the same way rxSolve does; C++ still
+      ## caps it with min2(cores, getOpCores(op)).
       .nc <- tryCatch({ .c <- am$cores
-        if (is.null(.c) || is.na(.c) || .c < 1L) 1L else as.integer(.c) },
+        if (is.null(.c) || is.na(.c) || .c < 1L) as.integer(rxode2::rxCores()) else as.integer(.c) },
         error = function(e) 1L)
       ## `tol` reaches the pooled solve too, not just the rxSolve fallback below.  It
       ## used to be dropped here, so the pooled route silently ran at the FIT's

--- a/R/odeSwapVerify.R
+++ b/R/odeSwapVerify.R
@@ -11,7 +11,8 @@
 #' @return list with `models` (a data.frame of slot/name/neq/nlhs/loaded/
 #'   sizesPool/deny), the chosen `poolSlot`/`poolName`/`poolNeq`/`poolNlhs`,
 #'   `maxNlhs`/`maxNlhsSlot`, `scratchNlhs`/`needsScratch`, `overrideNeeded`,
-#'   `nLoaded`, and the live `opNeq`/`opNlhs`.
+#'   `nLoaded`, the live `opNeq`/`opNlhs`, and `pooledSolveCores` (the thread
+#'   count the last pooled solve ran with, after every clamp).
 #' @noRd
 .odeSwapInfo <- function() odeSwapInfo_()
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -786,8 +786,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // vaeOuterSolve_
-RObject vaeOuterSolve_(NumericVector thVals, NumericMatrix ebes, List cols, int cores);
-RcppExport SEXP _nlmixr2est_vaeOuterSolve_(SEXP thValsSEXP, SEXP ebesSEXP, SEXP colsSEXP, SEXP coresSEXP) {
+RObject vaeOuterSolve_(NumericVector thVals, NumericMatrix ebes, List cols, int cores, double tol);
+RcppExport SEXP _nlmixr2est_vaeOuterSolve_(SEXP thValsSEXP, SEXP ebesSEXP, SEXP colsSEXP, SEXP coresSEXP, SEXP tolSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -795,7 +795,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericMatrix >::type ebes(ebesSEXP);
     Rcpp::traits::input_parameter< List >::type cols(colsSEXP);
     Rcpp::traits::input_parameter< int >::type cores(coresSEXP);
-    rcpp_result_gen = Rcpp::wrap(vaeOuterSolve_(thVals, ebes, cols, cores));
+    Rcpp::traits::input_parameter< double >::type tol(tolSEXP);
+    rcpp_result_gen = Rcpp::wrap(vaeOuterSolve_(thVals, ebes, cols, cores, tol));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/init.c
+++ b/src/init.c
@@ -44,7 +44,7 @@ extern SEXP _nlmixr2est_vaeDecoderPxz_(SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeDecoderSolveSubject_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeDecoderElboStep_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_vaeInnerLik(SEXP, SEXP, SEXP, SEXP);
-extern SEXP _nlmixr2est_vaeOuterSolve_(SEXP, SEXP, SEXP, SEXP);
+extern SEXP _nlmixr2est_vaeOuterSolve_(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_foceiAnalyticGradPooled_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_foceiGradPooledSetupLoad_(SEXP);
 extern SEXP _nlmixr2est_foceiGradPooledDirect_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -206,7 +206,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_vaeDecoderSolveSubject_", (DL_FUNC) &_nlmixr2est_vaeDecoderSolveSubject_, 6},
   {"_nlmixr2est_vaeDecoderElboStep_", (DL_FUNC) &_nlmixr2est_vaeDecoderElboStep_, 14},
   {"_nlmixr2est_vaeInnerLik", (DL_FUNC) &_nlmixr2est_vaeInnerLik, 4},
-  {"_nlmixr2est_vaeOuterSolve_", (DL_FUNC) &_nlmixr2est_vaeOuterSolve_, 4},
+  {"_nlmixr2est_vaeOuterSolve_", (DL_FUNC) &_nlmixr2est_vaeOuterSolve_, 5},
   {"_nlmixr2est_foceiAnalyticGradPooled_", (DL_FUNC) &_nlmixr2est_foceiAnalyticGradPooled_, 15},
   {"_nlmixr2est_foceiGradPooledSetupLoad_", (DL_FUNC) &_nlmixr2est_foceiGradPooledSetupLoad_, 1},
   {"_nlmixr2est_foceiGradPooledDirect_", (DL_FUNC) &_nlmixr2est_foceiGradPooledDirect_, 6},

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -12409,16 +12409,21 @@ RObject vaeOuterSolve_(NumericVector thVals, NumericMatrix ebes, List cols, int 
   // from the outer model to the inner one, inside this one gradient call, is exactly
   // what the shared-pool machinery exists for.
   std::unique_ptr<OdeSwapEsBatch> _esBatch(new OdeSwapEsBatch(odeSlotOuter));
-  // Tolerance for this batch.  A caller passing NA gets the fit's (OdeFitTolGuard),
-  // which is what a gradient needs.  The covariance passes its own -- covSolveTol, else
-  // tightened from sigdig (.foceiAnalyticSolveTol) -- because it Richardson-differences
-  // these 2nd-order sensitivities to recover the 3rd-order tensor, so the solve error IS
-  // the answer's error.  Dropping it here moved the SEs by 1.7e-2 on a 5-eta 2-cmt model
-  // and made foceiControl(fast=) change them, since fast=FALSE never pools.
-  std::unique_ptr<OdeFitTolGuard>   _fitTol;
+  // Tolerance for this batch.  A caller passing NA solves at the fit's, which is what a
+  // gradient needs.  The covariance passes its own -- covSolveTol, else tightened from
+  // sigdig (.foceiAnalyticSolveTol) -- because it Richardson-differences these 2nd-order
+  // sensitivities to recover the 3rd-order tensor, so the solve error IS the answer's
+  // error.  Dropping it here moved the SEs by 1.7e-2 on a 5-eta 2-cmt model and made
+  // foceiControl(fast=) change them, since fast=FALSE never pools.
+  //
+  // The fit guard is taken UNCONDITIONALLY and FIRST, even when it is about to be
+  // overridden: op_focei.fitAtol/fitRtol are captured lazily by whichever guard runs
+  // first in a fit, so tightening ahead of that capture would record the tight value as
+  // the FIT's for everything after it -- including the per-individual finite difference
+  // below, which takes its own OdeFitTolGuard while this one is live.
+  OdeFitTolGuard _fitTol;
   std::unique_ptr<OdeSolveTolGuard> _covTol;
   if (R_FINITE(tol) && tol > 0) _covTol.reset(new OdeSolveTolGuard(tol));
-  else                          _fitTol.reset(new OdeFitTolGuard());
   if (op_focei.vaeOuterNlhs <= 0 || rxVaeOuter.calc_lhs == NULL) return R_NilValue;
   rx = getRxSolve_();
   // Does the BOUND calc_lhs actually belong to the model the registry describes?

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -5604,24 +5604,6 @@ static void releaseCovSolveArgs_() {
     covSolveArgs_ = R_NilValue;
   }
 }
-static bool restoreFitSolve_() {
-  if (covSolveArgs_ == R_NilValue) return false;
-  try {
-    List args = as<List>(covSolveArgs_);
-    RObject obj = args[0]; List rxControl = as<List>(args[1]);
-    RObject params = args[2]; RObject data = args[3];
-    rxode2::rxSolve_(obj, rxControl, R_NilValue, R_NilValue, params, data, R_NilValue, 1);
-    rx = getRxSolve_();
-    return true;
-  } catch (Rcpp::internal::InterruptedException&) {
-    throw;   // Ctrl-C: Rcpp requires the interrupt to propagate, never swallow it
-  } catch (Rcpp::LongjumpException&) {
-    throw;   // Rcpp longjump protocol must be rethrown intact, not turned into false
-  } catch (...) {
-    return false;   // genuine solve error -> report a failed restore
-  }
-}
-
 // Record the fit's ODE tolerances, once per fit.
 //
 // op_focei.fitAtol/fitRtol are reset to NA per fit (rxOptionsFreeFocei) and filled in
@@ -5634,6 +5616,39 @@ static inline void foceiNoteFitTol(double atol, double rtol) {
   if (!R_FINITE(atol) || !R_FINITE(rtol)) return;
   if (R_FINITE(op_focei.fitAtol) && R_FINITE(op_focei.fitRtol)) return;
   op_focei.fitAtol = atol; op_focei.fitRtol = rtol;
+}
+
+static bool restoreFitSolve_() {
+  if (covSolveArgs_ == R_NilValue) return false;
+  try {
+    List args = as<List>(covSolveArgs_);
+    RObject obj = args[0]; List rxControl = as<List>(args[1]);
+    RObject params = args[2]; RObject data = args[3];
+    // Rebuilding from the fit's rxControl also resets atol/rtol to the fit's, which
+    // silently cancels whatever tolerance regime the caller has in force.  Both call
+    // sites are inside CovSolveTolGuard, so without this the finite-difference cov step
+    // it runs on afterwards drops foceiControl(covSolveTol=) -- the same defect this
+    // restores the solve in the middle of.  Carry the live tolerance across the rebuild.
+    double liveAtol = NA_REAL, liveRtol = NA_REAL;
+    rxGetSolveAtolRtol(&liveAtol, &liveRtol);
+    rxode2::rxSolve_(obj, rxControl, R_NilValue, R_NilValue, params, data, R_NilValue, 1);
+    rx = getRxSolve_();
+    // Straight off the fit's own rxControl, so this is the most authoritative reading of
+    // the fit tolerance there is -- better than any guard's capture of whatever was live.
+    {
+      double fitAtol = NA_REAL, fitRtol = NA_REAL;
+      rxGetSolveAtolRtol(&fitAtol, &fitRtol);
+      foceiNoteFitTol(fitAtol, fitRtol);
+    }
+    if (R_FINITE(liveAtol) && R_FINITE(liveRtol)) rxSetSolveAtolRtol(liveAtol, liveRtol);
+    return true;
+  } catch (Rcpp::internal::InterruptedException&) {
+    throw;   // Ctrl-C: Rcpp requires the interrupt to propagate, never swallow it
+  } catch (Rcpp::LongjumpException&) {
+    throw;   // Rcpp longjump protocol must be rethrown intact, not turned into false
+  } catch (...) {
+    return false;   // genuine solve error -> report a failed restore
+  }
 }
 
 // RAII: set atol/rtol for the duration of a pooled batch solve, restoring the live

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -5622,12 +5622,8 @@ static bool restoreFitSolve_() {
   }
 }
 
-// RAII: tighten the ODE solve tolerances to covSolveTol for the covariance-step
-// finite-difference solves, restoring the fit's tolerances on exit.  No-op unless the
-// user set foceiControl(covSolveTol=); the analytic R-matrix applies covSolveTol on its
-// own augmented solves (.foceiAnalyticSolveTol).
-// Set atol/rtol for the duration of a pooled batch solve, restoring the fit's
-// values afterwards.  Same mechanism as CovSolveTolGuard, driven by an explicit
+// RAII: set atol/rtol for the duration of a pooled batch solve, restoring the live
+// values afterwards.  Same mechanism as CovSolveTolGuard below, driven by an explicit
 // tolerance rather than a control field.
 struct OdeSolveTolGuard {
   bool active = false;
@@ -5646,10 +5642,10 @@ struct OdeSolveTolGuard {
 
 // Solve the augmented model at the FIT's own tolerance.
 //
-// There is deliberately NO separate "analytic" tolerance.  The gradient has to be the
-// gradient of the objective the optimizer is actually minimizing, so it is solved the
-// way that objective is solved; a tightened tolerance here would describe a different
-// objective than the one being optimized.  (This branch briefly did exactly that.)
+// This is what a GRADIENT wants: it has to be the gradient of the objective the
+// optimizer is actually minimizing, so it is solved the way that objective is solved,
+// and a tightened tolerance here would describe a different objective.  A caller that
+// DIFFERENCES the solves instead (the analytic covariance) wants OdeSolveTolGuard above.
 //
 // It still SETS the tolerance rather than leaving the live values alone, so a tolerance
 // shift earlier in the fit cannot leak in -- this is a RESET, not an override.  The
@@ -5670,6 +5666,10 @@ struct OdeFitTolGuard {
   ~OdeFitTolGuard() { if (active) rxSetSolveAtolRtol(savAtol, savRtol); }
 };
 
+// RAII: tighten the ODE solve tolerances to covSolveTol for the covariance-step
+// finite-difference solves, restoring the fit's tolerances on exit.  No-op unless the
+// user set foceiControl(covSolveTol=); the analytic R-matrix applies covSolveTol on its
+// own augmented solves (.foceiAnalyticSolveTol).
 struct CovSolveTolGuard {
   bool active = false;
   double savAtol = NA_REAL, savRtol = NA_REAL;
@@ -12409,14 +12409,12 @@ RObject vaeOuterSolve_(NumericVector thVals, NumericMatrix ebes, List cols, int 
   // from the outer model to the inner one, inside this one gradient call, is exactly
   // what the shared-pool machinery exists for.
   std::unique_ptr<OdeSwapEsBatch> _esBatch(new OdeSwapEsBatch(odeSlotOuter));
-  // Tolerance for this batch.  A GRADIENT caller passes no tolerance and gets the fit's
-  // (OdeFitTolGuard): the gradient has to be the gradient of the objective the optimizer
-  // is minimizing.  The COVARIANCE passes its own -- covSolveTol, else tightened from
-  // sigdig (.foceiAnalyticSolveTol) -- because it Richardson-differences these 2nd-order
-  // sensitivities to recover the 3rd-order tensor, so the solve error IS the answer's
-  // error.  Solving it at the fit's tolerance moved the SEs by 1.7e-2 on a 5-eta 2-cmt
-  // model, and made foceiControl(fast=) change the standard errors, since fast=FALSE
-  // never pools and so kept the tight route.
+  // Tolerance for this batch.  A caller passing NA gets the fit's (OdeFitTolGuard),
+  // which is what a gradient needs.  The covariance passes its own -- covSolveTol, else
+  // tightened from sigdig (.foceiAnalyticSolveTol) -- because it Richardson-differences
+  // these 2nd-order sensitivities to recover the 3rd-order tensor, so the solve error IS
+  // the answer's error.  Dropping it here moved the SEs by 1.7e-2 on a 5-eta 2-cmt model
+  // and made foceiControl(fast=) change them, since fast=FALSE never pools.
   std::unique_ptr<OdeFitTolGuard>   _fitTol;
   std::unique_ptr<OdeSolveTolGuard> _covTol;
   if (R_FINITE(tol) && tol > 0) _covTol.reset(new OdeSolveTolGuard(tol));

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -12381,7 +12381,7 @@ static void outerSolveFill(int slot, rxSolveF *fns,
   // through R -- so once the all-C++ gradient became the normal path the counter tracked
   // the R FALLBACK rather than the pooled route, and the tests asserting "the pooled
   // solve really ran" were satisfied by exactly the thing they existed to rule out.
-  odeSwapNotePooledSolve();
+  odeSwapNotePooledSolve(doParallel ? cores : 1);
 }
 
 //[[Rcpp::export]]

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -5622,6 +5622,20 @@ static bool restoreFitSolve_() {
   }
 }
 
+// Record the fit's ODE tolerances, once per fit.
+//
+// op_focei.fitAtol/fitRtol are reset to NA per fit (rxOptionsFreeFocei) and filled in
+// here by whichever tolerance guard runs first.  EVERY guard that is about to overwrite
+// the live values must call this with what it read BEFORE overwriting them -- a guard
+// that tightens without recording leaves the next one to capture the tightened value and
+// pin it as the fit's for everything after.  CovSolveTolGuard wraps the whole covariance
+// step, so it can be the first guard of a fit and reach vaeOuterSolve_ already tightened.
+static inline void foceiNoteFitTol(double atol, double rtol) {
+  if (!R_FINITE(atol) || !R_FINITE(rtol)) return;
+  if (R_FINITE(op_focei.fitAtol) && R_FINITE(op_focei.fitRtol)) return;
+  op_focei.fitAtol = atol; op_focei.fitRtol = rtol;
+}
+
 // RAII: set atol/rtol for the duration of a pooled batch solve, restoring the live
 // values afterwards.  Same mechanism as CovSolveTolGuard below, driven by an explicit
 // tolerance rather than a control field.
@@ -5632,6 +5646,7 @@ struct OdeSolveTolGuard {
     if (!R_FINITE(tol) || tol <= 0) return;
     rxGetSolveAtolRtol(&savAtol, &savRtol);
     if (!R_FINITE(savAtol) || !R_FINITE(savRtol)) return;   // no live solve
+    foceiNoteFitTol(savAtol, savRtol);
     rxSetSolveAtolRtol(tol, tol);
     active = true;
   }
@@ -5657,9 +5672,7 @@ struct OdeFitTolGuard {
   OdeFitTolGuard() {
     rxGetSolveAtolRtol(&savAtol, &savRtol);
     if (!R_FINITE(savAtol) || !R_FINITE(savRtol)) return;    // no live solve
-    if (!R_FINITE(op_focei.fitAtol) || !R_FINITE(op_focei.fitRtol)) {
-      op_focei.fitAtol = savAtol; op_focei.fitRtol = savRtol;
-    }
+    foceiNoteFitTol(savAtol, savRtol);
     rxSetSolveAtolRtol(op_focei.fitAtol, op_focei.fitRtol);
     active = true;
   }
@@ -5683,6 +5696,10 @@ struct CovSolveTolGuard {
     if (!R_FINITE(tol) || tol <= 0) return;
     rxGetSolveAtolRtol(&savAtol, &savRtol);
     if (!R_FINITE(savAtol) || !R_FINITE(savRtol)) return;   // no live solve to retune
+    // This guard wraps the WHOLE covariance step, so on a fit that never ran an analytic
+    // gradient it is the first to touch the tolerances -- record the fit's before
+    // tightening, or vaeOuterSolve_ inside it captures covSolveTol as the fit's.
+    foceiNoteFitTol(savAtol, savRtol);
     rxSetSolveAtolRtol(tol, tol);
     active = true;
   }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -12385,7 +12385,8 @@ static void outerSolveFill(int slot, rxSolveF *fns,
 }
 
 //[[Rcpp::export]]
-RObject vaeOuterSolve_(NumericVector thVals, NumericMatrix ebes, List cols, int cores) {
+RObject vaeOuterSolve_(NumericVector thVals, NumericMatrix ebes, List cols, int cores,
+                       double tol = NA_REAL) {
   // Structural gate, replacing the session-scoped .vaeGradEnv$active flag: this
   // solve is only valid if the augmented model is registered AND the pool is at
   // least its size.  odeSwapCanPool says exactly that -- a model larger than the
@@ -12408,8 +12409,18 @@ RObject vaeOuterSolve_(NumericVector thVals, NumericMatrix ebes, List cols, int 
   // from the outer model to the inner one, inside this one gradient call, is exactly
   // what the shared-pool machinery exists for.
   std::unique_ptr<OdeSwapEsBatch> _esBatch(new OdeSwapEsBatch(odeSlotOuter));
-  // Reset to the fit's tolerance for this solve -- see OdeFitTolGuard.
-  OdeFitTolGuard _tolGuard;
+  // Tolerance for this batch.  A GRADIENT caller passes no tolerance and gets the fit's
+  // (OdeFitTolGuard): the gradient has to be the gradient of the objective the optimizer
+  // is minimizing.  The COVARIANCE passes its own -- covSolveTol, else tightened from
+  // sigdig (.foceiAnalyticSolveTol) -- because it Richardson-differences these 2nd-order
+  // sensitivities to recover the 3rd-order tensor, so the solve error IS the answer's
+  // error.  Solving it at the fit's tolerance moved the SEs by 1.7e-2 on a 5-eta 2-cmt
+  // model, and made foceiControl(fast=) change the standard errors, since fast=FALSE
+  // never pools and so kept the tight route.
+  std::unique_ptr<OdeFitTolGuard>   _fitTol;
+  std::unique_ptr<OdeSolveTolGuard> _covTol;
+  if (R_FINITE(tol) && tol > 0) _covTol.reset(new OdeSolveTolGuard(tol));
+  else                          _fitTol.reset(new OdeFitTolGuard());
   if (op_focei.vaeOuterNlhs <= 0 || rxVaeOuter.calc_lhs == NULL) return R_NilValue;
   rx = getRxSolve_();
   // Does the BOUND calc_lhs actually belong to the model the registry describes?

--- a/src/odeSwap.cpp
+++ b/src/odeSwap.cpp
@@ -537,6 +537,7 @@ static std::atomic<long> _odePinnedN(0);
 // a test can tell a working pooled path from a silent fallback to rxode2::rxSolve
 // -- the two are numerically equivalent, which is how a dead path went unnoticed.
 static std::atomic<long> _odePooledSolveN(0);
+static std::atomic<int>  _odePooledSolveCores(NA_INTEGER);
 static std::atomic<long> _odePinCalledN(0);
 static std::atomic<int>  _odePinDeny(0);
 
@@ -581,7 +582,15 @@ long odeSwapScratchUsedN()   { return _odeScratchUsedN.load(std::memory_order_re
 long odeSwapScratchResizeN() { return _odeScratchResizeN.load(std::memory_order_relaxed); }
 long odeSwapPinnedN()        { return _odePinnedN.load(std::memory_order_relaxed); }
 long odeSwapPooledSolveN()   { return _odePooledSolveN.load(std::memory_order_relaxed); }
-void odeSwapNotePooledSolve() { _odePooledSolveN.fetch_add(1, std::memory_order_relaxed); }
+// The thread count the last pooled solve actually ran its subject loop with, AFTER every
+// clamp.  Recorded because the R-side cores it was asked for proves nothing on its own:
+// the request is capped again in C++, and a cap back to 1 is exactly the defect that made
+// this loop serial for the whole covariance step.
+int  odeSwapPooledSolveCores() { return _odePooledSolveCores.load(std::memory_order_relaxed); }
+void odeSwapNotePooledSolve(int cores) {
+  _odePooledSolveN.fetch_add(1, std::memory_order_relaxed);
+  _odePooledSolveCores.store(cores, std::memory_order_relaxed);
+}
 long odeSwapPinCalledN()     { return _odePinCalledN.load(std::memory_order_relaxed); }
 int  odeSwapPinDeny()        { return _odePinDeny.load(std::memory_order_relaxed); }
 
@@ -896,6 +905,7 @@ List odeSwapInfo_() {
     _["scratchResizeN"] = (double)odeSwapScratchResizeN(),
     _["pinnedN"] = (double)odeSwapPinnedN(),
     _["pooledSolveN"] = (double)odeSwapPooledSolveN(),
+    _["pooledSolveCores"] = odeSwapPooledSolveCores(),
     _["pinCalledN"] = (double)odeSwapPinCalledN(),
     _["pinDeny"] = (double)odeSwapPinDeny());
 }

--- a/src/odeSwap.h
+++ b/src/odeSwap.h
@@ -427,7 +427,8 @@ long odeSwapScratchUsedN();
 long odeSwapScratchResizeN();
 long odeSwapPinnedN();
 long odeSwapPooledSolveN();    // completed pooled outer solves; survives teardown
-void odeSwapNotePooledSolve();
+void odeSwapNotePooledSolve(int cores);
+int  odeSwapPooledSolveCores();
 long odeSwapPinCalledN();
 int  odeSwapPinDeny();   // cumulative pins; survives teardown, unlike odeSwapPinned()
 

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1189,9 +1189,15 @@ nmTest({
     # The augmented solves are run at solveTol (covSolveTol, else tightened from sigdig)
     # because the 3rd-order tensor is recovered by differencing them twice.  The pooled
     # route used to drop that and solve at the FIT's tolerance instead, and since the
-    # pool is only available with fast=TRUE, `fast=` moved the standard errors -- 1.7e-2
-    # on a 5-ETA 2-compartment model, and it TRACKED sigdig, which is what identified the
-    # tolerance as the cause.  Both routes now solve at solveTol.
+    # pool is only available with fast=TRUE, `fast=` moved the standard errors.  Both
+    # routes now solve at solveTol.
+    #
+    # On THIS model at sigdig = 4 the defect is 1.16e-5 relative and what is left after
+    # the fix is 5.6e-8 (two different code paths integrating the same quantity at the
+    # same tolerance), so 1e-6 below has ~18x margin under it and ~12x over it.  Do not
+    # loosen it without re-measuring: the gap TRACKS the fit tolerance, and at sigdig = 3
+    # the defect is only 1.9e-4, so a tolerance chosen off the 1.7e-2 seen on a 5-ETA
+    # 2-compartment model would pass with the bug still in.
     .m <- function() {
       ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- 0.7
             eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1 })
@@ -1205,17 +1211,20 @@ nmTest({
     .f0 <- suppressMessages(suppressWarnings(nlmixr2(.m, .d, "focei",
              foceiControl(print = 0L, covMethod = "", fast = TRUE, sigdig = 4))))
     .se <- function(fast) {
+      .n0 <- .odeSwapInfo()$pooledSolveN
       .f <- suppressMessages(suppressWarnings(nlmixr2(.f0$finalUi, .d, "focei",
               foceiControl(print = 0L, covMethod = "analytic", fast = fast, sigdig = 4,
                            maxOuterIterations = 0L))))
       expect_equal(.f$covMethod, "analytic")   # a fallback would compare the wrong thing
-      sqrt(diag(.f$cov))
+      list(se = sqrt(diag(.f$cov)), pooled = .odeSwapInfo()$pooledSolveN - .n0)
     }
-    .sT <- .se(TRUE); .sF <- .se(FALSE)
-    .n <- intersect(names(.sT), names(.sF))
+    .rT <- .se(TRUE); .rF <- .se(FALSE)
+    # Without this the comparison is vacuous: if fast=TRUE stopped reaching the pool the
+    # two runs would be the same route and would agree no matter what tolerance it used.
+    expect_gt(.rT$pooled, 0L)
+    expect_equal(.rF$pooled, 0L)
+    .n <- intersect(names(.rT$se), names(.rF$se))
     expect_gt(length(.n), 0L)
-    # 1e-4 is far below the 1.7e-2 defect and far above the ~4e-6 that separates two
-    # independent solves of the same quantity
-    expect_equal(unname(.sT[.n]), unname(.sF[.n]), tolerance = 1e-4)
+    expect_equal(unname(.rT$se[.n]), unname(.rF$se[.n]), tolerance = 1e-6)
   })
 })

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1183,4 +1183,39 @@ nmTest({
     expect_equal(E$f[1], 5, tolerance = 1e-4)   # A(0) = A0
     expect_true(E$f[2] < E$f[1])                # the ODE evolves away from the IC
   })
+
+  test_that("covMethod='analytic' SEs do not depend on foceiControl(fast=)", {
+    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    # The augmented solves are run at solveTol (covSolveTol, else tightened from sigdig)
+    # because the 3rd-order tensor is recovered by differencing them twice.  The pooled
+    # route used to drop that and solve at the FIT's tolerance instead, and since the
+    # pool is only available with fast=TRUE, `fast=` moved the standard errors -- 1.7e-2
+    # on a 5-ETA 2-compartment model, and it TRACKED sigdig, which is what identified the
+    # tolerance as the cause.  Both routes now solve at solveTol.
+    .m <- function() {
+      ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- 0.7
+            eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1 })
+      model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+              d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center
+              cp <- center / v; cp ~ add(add.sd) })
+    }
+    .d <- nlmixr2data::theo_sd
+    # fit ONCE, then evaluate the covariance at that theta under both settings, so the
+    # optimizer cannot contribute a difference of its own
+    .f0 <- suppressMessages(suppressWarnings(nlmixr2(.m, .d, "focei",
+             foceiControl(print = 0L, covMethod = "", fast = TRUE, sigdig = 4))))
+    .se <- function(fast) {
+      .f <- suppressMessages(suppressWarnings(nlmixr2(.f0$finalUi, .d, "focei",
+              foceiControl(print = 0L, covMethod = "analytic", fast = fast, sigdig = 4,
+                           maxOuterIterations = 0L))))
+      expect_equal(.f$covMethod, "analytic")   # a fallback would compare the wrong thing
+      sqrt(diag(.f$cov))
+    }
+    .sT <- .se(TRUE); .sF <- .se(FALSE)
+    .n <- intersect(names(.sT), names(.sF))
+    expect_gt(length(.n), 0L)
+    # 1e-4 is far below the 1.7e-2 defect and far above the ~4e-6 that separates two
+    # independent solves of the same quantity
+    expect_equal(unname(.sT[.n]), unname(.sF[.n]), tolerance = 1e-4)
+  })
 })

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1216,8 +1216,9 @@ nmTest({
               foceiControl(print = 0L, covMethod = "analytic", fast = fast, sigdig = 4,
                            maxOuterIterations = 0L))))
       expect_equal(.f$covMethod, "analytic")   # a fallback would compare the wrong thing
-      list(se = sqrt(diag(.f$cov)), pooled = .odeSwapInfo()$pooledSolveN - .n0,
-           bailed = .foceiOuterFlagged$n - .b0)
+      .i <- .odeSwapInfo()
+      list(se = sqrt(diag(.f$cov)), pooled = .i$pooledSolveN - .n0,
+           bailed = .foceiOuterFlagged$n - .b0, cores = .i$pooledSolveCores)
     }
     .rT <- .se(TRUE); .rF <- .se(FALSE)
     # Without this the comparison is vacuous: if fast=TRUE stopped reaching the pool the
@@ -1227,6 +1228,12 @@ nmTest({
     expect_gt(.rT$pooled, 0L)
     expect_equal(.rT$bailed, 0L)
     expect_equal(.rF$pooled, 0L)
+    # ... and that the pooled solve is actually threaded.  pooledSolveCores is the count
+    # its subject loop ran with AFTER every clamp, so this covers the whole chain the
+    # unit test on .foceiPoolCores() cannot reach: rxControl(cores = 0) -> rxode2's
+    # threads -> min2(cores, getOpCores(op)) -> doParallel.  Measured 11 with the fix and
+    # 1 without, on a host reporting 11 threads.
+    if (rxode2::getRxThreads() > 1L) expect_gt(.rT$cores, 1L)
     .n <- intersect(names(.rT$se), names(.rF$se))
     expect_gt(length(.n), 0L)
     expect_equal(unname(.rT$se[.n]), unname(.rF$se[.n]), tolerance = 1e-6)

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1211,17 +1211,21 @@ nmTest({
     .f0 <- suppressMessages(suppressWarnings(nlmixr2(.m, .d, "focei",
              foceiControl(print = 0L, covMethod = "", fast = TRUE, sigdig = 4))))
     .se <- function(fast) {
-      .n0 <- .odeSwapInfo()$pooledSolveN
+      .n0 <- .odeSwapInfo()$pooledSolveN; .b0 <- .foceiOuterFlagged$n
       .f <- suppressMessages(suppressWarnings(nlmixr2(.f0$finalUi, .d, "focei",
               foceiControl(print = 0L, covMethod = "analytic", fast = fast, sigdig = 4,
                            maxOuterIterations = 0L))))
       expect_equal(.f$covMethod, "analytic")   # a fallback would compare the wrong thing
-      list(se = sqrt(diag(.f$cov)), pooled = .odeSwapInfo()$pooledSolveN - .n0)
+      list(se = sqrt(diag(.f$cov)), pooled = .odeSwapInfo()$pooledSolveN - .n0,
+           bailed = .foceiOuterFlagged$n - .b0)
     }
     .rT <- .se(TRUE); .rF <- .se(FALSE)
     # Without this the comparison is vacuous: if fast=TRUE stopped reaching the pool the
     # two runs would be the same route and would agree no matter what tolerance it used.
+    # pooledSolveN counts the ATTEMPT, so it rises even when a flagged subject sends the
+    # population back to rxSolve; $n counts exactly those, and must not move.
     expect_gt(.rT$pooled, 0L)
+    expect_equal(.rT$bailed, 0L)
     expect_equal(.rF$pooled, 0L)
     .n <- intersect(names(.rT$se), names(.rF$se))
     expect_gt(length(.n), 0L)

--- a/tests/testthat/test-focei-pool-cores.R
+++ b/tests/testthat/test-focei-pool-cores.R
@@ -1,0 +1,20 @@
+nmTest({
+  test_that(".foceiPoolCores resolves the rxControl default to rxode2's threads", {
+    # rxControl(cores = 0) is the default and MEANS "use rxode2's thread setting"; the
+    # pooled augmented solve read it as a literal 1 and so never went parallel over
+    # subjects (outerSolveFill only forks when cores > 1).  Asserted here rather than
+    # through a fit because a host with getRxThreads() == 1 cannot tell the two apart.
+    .n <- as.integer(rxode2::getRxThreads())
+    expect_equal(.foceiPoolCores(0L), .n)
+    expect_equal(.foceiPoolCores(0), .n)
+    expect_equal(.foceiPoolCores(NULL), .n)
+    expect_equal(.foceiPoolCores(NA_integer_), .n)
+    # an explicit request is taken literally, including a deliberate cores = 1
+    expect_equal(.foceiPoolCores(1L), 1L)
+    expect_equal(.foceiPoolCores(3L), 3L)
+    # nothing usable -> rxode2's threads, silently: this runs inside a fit, and a
+    # coercion warning here would be collected into the fit's $runInfo
+    expect_silent(expect_equal(.foceiPoolCores("nope"), .n))
+    expect_equal(.foceiPoolCores(c(2L, 4L)), 2L)
+  })
+})

--- a/tests/testthat/test-focei-pooled-solve-args.R
+++ b/tests/testthat/test-focei-pooled-solve-args.R
@@ -17,4 +17,24 @@ nmTest({
     expect_silent(expect_equal(.foceiPoolCores("nope"), .n))
     expect_equal(.foceiPoolCores(c(2L, 4L)), 2L)
   })
+
+  test_that("covSolveTol beats the sigdig default for the augmented solve tolerance", {
+    # The tolerance the pooled route was ignoring.  Both sources reach it through the same
+    # `solveTol` argument, so there is no branch that could honour one and drop the other
+    # -- what needs pinning is which of the two wins, and that it tracks sigdig rather
+    # than a frozen literal.  No fit: this is control plumbing.
+    .m <- function() {
+      ini({ tka <- 0.45; add.sd <- 0.7; eta.ka ~ 0.6 })
+      model({ ka <- exp(tka + eta.ka); cp <- ka; cp ~ add(add.sd) })
+    }
+    .ui <- suppressMessages(rxode2::rxUiDecompress(nlmixr2(.m)))
+    .tol <- function(...) { .u <- .ui; .u$control <- foceiControl(...)
+      .foceiAnalyticSolveTol(.u) }
+    expect_equal(.tol(sigdig = 3), 1e-9)
+    expect_equal(.tol(sigdig = 4), 1e-10)
+    expect_equal(.tol(sigdig = 6), 1e-12)
+    # an explicit covSolveTol wins, and does not move with sigdig
+    expect_equal(.tol(covSolveTol = 1e-7), 1e-7)
+    expect_equal(.tol(covSolveTol = 1e-7, sigdig = 6), 1e-7)
+  })
 })

--- a/tests/testthat/test-vae-nonmutheta-grad.R
+++ b/tests/testthat/test-vae-nonmutheta-grad.R
@@ -238,9 +238,8 @@ nmTest({
     ## A vae grad fit must not leave the pooled-solve branch armed for the next focei
     ## fit.  This used to be a session flag (.vaeGradEnv$active); it is now the
     ## structural odeSwapCanPool(odeSlotOuter) check in C++, and this test pins
-    ## that the replacement holds.  (.foceiAnalyticSolveAll was the shared route when
-    ## this was written; the outer gradient is all-C++ now and the vae M-step goes
-    ## through foceiGradPooledDirect_, so the only caller left is the covariance.)
+    ## that the replacement holds.  (Written when .foceiAnalyticSolveAll was the shared
+    ## route; both fits now reach the pool through foceiGradPooledDirect_.)
     .n0 <- .odeSwapInfo()$pooledSolveN
     .ref <- suppressMessages(
       nlmixr2(.odeMod(), nlmixr2data::theo_sd, est = "focei",

--- a/tests/testthat/test-vae-nonmutheta-grad.R
+++ b/tests/testthat/test-vae-nonmutheta-grad.R
@@ -235,11 +235,12 @@ nmTest({
 
   test_that("a vae grad fit does not leak into a later focei fast fit", {
     skip_on_cran()
-    ## .foceiAnalyticSolveAll is SHARED with focei's own fast gradient, so a vae
-    ## grad fit must not leave the pooled-solve branch armed for the next focei
+    ## A vae grad fit must not leave the pooled-solve branch armed for the next focei
     ## fit.  This used to be a session flag (.vaeGradEnv$active); it is now the
     ## structural odeSwapCanPool(odeSlotOuter) check in C++, and this test pins
-    ## that the replacement holds.
+    ## that the replacement holds.  (.foceiAnalyticSolveAll was the shared route when
+    ## this was written; the outer gradient is all-C++ now and the vae M-step goes
+    ## through foceiGradPooledDirect_, so the only caller left is the covariance.)
     .n0 <- .odeSwapInfo()$pooledSolveN
     .ref <- suppressMessages(
       nlmixr2(.odeMod(), nlmixr2data::theo_sd, est = "focei",


### PR DESCRIPTION
Two independent bugs in the analytic covariance's pooled solve. They were found
together because the first one's benchmark exposed the second.

## 1. The pooled route ignored `covSolveTol`

The augmented solves behind the analytic R matrix are central-differenced twice and
Richardson extrapolated to recover the 3rd-order tensor, so the solve error **is** the
answer's error. They are run at `solveTol` -- `foceiControl(covSolveTol=)` if set, else
tightened from `sigdig` by `.foceiAnalyticSolveTol` (1e-9 at the default `sigdig = 3`).
`.foceiAnalyticSolveAll` honoured that only on its `rxode2::rxSolve` fallback; the pooled
route dropped it, and `vaeOuterSolve_`'s `OdeFitTolGuard` **reset** the live tolerances to
the fit's -- 1e-3 at the default.

`OdeFitTolGuard` is right for a *gradient*: it must be the gradient of the objective the
optimizer is minimising. But that caller no longer exists -- the outer gradient has been
all-C++ since the R core was deleted, so every caller of `.foceiAnalyticSolveAll` is in
`R/foceiCovAnalytic.R`, and `est="vae"`'s M-step goes through `foceiGradPooledDirect_`.
`vaeOuterSolve_` is the covariance's entry point and nothing else's.

So it takes a tolerance and picks the guard -- `OdeSolveTolGuard` when supplied,
`OdeFitTolGuard` otherwise (pass `NA`), so a future gradient caller keeps today's
behaviour. `OdeSolveTolGuard` already existed for exactly this and was unused.

**Two user-visible consequences.** SEs carried the fit's solve error rather than the
covariance's; and because the pool is only available with `fast = TRUE`,
**`foceiControl(fast=)` changed the standard errors**. A user who explicitly set
`covSolveTol` had it ignored.

Holding the fit fixed (`maxOuterIterations = 0`) so only the solve tolerance moves, max
relative SE difference between the pooled route and the rxSolve route that always
honoured `solveTol`:

| sigdig | fit rtol | before | after |
|---|---|---|---|
| 3 | 1e-3 | 1.73e-4 | **0** |
| 4 | 1e-4 | 1.15e-5 | **0** |
| 6 | 1e-6 | 8.38e-8 | **0** |

The gap tracking the fit tolerance across three decades is what identified the cause; it
is now identically zero at every one. With only `foceiControl(fast=)` differing at a fixed
theta on a 5-ETA 2-compartment model: **1.71e-2 -> 3.88e-6**, and `fast=TRUE` moved *onto*
the tight values rather than merely nearer them (`tv2` 0.31483354 against 0.31483476,
previously 0.32022658).

## 2. The pooled solve ran single-threaded

Found while benchmarking the above -- the pooled route was measurably *slower* than the
rxSolve route it replaced, which it structurally should never be.

```r
pooled    if (is.null(.c) || is.na(.c) || .c < 1L) 1L else as.integer(.c)
rxSolve   if (is.null(am$cores)) 0L else am$cores
```

`0` is `rxControl`'s default and means "use rxode2's thread setting". rxSolve passes it
through and gets a threaded solve; the pooled branch turned it into a literal `1`, and

```cpp
const bool doParallel = (cores > 1) && solveMethodThreadSafe(op);
```

so `outerSolveFill`'s OpenMP-over-subjects loop never ran. The pool's parallelism -- the
reason that function exists -- was off by default here.

## Measurements

All timings call `.foceiCovAnalyticCalc()` repeatedly on **one** fitted object, 8
alternating reps. Differencing whole fits (my first approach) cannot measure this: fit
variance is seconds against a sub-second step, and it produced *negative* covariance
costs.

| | pooled | rxSolve | ratio |
|---|---|---|---|
| 3 ETA, 1-cmt | 0.330 -> **0.260s** | 0.340s | 1.00 -> **0.76** |
| 5 ETA, 2-cmt | 1.040 -> **0.710s** | 0.845s | 1.20 -> **0.84** |

The 5-ETA "before" was non-overlapping, i.e. the pool really was slower. It is now faster
on both.

Cost of honouring `solveTol`, isolated the same way: **+0.010s** (3 ETA) and **+0.030s**
(5 ETA), 1.04x with overlapping samples -- at the noise floor, and far smaller than the
threading fix returns.

The threading fix is numerically inert: per-subject solves are independent. The
pooled-vs-rxSolve SE gap stays `0.000e+00` at sigdig 3/4/6 and the `fast=` difference
stays `3.877e-06`, bit for bit, before and after.

## Tests

New regression test in `test-cov-analytic.R` pins `fast=`-invariance of the analytic SEs
directly. Also corrects a stale comment in `test-vae-nonmutheta-grad.R` describing
`.foceiAnalyticSolveAll` as shared with the fast gradient.

**Not run here:** the full `test-cov-analytic.R` file. It is weekly-batched and
compile-bound (a distinct augmented model per direction set), and did not complete in this
environment. It should be run before merge -- its own header states the analytic augmented
solve runs at `10^-(sigdig+6)`, which is exactly the premise the pooled path was violating,
so it is the file most likely to have something to say.

## Registration

`vaeOuterSolve_` gains an argument, so `src/init.c`'s forward prototype and its
`callMethods[]` arity go 4 -> 5 alongside `Rcpp::compileAttributes()`, per the manual
registration convention in CLAUDE.md.
