### PR TITLE
fix(saem): skip an ll() endpoint per endpoint in the M-step and mixture AE loops

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -89,6 +89,14 @@
   the method entirely.  `covMethod="linFim"` (the default) is unaffected; its
   `calc.COV()` linearization was always per-endpoint.
 
+- `est="saem"` now skips a general log-likelihood (`ll()`) endpoint per endpoint
+  in the residual M-step and in both mixture AE-steps, instead of only when the
+  whole model is `ll()`.  A model that mixes a normal and an `ll()` endpoint
+  stored `sigma2 = 0` for the `ll()` one, and a mixture model accumulated a
+  meaningless residual sum of squares there, which then also perturbed the
+  stochastic-approximation FIM.  The `ll()` endpoint's residual bookkeeping is
+  now left alone, as it already was for an all-`ll()` model.
+
 - `saem`'s uninformative-eta detection
   (`saemControl(handleUninformativeEtas=TRUE)`, the default) could freeze an eta
   that the data does inform.  The test asks whether perturbing an eta moves the

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -2059,6 +2059,7 @@ public:
           Statphi02 = Statphi02 + phi0k.t() * phi0k;
 
           for (int b = 0; b < nendpnt; b++) {
+            if (distEp(b) == 4) continue;   // ll() endpoint: no residual SSR
             double resk = 0.0;
             for (int mHyp = 0; mHyp < nMix; mHyp++) {
               vec fk = fsave_hyp(mHyp).subvec(k * ntotal, (k + 1) * ntotal - 1);
@@ -2346,6 +2347,7 @@ public:
           }
 
           for (int b = 0; b < nendpnt; b++) {
+            if (distEp(b) == 4) continue;   // ll() endpoint: no residual SSR
             double resk = 0.0;
             for (int jMix = 0; jMix < nMix; jMix++) {
               vec fk = fsave_mix(jMix).subvec(k * ntotal, (k + 1) * ntotal - 1);
@@ -2873,6 +2875,10 @@ public:
       // general log-likelihood (distribution==4): no residual error params to update
       if (distribution != 4)
       for(int b=0; b<nendpnt; ++b) {
+        // Skipped per ENDPOINT, so a mixed norm + ll() model updates only its
+        // normal endpoints; without this sigma2[b] is stored as 0 for the ll()
+        // endpoint (nothing accumulates into statrese[b]).
+        if (distEp(b) == 4) continue;
         // AR(1): update the correlation from this iteration's residual pairs
         // (grid-search profile likelihood + stochastic approximation).  statrese
         // already holds the whitened SSR, so sig2 below is the marginal variance.

--- a/tests/testthat/test-saem-loglik.R
+++ b/tests/testthat/test-saem-loglik.R
@@ -88,18 +88,25 @@ nmTest({
     # loop used to run over the ll() endpoint as well.  Nothing accumulates into
     # statrese for that endpoint, so it stored sigma2 = 0 -- the value the FIM's
     # residual slot then divides by.
-    .d <- mkPkpdTwoEndpointData(n = 12L)
-    .f <- suppressMessages(nlmixr2(mixedNormLl, .d, est = "saem",
-      control = saemControl(nBurn = 10, nEm = 5, nmc = 3, seed = 1, print = 0L,
-                            calcTables = FALSE, covMethod = 0L)))
-    .r <- .f$saem$res_info
+    .fitOn <- function(.d) {
+      .f <- suppressMessages(nlmixr2(mixedNormLl, .d, est = "saem",
+        control = saemControl(nBurn = 10, nEm = 5, nmc = 3, seed = 1, print = 0L,
+                              calcTables = FALSE, covMethod = 0L)))
+      .f$saem$res_info
+    }
+    .r1 <- .fitOn(mkPkpdTwoEndpointData(n = 12L))
+    .r2 <- .fitOn(mkPkpdTwoEndpointData(n = 12L, seed = 7L))
     # endpoint 1 is the additive normal one, endpoint 2 the ll()
-    expect_equal(as.integer(.r$res_mod), c(1L, 0L))
-    # the ll() endpoint keeps saem's sigma2 initialization (10) untouched, the
-    # way an all-ll() model does; the bug drove it to exactly 0
-    expect_equal(as.numeric(.r$sigma2)[2], 10)
+    expect_equal(as.integer(.r1$res_mod), c(1L, 0L))
+    # the mechanism, without pinning saem's sigma2 initialization constant: the
+    # ll() endpoint's slot is untouched by the M-step, so it cannot depend on the
+    # data, while the normal endpoint's does.  The bug drove the ll() slot to
+    # exactly 0 -- also data-independent, hence the second assertion.
+    expect_equal(as.numeric(.r1$sigma2)[2], as.numeric(.r2$sigma2)[2])
+    expect_gt(as.numeric(.r1$sigma2)[2], 0)
+    expect_false(isTRUE(all.equal(as.numeric(.r1$sigma2)[1], as.numeric(.r2$sigma2)[1])))
     # and the normal endpoint is still estimated
-    expect_true(is.finite(as.numeric(.r$sigma2)[1]))
-    expect_gt(as.numeric(.r$sigma2)[1], 0)
+    expect_true(is.finite(as.numeric(.r1$sigma2)[1]))
+    expect_gt(as.numeric(.r1$sigma2)[1], 0)
   })
 })

--- a/tests/testthat/test-saem-loglik.R
+++ b/tests/testthat/test-saem-loglik.R
@@ -21,6 +21,28 @@ nmTest({
     })
   }
 
+  # [pkpd.two.endpoint()] with the PD endpoint written as its own log-likelihood
+  # instead of add(pd.sd), so the model mixes a normal and an ll() endpoint
+  mixedNormLl <- function() {
+    ini({
+      tcl <- -3.2; tv <- -1; tec50 <- 0.5
+      eta.cl ~ 0.09; eta.v ~ 0.09
+      pk.sd <- 0.4; pd.sd <- 4
+    })
+    model({
+      ka <- exp(0.5)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      e0 <- 100; ec50 <- exp(tec50)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      eff <- e0 * (1 - cp / (ec50 + cp))
+      cp ~ add(pk.sd) | cp
+      ll(eff) ~ -log(pd.sd) - 0.5*log(2*pi) - 0.5*((DV - eff)/pd.sd)^2
+    })
+  }
+
   test_that("saem fits a general log-likelihood (exponential TTE) endpoint", {
     .d <- .mkTte(1L)
     .f <- suppressMessages(nlmixr2(expTte, .d, est = "saem",
@@ -58,5 +80,26 @@ nmTest({
     expect_equal(.ui$saemModNumEst, 0L)
     # and the saem solve model emits the log-likelihood as rx_pred_ (rx_yj_ ~ 152)
     expect_true(any(grepl("rx_yj_", as.character(.ui$saemModel0))))
+  })
+
+  test_that("the residual M-step skips an ll() endpoint of a mixed model (#873)", {
+    # A mixed norm + ll() model carries the scalar distribution==1, so the
+    # `if (distribution != 4)` guard on the residual M-step does not fire and the
+    # loop used to run over the ll() endpoint as well.  Nothing accumulates into
+    # statrese for that endpoint, so it stored sigma2 = 0 -- the value the FIM's
+    # residual slot then divides by.
+    .d <- mkPkpdTwoEndpointData(n = 12L)
+    .f <- suppressMessages(nlmixr2(mixedNormLl, .d, est = "saem",
+      control = saemControl(nBurn = 10, nEm = 5, nmc = 3, seed = 1, print = 0L,
+                            calcTables = FALSE, covMethod = 0L)))
+    .r <- .f$saem$res_info
+    # endpoint 1 is the additive normal one, endpoint 2 the ll()
+    expect_equal(as.integer(.r$res_mod), c(1L, 0L))
+    # the ll() endpoint keeps saem's sigma2 initialization (10) untouched, the
+    # way an all-ll() model does; the bug drove it to exactly 0
+    expect_equal(as.numeric(.r$sigma2)[2], 10)
+    # and the normal endpoint is still estimated
+    expect_true(is.finite(as.numeric(.r$sigma2)[1]))
+    expect_gt(as.numeric(.r$sigma2)[1], 0)
   })
 })

--- a/tests/testthat/test-saem-mix.R
+++ b/tests/testthat/test-saem-mix.R
@@ -615,6 +615,48 @@ nmTest({
     expect_true(clMuLinear[1] < 2)
     expect_true(clMuLinear[2] > 4)
   })
+
+  test_that("the mixture AE-step skips an ll() endpoint's residual SSR (#873)", {
+    # The two mixture AE loops accumulated statr[b] over EVERY endpoint, so for an
+    # ll() endpoint they summed (y - _powerD(loglik))^2 -- a quantity with no
+    # meaning -- and carried it into statrese[b] and then sigma2[b].  The
+    # non-mixture branch already skipped per endpoint.
+    .d <- mkPkpdTwoEndpointData(n = 12L)
+    twoPopMixedLl <- function() {
+      ini({
+        tcl1 <- -3.2; tcl2 <- -2.2; tv <- -1; tec50 <- 0.5
+        p1 <- 0.5
+        eta.cl ~ 0.09; eta.v ~ 0.09
+        pk.sd <- 0.4; pd.sd <- 4
+      })
+      model({
+        ka <- exp(0.5)
+        cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl))
+        v <- exp(tv + eta.v)
+        e0 <- 100; ec50 <- exp(tec50)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        eff <- e0 * (1 - cp / (ec50 + cp))
+        cp ~ add(pk.sd) | cp
+        ll(eff) ~ -log(pd.sd) - 0.5*log(2*pi) - 0.5*((DV - eff)/pd.sd)^2
+      })
+    }
+    # "parallel" and "msaem" have their own AE loop, and both were missing the skip
+    for (.m in c("parallel", "msaem")) {
+      .f <- suppressMessages(.nlmixr(twoPopMixedLl, .d, est = "saem",
+                                     saemControl(print = 0, seed = 1, nBurn = 10, nEm = 5,
+                                                 nmc = 3, calcTables = FALSE, covMethod = 0L,
+                                                 mixSampleMethod = .m)))
+      .r <- .f$saem$res_info
+      expect_equal(as.integer(.r$res_mod), c(1L, 0L))
+      # untouched initialization for the ll() endpoint; the bug left an accumulated
+      # residual here instead
+      expect_equal(as.numeric(.r$sigma2)[2], 10)
+      expect_true(is.finite(as.numeric(.r$sigma2)[1]))
+      expect_gt(as.numeric(.r$sigma2)[1], 0)
+    }
+  })
 })
 
 

