### PR TITLE
fix(saem): build the FIM residual slot from its OWN endpoint (#872)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -111,6 +111,15 @@
     the matrix otherwise, leaving the fixed-effect and Omega blocks
     uncontaminated.
 
+  - When that residual slot **is** filled, it is now built from its own
+    endpoint's variance and observation count rather than the first endpoint's
+    variance and the total observation count, and the delta method that maps it
+    to a reported standard deviation reads the same endpoint's row.  A model
+    mixing a normal and an `ll()` endpoint has exactly one estimated residual, so
+    the slot is filled, but the endpoint carrying it need not be the first: with
+    the `ll()` endpoint on the lower compartment the residual standard error came
+    back roughly 1.7 times too large under `covMethod="sa"`/`"fim"` (#872).
+
   - `covMethod="fim"` and `"sa"` now say plainly that they do not apply to an
     `ll()` endpoint and use the linearized Fisher information, instead of
     reporting that the covariance "could not be computed".  The

--- a/R/saem.R
+++ b/R/saem.R
@@ -632,7 +632,15 @@
   # single additive residual: log-sigma2 -> reported SD, d(sd)/d(log sigma2) = 0.5 sd
   .ri <- .idf[!is.na(.idf$err) & !.idf$fix, , drop = FALSE]
   if (nrow(.ri) == 1L && .np == .nth + .nEta + 1L && !grepl("prop|pow", .ri$err)) {
-    .ares <- tryCatch(.saem$resMat[1, 1], error = function(e) NA_real_)
+    # resMat rows follow predDf's endpoint order, and the one estimated residual
+    # is not necessarily endpoint 1: a mixed normal + ll() model has a single
+    # residual row here while the ll() endpoint keeps its untouched resMat init.
+    .b <- match(.ri$condition, .ui$predDf$cond)
+    .ares <- if (length(.b) == 1L && !is.na(.b)) {
+      tryCatch(.saem$resMat[.b, 1], error = function(e) NA_real_)
+    } else {
+      NA_real_
+    }
     if (is.finite(.ares) && .ares > 0) {
       .idx <- c(.idx, .np); .nm <- c(.nm, .ri$name); .jac <- c(.jac, 0.5 * .ares)
     }

--- a/R/saem.R
+++ b/R/saem.R
@@ -635,8 +635,11 @@
     # resMat rows follow predDf's endpoint order, and the one estimated residual
     # is not necessarily endpoint 1: a mixed normal + ll() model has a single
     # residual row here while the ll() endpoint keeps its untouched resMat init.
-    .b <- match(.ri$condition, .ui$predDf$cond)
-    .ares <- if (length(.b) == 1L && !is.na(.b)) {
+    # Pick the row the way the kernel picks fimResidEp -- the endpoint that is not
+    # ll() -- rather than by matching condition names, so no naming convention can
+    # silently drop the residual.
+    .b <- which(.ui$predDf$distribution != "LL")
+    .ares <- if (length(.b) == 1L) {
       tryCatch(.saem$resMat[.b, 1], error = function(e) NA_real_)
     } else {
       NA_real_

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -1486,12 +1486,17 @@ public:
     }
     // The FIM carries exactly ONE residual slot (nb_param = nphi1 + nlambda + 1),
     // so it can only describe a model with ONE estimated residual: a single
-    // normal endpoint with a pure additive error.  d1_logsigma2 is
-    // 0.5*resy/sigma2 - 0.5*ntotal, which mixes endpoint 0's variance with
-    // whichever endpoint resy last held and counts EVERY observation.  Outside
-    // that one case the slot is left at zero and .saemFimToCov() drops the row
-    // before inverting, so theta + Omega still come out clean and the residual
-    // block comes from the linearized FIM instead.
+    // normal endpoint with a pure additive error.  Outside that one case the slot
+    // is left at zero and .saemFimToCov() drops the row before inverting, so
+    // theta + Omega still come out clean and the residual block comes from the
+    // linearized FIM instead.
+    //
+    // When it IS filled, every term has to be that endpoint's own: fimResidEp
+    // indexes sigma2 and fimResidN counts only its observations.  The endpoint is
+    // not necessarily 0 -- a mixed normal + ll() model whose ll() endpoint has the
+    // lower CMT leaves sigma2[0] at its init (the M-step skips an ll() endpoint),
+    // so the old sigma2[0]/ntotal spelling divided one endpoint's residual by
+    // another endpoint's variance over every observation in the fit (#872).
     //
     // Worth what it is worth: on a 2-endpoint PK/PD model the bogus row moved the
     // second endpoint's theta SE by ~4% (0.0561 -> 0.0539).  It is NOT why that
@@ -1502,12 +1507,15 @@ public:
     // singular and loses covMethod="fim"/"sa" outright, which is what used to
     // happen to every ll() model.
     {
-      int _nResidEp = 0, _theB = -1;
+      int _nResidEp = 0;
+      fimResidEp = -1;
       for (int b = 0; b < nendpnt; ++b) {
         if (distEp(b) == 4) continue;       // ll() endpoint: no residual param
-        ++_nResidEp; _theB = b;
+        ++_nResidEp; fimResidEp = b;
       }
-      fimSigma2Ok = (_nResidEp == 1) && ((int)res_mod(_theB) == rmAdd);
+      fimSigma2Ok = (_nResidEp == 1) && ((int)res_mod(fimResidEp) == rmAdd);
+      fimResidN = fimSigma2Ok ?
+        (double)(y_offset(fimResidEp + 1) - y_offset(fimResidEp)) : 0.0;
     }
     hasFixedObsTransform = true;
     for (unsigned int b = 0; b < res_mod.n_elem; ++b) {
@@ -2087,7 +2095,7 @@ public:
           vec d1_loggamma2_phi1 = 0.5 * sdg1 - 0.5 * N;
           vec d1_logsigma2(1);
           // only for a single additive normal endpoint -- see fimSigma2Ok
-          d1_logsigma2[0] = fimSigma2Ok ? 0.5 * resy(k) / sigma2[0] - 0.5 * ntotal : 0.0;
+          d1_logsigma2[0] = fimSigma2Ok ? 0.5 * resy(k) / sigma2[fimResidEp] - 0.5 * fimResidN : 0.0;
           vec d1logk = join_cols(d1_mu_phi1, join_cols(d1_mu_phi0, join_cols(d1_loggamma2_phi1, d1_logsigma2)));
           D1 = D1 + d1logk;
           D11 = D11 + d1logk * d1logk.t();
@@ -2102,7 +2110,7 @@ public:
             }
             d2logk(nlambda + j, nlambda + j) = w2phi(j);
           }
-          d2logk(nb_param - 1, nb_param - 1) = fimSigma2Ok ? -0.5 * resy(k) / sigma2[0] : 0.0;
+          d2logk(nb_param - 1, nb_param - 1) = fimSigma2Ok ? -0.5 * resy(k) / sigma2[fimResidEp] : 0.0;
           D2 = D2 + d2logk;
         }
       } else if (nMix > 1) {
@@ -2373,7 +2381,7 @@ public:
           vec d1_loggamma2_phi1 = 0.5 * sdg1 - 0.5 * N;
           vec d1_logsigma2(1);
           // only for a single additive normal endpoint -- see fimSigma2Ok
-          d1_logsigma2[0] = fimSigma2Ok ? 0.5 * resy(k) / sigma2[0] - 0.5 * ntotal : 0.0;
+          d1_logsigma2[0] = fimSigma2Ok ? 0.5 * resy(k) / sigma2[fimResidEp] - 0.5 * fimResidN : 0.0;
           vec d1logk = join_cols(d1_mu_phi1, join_cols(d1_mu_phi0, join_cols(d1_loggamma2_phi1, d1_logsigma2)));
           D1 = D1 + d1logk;
           D11 = D11 + d1logk * d1logk.t();
@@ -2388,7 +2396,7 @@ public:
             }
             d2logk(nlambda + j, nlambda + j) = w2phi(j);
           }
