### PR TITLE
Honor optExpression/sumProd for the final model each fit builds (#864)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -182,6 +182,15 @@
   observation was Gaussian and uncensored slipped past them and was fit with an
   objective FO does not support.
 
+- `optExpression=FALSE` (and `sumProd=TRUE`) are now honored for the last model
+  each fit builds: the EBE / Llik EBE models of the nlm-family estimators
+  (`bobyqa`, `newuoa`, `n1qn1`, `nlm`, `nlminb`, `optim`, `uobyqa`, `lbfgsb3c`,
+  `nls`) and `nlme`, plus the `saem` `predOnly` model.  The control was removed
+  from the model while finalizing the fit, before those models were built, so the
+  build read the defaults instead (issue #864).  This matters because
+  `optExpression=FALSE` is the workaround for a delay-differential model whose
+  `past()` duration is an expression.
+
 ### Crashes and stability
 
 - The shared solve pool's lhs-width probe could **segfault** instead of

--- a/R/nlmShared.R
+++ b/R/nlmShared.R
@@ -516,7 +516,7 @@
     .ui$ebe
   })
   # The control must stay on the ui until the EBE model is built; the build reads
-  # optExpression/sumProd/predMinusDv/eventSens off of it (#864)
+  # optExpression/sumProd/eventSens off of it (#864)
   if (exists("control", .ui)) {
     rm(list = "control", envir = .ui)
   }

--- a/R/nlmShared.R
+++ b/R/nlmShared.R
@@ -507,9 +507,6 @@
   .ret$extra <- if (is.function(extra)) extra(.control) else extra
   .nlmixr2FitUpdateParams(.ret)
   nmObjHandleControlObject(.ret$control, .ret)
-  if (exists("control", .ui)) {
-    rm(list = "control", envir = .ui)
-  }
   .ret$est <- method
   if (!is.null(objective)) {
     .ret$objective <- objective(.ret[[method]])
@@ -518,6 +515,11 @@
   .ret$model <- nlmixrWithTiming("setup", {
     .ui$ebe
   })
+  # The control must stay on the ui until the EBE model is built; the build reads
+  # optExpression/sumProd/predMinusDv/eventSens off of it (#864)
+  if (exists("control", .ui)) {
+    rm(list = "control", envir = .ui)
+  }
   .ret$ofvType <- method
   controlToFocei(.ret)
   .ret$theta <- .ret$ui$saemThetaDataFrame

--- a/R/nlme.R
+++ b/R/nlme.R
@@ -531,7 +531,7 @@ nmObjGetFoceiControl.nlme <- function(x, ...) {
   .ret$objective <- -2 * as.numeric(logLik(.ret$nlme))
   .ret$model <- .ui$ebe
   # The control must stay on the ui until the EBE model is built; the build reads
-  # optExpression/sumProd/predMinusDv/eventSens off of it (#864)
+  # optExpression/sumProd/eventSens off of it (#864)
   if (exists("control", .ui)) {
     rm(list="control", envir=.ui)
   }

--- a/R/nlme.R
+++ b/R/nlme.R
@@ -526,13 +526,15 @@ nmObjGetFoceiControl.nlme <- function(x, ...) {
   .ret$extra <- paste0(" by ", crayon::bold$yellow(ifelse(.control$method == "REML", "REML", "maximum likelihood")))
   .nlmixr2FitUpdateParams(.ret)
   nmObjHandleControlObject(.ret$control, .ret)
-  if (exists("control", .ui)) {
-    rm(list="control", envir=.ui)
-  }
   .ret$est <- "nlme"
   # There is no parameter history for nlme
   .ret$objective <- -2 * as.numeric(logLik(.ret$nlme))
   .ret$model <- .ui$ebe
+  # The control must stay on the ui until the EBE model is built; the build reads
+  # optExpression/sumProd/predMinusDv/eventSens off of it (#864)
+  if (exists("control", .ui)) {
+    rm(list="control", envir=.ui)
+  }
   .ret$est <- "nlme"
   .ret$ofvType <- "nlme"
   .nlmeControlToFoceiControl(.ret)

--- a/R/saem.R
+++ b/R/saem.R
@@ -1192,11 +1192,13 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
     .ui <- .ret$ui
     .saemAddParHist(.ret)
     .saemCalcLikelihood(.ret)
+    .ret$theta <- .ui$saemThetaDataFrame
+    .ret$model <- .ui$saemModelPred
+    # The control must stay on the ui until the predOnly model is built; the build
+    # reads optExpression/sumProd off of it (#864)
     if (is.environment(.ui) && exists("control", envir=.ui, inherits=FALSE)) {
       rm(list="control", envir=.ui)
     }
-    .ret$theta <- .ui$saemThetaDataFrame
-    .ret$model <- .ui$saemModelPred
     .ret$message <- "" # no message for now
     .ret$est <- "saem"
     .saemControlToFoceiControl(.ret)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -72,7 +72,8 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   c("focei-wang2007-boxcox-half", "nlm-cens", "issue-429", "issue-470",
     "focei-wang2007-bounded", "saem-loglik", "mu-timevarying", "saem-nearpd",
     "saem-nonmutheta", "focei-theta-reset-bounds",
-    "saem-cov-analytic", "focei-shi21-bounds", "splitbolus-interp"),
+    "saem-cov-analytic", "focei-shi21-bounds", "splitbolus-interp",
+    "optexpression-saem-nlme"),
 
   # batches 4-7 -- the former batches 4 (13 files) and 5 (15 files), each split
   # in two.  Both TIMED OUT on the weekly runner (run 30688874991, 2026-08-01):

--- a/tests/testthat/helper-quiet.R
+++ b/tests/testthat/helper-quiet.R
@@ -10,7 +10,9 @@
     suppressWarnings(nlmixr(...)),
     message = function(m) {
       .msg <<- c(.msg, conditionMessage(m))
-      invokeRestart("muffleMessage")
+      # tryInvokeRestart: a condition signaled with signalCondition() has no
+      # muffleMessage restart, and invokeRestart() would error on it
+      tryInvokeRestart("muffleMessage")
     })
   list(fit = .fit, msg = .msg)
 }

