### PR TITLE
saemControl: remove the four dead lbfgs* options and correct the NEWS claim

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # nlmixr2est 7.0.3
 
+## Breaking changes
+
+- `saemControl(lbfgsLmm=, lbfgsFactr=, lbfgsPgtol=, lbfgsMaxIter=)` have been
+  removed and now error as unused arguments.  They were announced in 7.0.2 as
+  controlling a bounded L-BFGS-B refinement of the fixed-effect-only (`phi0`)
+  parameters of a general log-likelihood model, but no such refinement was ever
+  implemented: the options were validated and stored and then read by nothing.
+  That `phi0` step is optimized by the bounded derivative-free routine (`bobyqa`,
+  or `stats::optimize` for a single parameter), which honors the `ini`-block
+  bounds and takes no L-BFGS-B settings.  Passing any of the four never changed a
+  fit, so removing them changes no result.
+
 ## New features
 
 - Requires `rxode2` (>= 5.1.7).  The compatibility layer that also let this
@@ -1320,9 +1332,11 @@
   `parHistData` records off-diagonal Omega block covariances.
 
 - `saem` fits general log-likelihood endpoints (`ll(name) ~ <expr>`,
-  e.g. time-to-event); fixed-effect-only parameters are refined by bounded
-  L-BFGS-B (`saemControl()` gains `lbfgsLmm`/`lbfgsFactr`/`lbfgsPgtol`/
-  `lbfgsMaxIter`).
+  e.g. time-to-event); fixed-effect-only parameters are refined by a bounded
+  derivative-free optimization honoring the `ini`-block bounds.  (This entry
+  originally said the refinement used bounded L-BFGS-B and that `saemControl()`
+  gained `lbfgsLmm`/`lbfgsFactr`/`lbfgsPgtol`/`lbfgsMaxIter`; that was never
+  true, and those options are removed in 7.0.3.)
 
 ### matExp() / indLin()
 

--- a/R/saemControl.R
+++ b/R/saemControl.R
@@ -278,23 +278,6 @@
 #'   the stochastic step a better starting residual scale.  Set `FALSE` to start
 #'   from the `ini`-block residual values instead.
 #'
-#' @param lbfgsLmm Integer number of BFGS corrections (the L-BFGS-B `lmm`
-#'   memory) used when refining the fixed-effect-only parameters of a general
-#'   log-likelihood model (`ll(name) ~ <expr>`) by direct L-BFGS-B
-#'   optimization of the observation likelihood.  Default 5.
-#'
-#' @param lbfgsFactr Convergence tolerance on the relative reduction in the
-#'   objective for that L-BFGS-B refinement (the `factr` control, in units of
-#'   machine epsilon).  When `NULL` (default) it is derived from `sigdig` the
-#'   same way as `foceiControl()` (`10^(-sigdig) / .Machine$double.eps`).
-#'
-#' @param lbfgsPgtol Convergence tolerance on the projected gradient for that
-#'   L-BFGS-B refinement (the `pgtol` control).  When `NULL` (default) it is
-#'   derived from `sigdig` (`10^(-sigdig)`).
-#'
-#' @param lbfgsMaxIter Integer maximum number of iterations for that L-BFGS-B
-#'   refinement.  Default 20.
-#'
 #' @param ... Other arguments to control SAEM.
 #'
 #' @inheritParams rxode2::rxSolve
