### PR TITLE
fix(saem): score ll() observations by their own density in the objective and covariance (#871)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,30 @@
 
 ### Estimation
 
+- Fixed `est="saem"` scoring a **general log-likelihood endpoint (`ll()`) as a
+  Gaussian observation** in both its objective function and its standard errors.
+  Such an endpoint estimates no residual error, so the residual step never runs
+  and the placeholder values it starts from survive: every log-density was scored
+  as a normal mean with standard deviation `10 + |ll|`.  The reported
+  `objf`/`logLik`/`AIC`/`BIC` and every standard error were meaningless, on the
+  default path -- `covMethod="sa"` cannot be computed for these models and
+  already fell back to the linearized Fisher information, which is where the
+  defect lives.  An `ll()` row now contributes its own log-density to the
+  objective, with the `log(2*pi)` normalizer applied only to normally-distributed
+  rows, and contributes the observed information of that log-density to the
+  covariance.  On an exponential time-to-event model with a closed-form marginal
+  likelihood the reported -2LL goes from 1124 to within 1e-3 of the exact 1392;
+  against the Gaussian twin of a one-compartment model (an `ll()` written as the
+  exact normal log-density versus the equivalent `add()` model) the standard
+  error ratios go from 4.0-80.5 to 0.99-1.02, and the two objective function
+  values now agree outright rather than up to a constant.
+
+- `saemControl(covMethod=)` `"sa"` and `"fim"` now say plainly that they do not
+  apply to a general log-likelihood endpoint and use the linearized Fisher
+  information, instead of reporting that the covariance "could not be computed".
+  The stochastic-approximation covariance phase is also skipped for such a model
+  rather than run and discarded.
+
 - `saem`'s uninformative-eta detection
   (`saemControl(handleUninformativeEtas=TRUE)`, the default) could freeze an eta
   that the data does inform.  The test asks whether perturbing an eta moves the

--- a/R/focei.R
+++ b/R/focei.R
@@ -3075,7 +3075,9 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       .saemCfg <- attr(.saem, "saem.cfg")
       # Delete unneeded variables
       .saemCfg2 <- list()
-      for (.v in c("i1", "nphi1", "nphi0", "N", "ntotal", "ix_endpnt", "y", "nmc", "niter", "opt", "inits", "Mcovariables")) {
+      # res.mod is kept because calc.2LL()/calc.COV() need it to tell an ll()
+      # observation from a normally-distributed one
+      for (.v in c("i1", "nphi1", "nphi0", "N", "ntotal", "ix_endpnt", "y", "nmc", "niter", "opt", "inits", "Mcovariables", "res.mod")) {
         .saemCfg2[[.v]] <- .saemCfg[[.v]]
       }
       attr(.saem, "saem.cfg") <- .saemCfg2

--- a/R/saem.R
+++ b/R/saem.R
@@ -238,7 +238,10 @@
                         odeRecalcFactor=rxode2::rxGetControl(ui, "odeRecalcFactor", 10^0.5),
                         maxOdeRecalc=rxode2::rxGetControl(ui, "maxOdeRecalc", 10^0.5),
                         indTolRelax=rxode2::rxGetControl(ui, "indTolRelax", TRUE),
-                        nSaCov=if (identical(rxode2::rxGetControl(ui, "covMethod", "linFim"), "sa"))
+                        # a general likelihood discards the SA covariance phase
+                        # (.saemCalcCov), so do not pay for it either
+                        nSaCov=if (identical(rxode2::rxGetControl(ui, "covMethod", "linFim"), "sa") &&
+                                     !.saemGeneralLik(ui))
                                  as.integer(rxode2::rxGetControl(ui, "nSaCov", 500L)) else 0L,
                         nres=ui$saemModNumEst,
                         perSa=rxode2::rxGetControl(ui, "perSa", 0.75),
@@ -641,6 +644,17 @@
     # (.saemInstallAnalyticCov, once the fit object exists); compute the
     # linearized FIM now as the ready fallback and flag the analytic attempt
     assign(".saemCovAnalyticPending", TRUE, envir = env)
+    rxode2::rxAssignControlValue(.ui, "covMethod", "linFim")
+    .cm <- "linFim"
+  }
+  if (.cm %in% c("sa", "fim") && .saemGeneralLik(.ui)) {
+    # The complete-data Louis FIM behind "sa"/"fim" subtracts the information lost
+    # to the latent eta as Var[score], estimated from a handful of MCMC chains.  A
+    # general log-likelihood endpoint carries no residual error to anchor that, and
+    # measured against an exact marginal likelihood the result is several-fold too
+    # small (0.41 and 0.14 of the true SEs on an exponential TTE model), where the
+    # linearized FIM lands at 0.93 and 0.82.  Go straight to it.
+    message(sprintf("covMethod=\"%s\" is not supported with a general likelihood; using the linearized FIM", .cm))
     rxode2::rxAssignControlValue(.ui, "covMethod", "linFim")
     .cm <- "linFim"
   }

--- a/R/saemControl.R
+++ b/R/saemControl.R
@@ -70,6 +70,10 @@
 #'  between-subject variability dominates the residual), so those variance-block standard
 #'  errors are spliced in from the linearized FIM (\code{linFim}).
 #'
+#'  Neither is used for a general log-likelihood endpoint (\code{ll()}), which has
+#'  no residual error to anchor the complete-data correction; such a model goes
+#'  straight to \code{linFim} with a message.
+#'
 #'  "\code{r,s}" Uses the sandwich matrix to calculate the covariance, that is: \eqn{R^-1 \times S \times R^-1}
 #'
 #'  "\code{r}" Uses the Hessian matrix to calculate the covariance as \eqn{2\times R^-1}

--- a/R/saem_fit_aux.R
+++ b/R/saem_fit_aux.R
@@ -3,18 +3,33 @@
 #' Per-observation mask of general log-likelihood (`ll()`) rows
 #'
 #' `res.mod == 0` marks an `ll()` endpoint and `ix_endpnt` maps each observation
-#' to its endpoint.  A fit stored before `res.mod` was kept in `saem.cfg` falls
-#' back to the scalar `distribution == 4`, which on such a fit implies every
-#' endpoint is `ll()`.
+#' to its endpoint.  `distribution == 4` says only that SOME endpoint is `ll()`,
+#' so it can stand in for a missing `res.mod` (a fit stored before it was kept in
+#' `saem.cfg`) only when there is one endpoint to attribute it to.  Anything
+#' ambiguous fails rather than guessing: guessing wrong in either direction
+#' silently reinstates the defect this mask exists to prevent.
 #'
 #' @param saemCfg saem configuration list (`attr(fit, "saem.cfg")`)
 #' @param ixEndpnt 1-based per-observation endpoint index
 #' @return logical vector, one element per observation
 #' @noRd
 .saemLlObsMask <- function(saemCfg, ixEndpnt) {
+  .gen <- isTRUE(saemCfg$opt$distribution == 4)
   .resMod <- saemCfg$res.mod
-  if (!is.null(.resMod)) return(.resMod[ixEndpnt] == 0L)
-  rep(isTRUE(saemCfg$opt$distribution == 4), length(ixEndpnt))
+  .bad <- function() {
+    stop("saem.cfg has a general likelihood but no 'res.mod'; cannot tell ll() observations apart",
+         call. = FALSE)
+  }
+  if (!is.null(.resMod)) {
+    .mask <- .resMod[ixEndpnt] == 0L
+    # a general-likelihood fit whose res.mod marks no ll() row was not built from
+    # the ui; scoring those rows as normal is exactly the defect
+    if (.gen && !any(.mask)) .bad()
+    return(.mask)
+  }
+  if (!.gen) return(rep(FALSE, length(ixEndpnt)))
+  if (max(ixEndpnt) > 1L) .bad()
+  rep(TRUE, length(ixEndpnt))
 }
 
 ##' Log-likelihood using Gaussian Quadrature
@@ -279,6 +294,9 @@ cutoff <- function(x, cut = .Machine$double.xmin) {
 #' the first-difference `DF` uses: a second difference divides by the SQUARE of
 #' the step, so a phi near zero would divide roundoff by 1e-20.
 #'
+#' Costs `2*nphi^2` population solves against the Gaussian route's `nphi`, paid
+#' once per covariance step.
+#'
 #' @param dopred saem prediction function, `attr(fit, "dopred")`
 #' @param saemCfg saem configuration list
 #' @param hatPhi N x nphi matrix of conditional modes
@@ -365,8 +383,10 @@ cutoff <- function(x, cut = .Machine$double.xmin) {
   .Ai <- kronecker(diag(nphi), mcov[i, ])
   .b <- NULL
   if (doVar && nom > 0L) {
-    # tr(Vi^-1 dVi/da Vi^-1 dVi/db) = tr(E_a M11 E_b M11) with M11 = M[i1, i1]
-    .M11 <- .M[i1, i1, drop = FALSE]
+    # tr(Vi^-1 dVi/da Vi^-1 dVi/db) = tr(E_a M11 E_b M11) with M11 = M[i1, i1].
+    # Take it from the clamped M the theta block uses, not the raw one -- a
+    # negative direction there would put a negative variance in the block.
+    .M11 <- crossprod(.S)[i1, i1, drop = FALSE]
     .A <- vector("list", nom)
     for (pp in seq_len(nom)) {
       .a <- omPairs[pp, 1]; .bb <- omPairs[pp, 2]

--- a/R/saem_fit_aux.R
+++ b/R/saem_fit_aux.R
@@ -1,5 +1,22 @@
 ## FIXME: g by endpoint
 
+#' Per-observation mask of general log-likelihood (`ll()`) rows
+#'
+#' `res.mod == 0` marks an `ll()` endpoint and `ix_endpnt` maps each observation
+#' to its endpoint.  A fit stored before `res.mod` was kept in `saem.cfg` falls
+#' back to the scalar `distribution == 4`, which on such a fit implies every
+#' endpoint is `ll()`.
+#'
+#' @param saemCfg saem configuration list (`attr(fit, "saem.cfg")`)
+#' @param ixEndpnt 1-based per-observation endpoint index
+#' @return logical vector, one element per observation
+#' @noRd
+.saemLlObsMask <- function(saemCfg, ixEndpnt) {
+  .resMod <- saemCfg$res.mod
+  if (!is.null(.resMod)) return(.resMod[ixEndpnt] == 0L)
+  rep(isTRUE(saemCfg$opt$distribution == 4), length(ixEndpnt))
+}
+
 ##' Log-likelihood using Gaussian Quadrature
 ##'
 ##' Estimate the log-likelihood using Gaussian Quadrature (multidimensional
@@ -47,6 +64,10 @@ calc.2LL <- function(fit, nnodes.gq = 8, nsd.gq = 4, phiM) {
   low <- low[ix_endpnt]
   hi <- hi[ix_endpnt]
   i1 <- saem.cfg$i1 + 1
+  # an ll() row's prediction IS its log-density; scoring it as a normal mean
+  # would use the placeholder residual (ares=10, bres=1) the M-step never updates
+  .isLL <- .saemLlObsMask(saem.cfg, ix_endpnt)
+  .nGauss <- sum(!.isLL)
 
   phi <- fit$mpost_phi
   IOmega.phi1 <- solve(fit$Gamma2_phi1)
@@ -96,7 +117,9 @@ calc.2LL <- function(fit, nnodes.gq = 8, nsd.gq = 4, phiM) {
     f <- .Call(`_nlmixr2est_powerD`, f, lambda, as.integer(yj), as.double(low), as.double(hi))
     g <- ares + bres * abs(fsave)
     g[g < 1.0e-200] <- 1.0e-200
-    DYF[ind.io] <- -0.5 * ((yobs - f) / g)^2 - log(g)
+    .dyf <- -0.5 * ((yobs - f) / g)^2 - log(g)
+    .dyf[.isLL] <- fsave[.isLL]
+    DYF[ind.io] <- .dyf
     ly <- colSums(DYF)
     dphi1 <- phi[, i1] - fit$mprior_phi[, i1]
     lphi1 <- -0.5 * rowSums((dphi1 %*% IOmega.phi1) * dphi1)
@@ -107,7 +130,9 @@ calc.2LL <- function(fit, nnodes.gq = 8, nsd.gq = 4, phiM) {
   }
   rxode2::rxProgressStop()
   # - 2 * saem.cfg$extraLL
-  ll2 <- 2 * sum(log(Q) + rowSums(log(b))) - N * log(det(Omega)) - (N * nphi1 + ntotal) * log(2 * pi) -
+  # only a Gaussian row's DYF omits its -0.5*log(2*pi); an ll() row already
+  # carries the constant its own expression supplies
+  ll2 <- 2 * sum(log(Q) + rowSums(log(b))) - N * log(det(Omega)) - (N * nphi1 + .nGauss) * log(2 * pi) -
     2 * .Call(`_nlmixr2est_powerL`, ysave, lambda, as.integer(yj), as.double(low), as.double(hi))
   -ll2
 }

--- a/R/saem_fit_aux.R
+++ b/R/saem_fit_aux.R
@@ -271,6 +271,119 @@ cutoff <- function(x, cut = .Machine$double.xmin) {
   x
 }
 
+#' Second derivatives of the per-observation log-likelihood with respect to phi
+#'
+#' Central differences of `dopred()`, which for an `ll()` endpoint returns the
+#' log-density itself.  The step is `|phi|*1e-4` (about `eps^(1/4)`, the scale a
+#' second derivative wants) rather than the `1e-4` used for the first-difference
+#' `DF`, which is a coincidence of magnitude, not the same quantity.
+#'
+#' @param dopred saem prediction function, `attr(fit, "dopred")`
+#' @param saemCfg saem configuration list
+#' @param hatPhi N x nphi matrix of conditional modes
+#' @param id 1-based subject index, one element per observation
+#' @param nphi number of phi columns
+#' @return ntotal x nphi x nphi array of second derivatives
+#' @noRd
+.saemLlObsHess <- function(dopred, saemCfg, hatPhi, id, nphi) {
+  .h <- cutoff(abs(hatPhi) * 1e-4, 1e-10)
+  .ev <- function(.j, .sj, .k = NULL, .sk = 0) {
+    .p <- hatPhi
+    .p[, .j] <- .p[, .j] + .sj * .h[, .j]
+    if (!is.null(.k)) .p[, .k] <- .p[, .k] + .sk * .h[, .k]
+    as.vector(dopred(.p, saemCfg$evt, saemCfg$opt))
+  }
+  .l0 <- as.vector(dopred(hatPhi, saemCfg$evt, saemCfg$opt))
+  .lp <- lapply(seq_len(nphi), function(.j) .ev(.j, 1))
+  .lm <- lapply(seq_len(nphi), function(.j) .ev(.j, -1))
+  .ret <- array(0, c(length(.l0), nphi, nphi))
+  for (.j in seq_len(nphi)) {
+    .ret[, .j, .j] <- (.lp[[.j]] - 2 * .l0 + .lm[[.j]]) / (.h[id, .j]^2)
+  }
+  if (nphi > 1L) {
+    for (.j in seq_len(nphi - 1L)) {
+      for (.k in seq(.j + 1L, nphi)) {
+        .v <- (.ev(.j, 1, .k, 1) - .ev(.j, 1, .k, -1) -
+                 .ev(.j, -1, .k, 1) + .ev(.j, -1, .k, -1)) /
+          (4 * .h[id, .j] * .h[id, .k])
+        .ret[, .j, .k] <- .v
+        .ret[, .k, .j] <- .v
+      }
+    }
+  }
+  .ret
+}
+
+#' One subject's contribution to the linearized FIM when any row is an `ll()` row
+#'
+#' Builds the conditional information of `phi` -- `DF' diag(g^2)^-1 DF` over the
+#' normal rows plus the observed information over the `ll()` rows -- and
+#' marginalizes over the random effects with the same Schur complement the
+#' Gaussian route reaches through `Vi` and the Woodbury identity, so a normal
+#' model computed either way agrees.  The result is returned as a matrix square
+#' root so the caller's `.nlmixr2RobustCov()` (and its rank-deficiency handling)
+#' is unchanged.
+#'
+#' @param i subject index
+#' @param ix logical, this subject's observation rows
+#' @param DF per-observation first differences with respect to phi
+#' @param g per-observation residual SD (normal rows)
+#' @param isLL per-observation `ll()` mask
+#' @param d2LL second derivatives from [.saemLlObsHess()]
+#' @param omega Omega matrix
+#' @param iOmega `solve(omega)`
+#' @param nphi,i1 number of phi columns; indexes of the random-effect columns
+#' @param mcov `saem.cfg$Mcovariables`
+#' @param covEstIx estimated covariate-parameter mask
+#' @param doVar assemble the variance block?
+#' @param nom,omPairs number of Omega pairs and the pairs themselves
+#' @return list with `x` (square-root block) and `b` (variance FIM, or `NULL`)
+#' @noRd
+.saemLlSubjectPart <- function(i, ix, DF, g, isLL, d2LL, omega, iOmega, nphi, i1,
+                               mcov, covEstIx, doVar, nom, omPairs) {
+  .H <- matrix(0, nphi, nphi)
+  .gx <- which(ix & !isLL)
+  if (length(.gx) > 0L) {
+    .DFg <- DF[.gx, , drop = FALSE]
+    dim(.DFg) <- c(length(.gx), nphi)
+    .H <- crossprod(.DFg / g[.gx])
+  }
+  .lx <- which(ix & isLL)
+  if (length(.lx) > 0L) {
+    .H <- .H - apply(d2LL[.lx, , , drop = FALSE], c(2, 3), sum)
+  }
+  .H <- 0.5 * (.H + t(.H))
+  # marginalize the random effects: M = H - H[,i1] (Omega^-1 + H[i1,i1])^-1 H[i1,]
+  .M <- .H - .H[, i1, drop = FALSE] %*%
+    solve(iOmega + .H[i1, i1, drop = FALSE]) %*% .H[i1, , drop = FALSE]
+  .M <- 0.5 * (.M + t(.M))
+  .e <- eigen(.M, symmetric = TRUE)
+  # a user ll() is not required to be concave, so drop any negative direction
+  # rather than take the square root of a negative eigenvalue
+  .S <- sqrt(pmax(.e$values, 0)) * t(.e$vectors)
+  .Ai <- kronecker(diag(nphi), mcov[i, ])
+  .b <- NULL
+  if (doVar && nom > 0L) {
+    # tr(Vi^-1 dVi/da Vi^-1 dVi/db) = tr(E_a M11 E_b M11) with M11 = M[i1, i1]
+    .M11 <- .M[i1, i1, drop = FALSE]
+    .A <- vector("list", nom)
+    for (pp in seq_len(nom)) {
+      .a <- omPairs[pp, 1]; .bb <- omPairs[pp, 2]
+      .E <- matrix(0, length(i1), length(i1))
+      .E[.a, .bb] <- 1
+      if (.a != .bb) .E[.bb, .a] <- 1
+      .A[[pp]] <- .E %*% .M11
+    }
+    .b <- matrix(0, nom, nom)
+    for (ii in seq_len(nom)) for (ij in ii:nom) {
+      .val <- sum(.A[[ii]] * t(.A[[ij]])) / 2
+      .b[ii, ij] <- .b[ij, ii] <- .val
+    }
+  }
+  rxode2::rxTick()
+  list(x = .S %*% t(.Ai[covEstIx, , drop = FALSE]), b = .b)
+}
+
 ##' Covariance matrix by Fisher Information Matrix via linearization
 ##'
 ##' Get the covariance matrix of fixed effect estimates via calculating Fisher Information Matrix by linearization
@@ -323,6 +436,7 @@ calc.COV <- function(fit0) {
   yj <- yj[ix_endpnt]
   low <- low[ix_endpnt]
   hi <- hi[ix_endpnt]
+  .isLL <- .saemLlObsMask(saem.cfg, ix_endpnt)
   if (is.null(names(saem.cfg$inits$theta))) {
     names(saem.cfg$inits$theta) <- rep("", length(saem.cfg$inits$theta))
   }
@@ -355,6 +469,12 @@ calc.COV <- function(fit0) {
   f0 <- .Call(`_nlmixr2est_powerD`, f0, lambda, as.integer(yj), as.double(low), as.double(hi))
   DF <- (f1 - f0) / dphi[id, ]
   g <- ares + bres * abs(f0s)
+  # An ll() endpoint has no mean to linearize and no residual variance -- dopred()
+  # returns the log-density itself -- so those rows contribute the observed
+  # information of their own log-likelihood instead (#871).
+  .anyLL <- any(.isLL)
+  .d2LL <- if (.anyLL) .saemLlObsHess(dopred, saem.cfg, hat.phi, id, nphi) else NULL
+  .iOmega <- if (.anyLL) solve(omega) else NULL
 
   # covFull: also assemble the variance block (residual + Omega) of the linearized
   # FIM (saemix func_FIM.R blocB), returned as attributes on the theta cov.  The FIM
@@ -382,11 +502,19 @@ calc.COV <- function(fit0) {
   .nom <- if (is.null(.omPairs)) 0L else nrow(.omPairs)
   .nvar <- length(.resNames) + .nom
   .doVar <- .covFull && .nvar > 0L
+  # the residual entries of the variance block are built in observation space from
+  # dVi/da, dVi/db, which have no counterpart once any row is a log-density; a
+  # pure-ll() model has no residual parameters, so only a future mixed model loses
+  # the block rather than reporting a wrong one
+  if (.anyLL && length(.resNames) > 0L) .doVar <- FALSE
   .absF0 <- abs(f0s)
 
   # spectral decom for invVi, idea from saemix; also accumulates the variance FIM (blocB)
   .parts <- lapply(1:N, function(i) {
     ix <- id == i
+    if (.anyLL) return(.saemLlSubjectPart(i, ix, DF, g, .isLL, .d2LL, omega, .iOmega,
+                                          nphi, i1, saem.cfg$Mcovariables, cov.est.ix,
+                                          .doVar, .nom, .omPairs))
     nobs <- sum(ix)
     DFi <- DF[ix, ]
     dim(DFi) <- c(nobs, nphi)

--- a/R/saem_fit_aux.R
+++ b/R/saem_fit_aux.R
@@ -21,11 +21,12 @@
          call. = FALSE)
   }
   if (!is.null(.resMod)) {
-    .mask <- .resMod[ixEndpnt] == 0L
-    # a general-likelihood fit whose res.mod marks no ll() row was not built from
-    # the ui; scoring those rows as normal is exactly the defect
-    if (.gen && !any(.mask)) .bad()
-    return(.mask)
+    # a general-likelihood fit whose res.mod marks no ll() ENDPOINT was not built
+    # from the ui; scoring those rows as normal is exactly the defect.  Test the
+    # cfg, not the observations -- an ll() endpoint with no rows in this data set
+    # is legitimately an all-FALSE mask.
+    if (.gen && !any(.resMod == 0L)) .bad()
+    return(.resMod[ixEndpnt] == 0L)
   }
   if (!.gen) return(rep(FALSE, length(ixEndpnt)))
   if (max(ixEndpnt) > 1L) .bad()

--- a/R/saem_fit_aux.R
+++ b/R/saem_fit_aux.R
@@ -275,8 +275,9 @@ cutoff <- function(x, cut = .Machine$double.xmin) {
 #'
 #' Central differences of `dopred()`, which for an `ll()` endpoint returns the
 #' log-density itself.  The step is `|phi|*1e-4` (about `eps^(1/4)`, the scale a
-#' second derivative wants) rather than the `1e-4` used for the first-difference
-#' `DF`, which is a coincidence of magnitude, not the same quantity.
+#' second derivative wants), floored at `1e-4` absolute rather than at the `1e-10`
+#' the first-difference `DF` uses: a second difference divides by the SQUARE of
+#' the step, so a phi near zero would divide roundoff by 1e-20.
 #'
 #' @param dopred saem prediction function, `attr(fit, "dopred")`
 #' @param saemCfg saem configuration list
@@ -286,7 +287,7 @@ cutoff <- function(x, cut = .Machine$double.xmin) {
 #' @return ntotal x nphi x nphi array of second derivatives
 #' @noRd
 .saemLlObsHess <- function(dopred, saemCfg, hatPhi, id, nphi) {
-  .h <- cutoff(abs(hatPhi) * 1e-4, 1e-10)
+  .h <- cutoff(abs(hatPhi) * 1e-4, 1e-4)
   .ev <- function(.j, .sj, .k = NULL, .sk = 0) {
     .p <- hatPhi
     .p[, .j] <- .p[, .j] + .sj * .h[, .j]

--- a/man/emviControl.Rd
+++ b/man/emviControl.Rd
@@ -261,6 +261,10 @@ wrapping. `NULL` (default) uses `floor((getOption("width") - 23) / 12)`.}
  between-subject variability dominates the residual), so those variance-block standard
  errors are spliced in from the linearized FIM (\code{linFim}).
 
+ Neither is used for a general log-likelihood endpoint (\code{ll()}), which has
+ no residual error to anchor the complete-data correction; such a model goes
+ straight to \code{linFim} with a message.
+
  "\code{r,s}" Uses the sandwich matrix to calculate the covariance, that is: \eqn{R^-1 \times S \times R^-1}
 
  "\code{r}" Uses the Hessian matrix to calculate the covariance as \eqn{2\times R^-1}

--- a/man/saemControl.Rd
+++ b/man/saemControl.Rd
@@ -137,6 +137,10 @@ typical fitting.}
  between-subject variability dominates the residual), so those variance-block standard
  errors are spliced in from the linearized FIM (\code{linFim}).
 
+ Neither is used for a general log-likelihood endpoint (\code{ll()}), which has
+ no residual error to anchor the complete-data correction; such a model goes
+ straight to \code{linFim} with a message.
+
  "\code{r,s}" Uses the sandwich matrix to calculate the covariance, that is: \eqn{R^-1 \times S \times R^-1}
 
  "\code{r}" Uses the Hessian matrix to calculate the covariance as \eqn{2\times R^-1}

--- a/tests/testthat/test-saem-cov-sa.R
+++ b/tests/testthat/test-saem-cov-sa.R
@@ -233,5 +233,32 @@ nmTest({
     expect_equal(unname(.got), unname(.se), tolerance = 0.25)
     # a hard guard: the pre-fix values were an order of magnitude out
     expect_true(all(.got / .se > 0.5 & .got / .se < 2))
+
+    # "fim" is refused for the same reason as "sa"
+    .ff <- .nlmixr(expTte, .d, est = "saem",
+                   control = saemControl(nBurn = 40, nEm = 20, nmc = 3, seed = 1,
+                                         print = 0L, calcTables = FALSE,
+                                         covMethod = "fim"))
+    expect_equal(.ff$covMethod, "linFim")
+  })
+
+  test_that(".saemLlObsMask refuses to guess rather than mis-score (#871)", {
+    .ix <- c(1L, 1L, 2L, 2L)
+    # res.mod present: per-observation, res.mod == 0 marks the ll() endpoint
+    expect_equal(.saemLlObsMask(list(res.mod = c(0L, 1L), opt = list(distribution = 4)), .ix),
+                 c(TRUE, TRUE, FALSE, FALSE))
+    expect_equal(.saemLlObsMask(list(res.mod = c(1L, 1L), opt = list(distribution = 1)), .ix),
+                 rep(FALSE, 4))
+    # res.mod missing (a fit stored before it was kept): a single endpoint can be
+    # attributed from the scalar distribution, more than one cannot
+    expect_equal(.saemLlObsMask(list(opt = list(distribution = 4)), c(1L, 1L)), c(TRUE, TRUE))
+    expect_equal(.saemLlObsMask(list(opt = list(distribution = 1)), .ix), rep(FALSE, 4))
+    expect_error(.saemLlObsMask(list(opt = list(distribution = 4)), .ix), "res.mod")
+    # a general-likelihood cfg whose res.mod marks no ll() row is inconsistent;
+    # scoring those rows as normal is the defect, so fail instead
+    expect_error(.saemLlObsMask(list(res.mod = c(1L, 1L), opt = list(distribution = 4)), .ix),
+                 "res.mod")
+    # no distribution at all (an old cfg) must not error
+    expect_equal(.saemLlObsMask(list(opt = list()), .ix), rep(FALSE, 4))
   })
 })

--- a/tests/testthat/test-saem-cov-sa.R
+++ b/tests/testthat/test-saem-cov-sa.R
@@ -170,4 +170,68 @@ nmTest({
     expect_equal(unname(sqrt(diag(fS$cov[.vn, .vn]))),
                  unname(sqrt(diag(.vc))), tolerance = 1e-6)
   })
+
+  test_that("a general log-likelihood endpoint is scored by its own density (#871)", {
+    # calc.2LL and calc.COV used to build a Gaussian residual SD for every row.  An
+    # ll() endpoint has res.mod == 0, so the residual M-step never runs and ares/bres
+    # keep their placeholder 10/1 -- every log-density was scored as a normal mean
+    # with SD 10 + |ll|.  Both are checked against an exponential time-to-event model
+    # whose marginal likelihood is a one-dimensional quadrature, so the reference is
+    # closed form rather than a second fit.
+    .mkTte <- function(seed = 1L, n = 150L, meanT = 40) {
+      .testSeed(seed)
+      do.call(rbind, lapply(seq_len(n), function(i) {
+        lami <- meanT * exp(rnorm(1, 0, sqrt(0.15)))
+        data.frame(ID = i, TIME = lami * -log(runif(1)), DV = 1, EVID = 0, CMT = 1)
+      }))
+    }
+    expTte <- function() {
+      ini({ tlam <- log(25); eta.lam ~ 0.2 })
+      model({
+        lam <- exp(tlam + eta.lam)
+        ll(dv) ~ -log(lam) - time / lam
+      })
+    }
+    .d <- .mkTte(1L)
+    # covMethod="sa" is the saemControl default; it must route to linFim here
+    .f <- .nlmixr(expTte, .d, est = "saem",
+                  control = saemControl(nBurn = 150, nEm = 80, nmc = 3, seed = 1,
+                                        print = 0L, calcTables = FALSE,
+                                        covMethod = "sa"))
+
+    # the per-observation ll() mask needs res.mod to survive into the trimmed
+    # post-fit saem.cfg -- without it neither function can tell the rows apart
+    expect_false(is.null(attr(.f$saem, "saem.cfg")$res.mod))
+    expect_equal(attr(.f$saem, "saem.cfg")$res.mod, 0L)
+    # sa/fim are refused for a general likelihood (the Louis correction has no
+    # residual error to anchor it); linFim is what gets reported
+    expect_equal(.f$covMethod, "linFim")
+
+    .tlam <- fixef(.f)[["tlam"]]
+    .om <- .f$omega[1, 1]
+    # exact marginal -2LL and its observed information, by quadrature over the eta
+    .nll <- function(p) {
+      if (p[2] <= 0) return(1e10)
+      .s <- sqrt(p[2])
+      -sum(vapply(.d$TIME, function(t)
+        log(integrate(function(e) {
+          .lam <- exp(p[1] + e)
+          exp(-log(.lam) - t / .lam) * dnorm(e, 0, .s)
+        }, -8 * .s, 8 * .s, rel.tol = 1e-10)$value), numeric(1)))
+    }
+
+    # objective: a fine quadrature must reproduce the exact marginal -2LL.  Before
+    # the fix this read 1124 against an exact 1392.
+    expect_equal(calc.2LL(.f$saem, nnodes.gq = 13, nsd.gq = 5, .f$phiM),
+                 2 * .nll(c(.tlam, .om)), tolerance = 1e-3)
+
+    # standard errors: the linearized FIM must approximate the exact observed
+    # information.  Before the fix these were off by roughly the placeholder SD.
+    .se <- sqrt(diag(solve(optimHess(c(.tlam, .om), .nll))))
+    .got <- sqrt(diag(.f$cov))
+    expect_equal(length(.got), 2L)
+    expect_equal(unname(.got), unname(.se), tolerance = 0.25)
+    # a hard guard: the pre-fix values were an order of magnitude out
+    expect_true(all(.got / .se > 0.5 & .got / .se < 2))
+  })
 })

--- a/tests/testthat/test-saem-loglik.R
+++ b/tests/testthat/test-saem-loglik.R
@@ -31,6 +31,62 @@ nmTest({
     expect_gt(.f$omega[1, 1], 0)
   })
 
+  test_that("a Gaussian twin agrees with the equivalent add() model (#871)", {
+    # An ll() written as the exact normal log-density and the equivalent add()
+    # model are the same likelihood, so they must give the same objective function
+    # value and the same standard errors.  The residual SD is fixed in both so the
+    # two fits estimate the identical free parameter set, and it is carried on the
+    # log scale in the ll() because an SD written bare inside an ll() has no
+    # positivity constraint.
+    mAdd <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        add.sd <- fixed(0.7)
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    mLl <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        lsd <- fixed(log(0.7))
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        sd <- exp(lsd)
+        cp <- linCmt()
+        ll(err) ~ -lsd - 0.5 * log(2 * pi) - 0.5 * ((DV - cp) / sd)^2
+      })
+    }
+    ctl <- saemControl(nBurn = 300, nEm = 400, seed = 42L, print = 0L,
+                       covMethod = "linFim", calcTables = FALSE)
+    fA <- .nlmixr(mAdd, theo_sd, est = "saem", control = ctl)
+    fL <- .nlmixr(mLl,  theo_sd, est = "saem", control = ctl)
+
+    # the ll() fit really did take the general-likelihood path
+    expect_equal(fL$ui$saemResMod, 0L)
+    expect_equal(fA$ui$saemResMod, 1L)
+    # the two fits land on the same estimates, so any difference below is the
+    # objective/covariance code rather than the fit
+    expect_equal(unname(fixef(fL)[1:3]), unname(fixef(fA)[1:3]), tolerance = 0.01)
+    expect_equal(unname(diag(fL$omega)), unname(diag(fA$omega)), tolerance = 0.05)
+
+    # objective: equal, not merely equal up to a 0.5*log(2*pi) per observation.
+    # Before the fix the ll() value was 766.5 against the add() model's 123.7.
+    expect_equal(fL$objf, fA$objf, tolerance = 0.005)
+
+    # standard errors: theta and the Omega variances.  Before the fix the ratios
+    # ran from 4.0 to 80.5; the residual spread is the two fits' own difference.
+    .k <- intersect(rownames(fL$cov), rownames(fA$cov))
+    expect_true(all(c("tka", "tcl", "tv", "om.eta.ka", "om.eta.cl", "om.eta.v") %in% .k))
+    expect_equal(unname(sqrt(diag(fL$cov))[.k]), unname(sqrt(diag(fA$cov))[.k]),
+                 tolerance = 0.05)
+  })
+
   test_that("a general log-likelihood endpoint uses distribution=4 (no residual)", {
     .ui <- rxode2::rxUiDecompress(rxode2::rxode2(expTte))
     # LL endpoint carries no residual bookkeeping


### PR DESCRIPTION
Closes #871.

`calc.2LL` (`R/saem_fit_aux.R`) and `calc.COV` build a Gaussian residual SD

```r
g <- ares + bres * abs(fsave)
```

for **every** observation.  A general log-likelihood endpoint (`ll(name) ~ expr`)
has `res.mod == 0`, so the residual M-step never runs (`src/saem.cpp`, the
`distribution != 4` guard), the residual warm start returns early, and nothing
zeroes `ares`/`bres` -- they keep the placeholder `10` and `1` they are
initialized with.  Every per-observation log-density was scored as a normal mean
with SD `10 + |ll|`.

This is not `fsaem`-specific and predates it: it is wrong for every `ll()` model
fit with plain `est="saem"`.

## Blast radius

Both defaults route through the broken code:

* `logLik=FALSE` is the `saemControl()` default, so `env$objective` is `NA` and
  the first access of `fit$objf`/`$AIC`/`$BIC`/`$logLik` runs
  `.nmObjEnsureObjective()` -> `setOfv(., "gauss3_1.6")` -> `calc.2LL`.
* `covMethod="sa"` is the default, but for `distribution == 4` the trailing
  log-sigma2 slot of the Louis FIM is hard-zeroed, so `Ha`/`HaSa` are singular,
  `.saemFimToCov()` returns `NULL`, and every `ll()` fit fell back to `linFim` --
  which is `calc.COV`.

## The two functions needed different fixes

**`calc.2LL`.** Excluding `ll()` rows from `g` is not enough: the row would still
be scored by a normal density, just with a different SD.  Those rows now take the
model's own per-observation log-likelihood (which is what `dopred()` returns for
such an endpoint) straight into `DYF`, and the `log(2*pi)` normalizer is applied
only to the normally-distributed rows, since an `ll()` expression already carries
its own constant.

**`calc.COV`.** It linearizes `dopred()` as if it returned a transformed mean --
`DF <- (f1 - f0)/dphi` -- and builds a Gaussian `Vi = DF Omega DF' + diag(g^2)`
from it.  For an `ll()` endpoint that Jacobian is of the log-likelihood, not of a
mean, so patching `g` cannot make the covariance right.

An intermediate form was tried first: because `DF` is then the per-observation
*score*, setting `g = 1` turns `DF' diag(g^2)^-1 DF` into the outer-product
(BHHH) information, with no other change.  Measured, that is biased -- it uses the
realized residual where the Gaussian route uses its expectation, and at the EBEs
the residuals are shrunk (SE ratios 1.14-1.88 against the Gaussian twin).

What shipped is the **observed information**: central differences of `dopred()`
with respect to phi, marginalized over the random effects with the Schur
complement

```
M = H - H[, i1] (Omega^-1 + H[i1, i1])^-1 H[i1, ]
```

which is exactly what the Gaussian branch already computes through `Vi` and the
Woodbury identity, so a normal model agrees by construction.  `M` is returned as
a matrix square root, leaving `.nlmixr2RobustCov()` and its rank-deficiency (`NA`
rows/columns) handling untouched.  The Omega variance block follows the same
identity, `tr(Vi^-1 dVi/da Vi^-1 dVi/db) = tr(E_a M11 E_b M11)`.

## Verification

The issue asks for the model's own Gaussian twin.  Both are measured.

**Objective, against a closed form.**  An exponential time-to-event model's
marginal likelihood is a one-dimensional quadrature:

| | -2LL |
|---|---|
| before | 1124.05 |
| after (`nnodesGq=13`, `nsdGq=5`) | 1392.08 |
| exact | 1392.157 |

**Standard errors, against the Gaussian twin** (theo_sd, an `ll()` written as the
exact normal log-density vs the equivalent `add()` model, residual SD fixed in
both so they estimate the identical free parameter set) -- ratio `ll/add`:

| | tka | tcl | tv | om.eta.ka | om.eta.cl | om.eta.v |
|---|---|---|---|---|---|---|
| before | 4.04 | 11.44 | 8.47 | 5.27 | 80.49 | 21.09 |
| after | 0.999 | 0.997 | 1.006 | 1.003 | 0.994 | 1.015 |

The two objective function values now agree outright rather than up to a
constant, matching what FOCEi already does (`test-focei-llik.R`) and improving on
npag, whose NEWS documents a residual `0.5*log(2*pi)` per observation.

A normal model is unchanged: the mask is all-`FALSE`, every expression reduces to
its current form, and the Gaussian branch of `calc.COV` is not touched.  All 18
`test-saem-*` files pass.

## Two things worth calling out

**`res.mod` was being dropped post-fit.** `R/focei.R` trims `saem.cfg` to a
whitelist that did not include it, so the per-observation mask could not be built
on the path that actually reports `$objf`.  It is now kept.

**`covMethod="sa"`/`"fim"` are refused for a general likelihood.** Unblocking
them was tried -- dropping the degenerate log-sigma2 slot so the remaining
mu/Omega block inverts, on the reasoning that those scores come from
`p(phi|mu,Omega)` alone.  Measured against the exact observed information that is
wrong: it returns SEs **0.41 and 0.14** of the true values where `linFim` lands
at **0.93 and 0.82**.  The complete-data Louis correction subtracts the
information lost to the latent eta as `Var[score]` from a handful of MCMC chains,
and a general likelihood has no residual error to anchor it -- the same
instability already recorded for proportional/combined residuals.  So the
combination is refused up front with a message saying why, and the SA covariance
phase is no longer run for such a model at all.

## Reviewed

Independently reviewed with Antigravity (Gemini).  Three findings fixed: the
second-difference step floor (`1e-10` squares to `1e-20`), `.saemLlObsMask()`
guessing where it cannot know, and the Omega variance block reading an unclamped
`M11`.  Two rejected with evidence: `ind.io` misnumbering a subject with no
observations is unreachable, because such a subject is dropped upstream (#687)
before `saem.cfg` is built; and the unprotected `solve(iOmega + H[i1, i1])`
matches what the Gaussian branch already does on a spectral-decomposition
failure, with the caller handling both identically.

## Not in this PR

* **#903** -- `calc.2LL`'s transform-both-sides Jacobian at `R/saem_fit_aux.R` subtracts
  `2*powerL` where FOCEi adds it (`src/inner.cpp`, `lik += fInd->tbsLik`), which
  would affect every `lnorm`/`boxCox`/`yeoJohnson`/`logitNorm` saem objective.
  Suspected, **not confirmed** -- the check via a `lnorm`/`ll()` twin was
  inconclusive because that quadrature has no log-sum-exp and overflows to `Inf`
  on such a model.  Different blast radius; needs its own issue and its own
  reference values.
* **#904** -- the residual entries of `calc.COV`'s variance block (`dVi/da`, `dVi/db`) are
  not masked to the owning endpoint, so they are already wrong for a
  multi-endpoint Gaussian model.  Untouched here; a pure-`ll()` model has no
  residual parameters, so the block is skipped rather than reported wrong for a
  future mixed model.