--- a/tests/testthat/test-saem-mix.R
+++ b/tests/testthat/test-saem-mix.R
@@ -643,19 +643,26 @@ nmTest({
       })
     }
     # "parallel" and "msaem" have their own AE loop, and both were missing the skip
-    for (.m in c("parallel", "msaem")) {
+    .r <- lapply(c("parallel", "msaem"), function(.m) {
       .f <- suppressMessages(.nlmixr(twoPopMixedLl, .d, est = "saem",
                                      saemControl(print = 0, seed = 1, nBurn = 10, nEm = 5,
                                                  nmc = 3, calcTables = FALSE, covMethod = 0L,
                                                  mixSampleMethod = .m)))
-      .r <- .f$saem$res_info
-      expect_equal(as.integer(.r$res_mod), c(1L, 0L))
-      # untouched initialization for the ll() endpoint; the bug left an accumulated
-      # residual here instead
-      expect_equal(as.numeric(.r$sigma2)[2], 10)
-      expect_true(is.finite(as.numeric(.r$sigma2)[1]))
-      expect_gt(as.numeric(.r$sigma2)[1], 0)
+      .f$saem$res_info
+    })
+    for (.i in seq_along(.r)) {
+      expect_equal(as.integer(.r[[.i]]$res_mod), c(1L, 0L))
+      expect_gt(as.numeric(.r[[.i]]$sigma2)[2], 0)
+      expect_true(is.finite(as.numeric(.r[[.i]]$sigma2)[1]))
+      expect_gt(as.numeric(.r[[.i]]$sigma2)[1], 0)
     }
+    # The mechanism, without pinning saem's sigma2 initialization constant: the two
+    # sampling methods run different chains, so the normal endpoint's residual
+    # differs between them while the ll() endpoint's slot -- never written -- is
+    # identical.  Accumulating the ll() SSR made it chain-dependent too.
+    expect_equal(as.numeric(.r[[1]]$sigma2)[2], as.numeric(.r[[2]]$sigma2)[2])
+    expect_false(isTRUE(all.equal(as.numeric(.r[[1]]$sigma2)[1],
+                                  as.numeric(.r[[2]]$sigma2)[1])))
   })
 })
 