@@ -363,10 +346,6 @@ saemControl <- function(seed = 99,
                         nonMuTheta = c("regress", "eta"),
                         residWarmStart = TRUE,
                         censOption = c("gauss", "laplace"),
-                        lbfgsLmm = 5L,
-                        lbfgsFactr = NULL,
-                        lbfgsPgtol = NULL,
-                        lbfgsMaxIter = 20L,
                         ...) {
   .xtra <- list(...)
   .bad <- names(.xtra)
@@ -463,26 +442,7 @@ saemControl <- function(seed = 99,
     if (is.null(sigdigTable)) {
       sigdigTable <- round(sigdig)
     }
-    # L-BFGS-B tolerances for the general-likelihood phi0 direct optimization,
-    # derived from sigdig the same way foceiControl() does (factr = tol/eps)
-    if (is.null(lbfgsFactr)) {
-      lbfgsFactr <- 10^(-sigdig) / .Machine$double.eps
-    }
-    if (is.null(lbfgsPgtol)) {
-      lbfgsPgtol <- 10^(-sigdig)
-    }
   }
-  # defaults when sigdig is not supplied (~4 significant digits)
-  if (is.null(lbfgsFactr)) {
-    lbfgsFactr <- 1e7
-  }
-  if (is.null(lbfgsPgtol)) {
-    lbfgsPgtol <- 0
-  }
-  checkmate::assertIntegerish(lbfgsLmm, lower=1, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(lbfgsFactr, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(lbfgsPgtol, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertIntegerish(lbfgsMaxIter, lower=1, len=1, any.missing=FALSE)
   if (is.null(sigdigTable)) {
     sigdigTable <- 3
   }
@@ -577,11 +537,7 @@ saemControl <- function(seed = 99,
     mixProbPriorN=mixProbPriorN,
     mixSampleMethod=mixSampleMethod,
     nonMuTheta=nonMuTheta,
-    residWarmStart=residWarmStart,
-    lbfgsLmm=as.integer(lbfgsLmm),
-    lbfgsFactr=lbfgsFactr,
-    lbfgsPgtol=lbfgsPgtol,
-    lbfgsMaxIter=as.integer(lbfgsMaxIter)
+    residWarmStart=residWarmStart
   )
   class(.ret) <- "saemControl"
   .ret

--- a/man/saemControl.Rd
+++ b/man/saemControl.Rd
@@ -56,10 +56,6 @@ saemControl(
   nonMuTheta = c("regress", "eta"),
   residWarmStart = TRUE,
   censOption = c("gauss", "laplace"),
-  lbfgsLmm = 5L,
-  lbfgsFactr = NULL,
-  lbfgsPgtol = NULL,
-  lbfgsMaxIter = 20L,
   ...
 )
 }
@@ -452,23 +448,6 @@ proper Laplace inner Hessian and analytic covariance).  Accepted by
 \code{saemControl}/\code{nlmControl} for a uniform interface but inert there --
 SAEM (stochastic EM) has no Laplace inner Hessian, and NLM uses a
 finite-difference Hessian that already reflects censoring exactly.}
-
-\item{lbfgsLmm}{Integer number of BFGS corrections (the L-BFGS-B `lmm`
-memory) used when refining the fixed-effect-only parameters of a general
-log-likelihood model (`ll(name) ~ <expr>`) by direct L-BFGS-B
-optimization of the observation likelihood.  Default 5.}
-
-\item{lbfgsFactr}{Convergence tolerance on the relative reduction in the
-objective for that L-BFGS-B refinement (the `factr` control, in units of
-machine epsilon).  When `NULL` (default) it is derived from `sigdig` the
-same way as `foceiControl()` (`10^(-sigdig) / .Machine$double.eps`).}
-
-\item{lbfgsPgtol}{Convergence tolerance on the projected gradient for that
-L-BFGS-B refinement (the `pgtol` control).  When `NULL` (default) it is
-derived from `sigdig` (`10^(-sigdig)`).}
-
-\item{lbfgsMaxIter}{Integer maximum number of iterations for that L-BFGS-B
-refinement.  Default 20.}
 
 \item{...}{Other arguments to control SAEM.}
 }

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -72,6 +72,17 @@ nmTest({
     expect_error(saemControl(foceiControl="matt"))
   })
 
+  test_that("saemControl rejects the withdrawn lbfgs* options (#878)", {
+    ## announced in 7.0.2 but never implemented; they must not silently be
+    ## accepted and stored again
+    expect_error(saemControl(lbfgsLmm=5L), "unused argument")
+    expect_error(saemControl(lbfgsFactr=1e7), "unused argument")
+    expect_error(saemControl(lbfgsPgtol=0), "unused argument")
+    expect_error(saemControl(lbfgsMaxIter=20L), "unused argument")
+    expect_false(any(c("lbfgsLmm", "lbfgsFactr", "lbfgsPgtol", "lbfgsMaxIter")
+                     %in% names(saemControl())))
+  })
+
   test_that("nlmixr2NlmeControl sanity", {
     expect_error(nlmixr2NlmeControl(), NA)
     nlmixrControlTest(nlmixr2NlmeControl())


### PR DESCRIPTION
Fixes #878.

## What was wrong

`saemControl(lbfgsLmm=, lbfgsFactr=, lbfgsPgtol=, lbfgsMaxIter=)` were accepted,
validated, defaulted from `sigdig` and stored in the returned control list -- and
read by nothing.  There is no L-BFGS-B anywhere in the SAEM path.  The
general-likelihood `phi0` refinement they claimed to control is the bounded
derivative-free optimization (`.boundedResidOpt` -> `bobyqa`, or
`stats::optimize` for a single parameter), which takes no L-BFGS-B settings.
The only other hits for these names are `foceiControl()`'s own options, which
`src/inner.cpp` reads out of the **focei** control list; `saem` builds a fresh
`foceiControl()` for its table step, so the saem-side fields never reached it.

They were also a published feature with a false description: the 7.0.2 NEWS
announced the L-BFGS-B refinement and the four new options.

## What this does

- Removes the four arguments outright -- roxygen, formals, `sigdig`-derived
  defaults, `checkmate` assertions, and the entries in the returned list.
  Passing one now errors as an unused argument, which is the point: they have
  never done anything.
- Adds a **Breaking changes** entry under 7.0.3 saying plainly that the
  announced refinement was never implemented and the options are withdrawn,
  rather than deleting them quietly.
- Corrects the 7.0.2 entry to describe the refinement that actually ships, with
  a note that the L-BFGS-B claim was untrue.
- Pins the removal in `test-control.R`: each of the four errors, and none
  survives in `names(saemControl())`.

## The two smaller doc defects in the issue

Neither applies to this tree:

- `fastInnerIt` -- `fsaem` and `R/fsaemInner.R` are no longer present (only
  `plans/fsaem.md` remains), so there is no hard-coded `100L` and nothing to
  document.
- `nu[4]` -- `nu` is validated at `len=3` (`R/saemControl.R:395`) and defaults to
  `c(2, 2, 2)`, which matches the roxygen "vector of 3 integers".  The `max.len=4`
  the issue cites is from the branch that carried the 4th kernel.

## Verification

`saemControl()` round-trips through `do.call()` unchanged, `sigdig=` still sets
`sigdigTable`, and `saemControl(lbfgsLmm=5L)` errors with `unused argument:
'lbfgsLmm'`.  No fit result can change: the removed fields were never read.