### PR TITLE
fix(odeSwap): make the lhs-width probe safe to run (#870)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,13 @@ Three rules, each of which has caused a real bug:
 - **Check the lhs width before reading.**  `rxUpdateFuns` resolves symbols by NAME, so the
   same model can re-resolve to a different dll's `calc_lhs` later in a session.
   `odeSwapCheckLhsWidth()` probes it; skipping the check reads columns nobody wrote.
+  The probe answers by CALLING `calc_lhs`, so it must first make that call safe --
+  the pool has to hold the model's states, the model's parameter layout has to match
+  the pool model's (`calc_lhs` reads `par_ptr` BY INDEX, so equal widths in a
+  different order mis-read), and subject 0's per-thread pointers (`ind->on`,
+  `ind->lhs`) have to be bound with `iniSubjectE`.  Those pointers come from a
+  SOLVE, not from building the pool, so a set-up-but-never-solved pool segfaulted
+  inside the probe (#870).  A gate that can crash is worse than no gate.
 - **`OdeSwapScope` is NOT enough on its own -- the pool also rebases COMPARTMENT
   NUMBERS.**  `OdeSwapScope` fixes the neq stride; `OdeSwapCmtScope` puts the CMT basis
   back to the solved model's.  A solve that guards only the stride reads the right

--- a/NEWS.md
+++ b/NEWS.md
@@ -142,6 +142,20 @@
   observation was Gaussian and uncensored slipped past them and was fit with an
   objective FO does not support.
 
+### Crashes and stability
+
+- The shared solve pool's lhs-width probe could **segfault** instead of
+  declining.  It verifies a model by calling that model's `calc_lhs`, and
+  generated `calc_lhs` dereferences per-subject pointers that are bound by a
+  solve, not by building the pool -- so an inner problem that had been set up but
+  had not solved yet crashed inside the check written to make a mismatched model
+  fall back safely.  The probe now binds the subject itself, and additionally
+  verifies that the pool holds the model's states and that its parameter layout
+  matches the one the pool's parameter vector was filled with (`calc_lhs` reads
+  it by index, so a same-width model in a different order mis-reads).  Fits are
+  unchanged; `.odeSwapInfo()` reports the new `npars`/`parLayoutOk` columns and
+  the `probeIniN`/`probeDenyN` counters.
+
 # nlmixr2est 7.0.2
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -154,7 +154,9 @@
   matches the one the pool's parameter vector was filled with (`calc_lhs` reads
   it by index, so a same-width model in a different order mis-reads).  Fits are
   unchanged; `.odeSwapInfo()` reports the new `npars`/`parLayoutOk` columns and
-  the `probeIniN`/`probeDenyN` counters.
+  the `probeIniN`/`probeDenyN` counters.  The lhs column map, which is installed
+  separately from the model it describes, is now checked against that model's
+  width at the pooled entries as well.
 
 # nlmixr2est 7.0.2
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -634,6 +634,19 @@ odeSwapPlanFor_ <- function(neq, nlhs) {
     .Call(`_nlmixr2est_odeSwapPlanFor_`, neq, nlhs)
 }
 
+#' Would `model`'s parameter layout be readable in a pool built for `pool`?
+#'
+#' The pure form of the lhs probe's parameter check, so both directions -- accept a
+#' peer that only spells the same slots differently, refuse one whose order differs --
+#' are testable without rigging a live registry.
+#' @param model peer model's `rxModelVars$params`
+#' @param pool pool model's `rxModelVars$params`
+#' @return TRUE when the peer may index the pool's parameter vector
+#' @noRd
+odeSwapParLayoutFor_ <- function(model, pool) {
+    .Call(`_nlmixr2est_odeSwapParLayoutFor_`, model, pool)
+}
+
 #' Record which model role rxode2's event path is bound to (R-side installs).
 #' Roles: -1 unknown, 0 pred, 1 inner, 2 outer, 3 hess2.
 #' @param slot role id

--- a/R/odeSwapVerify.R
+++ b/R/odeSwapVerify.R
@@ -8,11 +8,13 @@
 #' Counters that survive teardown (`pinnedN`, `pinCalledN`, `pooledSolveN`)
 #' let a test tell a working pooled solve from a silent rxSolve fallback.
 #'
-#' @return list with `models` (a data.frame of slot/name/neq/nlhs/loaded/
-#'   sizesPool/deny), the chosen `poolSlot`/`poolName`/`poolNeq`/`poolNlhs`,
-#'   `maxNlhs`/`maxNlhsSlot`, `scratchNlhs`/`needsScratch`, `overrideNeeded`,
-#'   `nLoaded`, the live `opNeq`/`opNlhs`, and `pooledSolveCores` (the thread
-#'   count the last pooled solve ran with, after every clamp).
+#' @return list with `models` (a data.frame of slot/name/neq/nlhs/npars/loaded/
+#'   sizesPool/parLayoutOk/deny), the chosen `poolSlot`/`poolName`/`poolNeq`/
+#'   `poolNlhs`, `maxNlhs`/`maxNlhsSlot`, `scratchNlhs`/`needsScratch`,
+#'   `overrideNeeded`, `nLoaded`, the live `opNeq`/`opNlhs`/`rxNpars`,
+#'   `probeIniN`/`probeDenyN` (the lhs probe's own counters), and
+#'   `pooledSolveCores` (the thread count the last pooled solve ran with, after
+#'   every clamp).
 #' @noRd
 .odeSwapInfo <- function() odeSwapInfo_()
 

--- a/R/odeSwapVerify.R
+++ b/R/odeSwapVerify.R
@@ -31,6 +31,21 @@
   odeSwapPlanFor_(as.integer(neq), as.integer(nlhs))
 }
 
