### PR TITLE
fix(fsaem): map each structural theta to its own phi column (#875)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -139,6 +139,27 @@
   `combined2()` on such an endpoint -- which the control cannot override --
   degrades to standard SAEM instead (#874).
 
+- `est="fsaem"` now builds its Metropolis-Hastings proposal at the fit's own
+  population parameters when the model has a parameter the SAEM phi vector does
+  not line up with positionally.  The fast kernel filled the FOCEi inner's
+  `THETA` by walking the structural thetas and the phi columns in parallel, and
+  that pairing breaks three ways: a non-mu eta (every **IOV** eta is one) appends
+  a phi column with no theta, a `fix()`ed theta keeps its phi column but leaves
+  the structural list, and a theta with no eta shifts every later index.  The
+  inner was then handed some other parameter's value -- an IOV model got
+  `iov sd = 0`, an IOV model with a no-eta theta got `V = 1`, and a `fix()`ed
+  `tcl` gave `tv` tcl's fixed value -- which costs acceptance and moves the
+  target without erroring.  Each structural theta is now matched to its own phi
+  column by name; on an IOV model with a no-eta theta the acceptance rate goes
+  from 0.50 to 0.89 (#875).
+
+- `est="fsaem"` on a model with **both a mu-referenced covariate and an IOV**
+  (or any other non-mu) eta ran the standard SAEM kernel instead of aborting the
+  fit.  The covariate proposal's inner absorbs each mu-referenced intercept into
+  a per-subject data column and is sized from those, so an eta with no such
+  column left it short and the fit died with "etaMat must have the same number
+  of ETAs (cols) as the model" (#875).
+
 - `est="fsaem"` no longer replaces the fit's own control while installing its
   fast kernel.  The FOCEi inner behind the proposal was set up on the fit's `ui`
   rather than a copy, so the `foceiControl` it installs there *became* the fit's

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,7 +41,9 @@
 
 - `est="saem"` fits now carry `fit$saemDiag`, the per-kernel Metropolis proposal
   and acceptance counts; `est="fsaem"` fits also carry `fit$fsaemDiag` with the
-  fast kernel's own step, proposal, acceptance and failure counts.
+  fast kernel's own step, proposal, acceptance and failure counts, plus
+  `lastTheta`, the inner `THETA` the last fast step was built with (the counts
+  show the kernel fired; only `lastTheta` shows what it was fired at).
 
 - Requires `rxode2` (>= 5.1.7).  The compatibility layer that also let this
   package build and run against 5.1.5 has been removed, so the event-sensitivity

--- a/R/fsaemInner.R
+++ b/R/fsaemInner.R
@@ -187,12 +187,13 @@
 
 #' Build the f-SAEM fast-simulation step for a SAEM fit and attach it to `cfg`.
 #'
-#' Sets up the FOCEi inner once and returns a closure the C++ SAEM loop calls
-#' each fast iteration with the current estimate.  The closure re-parameterizes
-#' the inner (theta = [structural fixed effects, residual] in THETA order; omega
-#' = current diagonal), optimizes the per-subject MAP + proposal covariance, and
-#' runs the independent Metropolis-Hastings kernel over the chains.
-#' @return `cfg` with `$fsaemStep` (closure) and `$fsaemInnerEnv` (keep-alive).
+#' Sets up the FOCEi inner once so the C++ SAEM loop can re-parameterize it each
+#' fast iteration (theta = [structural fixed effects, residual] in THETA order;
+#' omega = current diagonal), optimize the per-subject MAP + proposal
+#' covariance, and run the independent Metropolis-Hastings kernel over the
+#' chains.  The covariate path additionally needs an R closure (`$fsaemStep`)
+#' because its inner is rebuilt from data each iteration.
+#' @return `cfg` with the fast-kernel fields and `$fsaemInnerEnv` (keep-alive).
 #' @noRd
 #' Phi1 (random-effect) parameter bounds in inner-eta order, from the mu-ref
 #' theta iniDf bounds (the same bounds L-BFGS-B uses for phi0).  Used to keep the
@@ -314,12 +315,20 @@
                        c("ntheta", "name", "est", "fix", "err", "condition")]
   .thetaDf <- .thetaDf[order(.thetaDf$ntheta), ]
   .nTheta <- nrow(.thetaDf)
-  # Only ESTIMATED structural thetas have a phi: a fix()ed one is not in
-  # phi1/phi0, so counting it here made length(structPos) exceed nphi1 + nphi0,
-  # tripped the C++ length guard, and filled EVERY structural slot from the
-  # fallback.  The fixed theta also has to keep its own value, which is why the
-  # inner theta is seeded from the ini estimates rather than from zeros.
+  # A fix()ed theta keeps its own value, which is why the inner theta is seeded
+  # from the ini estimates rather than from zeros.
   .structPos <- which(is.na(.thetaDf$err) & !.thetaDf$fix)
+  # Which SAEM phi column holds each of those thetas' population value.  Matched
+  # BY NAME against the phi vector, because position does not survive: a
+  # nonMuEta (every IOV eta is one) appends phi columns that have no theta, a
+  # fix()ed theta keeps its phi column but leaves .structPos, and a phi0 shifts
+  # the phi1 indices.  All three made the inner read some other parameter's
+  # population value -- IOV handed the inner iov sd = 0 (#875).  Matching the
+  # phi NAMES is not the muRefDataFrame route: this is the phi vector itself,
+  # which follows ini (ntheta) order, so a mu-ref model maps to the identity.
+  .structPhi <- match(.thetaDf$name[.structPos], ui$saemParamsToEstimateCov)
+  .structPos <- .structPos[!is.na(.structPhi)]
+  .structPhi <- .structPhi[!is.na(.structPhi)]
   .residPos <- which(!is.na(.thetaDf$err))
   .residIsAdd <- .thetaDf$err[.residPos] == "add"
   .residEp <- match(.thetaDf$condition[.residPos], ui$predDf$cond) # 1-based endpoint
@@ -327,31 +336,14 @@
   .lower <- if (is.null(.bounds)) numeric(0) else as.numeric(.bounds$lower)
   .upper <- if (is.null(.bounds)) numeric(0) else as.numeric(.bounds$upper)
   .nbd   <- if (is.null(.bounds)) integer(0) else as.integer(.bounds$nbd)
-  cfg$fsaemStep <- function(mpriorMat, ares, bres, omega, plambda, etaCur, nchain, kiter, nsweep = .nsweep) {
-    .theta <- as.numeric(.thetaDf$est)     # fix()ed thetas keep their value
-    .theta[.structPos] <- mpriorMat[1, seq_along(.structPos)]
-    if (length(.residPos)) {
-      .theta[.residPos] <- ifelse(.residIsAdd, ares[.residEp], bres[.residEp])
-    }
-    .cores <- as.integer(rxode2::getRxThreads())
-    if (is.na(.cores) || .cores < 1L) .cores <- 1L
-    # whole per-iteration orchestration in C++ (inner update + MAP + IMH)
-    fsaemStepCpp_(.env, as.numeric(.theta), as.numeric(omega), mpriorMat, etaCur,
-                  as.integer(nchain), as.integer(nsweep), .cores,
-                  .lower, .upper, .nbd, as.double(.seed), as.integer(.nRetry),
-                  as.integer(kiter))
-  }
-  # C++-native direct-call fields: the SAEM C++ loop calls fsaemStepCpp_ itself
-  # (no per-iteration Rcpp::Function round-trip), which is safe for dynamic
-  # iteration changes.  The closure above is retained for the covariate path.
+  # C++-native direct-call fields: the SAEM C++ loop builds the inner theta and
+  # calls fsaemStepCpp_ itself (no per-iteration Rcpp::Function round-trip),
+  # which is what makes a dynamic iteration count safe.  There is deliberately
+  # no R closure on this path -- a second copy of the phi -> theta map is a
+  # second place to get it wrong, and it carried the pre-#875 positional read.
   cfg$fsaemNoCov      <- 1L
-  # phiPop is read POSITIONALLY (phi column j <-> structural theta j) and that is
-  # correct: the phi vector follows the ini (ntheta) order, the same order
-  # .structPos is built in.  It is NOT the eta order -- ui$muRefDataFrame can
-  # disagree with ini() -- and mapping through muRefDataFrame instead collapses
-  # the acceptance rate from 0.88 to 0.02 on a model whose ini() and eta orders
-  # differ, which is what pins this down.  See the permuted-ini regression test.
   cfg$fsaemStructPos  <- as.integer(.structPos - 1L)
+  cfg$fsaemStructPhi  <- as.integer(.structPhi - 1L)
   cfg$fsaemThetaIni   <- as.numeric(.thetaDf$est)
   cfg$fsaemResidPos   <- as.integer(.residPos - 1L)
   cfg$fsaemResidIsAdd <- as.integer(.residIsAdd)

--- a/R/fsaemInner.R
+++ b/R/fsaemInner.R
@@ -339,8 +339,13 @@
   # phi NAMES is not the muRefDataFrame route: this is the phi vector itself,
   # which follows ini (ntheta) order, so a mu-ref model maps to the identity.
   .structPhi <- match(.thetaDf$name[.structPos], ui$saemParamsToEstimateCov)
-  .structPos <- .structPos[!is.na(.structPhi)]
-  .structPhi <- .structPhi[!is.na(.structPhi)]
+  if (anyNA(.structPhi)) {
+    # nothing reaching here should hit this (mixtures and the covariate path are
+    # already handled), but leaving such a theta at its ini value silently would
+    # be the very failure #875 was
+    .minfo("fast kernel: a structural theta has no phi; running standard SAEM")
+    return(cfg)
+  }
   .residPos <- which(!is.na(.thetaDf$err))
   .residIsAdd <- .thetaDf$err[.residPos] == "add"
   .residEp <- match(.thetaDf$condition[.residPos], ui$predDf$cond) # 1-based endpoint

--- a/R/fsaemInner.R
+++ b/R/fsaemInner.R
@@ -263,10 +263,14 @@
   if (identical(.fc$fastCov, "auto")) {
     .fc$fastCov <- if (all(ui$predDf$distribution == "norm")) "jacobian" else "hessian"
   }
-  # bound-respecting reproducible IMH proposals (threefry seeded by the SAEM seed).
-  # Boundary clamping is ONLY for general log-likelihood models: for normal
-  # (add/prop/combined) data the residual error optimizer does the clamping, so
-  # the IMH proposal stays unconstrained there.
+  # Reproducible IMH proposals (threefry seeded by the SAEM seed), optionally
+  # bounded.  In practice the bound vectors come back all-zero (nbd = 0): fsaem
+  # is an "unbounded" method, so preProcessBoundedTransform has already rewritten
+  # every finite structural-theta bound into an unconstrained internal parameter
+  # by the time the kernel is installed, and the bound is then enforced by the
+  # back-transform rather than by the proposal.  Kept for the general-likelihood
+  # family, whose thetas the kernel scores directly; the kernel's own clamping is
+  # covered in test-fsaem-imh.R.
   .bounds <- if (.saemAnyGeneralLik(ui)) .fsaemPhi1Bounds(ui) else NULL
   .seed <- as.integer(rxode2::rxGetControl(ui, "seed", 99))
   .nRetry <- as.integer(rxode2::rxGetControl(ui, "nRetry", 10L))
@@ -280,6 +284,14 @@
                                 "chainMean")),
     hRefresh = as.integer(rxode2::rxGetControl(ui, "fastHRefresh", 1L))))
   .hasCov <- !is.null(ui$muRefCovariateDataFrame) && nrow(ui$muRefCovariateDataFrame) > 0L
