### PR TITLE
fix(npag/npb): drop an unmatched endpoint instead of filing it under endpoint 0 (#856)

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -50,8 +50,21 @@ jobs:
             local::.
           needs: website
 
+      # pkgdown downloads its JS assets (fuse.js, autocomplete.js, headroom, ...)
+      # from cdnjs into R_user_dir("pkgdown", "cache") on every cold run; caching
+      # them keeps a slow CDN from failing the build.
+      - name: Cache pkgdown assets
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/R/pkgdown
+          key: pkgdown-assets-${{ runner.os }}-${{ hashFiles('_pkgdown.yml') }}
+          restore-keys: pkgdown-assets-${{ runner.os }}-
+
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        run: |
+          # R's 60s default download timeout is not enough for a slow cdnjs
+          options(timeout = max(600, getOption("timeout")))
+          pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/NEWS.md
+++ b/NEWS.md
@@ -142,6 +142,16 @@
   observation was Gaussian and uncensored slipped past them and was fit with an
   objective FO does not support.
 
+- `est="npag"` / `est="npb"` now **exclude** an observation or a residual
+  parameter whose endpoint cannot be determined from the residual moment warm
+  start, instead of attributing it to the first endpoint.  Both the observation
+  `CMT` lookup and the residual parameter's `condition` lookup resolved "no
+  match" to endpoint 0, which is indistinguishable from the correct answer for a
+  single-endpoint model; on a multi-endpoint model that warm-started (and, where
+  there is a lone scale per endpoint, estimated) one endpoint's residual SD from
+  another endpoint's residuals.  Anything dropped this way is now reported in
+  `$runInfo` rather than being silent.
+
 # nlmixr2est 7.0.2
 
 ## Breaking changes

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -302,6 +302,10 @@ foceiAnalyticGradPooled_ <- function(thVals, ebes, cols, cores, Oi, dOiEst, tr28
     .Call(`_nlmixr2est_foceiAnalyticGradPooled_`, thVals, ebes, cols, cores, Oi, dOiEst, tr28, neta, nth, nsg, nom, dirTh, sigCol, censOpt, lamDir)
 }
 
+npEndpointForCmt_ <- function(cmt, endpointCmt) {
+    .Call(`_nlmixr2est_npEndpointForCmt_`, cmt, endpointCmt)
+}
+
 #' Build the nonparametric Psi (conditional-likelihood) matrix
 #'
 #' For an already set-up FOCEi inner problem (\code{vaeInnerSetup_}), evaluates

--- a/R/npCommon.R
+++ b/R/npCommon.R
@@ -187,6 +187,23 @@
   .npFamilyFit(env, .ui, ...)
 }
 
+# 0-based endpoint (predDf row order) of each residual parameter, from the `condition`
+# of its ini row; `endVar` is predDf$cond.  A condition naming no endpoint -- including
+# the case where predDf was unavailable, so endVar is empty -- becomes -1, the "not a
+# variance scale" sentinel the C++ warm start already skips.  Coercing it to 0 instead
+# charged that parameter's moment to the FIRST endpoint (nlmixr2/nlmixr2est#856).
+#' @noRd
+.npResidEndpointIdx <- function(errCond, endVar) {
+  .end <- match(as.character(errCond), as.character(endVar)) - 1L
+  .bad <- is.na(.end)
+  if (any(.bad)) {
+    warning("residual param endpoint unknown; moment warm start skipped",
+            call. = FALSE)
+    .end[.bad] <- -1L
+  }
+  as.integer(.end)
+}
+
 # Fit driver for the nonparametric engines.  Turns off the FOCEI outer optimizer
 # (npagOuter/npbOuter drive the cycle), builds the 0-based mu index maps that the
 # finalization (impMuInterceptStep) reuses, and -- unlike .impmapFamilyFit --
@@ -270,10 +287,8 @@
   # endpoint variable; a proportional term uses (err/f), everything else (additive,
   # lognormal, box-cox -- all additive on the transform-both-sides scale) uses err.
   .endVar <- tryCatch(as.character(ui$predDf$cond), error = function(e) character(0))