-          d2logk(nb_param - 1, nb_param - 1) = fimSigma2Ok ? -0.5 * resy(k) / sigma2[0] : 0.0;
+          d2logk(nb_param - 1, nb_param - 1) = fimSigma2Ok ? -0.5 * resy(k) / sigma2[fimResidEp] : 0.0;
           D2 = D2 + d2logk;
         }
         for (int k = 0; k < nmc; k++) {
@@ -2606,12 +2614,9 @@ public:
           vec d1_mu_phi0=Md0(ind_cov0);                              //CHK!! vec or mat
           vec d1_loggamma2_phi1=0.5*sdg1-0.5*N;
           vec d1_logsigma2(1);
-          // general log-likelihood: no residual param, so its FIM row is 0.
-          // The row has been single-sigma since before multiple endpoints (the
-          // standing FIXME on the next line); a mixed normal + ll() model
-          // inherits that rather than adding to it, with resy(k) now holding the
-          // last NORMAL endpoint's residual.
-          d1_logsigma2[0] = fimSigma2Ok ? 0.5*resy(k)/sigma2[0]-0.5*ntotal : 0.0;
+          // The row has been single-sigma since before multiple endpoints, so it
+          // is filled only for the one model it describes -- see fimSigma2Ok.
+          d1_logsigma2[0] = fimSigma2Ok ? 0.5*resy(k)/sigma2[fimResidEp]-0.5*fimResidN : 0.0;
           vec d1logk=join_cols(d1_mu_phi1, join_cols(d1_mu_phi0, join_cols(d1_loggamma2_phi1, d1_logsigma2)));
           D1 = D1+d1logk;
           D11= D11+d1logk*d1logk.t();
@@ -2626,7 +2631,7 @@ public:
             }
             d2logk(nlambda+j,nlambda+j)=w2phi(j);
           }