+  if (.hasCov && nrow(ui$muRefDataFrame) != .neta) {
+    # The covariate inner absorbs each mu-ref intercept into a per-subject data
+    # column, so it is sized by muRefDataFrame -- an eta with no mu-ref row (a
+    # nonMuEta; every IOV eta is one) leaves the inner short of etas and the
+    # setup dies on "etaMat must have the same number of ETAs".  Degrade.
+    .minfo("fast kernel needs mu-ref etas with covariates; running standard SAEM")
+    return(cfg)
+  }
   if (.hasCov) {
     # Covariate path: the time-invariant covariate effect is absorbed into the
     # per-subject prior mean, so the inner is built on the mprior-as-data model

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -16161,6 +16161,10 @@ static double _fsaemNBadGamma = 0;  // subjects with no usable proposal covarian
 static double _fsaemNMapReuse = 0;  // steps that reused a cached MAP + Gamma
 static double _fsaemNPriorFallback = 0; // bad-Gamma subjects rescued by the prior
 static double _fsaemNBoundFail = 0;     // proposals abandoned after nRetry out-of-bounds draws
+// The inner THETA the last no-covariate step was re-parameterized with.  The
+// counters prove the kernel fired; only this shows it was handed the RIGHT
+// population values (issue #875), which is what a wrong phi -> theta map breaks.
+static std::vector<double> _fsaemLastTheta;
 
 // fastHRefresh cache: the MAP centres and proposal Choleskys from the last step
 // that actually recomputed them.  Only the MAP optimization and the inv/chol are
@@ -16223,6 +16227,7 @@ RObject fsaemDiagReset_() {
   _fsaemNMapReuse = 0;
   _fsaemNPriorFallback = 0;
   _fsaemNBoundFail = 0;
+  _fsaemLastTheta.clear();
   fsaemCacheClear();
   // the options are per-fit too: a later fit must not inherit the previous one's
   fsaemResetOpts();
@@ -16238,7 +16243,8 @@ List fsaemDiag_() {
                       _["nBadGamma"] = _fsaemNBadGamma,
                       _["nMapReuse"] = _fsaemNMapReuse,
                       _["nPriorFallback"] = _fsaemNPriorFallback,
-                      _["nBoundFail"] = _fsaemNBoundFail);
+                      _["nBoundFail"] = _fsaemNBoundFail,
+                      _["lastTheta"] = wrap(_fsaemLastTheta));
 }
 
 // f-SAEM (Karimi, Lavielle & Moulines 2020) proposal builder: for each physical
