### PR TITLE
fix(fsaem): build the inner combined1 to match the SAEM E-step (#874)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -139,6 +139,14 @@
   `combined2()` on such an endpoint -- which the control cannot override --
   degrades to standard SAEM instead (#874).
 
+- `est="fsaem"` no longer replaces the fit's own control while installing its
+  fast kernel.  The FOCEi inner behind the proposal was set up on the fit's `ui`
+  rather than a copy, so the `foceiControl` it installs there *became* the fit's
+  control: everything read from the control after that point saw the inner's
+  settings.  The visible consequence was that the teardown of the inner problem
+  is gated on `fast`, which the inner's control reports as `FALSE`, so the FOCEi
+  inner state was left standing after every fast fit instead of being freed.
+
 - `saem`'s uninformative-eta detection
   (`saemControl(handleUninformativeEtas=TRUE)`, the default) could freeze an eta
   that the data does inform.  The test asks whether perturbing an eta moves the

--- a/NEWS.md
+++ b/NEWS.md
@@ -129,6 +129,16 @@
   `covMethod="linFim"` (the default) is unaffected throughout; its `calc.COV()`
   linearization was always per-endpoint.
 
+- `est="fsaem"`'s Metropolis-Hastings proposal is now built against the residual
+  variance the SAEM chain actually uses.  The FOCEi inner behind the proposal was
+  built with the fit's `addProp`, whose default is `"combined2"`, while the SAEM
+  simulation step's residual standard deviation is unconditionally `"combined1"`
+  (`ares + bres*|f|`); on an `add()` + `prop()` model the kernel was therefore
+  preconditioned against a different variance than the chain it guides, costing
+  acceptance.  The inner is now always `"combined1"`, and a model that *declares*
+  `combined2()` on such an endpoint -- which the control cannot override --
+  degrades to standard SAEM instead (#874).
+
 - `saem`'s uninformative-eta detection
   (`saemControl(handleUninformativeEtas=TRUE)`, the default) could freeze an eta
   that the data does inform.  The test asks whether perturbing an eta moves the

--- a/R/fsaemInner.R
+++ b/R/fsaemInner.R
@@ -40,15 +40,19 @@
 #' Set up the FOCEi inner problem for the f-SAEM proposal at `ui`'s current
 #' ini() estimates.  Mirrors `.vaeInnerSetup` but keeps a live inner optimizer.
 #' Returns the setup env (keep alive until `.fsaemInnerFree()`).
+#'
+#' `copyUi=FALSE` says the caller's `ui` is already private to the inner.
 #' @noRd
-.fsaemInnerSetup <- function(ui, data, etaMat, control) {
-  # A PRIVATE copy.  The inner replaces $control with its own foceiControl, and
-  # rxUiDecompress hands back the SAME environment for an already-decompressed
-  # ui, so without the copy the fit's saemControl is gone for the rest of the
-  # run -- everything read from the control after the fast kernel is installed
-  # (addProp included, which the inner now deliberately sets differently) would
-  # come from the inner's control instead.
-  .ui <- rxode2::.copyUi(rxode2::rxUiDecompress(ui))
+.fsaemInnerSetup <- function(ui, data, etaMat, control, copyUi = TRUE) {
+  # The inner replaces $control with its own foceiControl, and rxUiDecompress
+  # hands back the SAME environment for an already-decompressed ui -- so on the
+  # fit's ui that control would BE the fit's for the rest of the run, and
+  # everything read from it after the fast kernel is installed (addProp
+  # included, which the inner now deliberately sets differently) would come from
+  # the inner instead.  The covariate path opts out: its ui is its own, and it
+  # re-enters here every iteration.
+  .ui <- rxode2::rxUiDecompress(ui)
+  if (copyUi) .ui <- rxode2::.copyUi(.ui)
   .fc <- .fsaemInnerFoceiControl(control)
   .fc$est <- "focei"
   .ui$control <- .fc

--- a/R/fsaemInner.R
+++ b/R/fsaemInner.R
@@ -42,7 +42,13 @@
 #' Returns the setup env (keep alive until `.fsaemInnerFree()`).
 #' @noRd
 .fsaemInnerSetup <- function(ui, data, etaMat, control) {
-  .ui <- rxode2::rxUiDecompress(ui)
+  # A PRIVATE copy.  The inner replaces $control with its own foceiControl, and
+  # rxUiDecompress hands back the SAME environment for an already-decompressed
+  # ui, so without the copy the fit's saemControl is gone for the rest of the
+  # run -- everything read from the control after the fast kernel is installed
+  # (addProp included, which the inner now deliberately sets differently) would
+  # come from the inner's control instead.
+  .ui <- rxode2::.copyUi(rxode2::rxUiDecompress(ui))
   .fc <- .fsaemInnerFoceiControl(control)
   .fc$est <- "focei"
   .ui$control <- .fc
@@ -113,6 +119,21 @@
   list(eta = .r$eta, gamma = .gamma, hess = .hess, ok = .r$ok)
 }
 
+#' Which endpoints really carry BOTH an additive and a proportional residual?
+#'
+#' combined1 and combined2 coincide unless both are present, so only these
+#' endpoints care which of the two the inner is built with.
+#' @return logical, one per `predDf` row
+#' @noRd
+.fsaemCombinedEndpoint <- function(ui) {
+  .pred <- ui$predDf
+  if (is.null(.pred) || length(.pred$cond) < 1L) return(logical(0))
+  vapply(.pred$cond, function(.cnd) {
+    .e <- ui$iniDf$err[which(ui$iniDf$condition == .cnd)]
+    any(.e %in% "add") && any(.e %in% "prop")
+  }, logical(1), USE.NAMES = FALSE)
+}
+
 #' Is `ui` within the current f-SAEM fast-kernel support envelope?
 #'
 #' The C++ side reconstructs the inner's theta as [population phi (constant across
@@ -152,11 +173,8 @@
   # degrade rather than mis-target.  Only a real add+prop endpoint cares: with
   # one of the two the two forms coincide.
   .ap <- as.character(.pred$addProp)
-  .combined <- vapply(.pred$cond, function(.cnd) {
-    .e <- ui$iniDf$err[which(ui$iniDf$condition == .cnd)]
-    any(.e %in% "add") && any(.e %in% "prop")
-  }, logical(1), USE.NAMES = FALSE)
-  if (any(.combined & !is.na(.ap) & !(.ap %in% c("default", "combined1")))) return(FALSE)
+  if (any(.fsaemCombinedEndpoint(ui) & !is.na(.ap) &
+          !(.ap %in% c("default", "combined1")))) return(FALSE)
   # mu-ref covariates are supported: non-time-varying ones are absorbed into the
   # per-subject mprior data, time-varying ones are kept as inner regressor betas
   # refreshed from the live Plambda each iteration.
@@ -213,6 +231,17 @@
   .iniDf <- ui$iniDf
   .neta <- sum(.iniDf$neta1 == .iniDf$neta2, na.rm = TRUE)
   .N <- length(unique(data[[if ("ID" %in% names(data)) "ID" else "id"]]))
+  # The SAEM E-step's residual SD is unconditionally combined1
+  # (g = ares + bres*|f|, src/saem.cpp), so the inner asks for combined1 rather
+  # than the fit's addProp; a combined2 inner would precondition the IMH kernel
+  # against a variance the chain it guides never uses.  Left at the fit's value
+  # when no endpoint is really add+prop: the two forms coincide there, and
+  # diverging from it would only cost the focei model cache a duplicate build.
+  .addProp <- if (any(.fsaemCombinedEndpoint(ui))) {
+    "combined1"
+  } else {
+    rxode2::rxGetControl(ui, "addProp", "combined2")
+  }
   .fc <- list(rxControl = rxControl,
               fastCov = rxode2::rxGetControl(ui, "fastCov", "auto"),
               fastLik = rxode2::rxGetControl(ui, "fastLik", "focei"),
@@ -220,11 +249,7 @@
               sumProd = rxode2::rxGetControl(ui, "sumProd", FALSE),
               optExpression = rxode2::rxGetControl(ui, "optExpression", TRUE),
               literalFix = rxode2::rxGetControl(ui, "literalFix", FALSE),
-              # NOT the user's addProp: the SAEM E-step's residual SD is
-              # unconditionally combined1 (g = ares + bres*|f|, src/saem.cpp),
-              # so an inner built combined2 would precondition the IMH kernel
-              # against a different variance than the chain it guides.
-              addProp = "combined1",
+              addProp = .addProp,
               eventSens = rxode2::rxGetControl(ui, "eventSens", "jump"),
               indTolRelax = rxode2::rxGetControl(ui, "indTolRelax", TRUE),
               maxOdeRecalc = rxode2::rxGetControl(ui, "maxOdeRecalc", 5L),

--- a/R/fsaemInner.R
+++ b/R/fsaemInner.R
@@ -145,6 +145,18 @@
   .err <- ui$iniDf$err
   .err <- .err[!is.na(.err)]
   if (!all(.err %in% c("add", "prop"))) return(FALSE)           # additive/proportional/combined residual
+  # The inner is built combined1 to match the E-step's residual SD, which the
+  # control can only impose on an endpoint that leaves addProp at "default".  An
+  # endpoint that DECLARES combined2 keeps it (the declaration wins over the
+  # control), so the proposal would score a variance the chain never uses --
+  # degrade rather than mis-target.  Only a real add+prop endpoint cares: with
+  # one of the two the two forms coincide.
+  .ap <- as.character(.pred$addProp)
+  .combined <- vapply(.pred$cond, function(.cnd) {
+    .e <- ui$iniDf$err[which(ui$iniDf$condition == .cnd)]
+    any(.e %in% "add") && any(.e %in% "prop")
+  }, logical(1), USE.NAMES = FALSE)
+  if (any(.combined & !is.na(.ap) & !(.ap %in% c("default", "combined1")))) return(FALSE)
   # mu-ref covariates are supported: non-time-varying ones are absorbed into the
   # per-subject mprior data, time-varying ones are kept as inner regressor betas
   # refreshed from the live Plambda each iteration.
@@ -208,7 +220,11 @@
               sumProd = rxode2::rxGetControl(ui, "sumProd", FALSE),
               optExpression = rxode2::rxGetControl(ui, "optExpression", TRUE),
               literalFix = rxode2::rxGetControl(ui, "literalFix", FALSE),
-              addProp = rxode2::rxGetControl(ui, "addProp", "combined2"),
+              # NOT the user's addProp: the SAEM E-step's residual SD is
+              # unconditionally combined1 (g = ares + bres*|f|, src/saem.cpp),
+              # so an inner built combined2 would precondition the IMH kernel
+              # against a different variance than the chain it guides.
+              addProp = "combined1",
               eventSens = rxode2::rxGetControl(ui, "eventSens", "jump"),
               indTolRelax = rxode2::rxGetControl(ui, "indTolRelax", TRUE),
               maxOdeRecalc = rxode2::rxGetControl(ui, "maxOdeRecalc", 5L),

--- a/R/fsaemInnerCov.R
+++ b/R/fsaemInnerCov.R
@@ -89,7 +89,10 @@
   .built <- .fsaemInnerMpriorUi(ui)
   .neta <- nrow(ui$muRefDataFrame)
   .data <- .fsaemSetMpriorData(data, mpriorMat, .built)
-  .env <- .fsaemInnerSetup(.built$ui, .data, matrix(0, nrow(mpriorMat), .neta), control)
+  # .built$ui is rebuilt from model text by .fsaemInnerMpriorUi, so it is the
+  # inner's own already -- no copy (this is re-entered every iteration).
+  .env <- .fsaemInnerSetup(.built$ui, .data, matrix(0, nrow(mpriorMat), .neta), control,
+                           copyUi = FALSE)
   # inner THETA vector template (residual + any time-varying betas), in the inner
   # ui's ntheta order; refreshed each iteration.
   .innerTheta <- .built$ui$iniDf
@@ -148,7 +151,7 @@
     }
   }
   setup$env <- .fsaemInnerSetup(setup$built$ui, .data, matrix(0, nrow(mpriorMat), setup$neta),
-                                setup$control)
+                                setup$control, copyUi = FALSE)
   .fsaemInnerUpdate(setup$env, .theta, omega, matrix(0, nrow(mpriorMat), setup$neta))
   invisible(setup)
 }

--- a/tests/testthat/test-fsaem-inner.R
+++ b/tests/testthat/test-fsaem-inner.R
@@ -110,4 +110,97 @@ nmTest({
     expect_lt(sum(abs(.tight)), sum(abs(.wide)))
     expect_gt(mean(abs(.tight) <= abs(.wide) + 1e-8), 0.6)
   })
+
+  # issue #874: the SAEM E-step's residual SD is unconditionally combined1
+  # (ares + bres*|f|), so the f-SAEM inner has to be built combined1 too or the
+  # IMH proposal is preconditioned against a variance the chain never uses.  A
+  # wrong proposal costs acceptance, not the estimate, so pin the inner itself.
+  test_that("fsaem inner is combined1 whatever addProp the fit asks for", {
+    skip_if_not_installed("nlmixr2data")
+
+    comb <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.3; prop.sd <- 0.1
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd) + prop(prop.sd)
+      })
+    }
+    .data <- nlmixr2data::theo_sd
+    .ui <- rxode2::rxUiDecompress(rxode2::rxode2(comb))
+    # combined2 is saemControl()'s default, i.e. what the inner used to inherit
+    .ui$control <- saemControl(addProp = "combined2", print = 0L, calcTables = FALSE)
+    .neta <- 3L
+    .N <- length(unique(.data$ID))
+
+    .cfg <- .fsaemInstallStep(.ui, .data, rxode2::rxControl(), list())
+    expect_false(is.null(.cfg$fsaemStep))
+    # the mechanism: the inner's own foceiControl, not the fit's addProp
+    expect_equal(.cfg$fsaemInnerEnv$control$addProp, "combined1")
+    .hessInstalled <- .fsaemInnerMap(list(rxControl = rxode2::rxControl()), .neta)$hess
+    .fsaemInnerFree()
+
+    # ...and the proposal precision it produces is the one a combined1 inner
+    # gives, not a combined2 one.  Compared against the inner built each way
+    # rather than an analytic Eq-17 -- the control has to survive the focei
+    # model cache, which keys on it, and reach the residual the MAP is scored
+    # against.
+    .innerHess <- function(addProp) {
+      .ctl <- list(rxControl = rxode2::rxControl(), fastCov = "jacobian", fastLik = "focei",
+                   fastInnerIt = 100L, sumProd = FALSE, optExpression = TRUE, literalFix = FALSE,
+                   addProp = addProp, eventSens = "jump", indTolRelax = TRUE,
+                   maxOdeRecalc = 5L, odeRecalcFactor = 10^0.5)
+      .fsaemInnerSetup(.ui, .data, matrix(0, .N, .neta), .ctl)
+      on.exit(.fsaemInnerFree(), add = TRUE)
+      .fsaemInnerMap(.ctl, .neta)$hess
+    }
+    .h1 <- .innerHess("combined1")
+    .h2 <- .innerHess("combined2")
+    expect_equal(.hessInstalled, .h1)
+    # the two residual forms really are distinguishable here (guards the guard)
+    expect_false(isTRUE(all.equal(.h1, .h2)))
+  })
+
+  test_that("a model DECLARING combined2 degrades instead of mis-targeting", {
+    # the control cannot override a model-level declaration, so such an endpoint
+    # falls back to standard SAEM rather than building a combined2 proposal
+    default <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.ka ~ 0.6; add.sd <- 0.3; prop.sd <- 0.1})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        linCmt() ~ add(add.sd) + prop(prop.sd)
+      })
+    }
+    declared1 <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.ka ~ 0.6; add.sd <- 0.3; prop.sd <- 0.1})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        linCmt() ~ add(add.sd) + prop(prop.sd) + combined1()
+      })
+    }
+    declared2 <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.ka ~ 0.6; add.sd <- 0.3; prop.sd <- 0.1})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        linCmt() ~ add(add.sd) + prop(prop.sd) + combined2()
+      })
+    }
+    .sup <- function(m) .fsaemSupported(rxode2::rxUiDecompress(rxode2::rxode2(m)))
+    expect_true(.sup(default))     # default -> the control makes it combined1
+    expect_true(.sup(declared1))   # declared, and it agrees with the E-step
+    expect_false(.sup(declared2))  # declared, and it does not
+
+    # a lone add() endpoint is unaffected: the two forms coincide there
+    addOnly <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.ka ~ 0.6; add.sd <- 0.3})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        linCmt() ~ add(add.sd) + combined2()
+      })
+    }
+    expect_true(.fsaemSupported(rxode2::rxUiDecompress(rxode2::rxode2(addOnly))))
+  })
 })

