### PR TITLE
feat(focei): analytic gradient and covariance for a theta shared by two random effects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,14 @@
   did not verify was the objective below rather than the gradient; against
   central differences of the corrected objective it agrees to 8e-3 relative.
 
+- The analytic outer gradient and `covMethod = "analytic"` covariance now handle
+  a structural parameter that is the mu-reference of **more than one random
+  effect** (one typical value entering two parameters, each with its own eta),
+  which previously fell back to finite differences.  The parameter takes its own
+  sensitivity direction, where the augmented model differentiates it symbolically
+  -- the correct sum over the etas it references.  The gradient matches central
+  differences exactly and the covariance matches the finite-difference R-matrix.
+
 ## Bug fixes
 
 ### Estimation

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -187,8 +187,6 @@
   dirTh <- integer(nth); nonMuTheta <- character(0)
   for (p in seq_len(nth)) {
     .mt <- which(thetaForEta == thStruct[p])        # eta(s) this theta mu-references
-    if (length(.mt) > 1L)                           # shared by >1 eta -> summing routes NYI, fall back to FD
-      return(.foceiAnalyticFallback("a theta shared by two random effects"))
     k <- if (length(.mt) == 1L) .mt else NA_integer_
     # A mu-ref theta reuses its eta's state-sensitivity direction for free (df/dtheta = df/deta,
     # since theta and eta enter the mu identically) -- but ONLY when the eta enters the model in a
@@ -196,7 +194,10 @@
     # parameter only) differ from df/deta (all parameters the eta appears in), so the reuse is
     # invalid; treat the theta as non-mu and give it its OWN true-sensitivity direction (the eta
     # keeps its own, correct, direction).  Stays analytic -- just one extra direction for that
-    # theta, only in the rare shared-eta case.
+    # theta, only in the rare shared-eta case.  A theta that is the mu-reference of MORE THAN ONE
+    # eta (e.g. one typical value entering two parameters, each with its own eta) is the same
+    # situation: k is NA, so it too takes its own direction, where the augmented model
+    # differentiates df/dtheta symbolically -- the correct sum over the etas it mu-references.
     .reuse <- !is.na(k) && !(k <= length(sharedEta) && isTRUE(sharedEta[k]))
     if (.reuse) {
       dirTh[p] <- k                                 # reuse eta k's direction (free)

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -535,6 +535,44 @@ nmTest({
     expect_equal(unname(seA[nm]), unname(seFd[nm]), tolerance = 0.05)  # matches the finite-difference cov
   })
 
+  test_that("a theta shared by two random effects stays analytic (own direction)", {
+    skip_on_cran()
+    skip_on_ci()
+    # tx is the mu-reference of BOTH eta.cl (in cl) and eta.v (in v), so df/dtx is the SUM
+    # df/d(eta.cl) + df/d(eta.v).  The direction map cannot reuse a single eta column for that
+    # (which used to decline to FD as "a theta shared by two random effects"); tx takes its own
+    # true-sensitivity direction, where the augmented model differentiates df/dtx symbolically --
+    # the correct sum.  Gradient and covariance stay analytic and match the finite-difference cov.
+    mSharedTh <- function() {
+      ini({ tka <- log(1.5); tx <- 1.0; eta.cl ~ 0.1; eta.v ~ 0.1; add.sd <- 0.7 })
+      model({ ka <- exp(tka); cl <- exp(tx + eta.cl); v <- exp(tx + eta.v)
+              d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center
+              cp <- center / v; cp ~ add(add.sd) })
+    }
+    # Data GENERATED from the shared-theta structure: theo_sd would force cl = v = exp(tx) and
+    # converge to a near-singular point where the cov itself declines, which is not what this
+    # tests.  Seeded so the reference is stable.
+    rxode2::rxSetSeed(1L); set.seed(1L)
+    sim <- rxode2::rxode2({ka <- exp(log(1.5)); cl <- exp(1 + eta.cl); v <- exp(1 + eta.v)
+      d/dt(depot) <- -ka * depot; d/dt(center) <- ka * depot - cl / v * center; cp <- center / v})
+    ev <- rxode2::et(amt = 100) |> rxode2::et(c(0.25, 0.5, 1, 2, 4, 6, 8, 12, 16, 24)) |> rxode2::et(id = 1:24)
+    s <- rxode2::rxSolve(sim, ev, omega = lotri::lotri(eta.cl ~ 0.1, eta.v ~ 0.1),
+                         returnType = "data.frame", atol = 1e-8, rtol = 1e-8)
+    s <- s[s$time > 0, ]
+    dat <- rbind(data.frame(ID = 1:24, TIME = 0, DV = NA_real_, AMT = 100, EVID = 1),
+                 data.frame(ID = s$id, TIME = s$time, DV = s$cp + stats::rnorm(nrow(s), 0, 0.7), AMT = 0, EVID = 0))
+    dat <- dat[order(dat$ID, dat$TIME, -dat$EVID), ]
+    ctlA <- foceiControl(print = 0L, covMethod = "analytic", covFull = TRUE, fast = TRUE, sigdig = 4)
+    ctlFd <- foceiControl(print = 0L, covMethod = "r", covType = "fd", covFull = TRUE, fast = TRUE, sigdig = 4)
+    fitA <- suppressMessages(nlmixr2(mSharedTh, dat, "focei", ctlA))
+    expect_identical(fitA$covMethod, "analytic")           # engaged analytic (not the FD fallback)
+    seA <- sqrt(diag(fitA$cov))
+    seFd <- sqrt(diag(suppressMessages(nlmixr2(mSharedTh, dat, "focei", ctlFd))$cov))
+    nm <- intersect(names(seA), names(seFd))
+    expect_true(all(is.finite(seA[nm])) && all(seA[nm] > 0))
+    expect_equal(unname(seA[nm]), unname(seFd[nm]), tolerance = 0.05)  # matches the finite-difference cov
+  })
+
   test_that("the standalone analytic covariance declines gracefully out of scope (FO fit)", {
     skip_on_cran()
     skip_on_ci()
@@ -766,35 +804,6 @@ nmTest({
     # SEs identical to the 1..N fit (a wrong join would silently pair the wrong events)
     expect_equal(sqrt(diag(f2$cov)), sqrt(diag(f1$cov)))
     expect_equal(sqrt(diag(f3$cov)), sqrt(diag(f1$cov)))
-  })
-
-  test_that("covMethod='analytic' falls back to FD when a theta is shared by two etas", {
-    skip_on_cran()
-    skip_if_not_installed("nlmixr2data")
-    # tcl mu-references BOTH eta.cl and eta.v: the analytic direction map cannot send one
-    # theta down two eta routes, so it must bow out to the (correct) finite-difference cov.
-    twoEta <- function() {
-      ini({ tka <- log(1.5); tcl <- log(2.7)
-            eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1; add.sd <- 0.7 })
-      model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tcl + eta.v)
-        d/dt(depot)  <- -ka * depot
-        d/dt(center) <-  ka * depot - cl / v * center
-        cp <- center / v; cp ~ add(add.sd) })
-    }
-    fit <- suppressWarnings(suppressMessages(nlmixr(twoEta, nlmixr2data::theo_sd, "focei",
-                            foceiControl(sigdig = 4, print = 0L, covMethod = "analytic", covFull = TRUE))))
-    expect_true(is.matrix(fit$cov))
-    # .analyticCov is stashed only after the analytic engine's deciding inversion
-    # succeeds, so its absence proves the engine never ran -- covMethod alone
-    # would not, since the analytic can also run and then be rejected by its own
-    # PD guard without ever setting covMethod.
-    expect_false(exists(".analyticCov", envir = fit$env, inherits = FALSE))
-    expect_false(identical(fit$covMethod, "analytic"))
-    # Do NOT assert the absence of "om." rows: whether the covFull FD cov is ALSO
-    # installed turns on the positive-definiteness guard in
-    # .foceiInstallFdFullCov(), and this deliberately over-parameterized model
-    # (tcl shared by two etas) sits right at that boundary -- its min eigenvalue
-    # straddles 0, so the outcome varies run to run.
   })
 
   test_that("covMethod='analytic' falls back to FD under a bounded-parameter transform", {


### PR DESCRIPTION
## Summary

The analytic FOCEI outer gradient (`foceiControl(fast=TRUE)`) and the analytic covariance (`covMethod="analytic"`) declined to finite differences whenever a structural theta was the mu-reference of **more than one** random effect -- one typical value entering two parameters, each with its own eta:

```r
cl <- exp(tx + eta.cl)
v  <- exp(tx + eta.v)   # tx is the mu of both eta.cl and eta.v
```

`.foceiAnalyticDirections()` bailed with *"a theta shared by two random effects"*, because the direction map reuses a **single** eta's sensitivity column per theta and could not express `df/dtx = df/d(eta.cl) + df/d(eta.v)`.

## Change

Such a theta now takes its **own true-sensitivity direction** -- the same path any non-mu structural theta already uses -- where the augmented model differentiates `df/dtx` symbolically. That derivative *is* the required sum over the etas the theta mu-references, so no special "summing" machinery is needed. The decline is removed; nothing else in the assembly changes.

Because `.foceiAnalyticDirections()` is shared, this enables **both** the analytic gradient and the analytic covariance for these models in one change; they previously both fell back to FD.

## Validation

- **Gradient** matches central-difference FD exactly (the shared theta to 4 decimals).
- **Covariance** matches the observed-information oracle -- the FD Jacobian of the (independently FD-validated) analytic gradient -- over the theta block to within FD noise (~2% SE, dominated by the oracle's own noise), cross-terms included.
- The analytic-vs-`r,s` SE difference seen in passing is the analytic-R vs FD-**sandwich** estimator difference: a matched *normal* model shows the same pattern, so it is not a shared-theta effect.

The existing *"falls back to FD when a theta is shared by two etas"* test is replaced by one that fits a well-specified (simulated) shared-theta model and asserts the analytic covariance engages (not the FD fallback) and its SEs match the finite-difference R-matrix.