--- a/tests/testthat/helper-quiet.R
+++ b/tests/testthat/helper-quiet.R
@@ -2,6 +2,19 @@
   suppressWarnings(suppressMessages(nlmixr(...)))
 }
 
+# Fit while collecting the messages the run emitted; returns list(fit=, msg=).
+# Used to assert on the model-build messages (e.g. "duplicate expressions").
+.nlmixrMsg <- function(...) {
+  .msg <- character()
+  .fit <- withCallingHandlers(
+    suppressWarnings(nlmixr(...)),
+    message = function(m) {
+      .msg <<- c(.msg, conditionMessage(m))
+      invokeRestart("muffleMessage")
+    })
+  list(fit = .fit, msg = .msg)
+}
+
 # Drop-in replacement for set.seed() inside tests.  Sets the R RNG seed exactly
 # like set.seed(), but also snapshots the R and rxode2 RNG state and restores
 # both when the enclosing test (or calling frame) exits.  This keeps a test's

--- a/tests/testthat/test-optexpression-ebe.R
+++ b/tests/testthat/test-optexpression-ebe.R
@@ -36,4 +36,34 @@ nmTest({
     expect_false(any(grepl("duplicate expressions", .off$msg)))
     expect_false(grepl("rx_expr", rxode2::rxNorm(.off$fit$env$foceiModel$predOnly)))
   })
+
+  test_that("sumProd is honored for the nlm-family EBE model", {
+    oneCmt <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+
+    .on <- .nlmixrMsg(oneCmt, nlmixr2data::theo_sd, est = "bobyqa",
+                      control = bobyqaControl(sumProd = TRUE, optExpression = FALSE,
+                                              maxfun = 10, print = 0),
+                      table = tableControl(cwres = FALSE, npde = FALSE))
+    expect_true(any(grepl("stabilizing round off errors in predictions or EBE model",
+                          .on$msg)))
+    .txt <- rxode2::rxNorm(.on$fit$env$foceiModel$predOnly)
+    expect_true(grepl("prod(", .txt, fixed = TRUE))
+    expect_true(grepl("sum(", .txt, fixed = TRUE))
+  })
 })

--- a/tests/testthat/test-optexpression-ebe.R
+++ b/tests/testthat/test-optexpression-ebe.R
@@ -1,0 +1,39 @@
+nmTest({
+  # #864: the fit finalization removed the control from the ui before the
+  # EBE/predOnly model was built, so optExpression (and sumProd) silently fell
+  # back to the rxGetControl() defaults for that build.
+  test_that("optExpression is honored for the nlm-family EBE model", {
+    oneCmt <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+
+    .on <- .nlmixrMsg(oneCmt, nlmixr2data::theo_sd, est = "bobyqa",
+                      control = bobyqaControl(optExpression = TRUE, maxfun = 10,
+                                              print = 0),
+                      table = tableControl(cwres = FALSE, npde = FALSE))
+    expect_true(any(grepl("duplicate expressions in (Llik )?EBE model", .on$msg)))
+    expect_true(grepl("rx_expr", rxode2::rxNorm(.on$fit$env$foceiModel$predOnly)))
+
+    .off <- .nlmixrMsg(oneCmt, nlmixr2data::theo_sd, est = "bobyqa",
+                       control = bobyqaControl(optExpression = FALSE, maxfun = 10,
+                                               print = 0),
+                       table = tableControl(cwres = FALSE, npde = FALSE))
+    # the EBE model is still compiled ("compiling EBE model..."), just not rewritten
+    expect_false(any(grepl("duplicate expressions", .off$msg)))
+    expect_false(grepl("rx_expr", rxode2::rxNorm(.off$fit$env$foceiModel$predOnly)))
+  })
+})