--- a/tests/testthat/test-fsaem-inner.R
+++ b/tests/testthat/test-fsaem-inner.R
@@ -140,6 +140,12 @@ nmTest({
     expect_false(is.null(.cfg$fsaemStep))
     # the mechanism: the inner's own foceiControl, not the fit's addProp
     expect_equal(.cfg$fsaemInnerEnv$control$addProp, "combined1")
+    # ...and the fit keeps ITS addProp.  The inner works on a copy of the ui; on
+    # the ui itself the foceiControl it installs would BE the fit's control for
+    # the rest of the run, so the M-step would silently follow the inner.
+    expect_s3_class(.ui$control, "saemControl")
+    expect_equal(.ui$control$addProp, "combined2")
+    expect_equal(as.integer(.ui$saemAddProp), 2L)
     .hessInstalled <- .fsaemInnerMap(list(rxControl = rxode2::rxControl()), .neta)$hess
     .fsaemInnerFree()
 
@@ -202,5 +208,21 @@ nmTest({
       })
     }
     expect_true(.fsaemSupported(rxode2::rxUiDecompress(rxode2::rxode2(addOnly))))
+
+    # ...and its inner keeps the fit's addProp rather than diverging for nothing:
+    # the focei model cache keys on addProp, so forcing combined1 where the two
+    # forms coincide would only buy a duplicate build of the same model.
+    skip_if_not_installed("nlmixr2data")
+    .ui <- rxode2::rxUiDecompress(rxode2::rxode2(function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.ka ~ 0.6; add.sd <- 0.3})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }))
+    .ui$control <- saemControl(addProp = "combined2", print = 0L, calcTables = FALSE)
+    .cfg <- .fsaemInstallStep(.ui, nlmixr2data::theo_sd, rxode2::rxControl(), list())
+    on.exit(.fsaemInnerFree(), add = TRUE)
+    expect_equal(.cfg$fsaemInnerEnv$control$addProp, "combined2")
   })
 })