+#' May a peer's parameter layout be read in a pool built for another model?
+#'
+#' Pure form of the lhs probe's parameter check.  `calc_lhs` reads `par_ptr` BY
+#' INDEX, so a peer is only readable when its parameters sit at the pool model's
+#' positions -- which a count cannot establish.  Takes the two `rxModelVars$params`
+#' vectors directly, so both directions are testable without rigging a registry.
+#'
+#' @param model peer model's parameter names
+#' @param pool pool model's parameter names
+#' @return TRUE when the peer may index the pool's parameter vector
+#' @noRd
+.odeSwapParLayoutFor <- function(model, pool) {
+  odeSwapParLayoutFor_(as.character(model), as.character(pool))
+}
+
 #' Slot names in registry order, matching the C++ `OdeSwapSlot` enum.
 #'
 #' The last three are the analytic path's augmented models: the order-2 gradient

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1608,6 +1608,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// odeSwapParLayoutFor_
+bool odeSwapParLayoutFor_(CharacterVector model, CharacterVector pool);
+RcppExport SEXP _nlmixr2est_odeSwapParLayoutFor_(SEXP modelSEXP, SEXP poolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< CharacterVector >::type model(modelSEXP);
+    Rcpp::traits::input_parameter< CharacterVector >::type pool(poolSEXP);
+    rcpp_result_gen = Rcpp::wrap(odeSwapParLayoutFor_(model, pool));
+    return rcpp_result_gen;
+END_RCPP
+}
 // odeSwapEsNoteInstalled_
 RObject odeSwapEsNoteInstalled_(int slot);
 RcppExport SEXP _nlmixr2est_odeSwapEsNoteInstalled_(SEXP slotSEXP) {

--- a/src/init.c
+++ b/src/init.c
@@ -60,6 +60,7 @@ extern SEXP _nlmixr2est_odeSwapEsNoteInstalled_(SEXP);
 extern SEXP _nlmixr2est_foceiOuterFdInd_(SEXP, SEXP);
 extern SEXP _nlmixr2est_foceiIndLik_(SEXP, SEXP);
 extern SEXP _nlmixr2est_odeSwapPlanFor_(SEXP, SEXP);
+extern SEXP _nlmixr2est_odeSwapParLayoutFor_(SEXP, SEXP);
 extern SEXP _nlmixr2est_odeSwapRetryTest_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_adviLoop_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_adviElboGradFR_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -222,6 +223,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_foceiOuterFdInd_", (DL_FUNC) &_nlmixr2est_foceiOuterFdInd_, 2},
   {"_nlmixr2est_foceiIndLik_", (DL_FUNC) &_nlmixr2est_foceiIndLik_, 2},
   {"_nlmixr2est_odeSwapPlanFor_", (DL_FUNC) &_nlmixr2est_odeSwapPlanFor_, 2},
+  {"_nlmixr2est_odeSwapParLayoutFor_", (DL_FUNC) &_nlmixr2est_odeSwapParLayoutFor_, 2},
   {"_nlmixr2est_odeSwapRetryTest_", (DL_FUNC) &_nlmixr2est_odeSwapRetryTest_, 7},
   {"_nlmixr2est_adviLoop_", (DL_FUNC) &_nlmixr2est_adviLoop_, 27},
   {"_nlmixr2est_adviElboGradFR_", (DL_FUNC) &_nlmixr2est_adviElboGradFR_, 6},

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4724,6 +4724,11 @@ static bool outerColsWithin(const OuterCols &C, int nlhs) {
   if (nlhs <= 0) return false;
   const std::vector<int> *vs[] = {&C.f1, &C.f2, &C.rvar1, &C.rvar2, &C.rsig, &C.rsig2, &C.tr};
   const size_t nvs = sizeof(vs) / sizeof(vs[0]);
+  // predf/rvarf are read unconditionally (lhs[predf], lhs[rvarf]), and both default to
+  // -1 -- so they need their OWN negative test, not just the running maximum: another
+  // map pushing that maximum non-negative would otherwise pass a lhs[-1] read.
+  if (C.predf < 0) return false;
+  if (C.hasR && C.rvarf < 0) return false;
   int mx = C.predf;
   if (C.hasR && C.rvarf > mx) mx = C.rvarf;
   for (size_t v = 0; v < nvs; ++v) {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4711,6 +4711,38 @@ static std::vector<int> _ivFrom(SEXP x) {
   return o;
 }
 
+// Does every lhs column this map names exist in a model `nlhs` wide?
+//
+// The column map is installed SEPARATELY from the model it describes
+// (foceiGradPooledSetupLoad_ takes a list built in R, and the augmented model is
+// registered by the setup path), so a map built for a different model than the one
+// bound indexes columns nobody wrote -- past the end of the lhs buffer once it is
+// wider.  outerSolveFill reads every index below with no bound of its own, so this is
+// checked at the entries, which decline to the rxode2::rxSolve route.  Companion to
+// odeSwapCheckLhsWidth, which answers the same question about the MODEL (#870).
+static bool outerColsWithin(const OuterCols &C, int nlhs) {
+  if (nlhs <= 0) return false;
+  const std::vector<int> *vs[] = {&C.f1, &C.f2, &C.rvar1, &C.rvar2, &C.rsig, &C.rsig2, &C.tr};
+  const size_t nvs = sizeof(vs) / sizeof(vs[0]);
+  int mx = C.predf;
+  if (C.hasR && C.rvarf > mx) mx = C.rvarf;
+  for (size_t v = 0; v < nvs; ++v) {
+    for (size_t k = 0; k < vs[v]->size(); ++k) {
+      int c = (*vs[v])[k];
+      if (c < 0) return false;
+      if (c > mx) mx = c;
+    }
+  }
+  for (size_t s = 0; s < C.rsig1.size(); ++s) {
+    for (size_t k = 0; k < C.rsig1[s].size(); ++k) {
+      int c = C.rsig1[s][k];
+      if (c < 0) return false;
+      if (c > mx) mx = c;
+    }
+  }
+  return mx >= 0 && mx < nlhs;
+}
+
 // Flatten an R lhs column map into the POD.  Shared by the per-fit cache below and by
 // vaeOuterSolve_, which still receives its map from R.
 static void colsFromList(List cols, OuterCols &C) {
@@ -12509,6 +12541,8 @@ RObject vaeOuterSolve_(NumericVector thVals, NumericMatrix ebes, List cols, int 
   const int neta = (int)op_focei.neta;
   std::vector<VaeOuterE> Es((size_t)nsub);
   FoceiGradPooledSetup _gcols; colsFromList(cols, _gcols);
+  // ... and the map R just handed us must name columns this model actually has
+  if (!outerColsWithin(_gcols, op_focei.vaeOuterNlhs)) return R_NilValue;
   std::vector<double> _thv((size_t)thVals.size());
   for (int t = 0; t < thVals.size(); ++t) _thv[(size_t)t] = thVals[t];
   arma::mat _eb((unsigned int)ebes.nrow(), (unsigned int)ebes.ncol());
@@ -12868,6 +12902,8 @@ static bool gradPooledCoreLL(const FoceiGradPooledSetup &G,
   if (rx == NULL) return false;
   rx_solving_options *op = getSolvingOptions(rx);
   if (!odeSwapCheckLhsWidth(odeSlotOuter, &rxVaeOuter, rx, op)) return false;
+  // ... and the installed column map must name columns that model actually has
+  if (!outerColsWithin(G, odeSwapNlhs(odeSlotOuter))) return false;
   const int nsub = (int)getRxNsub(rx);
   if ((int)ebes.n_rows != nsub || (int)ebes.n_cols != neta) return false;
   // Censored (M2/M3/M4) observations enter an ll() objective as -logPhi, a contribution
@@ -13028,6 +13064,8 @@ static bool gradPooledCore(const FoceiGradPooledSetup &G,
   if (rx == NULL) return declineHere(6);
   rx_solving_options *op = getSolvingOptions(rx);
   if (!odeSwapCheckLhsWidth(odeSlotOuter, &rxVaeOuter, rx, op)) return declineHere(7);
+  // ... and the installed column map must name columns that model actually has
+  if (!outerColsWithin(G, odeSwapNlhs(odeSlotOuter))) return declineHere(24);
   const int nsub = (int)getRxNsub(rx);
   const int neta = G.neta, nth = G.nth, nsg = G.nsg, nom = G.nom, nd = G.nd;
   const int np = nth + nsg + nom;
@@ -13213,6 +13251,7 @@ static bool gradPooledCore(const FoceiGradPooledSetup &G,
     // here, outside outerSolveFill's OpenMP region, because the shape is a process
     // global; the destructor restores the outer slot for the assembly below.
     if (!odeSwapCheckLhsWidth(odeSlotOuterNode, &rxOuterNode, rx, op)) return declineHere(21);
+    if (!outerColsWithin(G.colsNode, odeSwapNlhs(odeSlotOuterNode))) return declineHere(25);
     OdeSwapEsBatch _nodeBatch(odeSlotOuterNode);
     Ek.resize((size_t)nn);
     for (int k = 0; k < nn; ++k) {
@@ -13547,6 +13586,8 @@ RObject foceiAnalyticGradPooled_(NumericVector thVals, NumericMatrix ebes, List 
   if (!hasR) return R_NilValue;            // (f,R) kernel only; the FOCE path stays in R
   std::vector<VaeOuterE> Es((size_t)nsub);
   FoceiGradPooledSetup _gcols; colsFromList(cols, _gcols);
+  // ... and the map R just handed us must name columns this model actually has
+  if (!outerColsWithin(_gcols, op_focei.vaeOuterNlhs)) return R_NilValue;
   std::vector<double> _thv((size_t)thVals.size());
   for (int t = 0; t < thVals.size(); ++t) _thv[(size_t)t] = thVals[t];
   arma::mat _eb((unsigned int)ebes.nrow(), (unsigned int)ebes.ncol());

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -13539,6 +13539,31 @@ RObject foceiGradPooledDirect_(NumericVector thVals, NumericMatrix ebes,
 }
 
 
+// Everything foceiAnalyticGradPooled_ must establish before it commits to a solve: the
+// augmented model is bound and its bound code matches the registry, the live pool is the
+// one the registry describes, the caller's etas match the problem, and the column map
+// names columns this model actually has.  Hands back the pieces the caller then needs
+// (`op`, `nsub`, the flattened map) so nothing is read twice.
+//
+// Split out of the entry rather than inlined: these are the checks, and keeping them
+// here leaves the entry itself about the gradient.  `rx` is the file-scope global the
+// rest of this file reads, and is assigned here exactly as before.
+static bool analyticGradPooledReady(const NumericMatrix &ebes, const List &cols, int neta,
+                                    rx_solving_options *&op, int &nsub,
+                                    FoceiGradPooledSetup &gcols) {
+  if (op_focei.vaeOuterNlhs <= 0 || rxVaeOuter.calc_lhs == NULL) return false;
+  rx = getRxSolve_();
+  if (rx == NULL) return false;
+  op = getSolvingOptions(rx);
+  if (!odeSwapCheckLhsWidth(odeSlotOuter, &rxVaeOuter, rx, op)) return false;
+  nsub = (int)getRxNsub(rx);
+  if (ebes.nrow() != nsub || (int)ebes.ncol() != neta) return false;
+  if (!as<bool>(cols["hasR"])) return false;  // (f,R) kernel only; the FOCE path stays in R
+  colsFromList(cols, gcols);
+  // ... and the map R just handed us must name columns this model actually has
+  return outerColsWithin(gcols, op_focei.vaeOuterNlhs);
+}
+
 //' FOCEI analytic outer gradient, computed entirely in C++.
 //'
 //' Phase 8E.  Solves the augmented model in the shared pool, finite-differences the
@@ -13578,21 +13603,13 @@ RObject foceiAnalyticGradPooled_(NumericVector thVals, NumericMatrix ebes, List 
   // The fit's tolerance, reset for this solve -- there is no separate analytic
   // tolerance; see OdeFitTolGuard.
   OdeFitTolGuard _tolGuard;
-  if (op_focei.vaeOuterNlhs <= 0 || rxVaeOuter.calc_lhs == NULL) return R_NilValue;
-  rx = getRxSolve_();
-  if (rx == NULL) return R_NilValue;
-  rx_solving_options *op = getSolvingOptions(rx);
-  if (!odeSwapCheckLhsWidth(odeSlotOuter, &rxVaeOuter, rx, op)) return R_NilValue;
-  const int nsub = (int)getRxNsub(rx);
-  if (ebes.nrow() != nsub || (int)ebes.ncol() != neta) return R_NilValue;
+  rx_solving_options *op = NULL;
+  int nsub = 0;
+  FoceiGradPooledSetup _gcols;
+  if (!analyticGradPooledReady(ebes, cols, neta, op, nsub, _gcols)) return R_NilValue;
   const int nd = as<int>(cols["nd"]);
-  const bool hasR = as<bool>(cols["hasR"]);
   const bool hasT = as<bool>(cols["hasT"]);
-  if (!hasR) return R_NilValue;            // (f,R) kernel only; the FOCE path stays in R
   std::vector<VaeOuterE> Es((size_t)nsub);
-  FoceiGradPooledSetup _gcols; colsFromList(cols, _gcols);
-  // ... and the map R just handed us must name columns this model actually has
-  if (!outerColsWithin(_gcols, op_focei.vaeOuterNlhs)) return R_NilValue;
   std::vector<double> _thv((size_t)thVals.size());
   for (int t = 0; t < thVals.size(); ++t) _thv[(size_t)t] = thVals[t];
   arma::mat _eb((unsigned int)ebes.nrow(), (unsigned int)ebes.ncol());

--- a/src/odeSwap.cpp
+++ b/src/odeSwap.cpp
@@ -418,21 +418,29 @@ static std::string odeSwapCanonPar(const std::string &s) {
 //
 // The pool model's own slot always matches itself, so a plain single-model fit and
 // every standalone solve answer true without comparing anything.
+// Pure form, so the comparison is testable without a fit -- as odeSwapPlanFor is for
+// the pool decision.  `m` is the peer's parameter names, `pool` the pool model's.
+bool odeSwapParLayoutMatch(const std::vector<std::string> &m,
+                           const std::vector<std::string> &pool) {
+  // A peer that reads NO parameters cannot mis-read them, whatever the pool holds.
+  if (m.empty()) return true;
+  // ... but a peer that DOES read them and has nothing to be checked against is
+  // unverifiable, and unverifiable must decline.  Answering "true" here would accept
+  // exactly the case this exists to catch.
+  if (pool.empty() || m.size() > pool.size()) return false;
+  for (size_t i = 0; i < m.size(); ++i) {
+    if (odeSwapCanonPar(m[i]) != odeSwapCanonPar(pool[i])) return false;
+  }
+  return true;
+}
+
 static bool odeSwapParLayoutOk(int slot, rx_solve *rx) {
   if (rx == NULL || !odeSwapLoaded(slot)) return false;
   const OdeModelReg &m = _odeReg[slot];
   if (m.npars > getRxNpars(rx)) return false;
   const OdePoolPlan &p = odeSwapPlan();
   if (p.poolSlot < 0 || p.poolSlot == slot) return true;
-  const OdeModelReg &pm = _odeReg[p.poolSlot];
-  // Nothing to compare against (a registry that predates parNames, or a model with no
-  // params at all) -- the width check above is then all that can be verified.
-  if (pm.parNames.empty() || m.parNames.empty()) return true;
-  if (m.parNames.size() > pm.parNames.size()) return false;
-  for (size_t i = 0; i < m.parNames.size(); ++i) {
-    if (odeSwapCanonPar(m.parNames[i]) != odeSwapCanonPar(pm.parNames[i])) return false;
-  }
-  return true;
+  return odeSwapParLayoutMatch(m.parNames, _odeReg[p.poolSlot].parNames);
 }
 
 SEXP odeSwapModelSEXP(int slot) {
@@ -894,6 +902,23 @@ List odeSwapPlanFor_(IntegerVector neq, IntegerVector nlhs) {
                       _["needsScratch"] = (p.scratchNlhs > 0),
                       _["nLoaded"] = p.nLoaded,
                       _["overrideNeeded"] = p.overrideNeeded);
+}
+
+//' Would `model`'s parameter layout be readable in a pool built for `pool`?
+//'
+//' The pure form of the lhs probe's parameter check, so both directions -- accept a
+//' peer that only spells the same slots differently, refuse one whose order differs --
+//' are testable without rigging a live registry.
+//' @param model peer model's `rxModelVars$params`
+//' @param pool pool model's `rxModelVars$params`
+//' @return TRUE when the peer may index the pool's parameter vector
+//' @noRd
+//[[Rcpp::export]]
+bool odeSwapParLayoutFor_(CharacterVector model, CharacterVector pool) {
+  std::vector<std::string> m((size_t)model.size()), p((size_t)pool.size());
+  for (int i = 0; i < model.size(); ++i) m[(size_t)i] = as<std::string>(model[i]);
+  for (int i = 0; i < pool.size(); ++i) p[(size_t)i] = as<std::string>(pool[i]);
+  return odeSwapParLayoutMatch(m, p);
 }
 
 //' Record which model role rxode2's event path is bound to (R-side installs).

--- a/src/odeSwap.cpp
+++ b/src/odeSwap.cpp
@@ -576,58 +576,67 @@ static inline bool probeDeny() {
   return false;
 }
 
-bool odeSwapCheckLhsWidth(int slot, rxSolveF *fns, rx_solve *rx, rx_solving_options *op) {
-  if (fns == NULL || fns->calc_lhs == NULL || rx == NULL || op == NULL) return false;
-  int want = odeSwapNlhs(slot);
-  int room = getOpNlhs(op);
-  if (want <= 0 || room < want) return false;
-  // Everything the calc_lhs below READS has to be checked too, not just the lhs vector
-  // it writes -- this probe answers by CALLING the model, so any buffer that is too
-  // small or laid out for someone else faults before it can return an answer, which is
-  // the one thing a gate like this must never do.
-  //
-  //   states:     it reads __zzStateVar__ = ind->solve, sized by the POOL;
-  //   parameters: it reads par_ptr by index, filled for the POOL model.
-  //
-  // Declining is the safe direction and what every other failure here does: the caller
-  // falls back to the rxode2::rxSolve reference path, which is correct, just slower.
+// Can the probe below safely CALL this slot's calc_lhs at all?
+//
+// Everything that call READS has to fit, not just the lhs vector it writes -- a buffer
+// that is too small, or laid out for someone else, faults before the probe can return an
+// answer, which is the one thing a gate like this must never do.
+//
+//   states:     it reads __zzStateVar__ = ind->solve, sized by the POOL;
+//   parameters: it reads par_ptr by index, filled for the POOL model.
+//
+// Declining is the safe direction and what every other failure here does: the caller
+// falls back to the rxode2::rxSolve reference path, which is correct, just slower.
+static bool odeSwapProbeFits(int slot, rx_solve *rx, rx_solving_options *op,
+                             int wantLhs) {
+  if (wantLhs <= 0 || getOpNlhs(op) < wantLhs) return false;
   // neq == 0 is legitimate, not a failure: an ODE-free model (a pure `ll()` regression)
   // has real lhs outputs and symbolic sensitivities, and pools like any other -- see
   // test-focei-ll-fast-grad-fit.R.  It simply reads no state.
   int wantNeq = odeSwapNeq(slot);
   if (wantNeq < 0 || getOpNeq(op) < wantNeq) return probeDeny();
   if (!odeSwapParLayoutOk(slot, rx)) return probeDeny();
+  return true;
+}
+
+// Bind subject 0's PER-THREAD pointers (ind->on, ind->lhs, the tolerance slices).
+//
+// iniSubject binds them; building the pool does NOT -- rx->subjects comes back zeroed
+// from a fresh pool, and generated calc_lhs dereferences ind->on for every state it
+// reports.  That is the crash in #870: the fit paths only ever probed after their inner
+// solve, so the probe had never met a pool that had been set up and not yet solved.
+//
+// Done the way every real read site does it, rather than declining, so the probe still
+// answers.  Unconditionally, NOT only when the pointers read NULL: rx->subjects is freed
+// and re-allocated per pool, so a stale non-NULL pointer into a previous pool's buffers
+// is just as unusable and cannot be told apart by inspection.
+//
+// tolFactor is pinned to 1 across the call because iniSubject MULTIPLIES this
+// individual's tolerance slices by it in place.  Without the pin, probing would loosen
+// subject 0's tolerances one extra step per gradient evaluation -- the probe would be
+// changing the fit it exists to guard.
+static void odeSwapProbeBind(rx_solving_options_ind *ind, rx_solve *rx,
+                             rx_solving_options *op, rxSolveF *fns) {
+  _odeProbeIniN.fetch_add(1, std::memory_order_relaxed);
+  double tf = getIndTolFactor(ind);
+  setIndTolFactor(ind, 1.0);
+  iniSubjectE(0, 1, ind, op, rx, fns->update_inis);
+  setIndTolFactor(ind, tf);
+}
+
+bool odeSwapCheckLhsWidth(int slot, rxSolveF *fns, rx_solve *rx, rx_solving_options *op) {
+  if (fns == NULL || fns->calc_lhs == NULL || rx == NULL || op == NULL) return false;
+  int want = odeSwapNlhs(slot);
+  if (!odeSwapProbeFits(slot, rx, op, want)) return false;
   rx_solving_options_ind *ind = getSolvingOptionsInd(rx, 0);   // base subject 0
   if (ind == NULL) return false;
-  // A subject's PER-THREAD pointers (ind->on, ind->lhs, the tolerance slices) are bound
-  // by iniSubject, not by building the pool: rx->subjects comes back zeroed from a fresh
-  // pool, and generated calc_lhs dereferences ind->on for every state it reports.  That
-  // is the crash in #870 -- the fit paths only ever probed after their inner solve, so
-  // the probe had never met a pool that had been set up and not yet solved.
-  //
-  // Bind them here the way every real read site does, rather than declining, so the probe
-  // still answers.  Unconditionally, NOT only when they read NULL: rx->subjects is freed
-  // and re-allocated per pool, so a stale non-NULL pointer into a previous pool's buffers
-  // is just as unusable and cannot be told apart by inspection.
-  //
-  // tolFactor is pinned to 1 across the call because iniSubject MULTIPLIES this
-  // individual's tolerance slices by it in place.  Without the pin, probing would loosen
-  // subject 0's tolerances one extra step per gradient evaluation -- the probe would be
-  // changing the fit it exists to guard.
-  _odeProbeIniN.fetch_add(1, std::memory_order_relaxed);
-  {
-    double _tf = getIndTolFactor(ind);
-    setIndTolFactor(ind, 1.0);
-    iniSubjectE(0, 1, ind, op, rx, fns->update_inis);
-    setIndTolFactor(ind, _tf);
-  }
-  if (getIndLhs(ind) == NULL) return probeDeny();
+  odeSwapProbeBind(ind, rx, op, fns);
   double *st = getIndSolve(ind);
-  if (st == NULL) return false;
+  if (getIndLhs(ind) == NULL || st == NULL) return probeDeny();
   // Only WHICH slots get written matters, not the values -- so use a sentinel no
   // model produces.  NaN would compare unequal and so read as "written".
   static const double _sent = -9.87654321e37;
-  std::vector<double> probe((size_t)room, _sent);
+  std::vector<double> probe((size_t)getOpNlhs(op), _sent);
   // Probe at this subject's own first time, not t=0: an lhs sitting inside a
   // time-dependent branch would go unassigned at an arbitrary time and look missing.
   fns->calc_lhs(0, getTime(getIndIx(ind, 0), ind), st, probe.data());
@@ -635,18 +644,16 @@ bool odeSwapCheckLhsWidth(int slot, rxSolveF *fns, rx_solve *rx, rx_solving_opti
   // assigns lhs[0] and lhs[want-1] while skipping the middle would otherwise pass.
   int missing = 0;
   for (int k = 0; k < want; ++k) if (probe[(size_t)k] == _sent) missing++;
-  if (missing > 0) {
-    // A model whose lhs are all inside conditional branches could in principle
-    // report missing here and lose the pooled route.  That is the safe direction:
-    // the caller then takes the rxode2::rxSolve reference path, which is correct,
-    // just slower -- and the counter plus the warning make it visible rather than
-    // silent.  odeSwapCanPool() computes deny reasons on demand.
-    if (_odeLhsWidthMismatchN.fetch_add(1, std::memory_order_relaxed) == 0) {
-      Rf_warning("analytic gradient: pooled solve disabled (model/code mismatch)");
-    }
-    return false;
+  if (missing == 0) return true;
+  // A model whose lhs are all inside conditional branches could in principle
+  // report missing here and lose the pooled route.  That is the safe direction:
+  // the caller then takes the rxode2::rxSolve reference path, which is correct,
+  // just slower -- and the counter plus the warning make it visible rather than
+  // silent.  odeSwapCanPool() computes deny reasons on demand.
+  if (_odeLhsWidthMismatchN.fetch_add(1, std::memory_order_relaxed) == 0) {
+    Rf_warning("analytic gradient: pooled solve disabled (model/code mismatch)");
   }
-  return true;
+  return false;
 }
 long odeSwapScratchUsedN()   { return _odeScratchUsedN.load(std::memory_order_relaxed); }
 long odeSwapScratchResizeN() { return _odeScratchResizeN.load(std::memory_order_relaxed); }

--- a/src/odeSwap.cpp
+++ b/src/odeSwap.cpp
@@ -19,6 +19,14 @@ struct OdeModelReg {
   std::vector<std::string> lhsNames;
   int neq = 0;
   int nlhs = 0;
+  // The model's OWN parameter layout, from rxModelVars$params.  Generated calc_lhs
+  // reads par_ptr BY INDEX (`THETA_1_ = _PP[0]` ...), while par_ptr is filled for
+  // whichever model the pool was built from -- so the width alone does not make a
+  // peer safe to read, its parameter ORDER has to be the pool's too.  Recorded
+  // here (declare time, no DLL load) so odeSwapCheckLhsWidth can verify the layout
+  // it is about to index into instead of trusting a count.
+  int npars = 0;
+  std::vector<std::string> parNames;
   // Endpoint (CMT) rebasing -- see odeSwapCmtRebase().  rxode2 compiles each
   // model's endpoint switch against the USER compartment numbering and emits
   //   #define _CMT ((fabs(CMT)<=nPhys) ? CMT : CMT - nSens)
@@ -75,10 +83,15 @@ bool odeSwapDeclare(int slot, const char *name, SEXP obj) {
   m.nSens = mv.containsElementNamed("sens") ?
     as<CharacterVector>(mv["sens"]).size() : 0;
   m.cmtPar = -1;
+  m.npars = 0;
+  m.parNames.clear();
   if (mv.containsElementNamed("params")) {
     CharacterVector pars = as<CharacterVector>(mv["params"]);
+    m.npars = pars.size();
+    m.parNames.resize((size_t)pars.size());
     for (int i = 0; i < pars.size(); ++i) {
-      if (as<std::string>(pars[i]) == "CMT") { m.cmtPar = i; break; }
+      m.parNames[(size_t)i] = as<std::string>(pars[i]);
+      if (m.parNames[(size_t)i] == "CMT") m.cmtPar = i;
     }
   }
   // Record only WHETHER this model carries event ("jump") sensitivities.  The
@@ -256,8 +269,9 @@ void odeSwapClear(int slot) {
   OdeModelReg &m = _odeReg[slot];
   if (m.fns != NULL) rxClearFuns(m.fns);
   m.fns = NULL; m.name = NULL; m.neq = 0; m.nlhs = 0; m.loaded = false;
-  m.nSens = 0; m.cmtPar = -1;
+  m.nSens = 0; m.cmtPar = -1; m.npars = 0;
   m.lhsNames.clear();
+  m.parNames.clear();
   if (_odeModels != R_NilValue) SET_VECTOR_ELT(_odeModels, slot, R_NilValue);
   _odePlanStale = true;
 }
@@ -370,7 +384,56 @@ OdeSwapCmtScope::~OdeSwapCmtScope() {
 
 int  odeSwapNeq(int slot)    { return odeSwapLoaded(slot) ? _odeReg[slot].neq  : 0; }
 int  odeSwapNlhs(int slot)   { return odeSwapLoaded(slot) ? _odeReg[slot].nlhs : 0; }
+int  odeSwapNpars(int slot)  { return odeSwapLoaded(slot) ? _odeReg[slot].npars : 0; }
 const char *odeSwapName(int slot) { return odeSwapLoaded(slot) ? _odeReg[slot].name : NULL; }
+
+// `THETA[k]`/`ETA[k]` and `THETA_k_`/`ETA_k_` name the SAME par_ptr position.  The
+// inner/pred/hess2 models carry rxode2's bracketed spelling; the augmented models are
+// generated with the underscore one because param() cannot declare a bracketed name.
+// Canonicalize so the layout comparison below sees positions rather than spellings --
+// measured: every peer of a fast=TRUE fit differs from the pool model in spelling only.
+static std::string odeSwapCanonPar(const std::string &s) {
+  static const char *pre[2] = {"THETA", "ETA"};
+  for (int i = 0; i < 2; ++i) {
+    std::string p(pre[i]);
+    if (s.size() <= p.size() + 2 || s.compare(0, p.size(), p) != 0) continue;
+    std::string rest = s.substr(p.size());
+    char a = rest[0], b = rest[rest.size() - 1];
+    if (!((a == '[' && b == ']') || (a == '_' && b == '_'))) continue;
+    std::string num = rest.substr(1, rest.size() - 2);
+    if (num.find_first_not_of("0123456789") != std::string::npos) continue;
+    return p + ":" + num;
+  }
+  return s;
+}
+
+// Does `slot`'s parameter layout match the one par_ptr was filled with?
+//
+// par_ptr is a per-subject slice of one gpars block, stride rx->npars, laid out for
+// the model rxSolve_ was given -- the POOL model.  A peer's calc_lhs indexes it with
+// ITS own positions, so the peer is only readable when its parameters are the pool's,
+// name for name, at the same indices.  A wider peer runs off its subject's slice into
+// the next one (past the end entirely for the last subject); an equally wide peer with
+// a different ORDER reads finite garbage, which counting cannot catch.
+//
+// The pool model's own slot always matches itself, so a plain single-model fit and
+// every standalone solve answer true without comparing anything.
+static bool odeSwapParLayoutOk(int slot, rx_solve *rx) {
+  if (rx == NULL || !odeSwapLoaded(slot)) return false;
+  const OdeModelReg &m = _odeReg[slot];
+  if (m.npars > getRxNpars(rx)) return false;
+  const OdePoolPlan &p = odeSwapPlan();
+  if (p.poolSlot < 0 || p.poolSlot == slot) return true;
+  const OdeModelReg &pm = _odeReg[p.poolSlot];
+  // Nothing to compare against (a registry that predates parNames, or a model with no
+  // params at all) -- the width check above is then all that can be verified.
+  if (pm.parNames.empty() || m.parNames.empty()) return true;
+  if (m.parNames.size() > pm.parNames.size()) return false;
+  for (size_t i = 0; i < m.parNames.size(); ++i) {
+    if (odeSwapCanonPar(m.parNames[i]) != odeSwapCanonPar(pm.parNames[i])) return false;
+  }
+  return true;
+}
 
 SEXP odeSwapModelSEXP(int slot) {
   if (!odeSwapLoaded(slot) || _odeModels == R_NilValue) return R_NilValue;
@@ -489,18 +552,68 @@ static std::atomic<long> _odePooledSolveN(0);
 static std::atomic<int>  _odePooledSolveCores(NA_INTEGER);
 static std::atomic<long> _odePinCalledN(0);
 static std::atomic<int>  _odePinDeny(0);
+// The probe bound subject 0 (iniSubjectE) before calling calc_lhs on it.
+static std::atomic<long> _odeProbeIniN(0);
+// The probe refused to run at all: the pool cannot hold what this model reads.
+static std::atomic<long> _odeProbeDenyN(0);
 
 long odeSwapOverrideArmedN() { return _odeOverrideArmedN.load(std::memory_order_relaxed); }
 long odeSwapLhsWidthMismatchN() { return _odeLhsWidthMismatchN.load(std::memory_order_relaxed); }
 long odeSwapOverrideNeutralizedN() { return _odeOverrideNeutralizedN.load(std::memory_order_relaxed); }
+long odeSwapProbeIniN()  { return _odeProbeIniN.load(std::memory_order_relaxed); }
+long odeSwapProbeDenyN() { return _odeProbeDenyN.load(std::memory_order_relaxed); }
+
+static inline bool probeDeny() {
+  _odeProbeDenyN.fetch_add(1, std::memory_order_relaxed);
+  return false;
+}
 
 bool odeSwapCheckLhsWidth(int slot, rxSolveF *fns, rx_solve *rx, rx_solving_options *op) {
   if (fns == NULL || fns->calc_lhs == NULL || rx == NULL || op == NULL) return false;
   int want = odeSwapNlhs(slot);
   int room = getOpNlhs(op);
   if (want <= 0 || room < want) return false;
+  // Everything the calc_lhs below READS has to be checked too, not just the lhs vector
+  // it writes -- this probe answers by CALLING the model, so any buffer that is too
+  // small or laid out for someone else faults before it can return an answer, which is
+  // the one thing a gate like this must never do.
+  //
+  //   states:     it reads __zzStateVar__ = ind->solve, sized by the POOL;
+  //   parameters: it reads par_ptr by index, filled for the POOL model.
+  //
+  // Declining is the safe direction and what every other failure here does: the caller
+  // falls back to the rxode2::rxSolve reference path, which is correct, just slower.
+  // neq == 0 is legitimate, not a failure: an ODE-free model (a pure `ll()` regression)
+  // has real lhs outputs and symbolic sensitivities, and pools like any other -- see
+  // test-focei-ll-fast-grad-fit.R.  It simply reads no state.
+  int wantNeq = odeSwapNeq(slot);
+  if (wantNeq < 0 || getOpNeq(op) < wantNeq) return probeDeny();
+  if (!odeSwapParLayoutOk(slot, rx)) return probeDeny();
   rx_solving_options_ind *ind = getSolvingOptionsInd(rx, 0);   // base subject 0
   if (ind == NULL) return false;
+  // A subject's PER-THREAD pointers (ind->on, ind->lhs, the tolerance slices) are bound
+  // by iniSubject, not by building the pool: rx->subjects comes back zeroed from a fresh
+  // pool, and generated calc_lhs dereferences ind->on for every state it reports.  That
+  // is the crash in #870 -- the fit paths only ever probed after their inner solve, so
+  // the probe had never met a pool that had been set up and not yet solved.
+  //
+  // Bind them here the way every real read site does, rather than declining, so the probe
+  // still answers.  Unconditionally, NOT only when they read NULL: rx->subjects is freed
+  // and re-allocated per pool, so a stale non-NULL pointer into a previous pool's buffers
+  // is just as unusable and cannot be told apart by inspection.
+  //
+  // tolFactor is pinned to 1 across the call because iniSubject MULTIPLIES this
+  // individual's tolerance slices by it in place.  Without the pin, probing would loosen
+  // subject 0's tolerances one extra step per gradient evaluation -- the probe would be
+  // changing the fit it exists to guard.
+  _odeProbeIniN.fetch_add(1, std::memory_order_relaxed);
+  {
+    double _tf = getIndTolFactor(ind);
+    setIndTolFactor(ind, 1.0);
+    iniSubjectE(0, 1, ind, op, rx, fns->update_inis);
+    setIndTolFactor(ind, _tf);
+  }
+  if (getIndLhs(ind) == NULL) return probeDeny();
   double *st = getIndSolve(ind);
   if (st == NULL) return false;
   // Only WHICH slots get written matters, not the values -- so use a sentinel no
@@ -798,29 +911,34 @@ RObject odeSwapEsNoteInstalled_(int slot) {
 List odeSwapInfo_() {
   const OdePoolPlan &p = odeSwapPlan();
   CharacterVector nm(odeSlotN);
-  IntegerVector neq(odeSlotN), nlhs(odeSlotN), deny(odeSlotN);
-  LogicalVector loaded(odeSlotN), sizesPool(odeSlotN);
+  IntegerVector neq(odeSlotN), nlhs(odeSlotN), npars(odeSlotN), deny(odeSlotN);
+  LogicalVector loaded(odeSlotN), sizesPool(odeSlotN), parLayoutOk(odeSlotN);
+  rx_solve *_rxl = getRxSolve_();
   for (int s = 0; s < odeSlotN; ++s) {
     nm[s] = _odeReg[s].name == NULL ? NA_STRING : Rf_mkChar(_odeReg[s].name);
     neq[s] = _odeReg[s].neq;
     nlhs[s] = _odeReg[s].nlhs;
+    npars[s] = _odeReg[s].npars;
     loaded[s] = _odeReg[s].loaded;
     sizesPool[s] = (s == p.poolSlot);
     deny[s] = odeSwapCanPool(s);
+    parLayoutOk[s] = _odeReg[s].loaded ? odeSwapParLayoutOk(s, _rxl) : NA_LOGICAL;
   }
   List models = List::create(_["slot"] = seq_len(odeSlotN) - 1, _["name"] = nm,
-                             _["neq"] = neq, _["nlhs"] = nlhs,
+                             _["neq"] = neq, _["nlhs"] = nlhs, _["npars"] = npars,
                              _["loaded"] = loaded, _["sizesPool"] = sizesPool,
+                             _["parLayoutOk"] = parLayoutOk,
                              _["deny"] = deny);
   models.attr("class") = "data.frame";
   models.attr("row.names") = IntegerVector::create(NA_INTEGER, -odeSlotN);
   // op->neq / op->nlhs are only meaningful once a solve pool exists.
-  int opNeq = NA_INTEGER, opNlhs = NA_INTEGER;
-  rx_solve *rxl = getRxSolve_();
+  int opNeq = NA_INTEGER, opNlhs = NA_INTEGER, rxNpars = NA_INTEGER;
+  rx_solve *rxl = _rxl;
   IntegerVector activeOv(0);
   if (rxl != NULL) {
     rx_solving_options *op = getSolvingOptions(rxl);
     if (op != NULL) { opNeq = getOpNeq(op); opNlhs = getOpNlhs(op); }
+    rxNpars = getRxNpars(rxl);
     int nsub = (int)getRxNsub(rxl);
     if (nsub > 0) {
       activeOv = IntegerVector(nsub);
@@ -841,7 +959,7 @@ List odeSwapInfo_() {
     _["needsScratch"] = (p.scratchNlhs > 0),
     _["overrideNeeded"] = p.overrideNeeded,
     _["nLoaded"] = p.nLoaded,
-    _["opNeq"] = opNeq, _["opNlhs"] = opNlhs,
+    _["opNeq"] = opNeq, _["opNlhs"] = opNlhs, _["rxNpars"] = rxNpars,
     _["pinned"] = odeSwapPinned(),
     _["pinnedSlot"] = odeSwapPinnedSlot(),
     // -1 per subject means "no override in force"; a non -1 left behind after a
@@ -850,6 +968,8 @@ List odeSwapInfo_() {
     _["overrideArmedN"] = (double)odeSwapOverrideArmedN(),
     _["overrideNeutralizedN"] = (double)odeSwapOverrideNeutralizedN(),
     _["lhsWidthMismatchN"] = (double)odeSwapLhsWidthMismatchN(),
+    _["probeIniN"] = (double)odeSwapProbeIniN(),
+    _["probeDenyN"] = (double)odeSwapProbeDenyN(),
     _["scratchUsedN"] = (double)odeSwapScratchUsedN(),
     _["scratchResizeN"] = (double)odeSwapScratchResizeN(),
     _["pinnedN"] = (double)odeSwapPinnedN(),

--- a/src/odeSwap.h
+++ b/src/odeSwap.h
@@ -136,6 +136,7 @@ bool odeSwapHasEs(int slot);
 
 int  odeSwapNeq(int slot);       // 0 when unloaded; matches rxode2's op->neq
 int  odeSwapNlhs(int slot);      // 0 when unloaded
+int  odeSwapNpars(int slot);     // 0 when unloaded; length($params)
 int  odeSwapNSens(int slot);     // length($sens): sensitivity compartments
 int  odeSwapCmtPar(int slot);    // index of "CMT" in $params, -1 when absent
 
@@ -415,14 +416,18 @@ long odeSwapOverrideNeutralizedN();
 // rxUpdateFuns resolves symbols with R_GetCCallable(lib, name) -- BY NAME -- so the
 // same model can re-resolve to another dll's symbol later in a session.  Returns
 // false on a mismatch, and the caller must then refuse to pool.
+//
+// It answers by CALLING calc_lhs, so it first has to make that call SAFE: the model's
+// states and its parameter layout have to fit the pool it would read them from, and
+// subject 0's per-thread pointers have to be bound (a pool that was set up but never
+// solved leaves ind->on NULL, which generated code dereferences).  All of that is
+// handled here rather than left to the caller -- a gate that can crash instead of
+// declining is worse than no gate.
 bool odeSwapCheckLhsWidth(int slot, rxSolveF *fns, rx_solve *rx, rx_solving_options *op);
-// Number of times a bound calc_lhs was found NOT to match its registry width.
-long odeSwapLhsWidthMismatchN();
-// Verify the function pointers bound for `slot` really write the registry's nlhs.
-// R_GetCCallable() resolves by symbol NAME, so a peer can silently re-resolve to a
-// different model's dll within one session.  Returns false on a mismatch (caller
-// must refuse to pool); the probe runs once per call and costs one calc_lhs.
-bool odeSwapCheckLhsWidth(int slot, rxSolveF *fns, rx_solve *rx, rx_solving_options *op);
+// Times the probe bound subject 0 (iniSubjectE) before calling calc_lhs.
+long odeSwapProbeIniN();
+// Times the probe refused to run because the pool cannot hold what the model reads.
+long odeSwapProbeDenyN();
 long odeSwapScratchUsedN();
 long odeSwapScratchResizeN();
 long odeSwapPinnedN();

--- a/src/odeSwap.h
+++ b/src/odeSwap.h
@@ -234,6 +234,12 @@ SEXP odeSwapPoolModelSEXP();
 // Pure form, so the tie-break and the scratch inversion are testable without a fit.
 OdePoolPlan odeSwapPlanFor(const std::vector<int> &neq, const std::vector<int> &nlhs);
 
+// May a peer whose parameters are `m` index a parameter vector laid out for `pool`?
+// Pure, for the same reason.  An empty `m` is readable (it indexes nothing); a
+// non-empty `m` against an empty `pool` is UNVERIFIABLE, hence refused.
+bool odeSwapParLayoutMatch(const std::vector<std::string> &m,
+                           const std::vector<std::string> &pool);
+
 int odeSwapCanPool(int slot);   // OdeSwapDeny reason code
 
 // ---- per-individual solve scope ----------------------------------------

--- a/tests/testthat/test-odeswap.R
+++ b/tests/testthat/test-odeswap.R
@@ -293,11 +293,21 @@ nmTest({
     ## fast=TRUE pools: the augmented model sizes the pool
     expect_identical(.odeSwapInfo()$poolName, "outer")
     .n0 <- .odeSwapInfo()$pooledSolveN
+    .d0 <- .odeSwapInfo()$probeDenyN
     gPool <- .foceiGradDirect(f)
     expect_false(is.null(gPool))
     expect_true(all(is.finite(gPool)))
     ## and the pooled solve must actually have run, or this asserts nothing about pooling
     expect_gt(.odeSwapInfo()$pooledSolveN, .n0)
+    ## The lhs probe checks the parameter LAYOUT before it indexes par_ptr (calc_lhs
+    ## reads it by index, so a same-width peer in a different order mis-reads).  Every
+    ## peer of this fit must pass it: the inner/pred models spell their parameters
+    ## THETA[k]/ETA[k] and the augmented pool model spells the same slots THETA_k_/ETA_k_,
+    ## so a literal name comparison would decline them all and quietly cost the pooled
+    ## route -- measured as 28 refused hess2 probes on an ll() fit.
+    .i <- .odeSwapInfo()
+    expect_true(all(.i$models$parLayoutOk[.i$models$loaded]))
+    expect_equal(.i$probeDenyN, .d0)
     ## This used to also compare against .foceiAnalyticGradViaRxSolve(), the same gradient
     ## forced through rxode2::rxSolve instead of the pool.  That route was the R gradient
     ## implementation, which is gone -- the pooled solve is now the only one -- so the

--- a/tests/testthat/test-odeswap.R
+++ b/tests/testthat/test-odeswap.R
@@ -51,6 +51,34 @@ nmTest({
     expect_identical(p$scratchNlhs, 0L)
   })
 
+  test_that("the parameter-layout check accepts spellings and refuses reorderings", {
+    ## calc_lhs reads par_ptr BY INDEX, and par_ptr is laid out for the POOL model, so
+    ## the probe has to compare POSITIONS.  Both directions are asserted here: a fit
+    ## only ever exercises the accept side, so without this a broken (or deleted)
+    ## check would still pass the whole suite.
+    inner <- c("THETA[1]", "THETA[2]", "ETA[1]", "ETA[2]")
+    outer <- c("THETA_1_", "THETA_2_", "ETA_1_", "ETA_2_")
+    ## the two spellings of the same slot are the same slot
+    expect_true(.odeSwapParLayoutFor(inner, outer))
+    expect_true(.odeSwapParLayoutFor(outer, inner))
+    expect_true(.odeSwapParLayoutFor(inner, inner))
+    ## same NAMES, same COUNT, different ORDER -- what counting cannot catch
+    expect_false(.odeSwapParLayoutFor(inner, c("THETA[2]", "THETA[1]", "ETA[1]", "ETA[2]")))
+    ## covariates and DV compare literally, at their own positions
+    expect_true(.odeSwapParLayoutFor(c(inner, "WT"), c(outer, "WT")))
+    expect_false(.odeSwapParLayoutFor(c(inner, "WT"), c(outer, "AGE")))
+    ## a peer WIDER than the pool would index past the subject's slice
+    expect_false(.odeSwapParLayoutFor(c(inner, "WT"), outer))
+    ## a peer that reads no parameters cannot mis-read them ...
+    expect_true(.odeSwapParLayoutFor(character(0), outer))
+    ## ... but one that does, with nothing to check against, is unverifiable
+    expect_false(.odeSwapParLayoutFor(inner, character(0)))
+    ## near-misses of the canonical form stay literal rather than collapsing together
+    expect_false(.odeSwapParLayoutFor("THETA[1]", "THETA[11]"))
+    expect_false(.odeSwapParLayoutFor("THETAX_1_", "THETA_1_"))
+    expect_true(.odeSwapParLayoutFor("THETAX_1_", "THETAX_1_"))
+  })
+
   test_that("a loaded model with zero ODE states still counts", {
     # A solved-form (linCmt) or purely algebraic model has neq == 0 but real lhs
     # outputs.  Treating neq == 0 as "not loaded" would drop it from maxNlhs and

--- a/tests/testthat/test-vae-nonmutheta-grad.R
+++ b/tests/testthat/test-vae-nonmutheta-grad.R
@@ -269,6 +269,44 @@ nmTest({
     expect_gt(.odeSwapInfo()$pooledSolveN, .n2)
   })
 
+  test_that("the pooled gradient runs on a pool that has not solved yet (#870)", {
+    skip_on_cran()
+    ## foceiGradPooledDirect_ SEGFAULTED when the inner problem had been set up but
+    ## nothing had solved in it yet.  odeSwapCheckLhsWidth answers by CALLING the
+    ## model's calc_lhs, and generated calc_lhs dereferences ind->on -- a pointer
+    ## iniSubject binds, not the pool build -- so the gate written to make a
+    ## mismatched model decline safely crashed instead.  The fit path always solves
+    ## first, which is why only this sequence reached it.
+    ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(.odeMod()))
+    ctl <- vaeControl(nonMuTheta = "grad", print = 0L, calcTables = FALSE,
+                      covariateSelection = FALSE)
+    d <- nlmixr2data::theo_sd
+    prep <- .vaeDataPrep(ui, d, ctl)
+    env <- .vaeInnerSetup(ui, d, matrix(0, prep$N, prep$zDim), ctl)
+    on.exit(.vaeInnerFree(), add = TRUE)
+    on.exit(.vaeGradReset(), add = TRUE)
+    .vaeGradInit(ui, d, "tv")
+    ebes <- matrix(0, length(unique(env$dataSav$ID)), 2L)
+    .b <- .odeSwapInfo()
+    g <- .vaeGradEval(as.numeric(ui$theta), ebes, diag(c(0.6, 0.3)))
+    .a <- .odeSwapInfo()
+    ## the probe bound subject 0 itself instead of faulting on it ...
+    expect_gt(.a$probeIniN, .b$probeIniN)
+    ## ... nothing was declined on a size/layout guard ...
+    expect_equal(.a$probeDenyN, .b$probeDenyN)
+    ## ... and the POOLED route then ran and returned a usable gradient, rather
+    ## than the entry declining to the rxSolve fallback
+    expect_gt(.a$pooledSolveN, .b$pooledSolveN)
+    expect_equal(length(g), 1L)
+    expect_true(all(is.finite(g)))
+    ## Same value the pool gives once a solve HAS bound the subject: the probe's
+    ## iniSubjectE has to leave the individual usable, not merely non-crashing.
+    o <- vaeInnerLik(ebes, 1L, FALSE, FALSE)
+    expect_true(all(is.finite(o$obj)))
+    g2 <- .vaeGradEval(as.numeric(ui$theta), ebes, diag(c(0.6, 0.3)))
+    expect_equal(g, g2, tolerance = 1e-8)
+  })
+
   test_that("in scope, the gradient path is actually taken", {
     skip_on_cran()
     r <- suppressWarnings(suppressMessages(

--- a/tests/testthat/test-vae-nonmutheta-grad.R
+++ b/tests/testthat/test-vae-nonmutheta-grad.R
@@ -305,6 +305,20 @@ nmTest({
     expect_true(all(is.finite(o$obj)))
     g2 <- .vaeGradEval(as.numeric(ui$theta), ebes, diag(c(0.6, 0.3)))
     expect_equal(g, g2, tolerance = 1e-8)
+
+    ## The lhs COLUMN MAP is installed separately from the model it describes, and the
+    ## reader indexes the lhs buffer with it unbounded.  A map naming a column past the
+    ## bound model's width must decline, not read past the buffer.  Asserted against a
+    ## LIVE pool (the same one that just worked), so it is the map that is rejected.
+    .cols <- .vaeGradEnv$outerCols
+    skip_if(is.null(.cols))
+    expect_false(is.null(vaeOuterSolve_(as.numeric(ui$theta), ebes, .cols, 1L)))
+    .bad <- .cols
+    .bad$predf <- 10000L                       # far past any real lhs width
+    expect_null(vaeOuterSolve_(as.numeric(ui$theta), ebes, .bad, 1L))
+    .bad2 <- .cols
+    .bad2$predf <- -1L                         # "absent", read unconditionally as lhs[-1]
+    expect_null(vaeOuterSolve_(as.numeric(ui$theta), ebes, .bad2, 1L))
   })
 
   test_that("in scope, the gradient path is actually taken", {


### PR DESCRIPTION
Fixes #870.

## What actually crashed -- not the parameter layout

The issue's hypothesis was that `odeSwapCheckLhsWidth` faults on `par_ptr`: generated
`calc_lhs` reads it by index, so a peer whose parameter layout does not match the
pool's reads off the end.  That is a real hazard, but it is **not** what the
reproducer hits.  Under gdb the faulting instruction is

```
=> cvtsi2sdl 0x1c(%r13),%xmm9      with r13 = 0
```

`_ON[...]` -- `ind->on` -- not `_PP[3]`.  (The `THETA_4_ = _PP[3]` attribution in
#868's backtrace is -O2 interleaving the reads.)

`ind->on` and `ind->lhs` are bound by `iniSubject`/`_setIndPointersByThread`, i.e. **by
a solve**, not by building the pool; `rx->subjects` comes back zeroed from a fresh
pool.  Every fit path solves before it asks for a gradient, which is why only
`.vaeInnerSetup` + `.vaeGradEval` reached it.  Measured directly: inserting one
`vaeInnerLik()` call before the gradient makes the identical sequence run clean on
`main`.

## The fix

`odeSwapCheckLhsWidth` now makes the call it is about to perform safe before
performing it:

1. **Binds subject 0** with `iniSubjectE`, the way every real read site does.
   Unconditionally, not only when the pointers read NULL: `rx->subjects` is freed and
   re-allocated per pool, so a stale non-NULL pointer into a previous pool's buffers is
   just as unusable and cannot be told apart by inspection.  `tolFactor` is pinned to 1
   across the call, because `iniSubject` multiplies the individual's tolerance slices by
   it in place -- without the pin the probe would loosen subject 0's tolerances one step
   per gradient evaluation, i.e. change the fit it exists to guard.
2. **Checks the state buffer** (`odeSwapNeq` vs `getOpNeq`), which the probe also reads
   and never checked.  `neq == 0` is allowed -- an ODE-free `ll()` model pools and reads
   no state.
3. **Checks the parameter layout** -- the issue's option (2).  `$params` names are
   recorded at declare time and compared positionally against the pool model's, plus a
   width check against the live `getRxNpars(rx)`.  `THETA[k]`/`ETA[k]` and
   `THETA_k_`/`ETA_k_` are canonicalized to one position first: measured, every peer of
   a `fast=TRUE` fit differs from the pool model in spelling only, and a literal
   comparison refused 28 legitimate `hess2` probes on an `ll()` fit.

The same class of defect one level up is closed too.  The lhs **column map** is
installed separately from the model it describes (`foceiGradPooledSetupLoad_` takes a
list built in R) and `outerSolveFill` indexes the lhs buffer with it unbounded;
`outerColsWithin()` verifies every named column exists in the bound model at the four
pooled entries (decline sites 24/25).

## Measurements

Identical objective and identical `pooledSolveN` against `main` for focei
`fast=TRUE`, AGQ `nAGQ=3`, an `ll()` fast fit, `impmap`, and one- and two-covariate
fits (130.4548 / 133.5304 / 186.7624 / 130.328), with `probeDenyN == 0` and
`parLayoutOk` true for every loaded peer.  The reproducer returns the same gradient
(-436.4623) it returns once a solve has bound the subject.

## Independent review

An Antigravity (Gemini) review found two real holes in the new guards, both fixed in
the second commit:

* `odeSwapParLayoutOk` answered TRUE when the pool model's parameter names were
  unavailable -- accepting exactly the case it exists to refuse.  A peer that reads no
  parameters still passes; one that does, with nothing to check against, now declines.
* `outerColsWithin` tested only the running maximum, so `predf`/`rvarf` (read
  unconditionally, both defaulting to -1) could be negative while another map pushed
  that maximum non-negative -- passing a `lhs[-1]` read through the guard meant to stop
  it.

Its third finding was a coverage gap and is also addressed: every test asserted the
guards ACCEPT legitimate models, so deleting them outright would still have passed.
Its concurrency question is answered and not a defect -- the probe binds subject 0 to
the master thread's slices, and whichever worker later solves that subject calls
`iniSubjectE` again through `outerSolveFill`, rebinding to its own.

## Tests

* `test-odeswap.R`: the parameter comparison is now a pure function exported as
  `odeSwapParLayoutFor_` (the way `odeSwapPlanFor_` already exposes the pool decision),
  and both directions are pinned -- spellings accepted, reorderings and over-wide peers
  refused.  Plus: every loaded peer of a `fast=TRUE` fit passes the layout check and the
  fit declines nothing, which is what pins the canonicalization.
* `test-vae-nonmutheta-grad.R`: drives the #870 sequence and asserts the probe bound the
  subject (`probeIniN`), that nothing was declined (`probeDenyN`), that the pooled route
  ran (`pooledSolveN`), and that the gradient equals the one taken after a real solve.
  Then drives a deliberately out-of-range column map through `vaeOuterSolve_` against a
  live pool and asserts it declines rather than reads.

`.odeSwapInfo()` gains `models$npars`, `models$parLayoutOk`, `rxNpars`, `probeIniN` and
`probeDenyN`.

Green: odeswap (116), odeswap-fit (24), vae-nonmutheta-grad (61), focei-fast-grad (46),
agq-fast-grad (33), focei-ll-fast-grad-fit (16), focei-fast-methods-fit (38), impmap
(169), vae-grad-fit (10), vae-ll-grad-fit (13).