-  .errCond <- as.character(.thOrd$condition[.errOpt])
-  .errEnd <- match(.errCond, .endVar) - 1L
-  .errEnd[is.na(.errEnd)] <- 0L
-  .control$npResidOptEnd <- as.integer(.errEnd)
+  .control$npResidOptEnd <-
+    .npResidEndpointIdx(.thOrd$condition[.errOpt], .endVar)
   .control$npResidOptProp <- as.integer(startsWith(.optType, "prop"))
   # per-endpoint compartment (predDf order) so the C++ side can map each observation's
   # cmt (rxode2 getIndCmt, the CMT time-varying covariate) to its endpoint index for the

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,4 @@
 url: https://nlmixr2.github.io/nlmixr2est/
 template:
   bootstrap: 5
-  params:
-    bootswatch: flatly
+  bootswatch: flatly

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -841,6 +841,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// npEndpointForCmt_
+Rcpp::IntegerVector npEndpointForCmt_(Rcpp::IntegerVector cmt, Rcpp::IntegerVector endpointCmt);
+RcppExport SEXP _nlmixr2est_npEndpointForCmt_(SEXP cmtSEXP, SEXP endpointCmtSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type cmt(cmtSEXP);
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type endpointCmt(endpointCmtSEXP);
+    rcpp_result_gen = Rcpp::wrap(npEndpointForCmt_(cmt, endpointCmt));
+    return rcpp_result_gen;
+END_RCPP
+}
 // npBuildPsi
 NumericMatrix npBuildPsi(NumericMatrix etaPoints, int cores);
 RcppExport SEXP _nlmixr2est_npBuildPsi(SEXP etaPointsSEXP, SEXP coresSEXP) {

--- a/src/init.c
+++ b/src/init.c
@@ -184,6 +184,7 @@ SEXP _rxode2version4(SEXP);
 SEXP _nlmixr2est_rxode2stateOde(SEXP);
 SEXP _nlmixr2est_npIpmBurke(SEXP);
 SEXP _nlmixr2est_npBuildPsi(SEXP, SEXP);
+SEXP _nlmixr2est_npEndpointForCmt_(SEXP, SEXP);
 SEXP _nlmixr2est_npSobolGrid_(SEXP, SEXP, SEXP);
 SEXP _nlmixr2est_npCondense_(SEXP, SEXP, SEXP, SEXP);
 SEXP _nlmixr2est_npagCycle_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -318,6 +319,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_nmNearPD_", (DL_FUNC) &_nlmixr2est_nmNearPD_, 10},
   {"_nlmixr2est_npIpmBurke", (DL_FUNC) &_nlmixr2est_npIpmBurke, 1},
   {"_nlmixr2est_npBuildPsi", (DL_FUNC) &_nlmixr2est_npBuildPsi, 2},
+  {"_nlmixr2est_npEndpointForCmt_", (DL_FUNC) &_nlmixr2est_npEndpointForCmt_, 2},
   {"_nlmixr2est_npSobolGrid_", (DL_FUNC) &_nlmixr2est_npSobolGrid_, 3},
   {"_nlmixr2est_npCondense_", (DL_FUNC) &_nlmixr2est_npCondense_, 4},
   {"_nlmixr2est_npagCycle_", (DL_FUNC) &_nlmixr2est_npagCycle_, 6},

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -13909,7 +13909,15 @@ arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint
       if (getIndEvid(ind, kk) != 0) continue;
       // obsIdx indexes obsEndpoint across ALL subjects, so it must advance even on a
       // skipped subject or every later subject's rows land in the wrong endpoint.
-      int e = (obsIdx < (int)obsEndpoint.n_elem) ? obsEndpoint[obsIdx] : 0;
+      // No map at all is unambiguous only for a single endpoint; running off the end
+      // of one means the map does not describe this solve, so drop the row (-1)
+      // rather than filing it under endpoint 0 (issue #856).
+      int e;
+      if (obsEndpoint.n_elem == 0) {
+        e = (nEnd <= 1) ? 0 : -1;
+      } else {
+        e = (obsIdx < (int)obsEndpoint.n_elem) ? obsEndpoint[obsIdx] : -1;
+      }
       obsIdx++;
       if (skipMoments) continue;
       double dv = tbs(getIndDv(ind, kk));
@@ -13930,30 +13938,56 @@ arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint
   return mom;
 }
 