--- a/tests/testthat/test-fsaem-inner.R
+++ b/tests/testthat/test-fsaem-inner.R
@@ -174,6 +174,36 @@ nmTest({
     expect_false(isTRUE(all.equal(.h1, .h2)))
   })
 
+  test_that("the covariate inner is combined1 too, and leaves the fit alone", {
+    skip_if_not_installed("nlmixr2data")
+    # the covariate path builds its inner on a ui rebuilt from model text
+    # (.fsaemInnerMpriorUi), so it takes no copy -- check that ui really is its
+    # own and that the residual form still follows the E-step
+    covMod <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.3; prop.sd <- 0.1
+        dclWt <- 0.75
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl + dclWt * WT)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd) + prop(prop.sd)
+      })
+    }
+    .ui <- rxode2::rxUiDecompress(rxode2::rxode2(covMod))
+    .ui$control <- saemControl(fast = TRUE, addProp = "combined2", print = 0L,
+                               calcTables = FALSE)
+    expect_true(nrow(.ui$muRefCovariateDataFrame) > 0L)
+    .cfg <- .fsaemInstallStep(.ui, nlmixr2data::theo_sd, rxode2::rxControl(), list())
+    on.exit(.fsaemInnerFree(), add = TRUE)
+    expect_equal(.cfg$fsaemInnerEnv$control$addProp, "combined1")
+    expect_s3_class(.ui$control, "saemControl")
+    expect_true(rxode2::rxGetControl(.ui, "fast", FALSE))
+  })
+
   test_that("a model DECLARING combined2 degrades instead of mis-targeting", {
     # the control cannot override a model-level declaration, so such an endpoint
     # falls back to standard SAEM rather than building a combined2 proposal

--- a/tests/testthat/test-fsaem-inner.R
+++ b/tests/testthat/test-fsaem-inner.R
@@ -132,7 +132,8 @@ nmTest({
     .data <- nlmixr2data::theo_sd
     .ui <- rxode2::rxUiDecompress(rxode2::rxode2(comb))
     # combined2 is saemControl()'s default, i.e. what the inner used to inherit
-    .ui$control <- saemControl(addProp = "combined2", print = 0L, calcTables = FALSE)
+    .ui$control <- saemControl(fast = TRUE, addProp = "combined2", print = 0L,
+                               calcTables = FALSE)
     .neta <- 3L
     .N <- length(unique(.data$ID))
 
@@ -146,6 +147,9 @@ nmTest({
     expect_s3_class(.ui$control, "saemControl")
     expect_equal(.ui$control$addProp, "combined2")
     expect_equal(as.integer(.ui$saemAddProp), 2L)
+    # the inner teardown after a fast fit is gated on this read, and a
+    # foceiControl answers FALSE
+    expect_true(rxode2::rxGetControl(.ui, "fast", FALSE))
     .hessInstalled <- .fsaemInnerMap(list(rxControl = rxode2::rxControl()), .neta)$hess
     .fsaemInnerFree()
 


### PR DESCRIPTION
Fixes #874.  Stacked on #852 (`feat/fsaem-restore`).

## The mismatch

The SAEM E-step's per-observation residual SD is unconditionally **combined1**:

```cpp
_scratch_g = vecares + vecbres % abs(_scratch_ftT);   // src/saem.cpp, 6 sites
```

but the f-SAEM inner -- whose FOCEi information matrix *is* the independent
Metropolis-Hastings proposal precision -- was built with the fit's `addProp`,
which defaults to `"combined2"`.  On an `add()` + `prop()` model the kernel was
therefore preconditioned against a variance the chain it guides never uses.
That costs acceptance, not correctness, which is exactly why nothing at fit
level would show it.

## What changed

- **`.fsaemInstallStep`** builds the inner `"combined1"`.  Only when some
  endpoint really carries both `add()` and `prop()` (`.fsaemCombinedEndpoint`):
  with one of the two the forms coincide, and diverging from the fit's value
  would only cost the focei model cache -- which keys on `addProp` -- a
  duplicate build of an identical model.
- **`.fsaemSupported`** rejects a model that *declares* `combined2()` on such an
  endpoint.  A model-level declaration wins over the control, so the inner
  cannot be moved; the fit degrades to standard SAEM rather than mis-target,
  which is what this function already does for a declared omega off-diagonal and
  for out-of-order endpoints.

### Found while fixing it: the inner was replacing the fit's control

`.fsaemInnerSetup` did `.ui <- rxUiDecompress(ui); .ui$control <- .fc`, and
`rxUiDecompress` hands back the **same environment** for an already-decompressed
ui -- so the inner's `foceiControl` *became* the fit's for the rest of the run.
Measured on a real `est="fsaem"` fit, before and after:

```
PROBE control class before: saemControl
PROBE control class after : foceiControl     # was: saemControl
PROBE fast after          : FALSE            # was: TRUE
```

The teardown of the inner problem at the end of a fast fit is gated on that
`fast` read, so `vaeInnerFree_()` never ran and the FOCEi inner state was left
standing after every fast fit.  It also would have flipped `ui$saemAddProp` from
2 to 1 once the inner started asking for a different `addProp`.  The inner now
works on `.copyUi()` of the ui; the covariate path opts out (`copyUi = FALSE`),
since its ui is rebuilt from model text by `.fsaemInnerMpriorUi` and it
re-enters the setup every iteration.

## Tests

`tests/testthat/test-fsaem-inner.R` (essential, not batched):

- the installed inner's control is `combined1` while the fit asked for
  `combined2`, and the proposal precision it produces equals the one an inner
  built `combined1` gives and differs from the `combined2` one -- compared
  against the inner built each way rather than an analytic Eq-17, so the control
  has to survive the focei model cache and reach the residual the MAP is scored
  against;
- the fit's `ui` keeps its `saemControl`, its `addProp`, its `saemAddProp` and
  its `fast` (the teardown gate) across the install, on both the plain and the
  covariate path;
- `.fsaemSupported` accepts a default or declared-`combined1` add+prop endpoint,
  rejects a declared-`combined2` one, and still accepts a lone `add()` endpoint
  that declares `combined2()`;
- an add-only model's inner keeps the fit's `addProp` (no gratuitous cache miss).

Full fsaem suite: `test-fsaem.R` 141 pass, `test-fsaem-multi.R` 42,
`test-fsaem-es.R` 15, `test-fsaem-imh.R` 13, `test-fsaem-inner.R` 48 -- 0 failures.

## Not fixed here

`saem` honours `addProp` in the M-step (`_saemAddProp`) while its E-step
hardcodes combined1, for plain `saem` as much as fsaem.  Aligning the inner
makes the kernel consistent with the chain but leaves that in place; #874 itself
says it is worth its own issue.