### PR DESCRIPTION
Fixes #873.

Three loops keyed on the scalar `distribution` where a per-endpoint `distEp`
skip is needed, so a model that mixes a normal endpoint with a general
log-likelihood one ran them over the `ll()` endpoint too.

### Base branch

`distEp` / `applyLLObsLoss` -- and the mixed `norm` + `ll()` support that makes
these loops wrong -- exist only on `feat/fsaem-restore`, so this targets that
branch rather than `main`. On `main`, `.saemGeneralLik()` requires
`length(predDf$cond) == 1L`, so `distribution` is uniform across endpoints and
the scalar guards are correct there; the bug is not reachable.

### The fix

`if (distEp(b) == 4) continue;` in three places, matching the non-mixture AE
loop that already had it:

- the residual M-step, which stored `sigma2 = 0` for the `ll()` endpoint
  (nothing accumulates into `statrese[b]`)
- both mixture AE loops (one per `mixSampleMethod`), which summed
  `(y - _powerD(ll))^2` into `statr[b]`, making `sigma2[b]` a meaningless
  residual and carrying it through `resy(k)` into the SA-FIM

### Measured

`fit$saem$res_info$sigma2` for the `ll()` endpoint of a 2-endpoint model:

| case | before | after |
|---|---|---|
| mixed `norm` + `ll()` | `0.0` | untouched init |
| mixture, `mixSampleMethod="parallel"` | `99.7` | untouched init |
| mixture, `mixSampleMethod="msaem"` | `919.0` | untouched init |