+// 0-based endpoint of one observation's cmt, or -1 when it belongs to no endpoint.
+// endpointCmt holds the cmt of each endpoint in predDf order (distinct, not
+// necessarily sequential).  A single-endpoint model has no CMT covariate, so
+// getIndCmt returns 1 rather than predDf$cmt -- there is nothing to match, and every
+// observation is that one endpoint.  With no endpoint at all, or a cmt that names
+// none of them (including NA_INTEGER, "no compartment recorded here"), the answer is
+// -1 so the caller can EXCLUDE the observation; laundering it into 0 filed it under
+// the first endpoint (issue #856).
+int npEndpointForCmt(int cmt, const std::vector<int>& endpointCmt) {
+  if (endpointCmt.size() == 1) return 0;
+  if (cmt == NA_INTEGER) return -1;
+  for (size_t ee = 0; ee < endpointCmt.size(); ++ee) {
+    if (endpointCmt[ee] == cmt) return (int)ee;
+  }
+  return -1;
+}
+
+//[[Rcpp::export]]
+Rcpp::IntegerVector npEndpointForCmt_(Rcpp::IntegerVector cmt,
+                                      Rcpp::IntegerVector endpointCmt) {
+  std::vector<int> ec(endpointCmt.begin(), endpointCmt.end());
+  Rcpp::IntegerVector ret(cmt.size());
+  for (R_xlen_t i = 0; i < cmt.size(); ++i) ret[i] = npEndpointForCmt(cmt[i], ec);
+  return ret;
+}
+
 // Per-observation 0-based endpoint index in the subject-major getIndIx order that
-// npResidMoments iterates, from the cached CMT covariate (getIndCmt).  endpointCmt gives
-// the cmt value of each endpoint in predDf order (cmt values are distinct, not
-// necessarily sequential); each observation's cmt is matched to it.  A single-endpoint
-// model has no CMT covariate, so getIndCmt returns 1 and every observation maps to
-// endpoint 0.  Lets the moment warm start be per-endpoint for a multi-endpoint model.
+// npResidMoments iterates, from the cached CMT covariate (getIndCmt).  Unmatched
+// observations come back as -1 (npResidMoments skips those).  Lets the moment warm
+// start be per-endpoint for a multi-endpoint model.
 arma::ivec npBuildObsEndpoint(const std::vector<int>& endpointCmt) {
   rx = getRxSolve_();
   rx_solving_options *op = getSolvingOptions(rx);
   int nsub = (int)getRxNsub(rx);
   std::vector<int> out;
+  int nUnmatched = 0;
   for (int i = 0; i < nsub; ++i) {
     rx_solving_options_ind *ind = getSolvingOptionsInd(rx, getRxId(i));
     int n = getIndNallTimes(ind);
     for (int j = 0; j < n; ++j) {
       int kk = getIndIx(ind, j);
       if (getIndEvid(ind, kk) != 0) continue;   // observations only, matching npResidMoments
-      int cmt = getIndCmt(op, ind, kk);
-      int e = 0;
-      for (size_t ee = 0; ee < endpointCmt.size(); ++ee) {
-        if (endpointCmt[ee] == cmt) { e = (int)ee; break; }
-      }
+      int e = npEndpointForCmt(getIndCmt(op, ind, kk), endpointCmt);
+      if (e < 0) nUnmatched++;
       out.push_back(e);
     }
+  }
+  if (nUnmatched > 0) {
+    Rf_warning("%d obs. match no endpoint, dropped from the residual warm start",
+               nUnmatched);
   }
   arma::ivec ret((arma::uword)out.size());
   for (size_t k = 0; k < out.size(); ++k) ret[k] = out[k];

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -13909,15 +13909,13 @@ arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint
       if (getIndEvid(ind, kk) != 0) continue;
       // obsIdx indexes obsEndpoint across ALL subjects, so it must advance even on a
       // skipped subject or every later subject's rows land in the wrong endpoint.
-      // No map at all is unambiguous only for a single endpoint; running off the end
-      // of one means the map does not describe this solve, so drop the row (-1)
-      // rather than filing it under endpoint 0 (issue #856).
-      int e;
-      if (obsEndpoint.n_elem == 0) {
-        e = (nEnd <= 1) ? 0 : -1;
-      } else {
-        e = (obsIdx < (int)obsEndpoint.n_elem) ? obsEndpoint[obsIdx] : -1;
-      }
+      // No map at all means no per-observation endpoint was supplied; running off the
+      // end of one means the map does not describe this solve.  Either way the row is
+      // dropped (-1) rather than filed under endpoint 0 (issue #856).  It is NOT safe
+      // to read nEnd == 1 as "single endpoint, so 0 is right": nEnd comes from the
+      // ESTIMATED residual parameters, and a multi-endpoint model with one estimated
+      // scale (the rest fixed) also gives 1.
+      int e = (obsIdx < (int)obsEndpoint.n_elem) ? obsEndpoint[obsIdx] : -1;
       obsIdx++;
       if (skipMoments) continue;
       double dv = tbs(getIndDv(ind, kk));

--- a/src/np.h
+++ b/src/np.h
@@ -35,9 +35,15 @@ void npResidFreezeClear();
 // residual optimization.
 arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint, int nEnd);
 