-          d2logk(nb_param-1,nb_param-1) = fimSigma2Ok ? -0.5*resy(k)/sigma2[0] : 0.0;
+          d2logk(nb_param-1,nb_param-1) = fimSigma2Ok ? -0.5*resy(k)/sigma2[fimResidEp] : 0.0;
           D2=D2+d2logk;
         }
       }//k
@@ -3792,6 +3797,8 @@ private:
   bool distMixed = false;        // has a normal endpoint AND an ll() one
   // May the FIM's single residual slot be filled?  See the note where it is set.
   bool fimSigma2Ok = false;
+  int fimResidEp = -1;           // endpoint that slot describes (-1 when unfilled)
+  double fimResidN = 0.0;        // that endpoint's own observation count
   // nonMuTheta="regress": estimate the fixed-effect-only (phi0) parameters by
   // the bounded direct optimizer (refinePhi0Lik) for NORMAL models too, instead
   // of only the stochastic phi0 block.  Keeps such thetas as plain regressors

--- a/tests/testthat/test-saem-cov-sa.R
+++ b/tests/testthat/test-saem-cov-sa.R
@@ -261,4 +261,54 @@ nmTest({
     # no distribution at all (an old cfg) must not error
     expect_equal(.saemLlObsMask(list(opt = list()), .ix), rep(FALSE, 4))
   })
+
+  test_that("the FIM residual slot uses ITS endpoint's variance and count (#872)", {
+    # A mixed normal + ll() model whose ll() endpoint has the LOWER cmt still has
+    # exactly one estimated residual, so the FIM's single residual slot IS filled
+    # -- but it describes endpoint 2.  The kernel used to divide that residual by
+    # sigma2[0] (the ll() endpoint's, which the M-step never touches) over ntotal
+    # (every observation in the fit), and .saemFimToCov took resMat[1, 1] for the
+    # delta-method SD.  est="fsaem" shares this kernel, so one fit pins both.
+    .d <- mkPkpdTwoEndpointData(n = 20L)
+    .mixed <- function() {
+      ini({
+        tcl <- -3.2; tv <- -1; tec50 <- 0.5
+        eta.cl ~ 0.09; eta.v ~ 0.09
+        lpk <- log(0.4)
+        pd.sd <- 4
+      })
+      model({
+        ka <- exp(0.5); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        e0 <- 100; ec50 <- exp(tec50)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        eff <- e0 * (1 - cp / (ec50 + cp))
+        s1 <- exp(lpk)
+        ll(cp) ~ -0.5 * log(2 * pi) - lpk - 0.5 * ((DV - cp) / s1)^2
+        eff ~ add(pd.sd) | eff
+      })
+    }
+    .f <- .nlmixr(.mixed, .d, est = "saem",
+                  control = saemControl(nBurn = 150, nEm = 200, seed = 1L, print = 0L,
+                                        covMethod = "sa", nSaCov = 300,
+                                        calcTables = FALSE))
+    # the slot really was filled by the SA FIM -- not a silent fall back to linFim
+    expect_equal(.f$covMethod, "sa")
+    .ep <- rxUiGet.saemDistEp(list(rxode2::rxUiDecompress(.f$ui)))
+    expect_equal(.ep, c(4L, 1L))
+    # resMat follows predDf order, so the residual is row 2; row 1 is the ll()
+    # endpoint's init, which the M-step correctly leaves alone
+    .ares <- .f$saem$resMat[2, 1]
+    .nb <- sum(.d$evid == 0 & .d$dvid == "eff")
+    # an additive residual's slot carries information n_b/2 in log-sigma2 coords,
+    # so SE(sd) = 0.5*sd*sqrt(2/n_b) -- endpoint 2's OWN count, not ntotal
+    .want <- 0.5 * .ares * sqrt(2 / .nb)
+    expect_equal(unname(.f$parFixedDf["pd.sd", "SE"]), .want, tolerance = 0.05)
+    # and it is not built from row 1 (the pre-fix R-side read); pre-fix the kernel
+    # returned ~1.7x .want here
+    expect_false(isTRUE(all.equal(unname(.f$parFixedDf["pd.sd", "SE"]),
+                                  0.5 * .f$saem$resMat[1, 1] * sqrt(2 / .nb),
+                                  tolerance = 0.05)))
+  })
 })