--- a/tests/testthat/test-optexpression-saem-nlme.R
+++ b/tests/testthat/test-optexpression-saem-nlme.R
@@ -1,0 +1,70 @@
+nmTest({
+  # #864 for the two other estimators that build their final model after the
+  # control was dropped from the ui: saem (predOnly) and nlme (EBE).
+  .oneCmtEta <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.cl ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  test_that("optExpression is honored for the saem predOnly model", {
+    .on <- .nlmixrMsg(.oneCmtEta, nlmixr2data::theo_sd, est = "saem",
+                      control = saemControl(optExpression = TRUE, nBurn = 1, nEm = 1,
+                                            print = 0),
+                      table = tableControl(cwres = FALSE, npde = FALSE))
+    expect_true(any(grepl("duplicate expressions in saem predOnly model", .on$msg)))
+    expect_true(grepl("rx_expr", rxode2::rxNorm(.on$fit$env$saemModel$predOnly)))
+
+    .off <- .nlmixrMsg(.oneCmtEta, nlmixr2data::theo_sd, est = "saem",
+                       control = saemControl(optExpression = FALSE, nBurn = 1, nEm = 1,
+                                             print = 0),
+                       table = tableControl(cwres = FALSE, npde = FALSE))
+    expect_false(any(grepl("duplicate expressions", .off$msg)))
+    expect_false(grepl("rx_expr", rxode2::rxNorm(.off$fit$env$saemModel$predOnly)))
+  })
+
+  test_that("optExpression is honored for the nlme EBE model", {
+    oneCmtLin <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+
+    .on <- .nlmixrMsg(oneCmtLin, nlmixr2data::theo_sd, est = "nlme",
+                      control = nlmeControl(optExpression = TRUE, verbose = FALSE),
+                      table = tableControl(cwres = FALSE, npde = FALSE))
+    expect_true(any(grepl("duplicate expressions in (Llik )?EBE model", .on$msg)))
+    expect_true(grepl("rx_expr", rxode2::rxNorm(.on$fit$env$foceiModel$predOnly)))
+
+    .off <- .nlmixrMsg(oneCmtLin, nlmixr2data::theo_sd, est = "nlme",
+                       control = nlmeControl(optExpression = FALSE, verbose = FALSE),
+                       table = tableControl(cwres = FALSE, npde = FALSE))
+    expect_false(any(grepl("duplicate expressions", .off$msg)))
+    expect_false(grepl("rx_expr", rxode2::rxNorm(.off$fit$env$foceiModel$predOnly)))
+  })
+})


### PR DESCRIPTION
Fixes #864.

## The bug

`optExpression = FALSE` (and `sumProd = TRUE`) were silently ignored for the last
model a fit builds.  The fit finalization removes `control` from the ui, and it
did so *before* reading `.ui$ebe` / `.ui$saemModelPred`, so the build's
`rxode2::rxGetControl(ui, "optExpression", TRUE)` fell back to its default and
`rxOptExpr()` ran anyway:

```
-> finding duplicate expressions in EBE model...
-> optimizing duplicate expressions in EBE model...
```

This matters because `optExpression = FALSE` is the documented workaround for a
DDE model whose `past()` duration is an expression (nlmixr2/rxode2#1192).

## The fix

Move the `rm(list = "control", envir = .ui)` block to *after* that model build, in
all three places that have the ordering:

* `R/nlmShared.R` (`.nlmFamilyFitGeneric` -- `bobyqa`, `newuoa`, `n1qn1`, `nlm`,
  `nlminb`, `optim`, `uobyqa`, `lbfgsb3c`, `nls`), EBE / Llik EBE models
* `R/nlme.R`, EBE model
* `R/saem.R`, `predOnly` model (same leak, found while fixing the reported one)

Nothing between the old and new position touches the ui, and every estimator
entry point already has a top-level `on.exit()` that strips `control`, so an
exception in the build cannot leave it installed.  For a default control the
built model is unchanged -- only `optExpression`, `sumProd`, `eventSens` and the
`rxOptExpr(parallel=)` core count are read there, and their control defaults
match the getter defaults.

The FD and FOCEi outer-gradient models were checked and were already correctly
gated (they are built while the control is still present).

## Tests

* `tests/testthat/test-optexpression-ebe.R` (essential push/PR subset): a
  `bobyqa` fit with `optExpression = TRUE` vs `FALSE`, and one with
  `sumProd = TRUE`.  Asserts both the build messages and the built model text
  (`rx_expr` / `sum(`+`prod(` in `fit$env$foceiModel$predOnly`).
* `tests/testthat/test-optexpression-saem-nlme.R` (weekly, `.slowBatches` batch
  3): the same for `saem`'s `predOnly` model and `nlme`'s EBE model.

Verified against the released 7.0.2 that the `optExpression = FALSE` assertions
fail without the fix.  `test-nlm.R`, `test-nlme.R`, `test-nlme-control.R`,
`test-nls.R`, `test-optim.R`, `test-saem-mu.R`, `test-saem-theo_sd.R`,
`test-nlmixr2output.R` and `test-nlmsetup-fresh-rx.R` all pass.

Reviewed independently with Antigravity (gemini-3.1-pro-high) over three passes;
its two findings (sumProd had no coverage, and `invokeRestart()` in the new test
helper) are addressed in the last two commits.