+// 0-based endpoint of one observation's cmt within endpointCmt (per-endpoint cmt
+// values, predDf order), or -1 when it matches none of them.  Always 0 for a
+// single-endpoint model (which carries no CMT covariate to match on).
+int npEndpointForCmt(int cmt, const std::vector<int>& endpointCmt);
+
 // Per-observation 0-based endpoint index (subject-major getIndIx order) from the cached
 // CMT covariate (rxode2 getIndCmt): matches each observation's cmt to endpointCmt (the
-// per-endpoint cmt values, predDf order).  All-zeros for a single-endpoint model.
+// per-endpoint cmt values, predDf order).  All-zeros for a single-endpoint model;
+// -1 for an observation matching no endpoint, which npResidMoments then skips.
 arma::ivec npBuildObsEndpoint(const std::vector<int>& endpointCmt);
 
 // Build the Psi matrix (nSub x nPoint) on the already set-up FOCEi inner solve:

--- a/tests/testthat/test-np-endpoint-map.R
+++ b/tests/testthat/test-np-endpoint-map.R
@@ -1,0 +1,64 @@
+## Endpoint mapping for the npag/npb residual moment warm start
+## (nlmixr2/nlmixr2est#856).
+##
+## Both halves of the mapping used to resolve "I could not match this" to endpoint
+## 0, which is indistinguishable from a correct answer for the (very common)
+## single-endpoint model.  A misattributed observation contributes its err^2 to the
+## wrong endpoint's moment bucket, and when there is a lone scale per endpoint that
+## bucket IS the estimate.  These pin the -1 ("no endpoint, drop it") sentinel.
+##
+## Mapping only, no fits, so this file stays in the push/PR subset.
+
+nmTest({
+
+  test_that("an observation cmt matching no endpoint maps to -1, not endpoint 0", {
+    ## two endpoints at cmt 3 and 4 (predDf order)
+    .ec <- c(3L, 4L)
+    expect_equal(nlmixr2est:::npEndpointForCmt_(c(3L, 4L), .ec), c(0L, 1L))
+    ## a cmt that names neither endpoint is dropped, NOT filed under the first
+    expect_equal(nlmixr2est:::npEndpointForCmt_(5L, .ec), -1L)
+    expect_equal(nlmixr2est:::npEndpointForCmt_(1L, .ec), -1L)
+    ## getIndCmt() returns NA_INTEGER for "no compartment recorded here"
+    expect_equal(nlmixr2est:::npEndpointForCmt_(NA_integer_, .ec), -1L)
+    ## cmt values need not be sequential
+    expect_equal(nlmixr2est:::npEndpointForCmt_(c(7L, 2L), c(2L, 7L)), c(1L, 0L))
+  })
+
+  test_that("a single-endpoint model maps every observation to endpoint 0", {
+    ## a single-endpoint model carries no CMT covariate, so getIndCmt() returns 1
+    ## rather than predDf$cmt (3 here) -- there is nothing to match, and every
+    ## observation is that one endpoint.  This is why the fallback could not simply
+    ## become -1 everywhere.
+    expect_equal(nlmixr2est:::npEndpointForCmt_(c(1L, 3L, NA_integer_), 3L),
+                 c(0L, 0L, 0L))
+  })
+
+  test_that("no endpoints at all drops every observation", {
+    expect_equal(nlmixr2est:::npEndpointForCmt_(c(1L, 3L), integer(0)), c(-1L, -1L))
+  })
+
+  test_that("a residual parameter naming no endpoint maps to -1 and warns", {
+    .endVar <- c("cp", "eff")
+    expect_equal(nlmixr2est:::.npResidEndpointIdx(c("cp", "eff", "cp"), .endVar),
+                 c(0L, 1L, 0L))
+    expect_warning(
+      .e <- nlmixr2est:::.npResidEndpointIdx(c("cp", "nosuch"), .endVar),
+      "endpoint unknown")
+    expect_equal(.e, c(0L, -1L))
+  })
+
+  test_that("an unavailable predDf drops every residual parameter", {
+    ## the tryCatch around predDf$cond yields character(0); every match() then
+    ## fails, which the old 0L coercion hid by charging them all to endpoint 0
+    expect_warning(
+      .e <- nlmixr2est:::.npResidEndpointIdx(c("cp", "eff"), character(0)),
+      "endpoint unknown")
+    expect_equal(.e, c(-1L, -1L))
+  })
+
+  test_that("no residual parameters is not a warning", {
+    expect_silent(.e <- nlmixr2est:::.npResidEndpointIdx(character(0), c("cp")))
+    expect_equal(.e, integer(0))
+  })
+
+})