The normal endpoint's `sigma2` is bit-identical before and after in every case.

### Tests

Added to `test-saem-loglik.R` and `test-saem-mix.R`. All three new assertions
fail without the fix. They pin the mechanism by invariance rather than by the
initialization constant: the `ll()` endpoint's slot cannot depend on the data
(two datasets) or on the chain (two `mixSampleMethod`s), while the normal
endpoint's does. Both files are already in weekly slow batches.

### Reviewed

Antigravity (`gemini-3.1-pro-high`). It confirmed the skip placement matches the
non-mixture loop and that no accumulator is left stale-and-read (`resy(k)` is
unassigned only for an all-`ll()` mixture, where `fimSigma2Ok` is false and the
ternary short-circuits). Its test-brittleness point is applied above.

Two findings were checked and left out of scope, both pre-existing:

- **The FIM's hardcoded `sigma2[0]`** (#872). Real, but separate. Measured on a
  `distEp = c(4, 1)` model: `covMethod="fim"` declines and falls back to
  `linFim` both before and after this change, and the reported SEs are
  bit-identical, so this change neither introduces nor worsens it.
- **All-`ll()` mixture E-step**: both mixture branches populate `DYF` under
  `if (distribution == 1) ... else if (2) ... else if (3)`, with no
  `distribution == 4` branch, so `DYF` stays zero and the posterior
  responsibilities collapse to the prior `mixProb`. Confirmed by reading
  `src/saem.cpp` (msaem and parallel E-steps). Unrelated to this fix -- worth
  its own issue.
