### PR TITLE
fix(npag/npb): support a hand-written general likelihood; remove the degenerate fit (#850)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Imports:
     nlme,
     Rcpp,
     rex,
-    rxode2 (>= 5.1.5),
+    rxode2 (>= 5.1.7),
     stats,
     symengine,
     utils
@@ -94,7 +94,7 @@ LinkingTo:
     Rcpp,
     RcppArmadillo (>= 0.11.2.3.1),
     RcppEigen,
-    rxode2 (>= 5.1.5)
+    rxode2 (>= 5.1.7)
 Biarch: true
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## New features
 
+- `est="npag"` / `est="npb"` now support a hand-written general likelihood
+  (`ll()`) properly.  A model whose `ll()` is written as the exact normal
+  log-density now agrees with the equivalent `add()` model to the known
+  `0.5*log(2*pi)` per observation, at every grid size.  Requires rxode2 5.1.7 for
+  the `safeLog=2` log-domain mode.
+
 - `foceiControl(fast = TRUE)` now uses the analytic outer gradient for
   general-likelihood models with **more than one endpoint**, which previously
   fell back to finite differences.  It was gated off as unverifiable, but what
@@ -11,6 +17,27 @@
 ## Bug fixes
 
 ### Estimation
+
+- Fixed `est="npag"` / `est="npb"` reporting a log-likelihood **above its
+  analytic maximum** for a model with a hand-written general likelihood, with the
+  residual parameters driven out of domain -- including to a **negative standard
+  deviation**.  On a 2-endpoint PK/PD fit the log-likelihood read +2364 to +2831
+  where the data bounds it at -155.  Three causes: the residual step scored every
+  row with a Gaussian extended-least-squares form even where `rx_pred_` is a
+  log-density (the same defect class as #838, in a function that fix did not
+  touch); the moment warm start took a moment of a log-density; and rxode2's
+  `safeLog` turned `log(negative)` into a large finite value, so an invalid
+  negative SD was *rewarded* by about +36 per observation rather than rejected.
+
+- Fixed npag's reported objective being inflated whenever a **residual variance
+  collapsed**, general likelihood or not.  `likInner0` floored the variance `r` to
+  1 for the `err^2/r` term but took `log()` of the *unfloored* value, so the two
+  terms disagreed -- and the disagreement paid +18.02 per affected observation.
+
+- The nonparametric engines no longer accept an evaluation the inner problem
+  refused.  `npEvalCondLik` discarded `likInner0`'s `NA` return, and because the
+  per-observation likelihoods are initialized only once, a rejected evaluation
+  summed a finite blend of two different parameter vectors.
 
 - Fixed the objective function for a model that has a **general-likelihood
   endpoint (`ll()`, `pois()`, `binom()`, ...) alongside any other endpoint**.

--- a/R/covRecompute.R
+++ b/R/covRecompute.R
@@ -49,6 +49,13 @@
   .a <- .covPinnedRefitArgs(fit)
   if (is.null(.a)) return(NULL)
   if (useEtaMat && !is.null(.a$etaMat)) control$etaMat <- .a$etaMat
+  # This re-fit is pinned at the converged estimates but still takes a frozen EM / SA
+  # step, so it CAN move a theta.  For a hand-written likelihood that means it can step a
+  # scale out of its domain, where rxode2's default safeLog hands back a large finite
+  # reward instead of a rejection -- and the covariance would then be formed around a
+  # point the likelihood cannot evaluate (nlmixr2/nlmixr2est#850).  Ask for the
+  # log-domain mode here too; a no-op while every parameter stays valid.
+  control$rxControl <- .npSafeLogDomain(control$rxControl, .a$ui)
   # the nested re-fit resets mu-referencing global state; save + restore
   .savedMuRef <- .muRefTrans$cur
   on.exit(.muRefTrans$cur <- .savedMuRef, add = TRUE)

--- a/R/npCommon.R
+++ b/R/npCommon.R
@@ -32,6 +32,13 @@
 #' @return the rxControl
 #' @noRd
 .npSafeLogDomain <- function(rxControl, ui) {
+  # The `safeLog %in% names()` test is REQUIRED, not defensive tidiness, and must not be
+  # replaced by an unconditional assignment after the capability probe: rxode2 reads this
+  # list POSITIONALLY -- `rxControl[Rxc_safeLog]` with `Rxc_safeLog == 93`
+  # (rxode2 src/rxData.cpp, inst/include/rxode2_control.h).  Assigning into a list that
+  # does not already carry the element APPENDS it, leaving index 93 holding some other
+  # control's value: a silently corrupted solve rather than a merely missing option.
+  # Replacing an element that is already present keeps its position, so only that is safe.
   if (is.null(rxControl) || !("safeLog" %in% names(rxControl))) return(rxControl)
   if (!.npIsGeneralLik(ui)) return(rxControl)
   if (!.rxode2HasSafeLogDomain()) return(rxControl)

--- a/R/npCommon.R
+++ b/R/npCommon.R
@@ -13,6 +13,32 @@
 # The npag Psi sums the inner per-observation llikObs, which for a non-normal
 # endpoint is exactly the user's log-likelihood -- so the nonparametric objective
 # is already correct; the residual-error (gamma) scaling is a no-op (r == 1).
+#' Ask rxode2 to treat a negative `log()` argument as a domain error, for a general
+#' likelihood only.
+#'
+#' A hand-written `ll()` commonly writes `-log(sigma)`.  rxode2's default `safeLog`
+#' returns `log(.Machine$double.eps)` for ANY non-positive argument, so an invalid
+#' negative sigma comes back as about +36 per observation -- a large REWARD rather than a
+#' rejection, and the optimizer settles there (nlmixr2/nlmixr2est#850).  `safeLog = 2`
+#' keeps the floor at exactly 0 (a benign numerical touch) but makes a negative argument
+#' `NaN`, which `likInner0` already refuses.
+#'
+#' Gaussian endpoints never take `log()` of an estimated parameter, so those fits are
+#' left alone.  Older rxode2 validates `safeLog` as a 0/1 logical and errors on 2, so the
+#' probe below keeps this a no-op there.
+#'
+#' @param rxControl the rxControl to adjust (returned unchanged when not applicable)
+#' @param ui decompressed rxode2 ui
+#' @return the rxControl
+#' @noRd
+.npSafeLogDomain <- function(rxControl, ui) {
+  if (is.null(rxControl) || !("safeLog" %in% names(rxControl))) return(rxControl)
+  if (!.npIsGeneralLik(ui)) return(rxControl)
+  if (!.rxode2HasSafeLogDomain()) return(rxControl)
+  rxControl$safeLog <- 2L
+  rxControl
+}
+
 #' Does the installed rxode2 understand `safeLog = 2` (floor at zero, but NaN for a
 #' NEGATIVE argument)?  Older builds validate `safeLog` as a 0/1 logical and error on 2,
 #' so probe once and cache the answer.
@@ -180,6 +206,9 @@
   }
   .control$maxOuterIterations <- 0L
   .control$covMethod <- 0L  # covariance is computed post-fit (.foceiRecomputeMuCov)
+  # This is the control that reaches foceiFitCpp_ -> foceiSetup_ -> rxSolve_, so it is
+  # where the log-domain request has to be made (see .npSafeLogDomain).
+  .control$rxControl <- .npSafeLogDomain(.control$rxControl, ui)
   .env <- ui$foceiOptEnv     # builds foceiMuGroupTheta (covariate mu-groups)
   .iniDf <- ui$iniDf
   .th <- .iniDf[!is.na(.iniDf$ntheta), ]

--- a/R/npCommon.R
+++ b/R/npCommon.R
@@ -13,6 +13,21 @@
 # The npag Psi sums the inner per-observation llikObs, which for a non-normal
 # endpoint is exactly the user's log-likelihood -- so the nonparametric objective
 # is already correct; the residual-error (gamma) scaling is a no-op (r == 1).
+#' Does the installed rxode2 understand `safeLog = 2` (floor at zero, but NaN for a
+#' NEGATIVE argument)?  Older builds validate `safeLog` as a 0/1 logical and error on 2,
+#' so probe once and cache the answer.
+#' @noRd
+.rxode2HasSafeLogDomain <- function() {
+  if (is.null(nlmixr2global$rxSafeLogDomain)) {
+    nlmixr2global$rxSafeLogDomain <-
+      tryCatch({
+        rxode2::rxControl(safeLog = 2L)
+        TRUE
+      }, error = function(e) FALSE)
+  }
+  isTRUE(nlmixr2global$rxSafeLogDomain)
+}
+
 #' @noRd
 .npIsGeneralLik <- function(ui) {
   .dist <- tryCatch(ui$predDfFocei$distribution, error = function(e) NULL)

--- a/R/npInner.R
+++ b/R/npInner.R
@@ -26,19 +26,7 @@
 .npInnerSetup <- function(ui, data, etaMat, control) {
   .ui <- rxode2::rxUiDecompress(ui)
   .fc <- .npInnerFoceiControl(control)
-  # A hand-written ll() commonly writes -log(sigma), and rxode2's default safeLog returns
-  # log(.Machine$double.eps) for any NON-POSITIVE argument -- so an invalid negative sigma
-  # comes back as about +36 per observation, a large REWARD rather than a rejection, and
-  # the optimizer settles there (nlmixr2/nlmixr2est#850).  safeLog=2 keeps the floor at
-  # exactly 0 (a benign numerical touch) but makes a negative argument NaN, which
-  # likInner0 already refuses.  Only for a general likelihood: a Gaussian endpoint never
-  # takes log() of an estimated parameter, so normal fits are untouched.  Guarded on the
-  # name so an older rxode2 (which rejects safeLog=2) is left alone.
-  if (.npIsGeneralLik(.ui) && !is.null(.fc$rxControl) &&
-        "safeLog" %in% names(.fc$rxControl) &&
-        .rxode2HasSafeLogDomain()) {
-    .fc$rxControl$safeLog <- 2L
-  }
+  .fc$rxControl <- .npSafeLogDomain(.fc$rxControl, .ui)
   .fc$est <- "focei"
   .ui$control <- .fc
   .env <- .ui$foceiOptEnv

--- a/R/npInner.R
+++ b/R/npInner.R
@@ -26,6 +26,19 @@
 .npInnerSetup <- function(ui, data, etaMat, control) {
   .ui <- rxode2::rxUiDecompress(ui)
   .fc <- .npInnerFoceiControl(control)
+  # A hand-written ll() commonly writes -log(sigma), and rxode2's default safeLog returns
+  # log(.Machine$double.eps) for any NON-POSITIVE argument -- so an invalid negative sigma
+  # comes back as about +36 per observation, a large REWARD rather than a rejection, and
+  # the optimizer settles there (nlmixr2/nlmixr2est#850).  safeLog=2 keeps the floor at
+  # exactly 0 (a benign numerical touch) but makes a negative argument NaN, which
+  # likInner0 already refuses.  Only for a general likelihood: a Gaussian endpoint never
+  # takes log() of an estimated parameter, so normal fits are untouched.  Guarded on the
+  # name so an older rxode2 (which rejects safeLog=2) is left alone.
+  if (.npIsGeneralLik(.ui) && !is.null(.fc$rxControl) &&
+        "safeLog" %in% names(.fc$rxControl) &&
+        .rxode2HasSafeLogDomain()) {
+    .fc$rxControl$safeLog <- 2L
+  }
   .fc$est <- "focei"
   .ui$control <- .fc
   .env <- .ui$foceiOptEnv

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -13809,19 +13809,32 @@ arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint
   for (int i = 0; i < nsub; ++i) {
     for (int j = 0; j < neta; ++j) eta[j] = postEta(i, j);
     double cl = npEvalCondLik(&eta[0], i);
+    // A likelihood-form model has NO prediction to take a moment of.  When any endpoint
+    // is non-normal, rxUiGet.predDfFocei rewrites every endpoint to dnorm, so rx_pred_
+    // is a log-DENSITY for all of them and `f - dv` below is a log-density minus a DV --
+    // meaningless, and it corrupts the bucket of whichever endpoint the row belongs to.
+    // likInner0 counts such observations, so use that rather than guessing per row.
+    // Leaving the buckets empty makes npOptimizeResid drop the warm start and its
+    // single-scale fast path, which is exactly right here (mirrors saem.cpp's
+    // whole-model residWarmStart guard).
+    bool skipMoments = (inds_focei[i].nNonNormal > 0);
     rx_solving_options_ind *ind = getSolvingOptionsInd(rx, getRxId(i));
-    arma::mat fr = grabRFmatFromInner(i, false);
+    arma::mat fr;
+    if (!skipMoments) fr = grabRFmatFromInner(i, false);
     int ko = 0;
     int n = getIndNallTimes(ind);
-    for (int j = 0; j < n && ko < (int)fr.n_rows; ++j) {
+    for (int j = 0; j < n && (skipMoments || ko < (int)fr.n_rows); ++j) {
       setIndIdx(ind, j);
       int kk = getIndIx(ind, j);
       if (getIndEvid(ind, kk) != 0) continue;
+      // obsIdx indexes obsEndpoint across ALL subjects, so it must advance even on a
+      // skipped subject or every later subject's rows land in the wrong endpoint.
+      int e = (obsIdx < (int)obsEndpoint.n_elem) ? obsEndpoint[obsIdx] : 0;
+      obsIdx++;
+      if (skipMoments) continue;
       double dv = tbs(getIndDv(ind, kk));
       double f = fr(ko, 0);
       ko++;
-      int e = (obsIdx < (int)obsEndpoint.n_elem) ? obsEndpoint[obsIdx] : 0;
-      obsIdx++;
       if (e < 0 || e >= nEnd) continue;
       if (!std::isfinite(cl) || !std::isfinite(f)) continue;
       double err = f - dv;

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -2159,14 +2159,15 @@ double likInner0(double *eta, int id) {
             // FOCE: log(R) from `r`, which already holds the mode-appropriate R
             // (eta=0 frozen for "nonmem", live conditional for "foce+"); FOCEI keeps lhs
             if (dist == rxDistributionNorm) {
-              if (op_focei.interaction == 0 && op_focei.neta > 0 && op_focei.fo == 0) {
-                lnr = _safe_log(r);
-              } else {
-                // npResidScale (npag/npb gamma) scales the log-variance to match
-                // the scaled r used in the err^2/r term; 1.0 for every other method.
-                lnr = _safe_log(lhs[op_focei.predOffset + op_focei.neta + 1] *
-                                op_focei.npResidScale * op_focei.npResidScale);
-              }
+              // Take the log of `r` ITSELF.  It already holds the mode-appropriate
+              // variance (eta=0 frozen for "nonmem" FOCE, live conditional for FOCEI and
+              // "foce+"), with npResidScale (npag/npb gamma) folded in AND the
+              // small-variance floor applied above.  Logging the RAW lhs instead made the
+              // two terms disagree exactly when it matters: a collapsing residual
+              // variance floors r to 1 (so err^2/r stays finite) while _safe_log(0)
+              // returns log(DBL_EPSILON), and -0.5*lnr then PAYS +18.02 per observation
+              // for driving the residual to zero.
+              lnr = _safe_log(r);
             }
             else lnr = 0;
             // fInd->r(k, 0) = lhs[op_focei.neta+1];
@@ -13731,22 +13732,34 @@ static inline void npRestoreFrozen(int i, int m, int nsub) {
 }
 
 // Residual objective at fixed per-subject etas (postEta, nsub x neta -- the
-// posterior-mean support eta of each subject).
+// posterior-mean support eta of each subject): the conditional negative log-likelihood
+// -sum_i log p(y_i | eta_i), which is exactly what the support step maximizes.  Both
+// branches now use the same quantity, so the residual step and the support step optimize
+// one function rather than two.
 //
-// Non-mixture (nMix == 1): the extended-least-squares normal negative log-likelihood
-// sum_obs(0.5*(f-dv)^2/r + 0.5*log(r) + 0.5*log(2*pi)) at the individual predictions
-// (f, r from the inner solve; dv on the transform-both-sides scale).  The 0.5*log(r)
-// term penalizes r -> 0, so -- unlike the marginal likelihood on a flexible support,
-// which rewards a vanishing residual -- the residual scale settles at the spread of the
-// data around the individual fits, as in saem/focei.
+// Non-mixture (nMix == 1): -npEvalCondLik, i.e. -sum of likInner0's per-observation
+// llikObs.  This USED to be an extended-least-squares form,
+// sum_obs(0.5*(f-dv)^2/r + 0.5*log(r) + 0.5*log(2*pi)), read back through
+// grabRFmatFromInner.  That was wrong for any model carrying a general likelihood:
+// rxUiGet.predDfFocei rewrites EVERY endpoint to dnorm as soon as one is non-normal, so
+// likInner0 puts a log-DENSITY in rx_pred_ for every row and sets r == 1 -- and the ELS
+// form then scored 0.5*(logLik - DV)^2, the same defect class as #838.  It also silently
+// dropped the transform-both-sides Jacobian (so a boxCox/yeoJohnson lambda was not
+// identifiable here) and ignored censoring, both of which likInner0 already folds into
+// llikObs.  Dropping the read-back also removes a second full calc_lhs sweep per subject
+// per optimizer candidate.  For an all-normal model the two differ by the constant
+// nObs*log(sqrt(2*pi)), and npOptimizeResid's return value is discarded at every call
+// site, so nothing observable moves.
 //
 // Mixture (nMix > 1): the EXACT mixture negative log-likelihood -sum_i log(sum_m a_m
 // exp(cll_m)) (npMixCondLik; NONMEM7 eq 1.182), marginalizing over the components with
 // the CURRENT mixture probabilities a_m (held here; the component structural parameters
 // that move each f_m are what this objective optimizes, so the components are estimated
-// rather than held).  The per-component cll_m carries the -0.5*log(r) penalty, so the
-// residual does not collapse.  The ELS approximation is not used for a mixture because
-// it evaluates a single component, which would not marginalize the proportions.
+// rather than held).
+//
+// The -0.5*log(r) inside llikObs still penalizes r -> 0, so -- unlike the marginal
+// likelihood on a flexible support, which rewards a vanishing residual -- the residual
+// scale settles at the spread of the data around the individual fits, as in saem/focei.
 //
 // Evaluated at the fixed posterior-mean etas, so a structural/component regressor that
 // re-solves the ODE is reflected; returns R_PosInf on a bad solve (bobyqa rejects it).
@@ -13772,21 +13785,7 @@ double npResidELS(const arma::mat& postEta) {
     npRestoreFrozen(i, 0, nsub);   // frozen resid opt: reuse cached states
     double cl = npEvalCondLik(&eta[0], i);
     if (!std::isfinite(cl)) return R_PosInf;
-    rx_solving_options_ind *ind = getSolvingOptionsInd(rx, getRxId(i));
-    arma::mat fr = grabRFmatFromInner(i, false);   // nObs x 2 (f, r), transformed scale
-    int ko = 0;
-    int n = getIndNallTimes(ind);
-    for (int j = 0; j < n && ko < (int)fr.n_rows; ++j) {
-      setIndIdx(ind, j);
-      int kk = getIndIx(ind, j);
-      if (getIndEvid(ind, kk) != 0) continue;      // observations only
-      double dv = tbs(getIndDv(ind, kk));
-      double f = fr(ko, 0), r = fr(ko, 1);
-      ko++;
-      if (!std::isfinite(r) || r <= 0.0) r = 1.0;
-      double e = f - dv;
-      nll += 0.5 * e * e / r + 0.5 * std::log(r) + M_LN_SQRT_2PI;
-    }
+    nll += -cl;
   }
   return nll;
 }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -13646,7 +13646,13 @@ struct NpInnerParallelScope {
 // Conditional log-likelihood log p(y_i | eta) for subject id (no Omega prior).
 // Returns -Inf if any observation had a non-finite density (e.g. a bad solve).
 double npEvalCondLik(double *eta, int id) {
-  likInner0(eta, id);
+  // Honor likInner0's refusal.  It has several mid-loop `return NA_REAL` exits (a bad
+  // solve, a non-finite f, an NA r); on those the rows AFTER the abort still hold
+  // llikObs from the previous successful evaluation, because llikObs is initialized
+  // only once at setup.  Dropping the return therefore summed a stale-but-finite blend
+  // of two evaluations, which the finite check below could never detect.
+  double li = likInner0(eta, id);
+  if (ISNA(li)) return R_NegInf;
   rx = getRxSolve_();
   rx_solving_options_ind *ind = getSolvingOptionsInd(rx, getRxId(id));
   focei_ind *fInd = &(inds_focei[id]);

--- a/src/npag.cpp
+++ b/src/npag.cpp
@@ -58,12 +58,27 @@ namespace {
     return v;                                                           // lambda etc.
   }
 
+  // Reference objective at the optimizer's starting point, used to scale the
+  // out-of-domain penalty below.  R_PosInf when unset (nothing to scale against yet).
+  double gNpResidRef = R_PosInf;
+
   double npResidObjVal(const double *p) {
     for (size_t j = 0; j < gNpOptIdx.size(); ++j)
       impSetThetaAll(gNpOptIdx[j], npResidVal(p[j], gNpOptKind[j]));
     if (gNpReDerive)
       gNpPostEta = npPosteriorEta(*gNpSupport, *gNpWeights, gNpCores);
-    return npResidELS(gNpPostEta);
+    double v = npResidELS(gNpPostEta);
+    if (std::isfinite(v)) return v;
+    // A candidate the model itself rejects -- e.g. a hand-written ll() taking log() of
+    // a parameter that went negative, which rxode2's safeLog=2 turns into NaN.  bobyqa
+    // builds a quadratic from 2n+1 sampled points, so handing it R_PosInf makes the
+    // interpolation coefficients NaN and the whole step is then garbage rather than a
+    // rejection -- which is how a negative SD still survived the domain check.  Give it
+    // a large FINITE value instead, scaled to the objective so it dominates without
+    // wrecking conditioning.  It is a flat plateau: it stops the infeasible region from
+    // attracting the optimizer, but carries no gradient back toward feasibility.
+    if (!std::isfinite(gNpResidRef)) return 1e10;
+    return gNpResidRef + 1e4 * (1.0 + std::fabs(gNpResidRef));
   }
   double npResidObjR(Rcpp::NumericVector p) { return npResidObjVal(p.begin()); }
 }
@@ -137,6 +152,14 @@ double npOptimizeResid(const arma::mat& support, const arma::vec& weights,
       if (!std::isfinite(hi[j])) hi[j] = v + 6.0;
     }
   }
+  // Scale for the out-of-domain penalty in npResidObjVal: the objective at the START,
+  // which is feasible by construction (it is the current fit).  Reset per call so a
+  // previous subject/cycle cannot leak its scale in.
+  gNpResidRef = R_PosInf;
+  {
+    double f0 = npResidELS(gNpPostEta);
+    if (std::isfinite(f0)) gNpResidRef = f0;
+  }
   // PIN the current solve for a residual-only optimization: the err params do not
   // change f, so cache each subject's (per-component) states at the posterior
   // etas and freeze the ODE -- npResidELS then recomputes only r, no
@@ -159,7 +182,19 @@ double npOptimizeResid(const arma::mat& support, const arma::vec& weights,
   if (!ISNA(f)) {
     Rcpp::NumericVector x = ret["x"];
     for (int j = 0; j < n; ++j) impSetThetaAll(idx[j], npResidVal(x[j], kind[j]));
-    return f;
+    // The optimizer's answer is only usable if the MODEL accepts it.  bobyqa returns the
+    // best point it sampled, and with an out-of-domain penalty that is still a finite
+    // number -- so `f` being non-NA says nothing about feasibility.  Committing an
+    // infeasible x is how a hand-written ll() ended up fit at a NEGATIVE standard
+    // deviation (nlmixr2/nlmixr2est#850): every later Psi was then built at a parameter
+    // the likelihood cannot evaluate.  Re-check the committed point and fall back to the
+    // start, which is feasible by construction, when it does not hold up.
+    double fx = npResidELS(gNpPostEta);
+    if (!std::isfinite(fx)) {
+      for (int j = 0; j < n; ++j) impSetThetaAll(idx[j], npResidVal(start[j], kind[j]));
+      return R_PosInf;
+    }
+    return fx;
   }
   for (int j = 0; j < n; ++j) impSetThetaAll(idx[j], npResidVal(start[j], kind[j]));
   return R_PosInf;

--- a/src/npag.cpp
+++ b/src/npag.cpp
@@ -62,6 +62,22 @@ namespace {
   // out-of-domain penalty below.  R_PosInf when unset (nothing to scale against yet).
   double gNpResidRef = R_PosInf;
 
+  // Out-of-domain penalty shape.  The penalty is
+  //     ref + NP_RESID_PENALTY_MULT * (1 + |ref|)
+  // which is strictly worse than `ref` for either sign of ref, and worse than any
+  // objective within a factor of NP_RESID_PENALTY_MULT of the starting point -- the
+  // multiplier is what buys the margin, so it wants to be large relative to how far a
+  // feasible objective can move during one residual step, and small enough not to
+  // wreck bobyqa's quadratic conditioning.  1e4 sits comfortably between: residual
+  // steps move the objective by O(1)-O(100) here.
+  const double NP_RESID_PENALTY_MULT = 1e4;
+  // Unscaled fallback, used only if gNpResidRef were somehow unset.  npOptimizeResid
+  // returns early when the starting objective is non-finite, so this is unreachable;
+  // it is kept so the function is total.  It is deliberately NOT the primary path: an
+  // absolute constant can be SMALLER than a legitimate objective on a large problem,
+  // which would make the infeasible region look attractive.
+  const double NP_RESID_PENALTY_ABS = 1e10;
+
   double npResidObjVal(const double *p) {
     for (size_t j = 0; j < gNpOptIdx.size(); ++j)
       impSetThetaAll(gNpOptIdx[j], npResidVal(p[j], gNpOptKind[j]));
@@ -77,8 +93,8 @@ namespace {
     // a large FINITE value instead, scaled to the objective so it dominates without
     // wrecking conditioning.  It is a flat plateau: it stops the infeasible region from
     // attracting the optimizer, but carries no gradient back toward feasibility.
-    if (!std::isfinite(gNpResidRef)) return 1e10;
-    return gNpResidRef + 1e4 * (1.0 + std::fabs(gNpResidRef));
+    if (!std::isfinite(gNpResidRef)) return NP_RESID_PENALTY_ABS;
+    return gNpResidRef + NP_RESID_PENALTY_MULT * (1.0 + std::fabs(gNpResidRef));
   }
   double npResidObjR(Rcpp::NumericVector p) { return npResidObjVal(p.begin()); }
 }

--- a/src/npag.cpp
+++ b/src/npag.cpp
@@ -152,13 +152,21 @@ double npOptimizeResid(const arma::mat& support, const arma::vec& weights,
       if (!std::isfinite(hi[j])) hi[j] = v + 6.0;
     }
   }
-  // Scale for the out-of-domain penalty in npResidObjVal: the objective at the START,
-  // which is feasible by construction (it is the current fit).  Reset per call so a
-  // previous subject/cycle cannot leak its scale in.
+  // Scale for the out-of-domain penalty in npResidObjVal: the objective at the START.
+  // Reset per call so a previous cycle (or the other engine -- npb shares this file's
+  // statics) cannot leak its scale in.  If the START itself is infeasible there is
+  // nothing to scale against and no feasible point to improve on, so do not run the
+  // optimizer at all: leave the thetas where they are and report failure.  That also
+  // keeps npResidObjVal's unscaled fallback unreachable, so it cannot ever be smaller
+  // than a legitimate objective.
   gNpResidRef = R_PosInf;
   {
     double f0 = npResidELS(gNpPostEta);
-    if (std::isfinite(f0)) gNpResidRef = f0;
+    if (!std::isfinite(f0)) {
+      for (int j = 0; j < n; ++j) impSetThetaAll(idx[j], npResidVal(start[j], kind[j]));
+      return R_PosInf;
+    }
+    gNpResidRef = f0;
   }
   // PIN the current solve for a residual-only optimization: the err params do not
   // change f, so cache each subject's (per-component) states at the posterior
@@ -178,10 +186,16 @@ double npOptimizeResid(const arma::mat& support, const arma::vec& weights,
                                                                      Rcpp::_["rhoend"] = rhoend));
   if (doFreeze) npResidFreezeClear();   // unfreezes op_focei.freezeOde
   double f = as<double>(ret["value"]);
+  bool didReDerive = gNpReDerive;
   gNpReDerive = false;
   if (!ISNA(f)) {
     Rcpp::NumericVector x = ret["x"];
     for (int j = 0; j < n; ++j) impSetThetaAll(idx[j], npResidVal(x[j], kind[j]));
+    // With a regressor, gNpPostEta was re-derived for every candidate bobyqa sampled, so
+    // it currently belongs to the LAST point tried -- which is not the optimum it
+    // returned.  Re-derive at the committed thetas before judging them, or the check
+    // pairs the new thetas with someone else's etas.
+    if (didReDerive) gNpPostEta = npPosteriorEta(*gNpSupport, *gNpWeights, gNpCores);
     // The optimizer's answer is only usable if the MODEL accepts it.  bobyqa returns the
     // best point it sampled, and with an out-of-domain penalty that is still a finite
     // number -- so `f` being non-NA says nothing about feasibility.  Committing an

--- a/tests/testthat/test-npag-general-lik.R
+++ b/tests/testthat/test-npag-general-lik.R
@@ -43,4 +43,104 @@ nmTest({
     expect_true(is.finite(as.numeric(f$objf)))
     expect_equal(ncol(f$env$npbSupport), 2L)   # eta.ka, eta.v support dimensions
   })
+
+  ## ---- MULTIPLE endpoints (#850) ------------------------------------------------
+  ## Everything above is SINGLE-endpoint, which was never the broken case.  With a
+  ## second endpoint the residual step scored a log-density with a Gaussian ELS form,
+  ## the moment warm start took a moment of a log-density, and rxode2's safeLog paid
+  ## +36 per observation for a NEGATIVE sd -- together giving a log-likelihood of
+  ## +2364 to +2831 where the data bounds it at -155, with pdadd.sd at -0.83 to -1.93.
+  ##
+  ## The reference is the model's own GAUSSIAN TWIN, not a checked-in constant.  An
+  ## ll() written as the exact normal log-density is the same likelihood as the
+  ## equivalent add() endpoint, and likInner0 stores the full density for ll() rows
+  ## while the Gaussian path omits the 0.5*log(2*pi) term -- so the two
+  ## log-likelihoods must differ by EXACTLY nObs*0.5*log(2*pi) and by nothing else.
+  ## Self-validating, nothing to drift.
+  .npMkPkPd <- function(pdLine) {
+    .b <- quote({ ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+      ec50 <- exp(tec50); kout <- exp(tkout); e0 <- exp(te0)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      effect(0) <- e0
+      d/dt(effect) <- kout * (e0 * (1 - cp / (ec50 + cp)) - effect)
+      cp ~ add(add.sd) | center })
+    .b[[length(.b) + 1]] <- pdLine
+    .f <- function() {}
+    body(.f) <- bquote({
+      ini({ tka <- 0.5; tcl <- -3.2; tv <- -0.7; tec50 <- 2; tkout <- -2; te0 <- 4.6
+        eta.cl ~ 0.09; add.sd <- 0.4; pdadd.sd <- 2 })
+      model(.(.b))
+    })
+    .f
+  }
+  .npPkPdData <- function(m) {
+    .testSeed(1); rxode2::rxSetSeed(1)
+    .ev <- rxode2::et(amt = 100, cmt = "depot", id = 1:12)
+    .ev <- rxode2::et(.ev, seq(0.5, 24, by = 3), cmt = "center")
+    .ev <- rxode2::et(.ev, seq(0.5, 24, by = 3), cmt = "effect")
+    .d <- as.data.frame(rxode2::rxSolve(m, .ev, addDosing = TRUE))
+    .dose <- .d[.d$evid != 0, c("id", "time", "CMT", "amt", "evid")]
+    .dose$dv <- NA_real_
+    names(.dose)[names(.dose) == "CMT"] <- "cmt"
+    .obs <- .d[.d$evid == 0, c("id", "time", "CMT", "sim")]
+    .obs$amt <- 0; .obs$evid <- 0
+    names(.obs)[names(.obs) == "CMT"] <- "cmt"
+    names(.obs)[names(.obs) == "sim"] <- "dv"
+    .dat <- rbind(.dose[, c("id", "time", "dv", "cmt", "amt", "evid")],
+                  .obs[, c("id", "time", "dv", "cmt", "amt", "evid")])
+    .dat[order(.dat$id, .dat$time, -.dat$evid), ]
+  }
+
+  test_that("est='npag' scores a general likelihood alongside a second endpoint (#850)", {
+    skip_if_not(rxode2hasLlik(), "rxode2 build has no llik support")
+    skip_if_not(nlmixr2est:::.rxode2HasSafeLogDomain(),
+                "rxode2 too old for the safeLog log-domain mode")
+    .gauss <- .npMkPkPd(quote(effect ~ add(pdadd.sd) | effect))
+    .ll <- .npMkPkPd(quote(ll(effect) ~ -0.5 * log(2 * pi) - log(pdadd.sd) -
+                             0.5 * ((DV - effect) / pdadd.sd)^2))
+    .dat <- .npPkPdData(.gauss)
+    .nObs <- sum(.dat$evid == 0)
+    .ctl <- function() npagControl(points = 24L, cycles = 3L, seed = 1L, print = 0L)
+    rxode2::rxSetSeed(42); .fg <- suppressWarnings(nlmixr2(.gauss, .dat, "npag", .ctl()))
+    rxode2::rxSetSeed(42); .fl <- suppressWarnings(nlmixr2(.ll, .dat, "npag", .ctl()))
+    .lg <- as.numeric(.fg$env$npagLogLik)
+    .ll2 <- as.numeric(.fl$env$npagLogLik)
+    # a per-observation log-density cannot exceed -log(sd) - 0.5*log(2*pi), so no fit
+    # of this data can clear this bound.  The defect cleared it by more than 2000.
+    .maxLL <- -.nObs * 0.5 * log(2 * pi) - 96 * log(0.4) - 96 * log(2)
+    expect_lt(.ll2, .maxLL)
+    # every scale stays in its domain -- this is what actually went wrong
+    expect_gt(unname(fixef(.fl)["pdadd.sd"]), 0)
+    expect_gt(unname(fixef(.fl)["add.sd"]), 0)
+    # the twin: the ONLY admissible difference is the 2*pi term the Gaussian path omits
+    expect_equal(.lg - .ll2, .nObs * 0.5 * log(2 * pi), tolerance = 0.02)
+    expect_equal(unname(fixef(.fl)["add.sd"]), unname(fixef(.fg)["add.sd"]),
+                 tolerance = 0.05)
+    expect_equal(unname(fixef(.fl)["pdadd.sd"]), unname(fixef(.fg)["pdadd.sd"]),
+                 tolerance = 0.05)
+  })
+
+  test_that("an ini() lower bound constrains a parameter inside ll() (#850)", {
+    # A hand-written likelihood's domain is not always a box -- log(a-b) needs a > b --
+    # so nlmixr2est does not try to INFER that a parameter is a scale.  Declaring the
+    # bound in ini() is the supported way to say so, and it reaches the nonparametric
+    # residual step as the optimizer's box.  This pins that contract.
+    skip_if_not(rxode2hasLlik(), "rxode2 build has no llik support")
+    .m <- function() {
+      ini({ tka <- log(1.5); tv <- log(32); tke <- fix(log(0.08))
+        eta.ka ~ 0.3; eta.v ~ 0.1; add.sd <- c(0.05, 0.7) })
+      model({ ka <- exp(tka + eta.ka); v <- exp(tv + eta.v); ke <- exp(tke)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - ke * center
+        cp <- center / v
+        ll(cp) ~ -0.5 * log(2 * pi) - log(add.sd) - 0.5 * ((DV - cp) / add.sd)^2 })
+    }
+    f <- suppressWarnings(nlmixr2(.m, nlmixr2data::theo_sd, est = "npag",
+                                  control = npagControl(points = 24L, cycles = 3L,
+                                                        seed = 1L, print = 0L)))
+    expect_s3_class(f, "nlmixr2FitData")
+    expect_gte(unname(fixef(f)["add.sd"]), 0.05)   # the declared lower bound holds
+  })
 })

--- a/tests/testthat/test-npag-general-lik.R
+++ b/tests/testthat/test-npag-general-lik.R
@@ -107,13 +107,23 @@ nmTest({
     rxode2::rxSetSeed(42); .fl <- suppressWarnings(nlmixr2(.ll, .dat, "npag", .ctl()))
     .lg <- as.numeric(.fg$env$npagLogLik)
     .ll2 <- as.numeric(.fl$env$npagLogLik)
-    # a per-observation log-density cannot exceed -log(sd) - 0.5*log(2*pi), so no fit
-    # of this data can clear this bound.  The defect cleared it by more than 2000.
-    .maxLL <- -.nObs * 0.5 * log(2 * pi) - 96 * log(0.4) - 96 * log(2)
-    expect_lt(.ll2, .maxLL)
-    # every scale stays in its domain -- this is what actually went wrong
+    # every scale stays in its domain -- this is what actually went wrong, and the
+    # bound below is only well defined once it holds
     expect_gt(unname(fixef(.fl)["pdadd.sd"]), 0)
     expect_gt(unname(fixef(.fl)["add.sd"]), 0)
+    # A per-observation normal log-density cannot exceed -log(sd) - 0.5*log(2*pi), so the
+    # total cannot exceed the sum of those maxima.  Take the sd's from the FIT, not from
+    # the simulation: the fit chooses its own, and pdadd.sd lands near 0.76 against the
+    # simulated 2 -- a bound built on the simulation values would be one this fit is
+    # entitled to beat, and would fail for a legitimate reason.  At the fitted sd's this
+    # is a theorem.  The defect cleared even the looser bound by more than 2000.
+    .nPk <- sum(.dat$evid == 0 & .dat$cmt == 2)
+    .nPd <- sum(.dat$evid == 0 & .dat$cmt == 3)
+    expect_equal(.nPk + .nPd, .nObs)
+    .maxLL <- -.nObs * 0.5 * log(2 * pi) -
+      .nPk * log(unname(fixef(.fl)["add.sd"])) -
+      .nPd * log(unname(fixef(.fl)["pdadd.sd"]))
+    expect_lt(.ll2, .maxLL)
     # the twin: the ONLY admissible difference is the 2*pi term the Gaussian path omits
     expect_equal(.lg - .ll2, .nObs * 0.5 * log(2 * pi), tolerance = 0.02)
     expect_equal(unname(fixef(.fl)["add.sd"]), unname(fixef(.fg)["add.sd"]),

--- a/tests/testthat/test-npag-general-lik.R
+++ b/tests/testthat/test-npag-general-lik.R
@@ -95,7 +95,7 @@ nmTest({
 
   test_that("est='npag' scores a general likelihood alongside a second endpoint (#850)", {
     skip_if_not(rxode2hasLlik(), "rxode2 build has no llik support")
-    skip_if_not(nlmixr2est:::.rxode2HasSafeLogDomain(),
+    skip_if_not(.rxode2HasSafeLogDomain(),
                 "rxode2 too old for the safeLog log-domain mode")
     .gauss <- .npMkPkPd(quote(effect ~ add(pdadd.sd) | effect))
     .ll <- .npMkPkPd(quote(ll(effect) ~ -0.5 * log(2 * pi) - log(pdadd.sd) -


### PR DESCRIPTION
Fixes #850. **Depends on nlmixr2/rxode2#1179** (`safeLog=2`); the end-to-end test is gated on it, so this file stays green against an older rxode2 rather than failing for an unrelated reason.

## The defect

`est="npag"` / `est="npb"` on a model with a hand-written `ll()` reported a log-likelihood **above its analytic maximum** and drove residual parameters out of domain -- to a **negative standard deviation**. On a 2-endpoint PK/PD fit (12 subjects, 192 observations, simulated at `add.sd = 0.4`, `pdadd.sd = 2`):

| points | gauss LL | `ll()` LL | `ll()` add.sd | `ll()` pdadd.sd |
|---|---|---|---|---|
| 16 | -125.25 | **+2831.21** | 80.37 | **-1.386** |
| 24 | -45.35 | **+2440.47** | 80.09 | **-1.930** |
| 32 | -66.67 | **+2364.24** | 75.08 | **-0.831** |

A per-observation log-density is bounded above by `-log(sd) - 0.5*log(2*pi)`, so the total **cannot exceed -155.0**. Those values are not a bad fit; they are unreachable.

## Three compounding causes

1. **`npResidELS` scored every row with a Gaussian extended-least-squares form.** `rxUiGet.predDfFocei` rewrites *every* endpoint to `dnorm` once any is non-normal, so `rx_pred_` is a log-density for all of them -- and the ELS form computed `0.5*(logLik - DV)^2`. Same defect class as #838, in a function that PR did not touch. This is what drove `add.sd` to 75-80.
2. **The moment warm start took a moment of a log-density**, corrupting the *other* endpoint's bucket too.
3. **rxode2's `safeLog` paid +36.04 per observation for a negative SD** (`-log(sigma)` at `sigma < 0` returns `-log(DBL_EPSILON)`), so the degenerate optimum was actively attractive.

## Result

The `ll()` model now matches its **Gaussian twin** to the exact `0.5*log(2*pi)` per observation, at every grid size (192 obs -> 176.4):

| points | gauss LL | `ll()` LL | difference | pdadd.sd (gauss / ll) |
|---|---|---|---|---|
| 16 | -123.897 | -299.744 | -175.85 | 0.7290 / 0.7290 |
| 24 | -45.350 | -221.786 | -176.44 | 0.7528 / 0.7573 |
| 32 | -66.485 | -242.891 | -176.41 | 0.7515 / 0.7634 |

`add.sd` agrees to ~0.2%; every scale is positive.

## Two further bugs found along the way

**`likInner0` paid +18.02 per observation for a collapsing residual variance** -- `r` was floored to 1 for the `err^2/r` term while `lnr` logged the *unfloored* value. The old ELS objective masked this by computing its own `log(r)`, so the optimizer never steered there, but the reward was always in `llikObs`, hence in Psi and the reported objective. **npag's objf has therefore been inflated whenever a residual collapsed, general likelihood or not.**

**`npEvalCondLik` discarded `likInner0`'s `NA` return.** Since the per-observation likelihoods are initialized only once at setup, a rejected evaluation summed a finite blend of two different parameter vectors, and the existing finite check could never see it.

## Design note: declare the domain, do not infer it

This deliberately does **not** try to infer that a parameter is a scale. `npResidVal`'s `kind == 1` applies `fabs()`, which would silently mirror a legitimate slope of `-0.4` to `+0.4`; and boxCox/yeoJohnson lambdas are `kind == 0` and legitimately negative. A hand-written likelihood's domain is not always a box either (`log(a-b)` needs `a > b`). So: `safeLog=2` makes the model itself reject what it cannot evaluate, and an `ini()` lower bound is the supported way to declare a constraint -- now documented and pinned by a test.

## Verification

- Batch 10 (all 10 npag/npb files): **34 blocks, 0 failures**
- New multi-endpoint block: 6 assertions; `ini()`-bound block: 2 assertions -- both pass
- boxCox lambda moves 0.438919 -> 0.451583 (2.9%, assertion is `0.44 +/- 0.2`); `add.sd` 0.38721 -> 0.387991
- Reviewed with a second-opinion model across three rounds. Round 1 on the first three commits: no findings. Round 2 found two real bugs in my own code -- a feasibility re-check pairing the committed optimum with **stale etas**, and a penalty fallback that could be *smaller* than a legitimate objective and so steer *toward* the infeasible region -- both fixed. Its remaining claim (that the control never reaches C++) I checked directly by disabling the line: the degeneracy returned bit-identically, so the fix works for the stated reason.

## Corrections to commit messages

`e8e78bb8f` says `.npInnerSetup` "has NO callers". It has none in `R/`, but `test-npag-cycle.R` and `test-npag-psi.R` call it directly -- which is why `.npSafeLogDomain` is applied there as well as in `.npFamilyFit`.

## Not fixed here

#846 (support condensation vs Pmetrics) is separate; two concrete leads are recorded on that issue. Also worth its own issue: `npBuildObsEndpoint` (`src/inner.cpp:13850`) silently files an unmatched-CMT observation into endpoint 0, and `R/npCommon.R` does the same for an unmatched `err` condition.