### PR DESCRIPTION
Fixes #872.

## The defect

The SAEM information matrix carries exactly one residual slot
(`nb_param = nphi1 + nlambda + 1`), filled only when the model has a single
estimated additive residual (`fimSigma2Ok`). A model mixing a normal endpoint
with a general-likelihood `ll()` one **qualifies** -- an `ll()` endpoint
estimates no residual error -- but the endpoint carrying that residual need not
be endpoint 0.

All six FIM sites spelled the slot `sigma2[0]` over `0.5*ntotal`. With the
`ll()` endpoint on the lower CMT that divided the normal endpoint's residual by
the `ll()` endpoint's variance, over every observation in the fit.
`.saemFimToCov()` had the same defect on the R side, reading `resMat[1, 1]` for
the delta-method Jacobian -- and its `nrow(.ri) == 1L` guard is *satisfied* by a
mixed model, so nothing stopped it.

## The fix

`_theB` was computed and discarded; it is now the member `fimResidEp`, with the
endpoint's own observation count in `fimResidN`. Both index all six sites. The
R side selects the same row the same way the kernel does (the endpoint that is
not `ll()`).

A single-endpoint model is unchanged by construction: `fimResidEp == 0` and
`fimResidN == ntotal`.

## Measured

20-subject two-endpoint PK/PD model, `ll()` on `cp` and `add(pd.sd)` on `eff`,
`covMethod="sa"`:

| | residual SE |
|---|---|
| before | 0.437 |
| after | 0.2589 |
| exact `0.5*sd*sqrt(2/n_b)` | 0.2586 |

An additive residual's slot carries information `n_b/2` in log-sigma2
coordinates, so the closed form is available and the fixed value lands on it to
0.1%. The new test in `test-saem-cov-sa.R` asserts against that closed form (and
that the value is *not* the one built from `resMat[1, 1]`), so both halves of the
fix are pinned; it fails on the pre-fix build.

## Note on the issue's predicted symptom

The issue predicted `sigma2[0] == 0` -> `Inf` -> `.saemFimToCov` returns NULL ->
silent fallback to linFim. That is no longer the path: 5425e645e (already on this
branch) made the M-step skip an `ll()` endpoint *per endpoint*, so `sigma2[0]`
keeps its init instead of being zeroed. The result is a **finite but wrong**
residual SE with no fallback signal -- worse to detect, same root cause, same fix.

## Tests

`test-saem-cov-sa.R` (53), `test-saem-cov-analytic.R` (28), `test-fsaem-multi.R`
(42), `test-saem-cov-transpose.R` (8) all pass.

## Review

Reviewed by Antigravity (`gemini-3.1-pro-high`). It cleared the C++ bounds and
concurrency questions. Its one correctness finding -- that `iniDf$condition` is
`NA` for an endpoint written without an explicit `|`, so the R-side name match
would drop the residual -- does **not** reproduce; measured across `linCmt()`,
`cp ~ add()`, and `cp ~ add() | cp`, `condition` is always populated and the
match always resolves. The second commit designs out the silent-failure shape
anyway by selecting the row structurally rather than by name.

## Out of scope, found while verifying

Two pre-existing `covMethod="sa"`/`"fim"` defects, present before this change and
untouched by it, both reproducible on a plain single-endpoint `theo_sd` fit:

1. A non-mu-referenced (phi0) theta's SE collapses to ~1e-6. `d2logk` fills only
   the phi1 diagonal (`nlambda + j` for `j < nphi1`), so the phi0 mu block has no
   complete-data Hessian.
2. When a phi0 theta is not last in model order, `.saemFimToCov`'s
   `match(.ini, .tn)` mis-indexes: the FIM's rows are `[phi1 mus][phi0 mus]`
   (`i1` then `i0` from `covstruct`), which is not `saemParamsToEstimate` order,
   so SEs are attached to the wrong parameters.

Worth their own issue -- happy to file it.