@@ -16589,6 +16595,7 @@ NumericMatrix fsaemStepCpp_(Environment env, NumericVector theta, NumericVector 
                             IntegerVector nbd, double seed, int nRetry, int kiter) {
   // ---- re-parameterize the inner (mirror .fsaemInnerUpdate) ----
   int nth = theta.size();
+  _fsaemLastTheta.assign(theta.begin(), theta.end());
   NumericVector th = clone(theta);
   CharacterVector thNames(nth);
   for (int i = 0; i < nth; ++i) thNames[i] = "THETA[" + std::to_string(i + 1) + "]";

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -681,6 +681,10 @@ public:
 
   ~SAEM() {}
 
+  // Is the f-SAEM fast kernel installed?  The no-covariate path is driven from
+  // C++ (fsaemNoCov) and has no R closure; the covariate path is the closure.
+  bool fsaemInstalled() { return fsaemNoCov != 0 || !Rf_isNull(fsaemStepFn); }
+
   // Total observation -log-likelihood at candidate fixed-effect (phi0) values p,
   // holding the current phi1 samples fixed (general-likelihood / distribution==4:
   // the model prediction column is the per-observation log-likelihood).  Summed
@@ -922,7 +926,7 @@ public:
     if (fixedIx0.n_elem > 0) mcov0Fixed = vec(MCOV0(jcov0(fixedIx0)));
     // If the fast kernel re-pointed the global solve to the FOCEi inner, restore
     // the SAEM (N*nmc) solve before the direct-optim user_fn calls.
-    if (!Rf_isNull(fsaemStepFn)) {
+    if (fsaemInstalled()) {
       fsaemRestoreSaemSolve(fsaemSaemOpt, fsaemSaemEvt, nmc, N);
     }
     // Decide whether to freeze the ODE during the phi0 optimization.  General-
@@ -1288,17 +1292,22 @@ public:
       fsaemFastKernel = as<std::string>(x["fastKernel"]);
       fsaemFastCov = as<std::string>(x["fastCov"]);
       fsaemFastLik = as<std::string>(x["fastLik"]);
-      if (x.containsElementNamed("fsaemStep")) {
-        fsaemStepFn = x["fsaemStep"];
-        fsaemSaemOpt = as<List>(x["opt"]);
-        fsaemSaemEvt = x["evt"];
-      }
+      if (x.containsElementNamed("fsaemStep")) fsaemStepFn = x["fsaemStep"];
       // C++-native direct-call fields (no-covariate path): the loop calls
       // fsaemStepCpp_ itself, with no per-iteration Rcpp::Function round-trip.
       fsaemNoCov = x.containsElementNamed("fsaemNoCov") ? as<int>(x["fsaemNoCov"]) : 0;
+      if (fsaemInstalled()) {
+        // needed by BOTH paths: the fast step re-points the global solve to the
+        // FOCEi inner, and this is what puts the SAEM solve back
+        fsaemSaemOpt = as<List>(x["opt"]);
+        fsaemSaemEvt = x["evt"];
+      }
       if (fsaemNoCov) {
         fsaemInnerEnv   = x["fsaemInnerEnv"];
         fsaemStructPos  = as<ivec>(x["fsaemStructPos"]);
+        fsaemStructPhi  = as<ivec>(x["fsaemStructPhi"]);
+        if (fsaemStructPhi.n_elem != fsaemStructPos.n_elem)
+          stop("fsaem: the structural theta -> phi map is the wrong length");
         fsaemThetaIni   = x.containsElementNamed("fsaemThetaIni") ?
           as<vec>(x["fsaemThetaIni"]) : vec();
         fsaemResidPos   = as<ivec>(x["fsaemResidPos"]);
@@ -1435,6 +1444,10 @@ public:
     nlambda = nlambda1 + nlambda0;
     nb_param = nphi1 + nlambda + 1;
     nphi = nphi1+nphi0;
+    // fsaemStructPhi indexes the phi vector, whose length is only known now
+    for (arma::uword _j = 0; _j < fsaemStructPhi.n_elem; _j++)
+      if (fsaemStructPhi(_j) < 0 || fsaemStructPhi(_j) >= nphi)
+        stop("fsaem: the structural theta -> phi map is out of range");
     Plambda.zeros(nlambda);
     ilambda1 = as<uvec>(x["ilambda1"]);
     ilambda0 = as<uvec>(x["ilambda0"]);
@@ -2496,7 +2509,7 @@ public:
         // likelihood (distribution==4) the IMH proposal is already the calibrated
         // posterior kernel, so it REPLACES the phi1 random walk: running both
         // stacks extra exploration and inflates the between-subject variance.
-        bool imhFired = (fsaemActive && nphi1 > 0 && !Rf_isNull(fsaemStepFn));
+        bool imhFired = (fsaemActive && nphi1 > 0 && fsaemInstalled());
         bool imhReplacesRwm = (imhFired && distribution == 4);
         if (imhFired) {
           fsaemImhStep(phiM, (int)kiter);
@@ -3704,7 +3717,7 @@ private:
   int fsaemNoCov = 0;
   RObject fsaemInnerEnv = R_NilValue;
   vec fsaemThetaIni;
-  ivec fsaemStructPos, fsaemResidPos, fsaemResidEp, fsaemResidIsAdd, fsaemNbdVec;
+  ivec fsaemStructPos, fsaemStructPhi, fsaemResidPos, fsaemResidEp, fsaemResidIsAdd, fsaemNbdVec;
   vec fsaemLower, fsaemUpper;
   int fsaemNTheta = 0, fsaemNsweep = 5, fsaemNRetry = 10, fsaemCores = 1;
 
@@ -3972,14 +3985,15 @@ private:
     arma::vec phiPop(nphi1 + nphi0, arma::fill::zeros);
     for (int k = 0; k < nphi1; k++) phiPop(i1(k)) = mprior_phi1(0, k);
     for (int k = 0; k < nphi0; k++) phiPop(i0(k)) = mprior_phi0(0, k);
-    // phi column j IS structural theta j: the phi vector follows the ini (ntheta)
-    // order that fsaemStructPos is built in, not the eta order.  Verified by
-    // construction: routing through ui$muRefDataFrame instead drops acceptance from
-    // 0.88 to 0.02 when ini() and the eta declarations disagree.
-    bool phiPopOk = ((int)fsaemStructPos.n_elem == nphi1 + nphi0);
+    // fsaemStructPhi(j) is the phi column holding structural theta
+    // fsaemStructPos(j)'s population value, matched by NAME in R.  The map is
+    // the identity for a plain mu-referenced model, but the phi vector is NOT a
+    // positional copy of the structural thetas: nonMuEtas (every IOV eta) append
+    // phi columns with no theta, and a fix()ed theta keeps its phi column while
+    // leaving the structural set.  Reading it positionally handed the inner
+    // another parameter's value -- IOV sd = 0, or a phi0 theta = 0 (#875).
     for (int j = 0; j < (int)fsaemStructPos.n_elem; j++)
-      theta[fsaemStructPos(j)] =
-        phiPopOk ? phiPop((arma::uword)j) : mprior_phi1(0, std::min(j, nphi1 - 1));
+      theta[fsaemStructPos(j)] = phiPop((arma::uword)fsaemStructPhi(j));
     for (int j = 0; j < (int)fsaemResidPos.n_elem; j++) {
       int ep = fsaemResidEp(j);
       theta[fsaemResidPos(j)] = fsaemResidIsAdd(j) ? ares(ep) : bres(ep);

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -89,7 +89,7 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   c("focei-wang2007-boxcox-lnorm", "nlme-cov", "agq-fast-grad",
     "focei-ll-fast-grad-fit", "focei-fast-methods-fit", "odeswap-fit"),
   # batch 6
-  c("focei-llik", "iov", "iov-zero-eta", "saem-mix", "saem-mix-regress",
+  c("focei-llik", "iov", "iov-zero-eta", "fsaem-iov", "saem-mix", "saem-mix-regress",
     "posthoc", "ar-est", "mu-family", "uninformative-etas-revisit"),
   # batch 7
   c("mu-plain-fit", "vae-fit", "focei-wang2007-basic", "vae-neonatal",

--- a/tests/testthat/test-fsaem-inner.R
+++ b/tests/testthat/test-fsaem-inner.R
@@ -138,7 +138,10 @@ nmTest({
     .N <- length(unique(.data$ID))
 
     .cfg <- .fsaemInstallStep(.ui, .data, rxode2::rxControl(), list())
-    expect_false(is.null(.cfg$fsaemStep))
+    # the fast kernel really was installed (the no-covariate path is driven from
+    # C++ and carries no R closure)
+    expect_equal(.cfg$fsaemNoCov, 1L)
+    expect_false(is.null(.cfg$fsaemInnerEnv))
     # the mechanism: the inner's own foceiControl, not the fit's addProp
     expect_equal(.cfg$fsaemInnerEnv$control$addProp, "combined1")
     # ...and the fit keeps ITS addProp.  The inner works on a copy of the ui; on

--- a/tests/testthat/test-fsaem-iov.R
+++ b/tests/testthat/test-fsaem-iov.R
@@ -1,0 +1,138 @@
+nmTest({
+  # f-SAEM with non-mu etas (issue #875).  Every IOV eta is a nonMuEta, and a
+  # nonMuEta appends a phi column that has no theta -- so the SAEM phi vector
+  # stops being a positional copy of the structural thetas and the fast kernel's
+  # inner THETA has to be filled by NAME.  fsaemDiag()$lastTheta is the inner
+  # THETA the last fast step was built with; the counters alone cannot see a
+  # mis-parameterized inner (it costs acceptance, it does not crash).
+
+  .iovData <- function() {
+    .d <- nlmixr2data::theo_md
+    .d$occ <- 1
+    .d$occ[.d$TIME >= 144] <- 2
+    .d
+  }
+
+  .iovCtl <- function() {
+    saemControl(nBurn = 60, nEm = 30, nmc = 3, seed = 42, print = 0L,
+                calcTables = FALSE)
+  }
+
+  test_that("est='fsaem' fits an IOV model and keeps the inner's IOV sd live", {
+    skip_if_not_installed("nlmixr2data")
+    # Every structural theta is mu-referenced here, so the mu-ref slots line up
+    # positionally by accident.  The IOV magnitude theta does NOT: it is a phi0,
+    # and the positional read handed the inner the prior mean of a nonMuEta phi
+    # column -- identically 0 for every iteration, i.e. an inner with no IOV.
+    .iov <- function() {
+      ini({
+        tka <- log(1.2); tcl <- log(0.25); tv <- log(5)
+        eta.ka ~ 0.1; eta.cl ~ 0.09; eta.v ~ 0.05
+        iov.cl ~ 0.05 | occ
+        prop.sd <- 0.15
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl + iov.cl)
+        v  <- exp(tv + eta.v)
+        d/dt(depot) <- -ka*depot
+        d/dt(central) <- ka*depot - cl/v*central
+        cp <- central/v
+        cp ~ prop(prop.sd)
+      })
+    }
+    .d <- .iovData()
+    .fs <- suppressMessages(nlmixr2(.iov, .d, est = "fsaem", control = .iovCtl()))
+    .ss <- suppressMessages(nlmixr2(.iov, .d, est = "saem", control = .iovCtl()))
+
+    # the fast kernel really ran, and ran healthily
+    expect_gt(.fs$fsaemDiag$nStep, 0)
+    expect_gt(.fs$fsaemDiag$accRate, 0.5)
+    expect_equal(.fs$fsaemDiag$nMapFail, 0)
+
+    # the inner carries all five thetas (tka, tcl, tv, prop.sd, iov.cl) ...
+    .lt <- .fs$fsaemDiag$lastTheta
+    expect_equal(length(.lt), 5L)
+    # ... the structural + residual ones at the fit's own values ...
+    .fe <- fixef(.fs)
+    expect_lt(max(abs(.lt[1:4] - .fe[c("tka", "tcl", "tv", "prop.sd")])), 0.05)
+    # ... and the IOV magnitude at the chain's live value, not the 0 the
+    # nonMuEta phi column would have supplied
+    expect_gt(abs(.lt[5]), 0)
+
+    expect_lt(max(abs(.fe - fixef(.ss))), 0.1)
+  })
+
+  test_that("est='fsaem' fills an IOV model's phi0 theta from its own phi column", {
+    skip_if_not_installed("nlmixr2data")
+    # tv carries no eta, so it is a phi0 sitting BETWEEN two phi1 columns.  The
+    # positional read walked mprior_phi1 instead, which skips phi0 columns, so
+    # tv was filled from an IOV eta's prior mean (0) rather than from log(V).
+    .iovPhi0 <- function() {
+      ini({
+        tka <- log(1.2); tcl <- log(0.25); tv <- log(5)
+        eta.ka ~ 0.1; eta.cl ~ 0.09
+        iov.cl ~ 0.05 | occ
+        prop.sd <- 0.15
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl + iov.cl)
+        v  <- exp(tv)
+        d/dt(depot) <- -ka*depot
+        d/dt(central) <- ka*depot - cl/v*central
+        cp <- central/v
+        cp ~ prop(prop.sd)
+      })
+    }
+    .d <- .iovData()
+    .fs <- suppressMessages(nlmixr2(.iovPhi0, .d, est = "fsaem", control = .iovCtl()))
+    .ss <- suppressMessages(nlmixr2(.iovPhi0, .d, est = "saem", control = .iovCtl()))
+
+    .lt <- .fs$fsaemDiag$lastTheta
+    .fe <- fixef(.fs)
+    expect_equal(length(.lt), 5L)
+    # the phi0 slot, which is what the fallback got wrong (inner tv was 0)
+    expect_lt(abs(.lt[3] - .fe[["tv"]]), 0.05)
+    expect_lt(max(abs(.lt[1:4] - .fe[c("tka", "tcl", "tv", "prop.sd")])), 0.05)
+
+    # a mis-filled inner theta shows up in the acceptance rate long before the
+    # estimates: this model ran at 0.50 with tv = 0 and at 0.89 with tv = log(V)
+    expect_gt(.fs$fsaemDiag$accRate, 0.7)
+    expect_equal(.fs$fsaemDiag$nMapFail, 0)
+    expect_lt(max(abs(.fe - fixef(.ss))), 0.1)
+  })
+
+  test_that("est='fsaem' degrades covariates + IOV instead of dying", {
+    skip_if_not_installed("nlmixr2data")
+    # The covariate inner absorbs each mu-ref intercept into a per-subject data
+    # column and is therefore sized by muRefDataFrame; an IOV eta has no row
+    # there, so the setup used to abort the whole fit with "etaMat must have the
+    # same number of ETAs".  Degrade to standard SAEM instead.
+    .iovCov <- function() {
+      ini({
+        tka <- log(1.2); tcl <- log(0.25); tv <- log(5); covwt <- 0.1
+        eta.ka ~ 0.1; eta.cl ~ 0.09; eta.v ~ 0.05
+        iov.cl ~ 0.05 | occ
+        prop.sd <- 0.15
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl + covwt*log(WT/70) + iov.cl)
+        v  <- exp(tv + eta.v)
+        d/dt(depot) <- -ka*depot
+        d/dt(central) <- ka*depot - cl/v*central
+        cp <- central/v
+        cp ~ prop(prop.sd)
+      })
+    }
+    .d <- .iovData()
+    .d$WT <- ifelse(.d$ID %% 2 == 0, 70, 90)
+    .fs <- suppressMessages(nlmixr2(.iovCov, .d, est = "fsaem",
+                                    control = saemControl(nBurn = 20, nEm = 10, nmc = 3,
+                                                          seed = 42, print = 0L,
+                                                          calcTables = FALSE)))
+    expect_equal(.fs$fsaemDiag$nStep, 0)   # the fast kernel was not installed
+    expect_true(all(is.finite(fixef(.fs))))
+  })
+})

--- a/tests/testthat/test-fsaem-iov.R
+++ b/tests/testthat/test-fsaem-iov.R
@@ -94,7 +94,6 @@ nmTest({
     }
     .d <- .iovData()
     .fs <- suppressMessages(nlmixr2(.iovPhi0, .d, est = "fsaem", control = .iovCtl()))
-    .ss <- suppressMessages(nlmixr2(.iovPhi0, .d, est = "saem", control = .iovCtl()))
 
     .lt <- .fs$fsaemDiag$lastTheta
     .fe <- fixef(.fs)
@@ -104,10 +103,13 @@ nmTest({
     expect_lt(max(abs(.lt[1:4] - .fe[c("tka", "tcl", "tv", "prop.sd")])), 0.05)
 
     # a mis-filled inner theta shows up in the acceptance rate long before the
-    # estimates: this model ran at 0.50 with tv = 0 and at 0.89 with tv = log(V)
+    # estimates: this model ran at 0.50 with tv = 0 and at 0.92 with tv = log(V)
     expect_gt(.fs$fsaemDiag$accRate, 0.7)
     expect_equal(.fs$fsaemDiag$nMapFail, 0)
-    expect_lt(max(abs(.fe - fixef(.ss))), 0.1)
+    expect_true(all(is.finite(.fe)))
+    # deliberately NOT compared against plain SAEM: at this budget the fast
+    # kernel has moved tcl to 1.02 while standard SAEM is still at 0.76, so an
+    # agreement band would pin the slower method rather than this one.
   })
 
   test_that("est='fsaem' degrades covariates + IOV instead of dying", {

--- a/tests/testthat/test-fsaem-iov.R
+++ b/tests/testthat/test-fsaem-iov.R
@@ -13,9 +13,13 @@ nmTest({
     .d
   }
 
+  # fastKernel="throughout" so the LAST fast step is the last iteration and
+  # lastTheta can be compared against the fit's own estimates; the default
+  # "firstN" stops the kernel at iteration 20 and lastTheta is then a snapshot
+  # of a much earlier chain.
   .iovCtl <- function() {
     saemControl(nBurn = 60, nEm = 30, nmc = 3, seed = 42, print = 0L,
-                calcTables = FALSE)
+                calcTables = FALSE, fastKernel = "throughout")
   }
 
   test_that("est='fsaem' fits an IOV model and keeps the inner's IOV sd live", {
@@ -60,7 +64,10 @@ nmTest({
     # nonMuEta phi column would have supplied
     expect_gt(abs(.lt[5]), 0)
 
-    expect_lt(max(abs(.fe - fixef(.ss))), 0.1)
+    # A smoke band, NOT the pin: a wrong inner theta shifts the target without
+    # crashing, so the estimates are the last thing to notice it.  Plain SAEM is
+    # itself not converged at 90 iterations here (measured gap 0.135 on tcl).
+    expect_lt(max(abs(.fe - fixef(.ss))), 0.3)
   })
 
   test_that("est='fsaem' fills an IOV model's phi0 theta from its own phi column", {

--- a/tests/testthat/test-fsaem-iov.R
+++ b/tests/testthat/test-fsaem-iov.R
@@ -57,7 +57,9 @@ nmTest({
     # the inner carries all five thetas (tka, tcl, tv, prop.sd, iov.cl) ...
     .lt <- .fs$fsaemDiag$lastTheta
     expect_equal(length(.lt), 5L)
-    # ... the structural + residual ones at the fit's own values ...
+    # ... the structural + residual ones at the fit's own values.  A regression
+    # guard, not the pin: every mu-ref theta here is a leading phi1 column, so
+    # the old positional fill got these four right by accident.
     .fe <- fixef(.fs)
     expect_lt(max(abs(.lt[1:4] - .fe[c("tka", "tcl", "tv", "prop.sd")])), 0.05)
     # ... and the IOV magnitude at the chain's live value, not the 0 the

--- a/tests/testthat/test-fsaem.R
+++ b/tests/testthat/test-fsaem.R
@@ -556,13 +556,14 @@ nmTest({
     # the kernel is healthy -- a mis-filled inner theta shows up here first
     expect_gt(.fs$fsaemDiag$accRate, 0.5)
     expect_equal(.fs$fsaemDiag$nMapFail, 0)
-    # and the inner really was built at the fit's own thetas: tv used to come
-    # back as tcl's fixed 1 rather than log(V)
+    # and the inner really was built at the fit's own thetas.  fastKernel is
+    # "firstN" here, so lastTheta is the chain at iteration 20, not the final
+    # estimate -- but tv is well identified and never near tcl's fixed 1, which
+    # is exactly what the positional fill used to hand it.
     .lt <- .fs$fsaemDiag$lastTheta
     expect_equal(length(.lt), 4L)
     expect_equal(.lt[2], 1)
-    expect_lt(max(abs(.lt[c(1, 3, 4)] -
-                        fixef(.fs)[c("tka", "tv", "add.sd")])), 0.05)
+    expect_lt(abs(.lt[3] - fixef(.fs)[["tv"]]), 0.5)
     # the fixed value is honored, and the rest agrees with plain SAEM
     expect_equal(unname(fixef(.fs)[["tcl"]]), 1)
     expect_lt(max(abs(fixef(.fs) - fixef(.ss))), 0.05)

--- a/tests/testthat/test-fsaem.R
+++ b/tests/testthat/test-fsaem.R
@@ -532,10 +532,10 @@ nmTest({
 
   test_that("est='fsaem' handles a fix()ed structural theta", {
     skip_if_not_installed("nlmixr2data")
-    # A fix()ed structural theta is NOT in phi1/phi0, so counting it among the
-    # structural positions made their number exceed nphi1 + nphi0, tripped the
-    # C++ length guard, and filled EVERY structural slot from the fallback -- and
-    # the fixed theta itself was left at 0 rather than its own value.
+    # A fix()ed structural theta keeps its phi column (saemControl's default is
+    # literalFix=FALSE) but drops out of the structural positions, so the two
+    # lists stop lining up.  Filling the inner positionally then walked past the
+    # fixed theta and handed tv the value of tcl.
     .fixm <- function() {
       ini({
         tka <- 0.45; tcl <- fix(1); tv <- 3.45
@@ -556,6 +556,13 @@ nmTest({
     # the kernel is healthy -- a mis-filled inner theta shows up here first
     expect_gt(.fs$fsaemDiag$accRate, 0.5)
     expect_equal(.fs$fsaemDiag$nMapFail, 0)
+    # and the inner really was built at the fit's own thetas: tv used to come
+    # back as tcl's fixed 1 rather than log(V)
+    .lt <- .fs$fsaemDiag$lastTheta
+    expect_equal(length(.lt), 4L)
+    expect_equal(.lt[2], 1)
+    expect_lt(max(abs(.lt[c(1, 3, 4)] -
+                        fixef(.fs)[c("tka", "tv", "add.sd")])), 0.05)
     # the fixed value is honored, and the rest agrees with plain SAEM
     expect_equal(unname(fixef(.fs)[["tcl"]]), 1)
     expect_lt(max(abs(fixef(.fs) - fixef(.ss))), 0.05)


### PR DESCRIPTION
Closes #875.

The issue asked to measure before changing anything, so the first commit adds
the instrument: `fsaemDiag()$lastTheta`, the inner `THETA` the last fast step
was re-parameterized with.  The kernel counters only show that the fast step
fired; a wrong phi -> theta map costs acceptance and moves the target without
erroring, so nothing existing could see it.

## Measured, before any fix

`nBurn=6`, `nEm=4`, `fastKernel="throughout"`, inner `THETA` read back from
`fsaemDiag()`:

| model | inner slot | got | fit's own value |
| --- | --- | --- | --- |
| IOV, every structural theta mu-referenced | IOV sd | `0` | live estimate |
| IOV + a no-eta theta (`tv`) | `tv` | `0` | `3.53` (accRate `0.499`) |
| `fix()`ed `tcl` (`literalFix=FALSE`, the default) | `tv` | `1.0` (tcl's value) | `3.51` |

So the issue's hypothesis is confirmed, and it is broader than it describes.
It is not only nonMuEtas + a phi0: **plain IOV is already wrong**, because the
IOV magnitude theta is itself a phi0, and so is **any `fix()`ed structural
theta**, which the existing "handles a fix()ed structural theta" test did not
catch.

The mechanism is the same in all three: `fsaemStructPos` and the phi columns
were walked in parallel, guarded by a length test (`phiPopOk`) that a nonMuEta
always fails, and the fallback it fell to walked `mprior_phi1`, which skips
phi0 columns entirely.

## The fix

Each structural theta is matched to its own phi column **by name** against
`ui$saemParamsToEstimateCov`, and the fallback is gone.  For a plain
mu-referenced model the map is the identity, so the permuted-ini finding this
code was built around still holds -- this is the phi vector itself (ini/ntheta
order), not the `muRefDataFrame` route that collapsed acceptance to 0.02.

After: every slot matches the fit's own value (`lastTheta` vs `fixef` max
`0.002`), and the IOV + phi0 acceptance rate goes **0.499 -> 0.922**.

The no-covariate R closure carried a second copy of the same wrong map and was
already unreachable (`fsaemNoCov` routes the SAEM loop straight to
`fsaemStepCpp_`); it is removed, and the "kernel installed" test in
`src/saem.cpp` is now `fsaemInstalled()`.

## Second bug found alongside

`est="fsaem"` on a model with **both a mu-referenced covariate and an IOV eta**
aborted the fit: the covariate inner absorbs each mu-ref intercept into a
per-subject data column and is sized from `muRefDataFrame`, so an eta with no
row there left it short -- `etaMat must have the same number of ETAs (cols) as
the model`.  It now degrades to standard SAEM, measured.

## The issue's bounds report

Both halves are **refuted by measurement**, so behavior is unchanged and only
the misleading comment is corrected:

- *"a normal model with `lower=`/`upper=` on a mu-ref theta gets no IMH bounds
  at all"* -- `fsaem` is an `unbounded` method, so `preProcessBoundedTransform`
  rewrites every finite structural-theta bound into an unconstrained internal
  parameter **before** the kernel is installed; the bound is enforced by the
  back-transform, not by the proposal.  Measured on `tka <- c(0, 0.45, 3)`:
  post-hook bounds are `-Inf/Inf` and `.fsaemPhi1Bounds` returns `nbd = 0,0,0`.
- *"`hasBounds` drops every bound silently on a length mismatch"* --
  `fsaemImhCheckDims` **errors** on `nbd.size() != 0 && != neta`.  And for an
  IOV model the length matches anyway (`neta = 4`, `length(nbd) = 4`).

## Tests

There was no IOV fsaem test at all.  New `test-fsaem-iov.R` (weekly batch 6,
beside `iov` / `iov-zero-eta`):

- plain IOV -- the inner must carry a **live** IOV sd, not the `0` a nonMuEta's
  phi column supplies;
- IOV + a no-eta theta -- the inner `tv` and the acceptance rate, which is the
  discriminator (`0.50` broken, `0.92` fixed);
- covariates + IOV -- must degrade, not abort.

`test-fsaem.R`'s fix()ed-theta test now also checks the inner `THETA`.  The
fsaem-vs-saem estimate comparison is deliberately a smoke band or absent, per
the issue's own guidance that estimates are not a reliable pin -- measured, the
fast kernel reaches `tcl = 1.02` on the IOV+phi0 model while plain SAEM is
still at `0.76` at the same budget.

All six fsaem test files pass (`test-fsaem`, `-iov`, `-inner`, `-multi`,
`-imh`, `-es`).

## Review

Three Antigravity (Gemini) passes.  One real finding: `test-fsaem-inner.R`
still asserted the removed no-covariate closure existed -- fixed.  Two further
claims about the covariate path were checked and **refuted by measurement**
rather than acted on:

- *`muRefCov=FALSE` leaves the covariate frozen* -- measured, `cl.wt` moves
  `0.5 -> 0.211` (fsaem) against saem's `0.272`, accRate `0.911`.  `Plambda` is
  never length 0; `nlambda` counts every mcov design cell.
- *a phi0 theta on the covariate path is frozen or overwritten* -- measured,
  `tv` moves `1.609 -> 3.519` against saem's `3.522`, accRate `0.918`.  `mcov`
  is numbered phi-column-major with the intercept first, which is exactly the
  order `saemParamsToEstimate` interleaves, so `match()` returns the right
  `Plambda` slot for an intercept as well as a covariate coefficient.