--- a/tests/testthat/test-np-endpoint-map.R
+++ b/tests/testthat/test-np-endpoint-map.R
@@ -11,17 +11,22 @@
 
 nmTest({
 
+  ## both helpers are internal; resolve them explicitly so this works under the
+  ## test_check() route and the test_dir() one nlmixr2Validate() uses
+  .cmtIdx <- utils::getFromNamespace("npEndpointForCmt_", "nlmixr2est")
+  .residIdx <- utils::getFromNamespace(".npResidEndpointIdx", "nlmixr2est")
+
   test_that("an observation cmt matching no endpoint maps to -1, not endpoint 0", {
     ## two endpoints at cmt 3 and 4 (predDf order)
     .ec <- c(3L, 4L)
-    expect_equal(nlmixr2est:::npEndpointForCmt_(c(3L, 4L), .ec), c(0L, 1L))
+    expect_equal(.cmtIdx(c(3L, 4L), .ec), c(0L, 1L))
     ## a cmt that names neither endpoint is dropped, NOT filed under the first
-    expect_equal(nlmixr2est:::npEndpointForCmt_(5L, .ec), -1L)
-    expect_equal(nlmixr2est:::npEndpointForCmt_(1L, .ec), -1L)
+    expect_equal(.cmtIdx(5L, .ec), -1L)
+    expect_equal(.cmtIdx(1L, .ec), -1L)
     ## getIndCmt() returns NA_INTEGER for "no compartment recorded here"
-    expect_equal(nlmixr2est:::npEndpointForCmt_(NA_integer_, .ec), -1L)
+    expect_equal(.cmtIdx(NA_integer_, .ec), -1L)
     ## cmt values need not be sequential
-    expect_equal(nlmixr2est:::npEndpointForCmt_(c(7L, 2L), c(2L, 7L)), c(1L, 0L))
+    expect_equal(.cmtIdx(c(7L, 2L), c(2L, 7L)), c(1L, 0L))
   })
 
   test_that("a single-endpoint model maps every observation to endpoint 0", {
@@ -29,20 +34,20 @@ nmTest({
     ## rather than predDf$cmt (3 here) -- there is nothing to match, and every
     ## observation is that one endpoint.  This is why the fallback could not simply
     ## become -1 everywhere.
-    expect_equal(nlmixr2est:::npEndpointForCmt_(c(1L, 3L, NA_integer_), 3L),
+    expect_equal(.cmtIdx(c(1L, 3L, NA_integer_), 3L),
                  c(0L, 0L, 0L))
   })
 
   test_that("no endpoints at all drops every observation", {
-    expect_equal(nlmixr2est:::npEndpointForCmt_(c(1L, 3L), integer(0)), c(-1L, -1L))
+    expect_equal(.cmtIdx(c(1L, 3L), integer(0)), c(-1L, -1L))
   })
 
   test_that("a residual parameter naming no endpoint maps to -1 and warns", {
     .endVar <- c("cp", "eff")
-    expect_equal(nlmixr2est:::.npResidEndpointIdx(c("cp", "eff", "cp"), .endVar),
+    expect_equal(.residIdx(c("cp", "eff", "cp"), .endVar),
                  c(0L, 1L, 0L))
     expect_warning(
-      .e <- nlmixr2est:::.npResidEndpointIdx(c("cp", "nosuch"), .endVar),
+      .e <- .residIdx(c("cp", "nosuch"), .endVar),
       "endpoint unknown")
     expect_equal(.e, c(0L, -1L))
   })
@@ -51,13 +56,13 @@ nmTest({
     ## the tryCatch around predDf$cond yields character(0); every match() then
     ## fails, which the old 0L coercion hid by charging them all to endpoint 0
     expect_warning(
-      .e <- nlmixr2est:::.npResidEndpointIdx(c("cp", "eff"), character(0)),
+      .e <- .residIdx(c("cp", "eff"), character(0)),
       "endpoint unknown")
     expect_equal(.e, c(-1L, -1L))
   })
 
   test_that("no residual parameters is not a warning", {
-    expect_silent(.e <- nlmixr2est:::.npResidEndpointIdx(character(0), c("cp")))
+    expect_silent(.e <- .residIdx(character(0), "cp"))
     expect_equal(.e, integer(0))
   })
 

--- a/tests/testthat/test-npag-error-models.R
+++ b/tests/testthat/test-npag-error-models.R
@@ -152,4 +152,41 @@ nmTest({
     expect_true(any(grepl("<=0 prediction|0-prediction obs", f$runInfo)))
   })
 
+  test_that("est='npag' buckets the residual moment per endpoint", {
+    ## nlmixr2/nlmixr2est#856 turned "this observation matches no endpoint" into a
+    ## -1 drop instead of a silent endpoint-0 filing; this pins that a real
+    ## multi-endpoint model still maps every observation to its own endpoint.  eff
+    ## is cp scaled by 0.1 with the DV scaled to match, so the two additive SDs
+    ## come out in the same 10:1 ratio, and nothing is reported as unmatched.
+    .d <- nlmixr2data::theo_sd
+    .obs <- .d[.d$EVID == 0, ]
+    .obs$CMT <- "cp"
+    .obs2 <- .obs
+    .obs2$CMT <- "eff"
+    .obs2$DV <- 1 + 0.1 * .obs2$DV
+    .dose <- .d[.d$EVID != 0, ]
+    .dose$CMT <- "depot"
+    .d <- rbind(.dose, .obs, .obs2)
+    .d <- .d[order(.d$ID, .d$TIME), ]
+    .m <- function() {
+      ini({ tka<-log(1.5); tv<-log(31.5); tke<-log(0.08)
+        add.sd<-2.0; eff.sd<-1.0
+        eta.ka~0.3; eta.ke~0.1 })
+      model({ ka<-exp(tka+eta.ka); v<-exp(tv); ke<-exp(tke+eta.ke)
+        d/dt(depot)<- -ka*depot; d/dt(center)<-ka*depot-ke*center
+        cp<-center/v
+        eff <- 1 + 0.1*cp
+        cp~add(add.sd)
+        eff~add(eff.sd) })
+    }
+    f <- nlmixr2(.m, .d, est="npag",
+                 control=npagControl(points=300L, cycles=15L, gammaOptimize=TRUE, muExpand=FALSE))
+    expect_s3_class(f, "nlmixr2FitData")
+    .add <- unname(f$parFixedDf["add.sd", "Estimate"])
+    .eff <- unname(f$parFixedDf["eff.sd", "Estimate"])
+    expect_equal(.eff, 0.1 * .add, tolerance = 1e-3)
+    ## every observation matched an endpoint, so nothing was dropped
+    expect_false(any(grepl("match no endpoint", f$runInfo)))
+  })
+
 })


### PR DESCRIPTION
Closes #856.

Two places in the nonparametric (`est="npag"` / `est="npb"`) endpoint mapping
resolved "I could not match this" to **endpoint 0** rather than reporting it.
Endpoint 0 is also the correct answer for every single-endpoint model, so the
fallback was indistinguishable from a real result. Both feed `npResidMoments`'
per-endpoint moment buckets -- the saem-style residual warm start, and (when
there is a lone scale per endpoint) the estimate itself -- so a misattributed
observation warm-started one endpoint's residual SD from another endpoint's
residuals.

## What changed

**`src/inner.cpp`** -- the CMT match is now `npEndpointForCmt()`, which returns
`-1` for a cmt naming no endpoint (including `NA_INTEGER`, rxode2's "no
compartment recorded here"). `npResidMoments` already skips `e < 0`, so the only
change needed was to stop laundering the sentinel into a valid index.

The single-endpoint case is special-cased to `0` explicitly rather than falling
out of the match: such a model carries no CMT covariate, so `getIndCmt()` returns
`1` while `predDf$cmt` is the endpoint's compartment (3, say). There is nothing
to match there, and a blanket `-1` would have silently dropped the warm start for
the most common model shape.

`npResidMoments` also no longer files an observation past the end of
`obsEndpoint` under endpoint 0. It is deliberately *not* conditioned on
`nEnd <= 1`: `nEnd` is derived from the **estimated** residual parameters, so a
multi-endpoint model with one estimated scale and the rest fixed also gives
`nEnd == 1`.

**`R/npCommon.R`** -- new `.npResidEndpointIdx()` leaves `-1` (and warns) when an
`err` row's `condition` names no endpoint. This also covers the case the issue
flagged as compounding: when `tryCatch(as.character(ui$predDf$cond), ...)` falls
back to `character(0)`, *every* `match()` fails, and the old `0L` coercion sent
every residual parameter to the first endpoint.

Anything dropped either way is now reported (the warning lands in `$runInfo`)
instead of being silent.

## Tests

`tests/testthat/test-np-endpoint-map.R` (essential push/PR subset, no fits) pins
the sentinel semantics on both sides via a small `npEndpointForCmt_` export:
matched, unmatched, `NA` cmt, non-sequential cmt values, the single-endpoint
`0`, the no-endpoints case, and the R-side condition mapping including the
empty-`predDf` path.

A two-endpoint npag fit in `test-npag-error-models.R` (weekly batch) pins that a
real multi-endpoint model still maps every observation to its own endpoint: `eff`
is `cp` scaled by 0.1 with the DV scaled to match, and the two additive SDs come
back in that same 10:1 ratio (`0.7236` / `0.07237`) with nothing reported
unmatched.

Both fallbacks remain unreachable end-to-end, as the issue states -- rxode2's
`etTrans` rejects an observation whose CMT is not an endpoint (even for a valid
model compartment such as `depot`), and the model parser guarantees every `err`
row's `condition` names a `predDf` endpoint. This closes the hazard rather than
fixing an observed failure.

## Verification

- All 11 npag/npb test files pass: `np-endpoint-map` 14, `np-control-surface` 64,
  `np` 9, `npag-dispatch` 34, `npag-grid` 22, `npag-ipm` 21, `npag-error-models`
  20, `npag-fit` 16, `npb-fit` 29, `npag-general-lik` 19, `npag-fixed` 7,
  `npag-mixture` 20, `npag-muexpand` 11, `npag-psi` 76, `npag-cycle` 22,
  `npag-bimodal` 6, `npag-golden` 13 -- 0 failures.
- Single-endpoint npag fit still recovers `add.sd` at 0.799 through the
  `allSimpleScale` fast path (unchanged).
- Reviewed independently with Antigravity (gemini-3.1-pro-high) over three
  rounds; the one accepted finding (the `nEnd <= 1` guard above) is fixed in
  5afa022, and the final round found no remaining issues.

## Note for reviewers

`src/init.c` was hand-edited alongside `Rcpp::compileAttributes()` for the new
`npEndpointForCmt_` export, per the manual `.Call` table convention.
