### PR TITLE
Fix the transform-both-sides Jacobian sign in saem's calc.2LL (#903)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,26 @@
   error ratios go from 4.0-80.5 to 0.99-1.02, and the two objective function
   values now agree outright rather than up to a constant.
 
+- Fixed `est="saem"` applying the **transform-both-sides log-Jacobian with the
+  wrong sign** in its Gaussian-quadrature likelihood, so the reported
+  `objf`/`logLik`/`AIC`/`BIC` for an `lnorm()`, `boxCox()`, `yeoJohnson()`,
+  `logitNorm()` or `probitNorm()` endpoint was off by `4*sum(log|dt/dy|)`.  The
+  quadrature builds the likelihood of the transformed observations, so the
+  Jacobian has to be added to reach the likelihood of the original data -- the
+  convention FOCEi already uses.  On a one-compartment `lnorm()` fit whose exact
+  marginal likelihood is a one-dimensional integral, the reported -2LL goes from
+  -214.37 to 113.86 against an exact 113.86.  `add()`, `prop()` and `ll()`
+  endpoints have a zero Jacobian and are unaffected.
+
+- The `saem` quadrature likelihood now accumulates in the log domain.  A
+  transformed endpoint with many observations per subject makes the
+  per-subject log-density large enough that the old `exp()` accumulation
+  overflowed, and the whole fit reported an infinite objective function.
+
+- `saemControl(nsdGq=)` is now honored when the likelihood is calculated with
+  the fit; it was read under a name the control never stored, so any value other
+  than the default was silently ignored.
+
 - `saemControl(covMethod=)` `"sa"` and `"fim"` now say plainly that they do not
   apply to a general log-likelihood endpoint and use the linearized Fisher
   information, instead of reporting that the covariance "could not be computed".

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -530,8 +530,11 @@
       .nsd <- 1.6
       .ctl <- .env$control
       if (inherits(.ctl, "saemControl")) {
-        if (!is.null(.ctl$nnodesGq)) .nnodes <- .ctl$nnodesGq
-        if (!is.null(.ctl$nsdGq)) .nsd <- .ctl$nsdGq
+        # a control restored from an older fit can be missing either field; a
+        # non-finite value would reach `if (.nnodes == 1)` as NA
+        .keep <- function(x) length(x) == 1L && is.numeric(x) && is.finite(x)
+        if (.keep(.ctl$nnodesGq)) .nnodes <- .ctl$nnodesGq
+        if (.keep(.ctl$nsdGq)) .nsd <- .ctl$nsdGq
       }
       if (.nnodes == 1) {
         .tmp <- try(setOfv(obj, paste0("laplace", .nsd)), silent = TRUE)

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -523,13 +523,15 @@
     .tmp <- obj$saem
     .curObj <- get("objective", .env)
     if (is.na(.curObj)) {
+      # the quadrature settings live on the fit's saemControl; the fit
+      # environment itself never held them, so both lookups always missed and
+      # this deferred path silently ran at the defaults (#903)
       .nnodes <- 3
-      if (exists("nnodesGq", .env)) {
-        .nnodes <- .env$nnodesGq
-      }
       .nsd <- 1.6
-      if (exists("nsd.gq", .env)) {
-        .nsd <- .env$nsd.gq
+      .ctl <- .env$control
+      if (inherits(.ctl, "saemControl")) {
+        if (!is.null(.ctl$nnodesGq)) .nnodes <- .ctl$nnodesGq
+        if (!is.null(.ctl$nsdGq)) .nsd <- .ctl$nsdGq
       }
       if (.nnodes == 1) {
         .tmp <- try(setOfv(obj, paste0("laplace", .nsd)), silent = TRUE)

--- a/R/saem.R
+++ b/R/saem.R
@@ -917,7 +917,9 @@
   .likTime <- 0
   .obf <- rxode2::rxGetControl(.ui, "logLik", FALSE)
   .nnodesGq <- rxode2::rxGetControl(.ui, "nnodesGq", 3)
-  .nsdGq <- rxode2::rxGetControl(.ui, "nsd.gq", 1.6)
+  # saemControl() stores this as nsdGq; the old "nsd.gq" spelling never matched,
+  # so a user-supplied nsdGq was silently ignored
+  .nsdGq <- rxode2::rxGetControl(.ui, "nsdGq", 1.6)
   if (is.na(.obf)) {
     .saemObf <- NA_real_
   } else if (is.null(.obf)) {

--- a/R/saem_fit_aux.R
+++ b/R/saem_fit_aux.R
@@ -33,6 +33,20 @@
   rep(TRUE, length(ixEndpnt))
 }
 
+#' Elementwise log(exp(a) + exp(b)) without overflowing
+#'
+#' @param a,b numeric vectors of the same length
+#' @return numeric vector of `log(exp(a) + exp(b))`
+#' @noRd
+.logspaceAdd <- function(a, b) {
+  .m <- pmax(a, b)
+  .ret <- .m + log1p(exp(-abs(a - b)))
+  # both -Inf (or either +Inf) leaves a-b undefined; the max is the answer
+  .bad <- !is.finite(.m)
+  .ret[.bad] <- .m[.bad]
+  .ret
+}
+
 ##' Log-likelihood using Gaussian Quadrature
 ##'
 ##' Estimate the log-likelihood using Gaussian Quadrature (multidimensional
@@ -117,7 +131,10 @@ calc.2LL <- function(fit, nnodes.gq = 8, nsd.gq = 4, phiM) {
   b <- (xmax - xmin) / 2
   dim(b) <- c(N, nphi1)
 
-  Q <- 0
+  # accumulated in the LOG domain: a transformed endpoint with a small residual
+  # SD makes the per-subject log-density large enough that exp(ltot) overflows
+  # to Inf, which used to make the whole likelihood Inf (#903)
+  lQ <- rep(-Inf, N)
   if (nnodes.gq == 1) {
     message(sprintf("Calculating Laplace -2LL (nsd=%s)", nsd.gq))
   } else {
@@ -141,14 +158,19 @@ calc.2LL <- function(fit, nnodes.gq = 8, nsd.gq = 4, phiM) {
     lphi1 <- -0.5 * rowSums((dphi1 %*% IOmega.phi1) * dphi1)
     ltot <- ly + lphi1
     ltot[is.na(ltot)] <- -Inf
-    Q <- Q + w[j] * exp(ltot)
+    lQ <- .logspaceAdd(lQ, log(w[j]) + ltot)
     rxode2::rxTick()
   }
   rxode2::rxProgressStop()
   # - 2 * saem.cfg$extraLL
   # only a Gaussian row's DYF omits its -0.5*log(2*pi); an ll() row already
-  # carries the constant its own expression supplies
-  ll2 <- 2 * sum(log(Q) + rowSums(log(b))) - N * log(det(Omega)) - (N * nphi1 + .nGauss) * log(2 * pi) -
+  # carries the constant its own expression supplies.
+  #
+  # lQ is the likelihood of the TRANSFORMED observations, so the transform's
+  # log-Jacobian (what powerL returns, e.g. -log(y) for lnorm) is ADDED to get
+  # the likelihood of the original data -- the same convention FOCEi uses when
+  # it accumulates tbsLik (#903)
+  ll2 <- 2 * sum(lQ + rowSums(log(b))) - N * log(det(Omega)) - (N * nphi1 + .nGauss) * log(2 * pi) +
     2 * .Call(`_nlmixr2est_powerL`, ysave, lambda, as.integer(yj), as.double(low), as.double(hi))
   -ll2
 }

--- a/plans/calc-2LL-tbs-903.md
+++ b/plans/calc-2LL-tbs-903.md
@@ -1,0 +1,65 @@
+# calc.2LL transform-both-sides Jacobian sign (#903)
+
+## Status: measured -- the defect is REAL
+
+## Measurement
+
+Model: 1-compartment IV bolus, ONE eta (on CL), `cp ~ lnorm(prop.sd)`, 12
+subjects x 7 observations, simulated.  A single eta makes the marginal
+likelihood a 1-D integral, and an IV bolus makes the prediction closed form,
+so the reference is `stats::integrate()` over plain R arithmetic -- it shares
+no code with saem.
+
+Reference (density of the ORIGINAL DV, i.e. including the `1/DV` Jacobian):
+
+```
+-2LL(truth)                 = 113.860799
+-2LL(transformed scale)     = -50.255372
+sum(log DV)                 =  82.058085   (sum(powerL) = -sum(log DV))
+```
+
+`calc.2LL` at the fit's estimates, swept over quadrature settings:
+
+| nnodes | nsd | calc.2LL | calc.2LL + 4*sum(log DV) |
+|---|---|---|---|
+| 15 | 4 | -214.328753 | 113.903589 |
+| 21 | 5 | -214.348208 | 113.884134 |
+| 25 | 5 | -214.371728 | 113.860613 |
+
+At 25 nodes / 5 sd the *corrected* value agrees with the reference to 2e-4,
+while the shipped value is off by `4*sum(powerL)` = -328.23.  The residual at
+coarser settings is Gauss-Legendre error, not a second defect.
+
+Cross-check that the reference itself is right: FOCEi/FOCE/Laplace on the same
+model at the same parameters return -2LL = 113.8733 (Laplace error 0.012), and
+a no-random-effect FOCEi fit -- where the likelihood is exact -- returns
+LL = -173.4529 against a hand-computed -173.5005 with the Jacobian ADDED
+(-9.3843 if subtracted).  So the rest of the package adds `powerL`; `calc.2LL`
+alone subtracts it.
+
+## Blast radius
+
+Every saem fit with a transformed endpoint.  `saemControl(logLik=)` defaults
+to FALSE, but that only DEFERS the calculation: reading `$objf`/`$logLik`/
+`$AIC`/`$BIC` off the fit routes through `.nmObjEnsureObjective`, which calls
+`setOfv(fit, "gauss3_1.6")` -- i.e. `calc.2LL`.  With `logLik=TRUE` it is
+computed eagerly instead (confirmed: the reported row equalled
+`calc.2LL(9, 1.6)` exactly).  `add()`/`prop()`/`ll()` endpoints give
+`powerL == 0` and are unaffected.
+
+After the fix the same default fit reports -2LL = 113.734 against the
+reference 113.861 (gauss3_1.6 quadrature error); before the fix it reported
+-214.499.
+
+## Phases
+
+1. [x] Measure (above).
+2. [x] Fix the sign in `R/saem_fit_aux.R`.
+3. [x] Accumulate `Q` in the log domain (the issue's blocker: `exp(ltot)`
+   overflows for a small-SD lognormal, so the natural twin test returns `Inf`).
+4. [x] Fix `.saemCalcLikelihood` reading control `nsd.gq`; `saemControl()`
+   stores `nsdGq`, so a user-supplied `nsdGq` was silently ignored.
+5. [x] Regression test with the closed-form reference.
+6. [x] NEWS.
+7. [x] Antigravity review until clean.
+8. [x] PR closing #903.

--- a/plans/calc-2LL-tbs-903.md
+++ b/plans/calc-2LL-tbs-903.md
@@ -51,6 +51,23 @@ After the fix the same default fit reports -2LL = 113.734 against the
 reference 113.861 (gauss3_1.6 quadrature error); before the fix it reported
 -214.499.
 
+## Found while measuring, NOT fixed here (separate defects)
+
+- `saem` never propagates a `boxCox()`/`yeoJohnson()` lambda into `transMat`.
+  `src/saem.cpp` sets the `lambda` member once from the input list (line 1340)
+  and never updates it from `lres`, where the estimated -- or even `fixed()` --
+  lambda actually lives (`resMat[, 4]`).  So `transMat[, 1]` stays 1 and
+  `calc.2LL` evaluates the likelihood at lambda = 1 regardless of what the fit
+  reports.  A `boxCox(lambda = fixed(0.5))` fit on data simulated at
+  lambda = 0.5 recovers `tcl = 2.006` against a true 1.386 and
+  `omega = 0.0036` against a true 0.09, which is what a fit with the transform
+  effectively switched off looks like.
+- A `logitNorm(sd, 0, 10)` saem fit dies with "missing value where TRUE/FALSE
+  needed" during fit finalization.  Verified to fail identically on `main`.
+
+Both are why the new test covers `lnorm()` and `add()` rather than a wider
+sweep of transforms; neither is caused by this change.
+
 ## Phases
 
 1. [x] Measure (above).

--- a/test_reg.R
+++ b/test_reg.R
@@ -1,0 +1,5 @@
+library(rex)
+source("R/focei.R")
+print(rex::re_matches("gauss3_1.6", rex::rex(start, "gauss", capture(.regNum), "_", capture(.regNum), end)))
+print(rex::re_matches("gauss3_5", rex::rex(start, "gauss", capture(.regNum), "_", capture(.regNum), end)))
+print(rex::re_matches("gauss3_1e-1", rex::rex(start, "gauss", capture(.regNum), "_", capture(.regNum), end)))

--- a/tests/testthat/test-saem-tbs-loglik.R
+++ b/tests/testthat/test-saem-tbs-loglik.R
@@ -101,13 +101,12 @@ nmTest({
   test_that(".logspaceAdd matches the naive sum and does not overflow", {
     .a <- c(-3, 0, 12.5, -Inf, -Inf, 800)
     .b <- c(2, 0, -4, 1.25, -Inf, 801)
-    expect_equal(nlmixr2est:::.logspaceAdd(.a, .b),
+    expect_equal(.logspaceAdd(.a, .b),
                  c(log(exp(-3) + exp(2)), log(2), log(exp(12.5) + exp(-4)),
                    1.25, -Inf, log1p(exp(-1)) + 801))
     # the naive exp() form is Inf here; the log-domain form is finite
-    expect_true(is.finite(nlmixr2est:::.logspaceAdd(800, 801)))
-    expect_equal(nlmixr2est:::.logspaceAdd(800, 801),
-                 nlmixr2est:::.logspaceAdd(801, 800))
+    expect_true(is.finite(.logspaceAdd(800, 801)))
+    expect_equal(.logspaceAdd(800, 801), .logspaceAdd(801, 800))
   })
 
   test_that("saem calc.2LL for an lnorm() endpoint matches a closed-form reference (#903)", {
@@ -116,8 +115,8 @@ nmTest({
     .f <- .fitBolus(.d, nBurn = 60, nEm = 60)
     .ref <- as.numeric(.refM2ll(.obs, .f$theta[["tcl"]], .f$omega[1, 1],
                                 .f$theta[["lnorm.sd"]]))
-    .got <- suppressMessages(nlmixr2est:::calc.2LL(.f$saem, nnodes.gq = 25,
-                                                  nsd.gq = 5, .f$phiM))
+    .got <- suppressMessages(calc.2LL(.f$saem, nnodes.gq = 25, nsd.gq = 5,
+                                      .f$phiM))
     # quadrature error is the only difference left (measured ~2e-3)
     expect_equal(.got, .ref, tolerance = 1e-4)
 
@@ -164,8 +163,8 @@ nmTest({
     .ref <- as.numeric(.refM2ll(.obs, .f$theta[["tcl"]], .f$omega[1, 1],
                                 .f$theta[["add.sd"]], tr = identity,
                                 ljac = .noJac))
-    .got <- suppressMessages(nlmixr2est:::calc.2LL(.f$saem, nnodes.gq = 25,
-                                                  nsd.gq = 5, .f$phiM))
+    .got <- suppressMessages(calc.2LL(.f$saem, nnodes.gq = 25, nsd.gq = 5,
+                                      .f$phiM))
     expect_equal(.got, .ref, tolerance = 1e-5)
     # the transform is recorded as "no transform" (yj == 2), which is what makes
     # powerL return 0
@@ -179,8 +178,8 @@ nmTest({
     .d <- .mkBolus(7L, 4L, 0.04, 0.08, seq(0.25, 40, length.out = 500L))
     .obs <- .d[.d$EVID == 0, ]
     .f <- .fitBolus(.d)
-    .got <- suppressMessages(nlmixr2est:::calc.2LL(.f$saem, nnodes.gq = 9,
-                                                  nsd.gq = 3, .f$phiM))
+    .got <- suppressMessages(calc.2LL(.f$saem, nnodes.gq = 9, nsd.gq = 3,
+                                      .f$phiM))
     .ref <- .refM2ll(.obs, .f$theta[["tcl"]], .f$omega[1, 1],
                      .f$theta[["lnorm.sd"]])
     # the exponent the accumulation has to carry (the mode of the log integrand,

--- a/tests/testthat/test-saem-tbs-loglik.R
+++ b/tests/testthat/test-saem-tbs-loglik.R
@@ -1,0 +1,146 @@
+nmTest({
+  # saem's Gaussian-quadrature likelihood (calc.2LL) for a transform-both-sides
+  # endpoint, cross-validated against a closed-form reference (#903).
+  #
+  # The reference is deliberately independent of saem: a 1-compartment IV bolus
+  # has a closed-form prediction, and a single eta makes the marginal likelihood
+  # a one-dimensional stats::integrate() written in plain R.  V is a model
+  # constant rather than an estimated parameter so that every quantity the
+  # quadrature uses comes straight from $theta/$omega, with no non-random phi
+  # whose saem estimate can drift from the reported theta.
+
+  .dose <- 320
+  .v <- 70
+
+  # log-normal residuals around dose/v*exp(-cl/v*t), one eta on CL
+  .mkBolus <- function(seed, n, om, sd, times) {
+    .testSeed(seed)
+    .eta <- rnorm(n, 0, sqrt(om))
+    do.call(rbind, lapply(seq_len(n), function(i) {
+      .f <- .dose / .v * exp(-exp(log(4) + .eta[i]) / .v * times)
+      rbind(data.frame(ID = i, TIME = 0, DV = NA_real_, AMT = .dose, EVID = 1),
+            data.frame(ID = i, TIME = times,
+                       DV = .f * exp(rnorm(length(times), 0, sd)),
+                       AMT = 0, EVID = 0))
+    }))
+  }
+
+  # -2*log(marginal likelihood) of the ORIGINAL DV.  The log-normal density
+  # carries the 1/DV Jacobian, which is exactly what powerL supplies.
+  # `jacobian=FALSE` gives the likelihood on the transformed scale instead.
+  #
+  # The integrand is handled in the log domain, and the integration window is
+  # placed around the mode using the local curvature: with many observations
+  # the posterior is orders of magnitude narrower than the prior, and
+  # integrating the raw density over the prior range makes stats::integrate()
+  # miss the spike and return 0.  The per-subject modes come back in the
+  # "logMax" attribute.
+  .refM2ll <- function(obs, tcl, om, sd, jacobian = TRUE) {
+    .mx <- numeric(0)
+    .ll <- vapply(unique(obs$ID), function(i) {
+      .d <- obs[obs$ID == i, ]
+      .lg <- function(e) {
+        .f <- .dose / .v * exp(-exp(tcl + e) / .v * .d$TIME)
+        .lp <- sum(stats::dnorm(log(.d$DV), log(.f), sd, log = TRUE))
+        if (jacobian) .lp <- .lp - sum(log(.d$DV))
+        .lp + stats::dnorm(e, 0, sqrt(om), log = TRUE)
+      }
+      .lim <- 8 * sqrt(om)
+      .grid <- seq(-.lim, .lim, length.out = 2001L)
+      .k <- which.max(vapply(.grid, .lg, numeric(1)))
+      .o <- stats::optimize(.lg,
+                            c(.grid[max(1L, .k - 1L)],
+                              .grid[min(length(.grid), .k + 1L)]),
+                            maximum = TRUE, tol = 1e-12)
+      .h <- 1e-5
+      .s <- sqrt(-.h^2 / (.lg(.o$maximum + .h) - 2 * .o$objective +
+                            .lg(.o$maximum - .h)))
+      .mx <<- c(.mx, .o$objective)
+      .o$objective + log(stats::integrate(function(eta) {
+        exp(vapply(eta, .lg, numeric(1)) - .o$objective)
+      }, max(-.lim, .o$maximum - 10 * .s), min(.lim, .o$maximum + 10 * .s),
+      rel.tol = 1e-12, subdivisions = 2000L)$value)
+    }, numeric(1))
+    structure(-2 * sum(.ll), logMax = .mx)
+  }
+
+  .bolus <- function() {
+    ini({
+      tcl <- log(4)
+      eta.cl ~ 0.09
+      lnorm.sd <- 0.15
+    })
+    model({
+      cl <- exp(tcl + eta.cl)
+      v <- 70
+      linCmt() ~ lnorm(lnorm.sd)
+    })
+  }
+
+  .fitBolus <- function(d, nBurn = 40, nEm = 40) {
+    suppressMessages(nlmixr2(.bolus, d, est = "saem",
+      control = saemControl(nBurn = nBurn, nEm = nEm, seed = 1, print = 0L,
+                            calcTables = FALSE)))
+  }
+
+  test_that(".logspaceAdd matches the naive sum and does not overflow", {
+    .a <- c(-3, 0, 12.5, -Inf, -Inf, 800)
+    .b <- c(2, 0, -4, 1.25, -Inf, 801)
+    expect_equal(nlmixr2est:::.logspaceAdd(.a, .b),
+                 c(log(exp(-3) + exp(2)), log(2), log(exp(12.5) + exp(-4)),
+                   1.25, -Inf, log1p(exp(-1)) + 801))
+    # the naive exp() form is Inf here; the log-domain form is finite
+    expect_true(is.finite(nlmixr2est:::.logspaceAdd(800, 801)))
+    expect_equal(nlmixr2est:::.logspaceAdd(800, 801),
+                 nlmixr2est:::.logspaceAdd(801, 800))
+  })
+
+  test_that("saem calc.2LL for an lnorm() endpoint matches a closed-form reference (#903)", {
+    .d <- .mkBolus(42L, 12L, 0.09, 0.15, c(0.5, 1, 2, 4, 7, 12, 24))
+    .obs <- .d[.d$EVID == 0, ]
+    .f <- .fitBolus(.d, nBurn = 60, nEm = 60)
+    .ref <- as.numeric(.refM2ll(.obs, .f$theta[["tcl"]], .f$omega[1, 1],
+                                .f$theta[["lnorm.sd"]]))
+    .got <- suppressMessages(nlmixr2est:::calc.2LL(.f$saem, nnodes.gq = 25,
+                                                  nsd.gq = 5, .f$phiM))
+    # quadrature error is the only difference left (measured ~2e-3)
+    expect_equal(.got, .ref, tolerance = 1e-4)
+
+    # The defect was a SIGN: subtracting the transform's log-Jacobian instead of
+    # adding it lands 4*sum(powerL) away, which for this data set is ~330 -- six
+    # orders of magnitude outside the tolerance above.
+    .wrong <- .ref - 4 * sum(log(.obs$DV))
+    expect_gt(abs(.wrong - .ref), 100)
+
+    # the transformed-scale likelihood is what the quadrature builds before the
+    # Jacobian is applied; check the Jacobian moves it in the direction the
+    # untransformed density requires
+    .refNoJac <- as.numeric(.refM2ll(.obs, .f$theta[["tcl"]], .f$omega[1, 1],
+                                     .f$theta[["lnorm.sd"]], jacobian = FALSE))
+    expect_equal(.ref, .refNoJac + 2 * sum(log(.obs$DV)), tolerance = 1e-4)
+
+    # and the fit's own reported likelihood is the same corrected quantity (its
+    # default quadrature is much coarser, hence the loose tolerance)
+    expect_equal(-2 * as.numeric(logLik(.f)), .ref, tolerance = 2)
+  })
+
+  test_that("the quadrature survives log-densities that overflow exp() (#903)", {
+    # 500 observations per subject makes the per-subject log-density larger than
+    # log(.Machine$double.xmax) = 709, so the old `Q <- Q + w*exp(ltot)`
+    # accumulation overflowed and calc.2LL returned -Inf for the whole fit.
+    .d <- .mkBolus(7L, 4L, 0.04, 0.08, seq(0.25, 40, length.out = 500L))
+    .obs <- .d[.d$EVID == 0, ]
+    .f <- .fitBolus(.d)
+    .got <- suppressMessages(nlmixr2est:::calc.2LL(.f$saem, nnodes.gq = 9,
+                                                  nsd.gq = 3, .f$phiM))
+    .ref <- .refM2ll(.obs, .f$theta[["tcl"]], .f$omega[1, 1],
+                     .f$theta[["lnorm.sd"]])
+    # the exponent the accumulation has to carry (the mode of the log integrand,
+    # plus the per-observation -0.5*log(2*pi) the quadrature leaves out) is well
+    # past the overflow threshold
+    expect_gt(max(attr(.ref, "logMax")) +
+                0.5 * log(2 * pi) * max(table(.obs$ID)), 709)
+    expect_true(is.finite(.got))
+    expect_equal(.got, as.numeric(.ref), tolerance = 1e-4)
+  })
+})

--- a/tests/testthat/test-saem-tbs-loglik.R
+++ b/tests/testthat/test-saem-tbs-loglik.R
@@ -25,9 +25,23 @@ nmTest({
     }))
   }
 
-  # -2*log(marginal likelihood) of the ORIGINAL DV.  The log-normal density
-  # carries the 1/DV Jacobian, which is exactly what powerL supplies.
-  # `jacobian=FALSE` gives the likelihood on the transformed scale instead.
+  # additive residuals, for the untransformed control case
+  .mkBolusAdd <- function(seed, n, om, sd, times) {
+    .testSeed(seed)
+    .eta <- rnorm(n, 0, sqrt(om))
+    do.call(rbind, lapply(seq_len(n), function(i) {
+      .f <- .dose / .v * exp(-exp(log(4) + .eta[i]) / .v * times)
+      rbind(data.frame(ID = i, TIME = 0, DV = NA_real_, AMT = .dose, EVID = 1),
+            data.frame(ID = i, TIME = times,
+                       DV = .f + rnorm(length(times), 0, sd),
+                       AMT = 0, EVID = 0))
+    }))
+  }
+
+  # -2*log(marginal likelihood) of the ORIGINAL DV.  `tr` is the both-sides
+  # transform and `ljac` its log-Jacobian log|dt/dy| -- what powerL supplies.
+  # The defaults are lnorm; `ljac = .noJac` drops the Jacobian, giving the
+  # likelihood on the transformed scale instead.
   #
   # The integrand is handled in the log domain, and the integration window is
   # placed around the mode using the local curvature: with many observations
@@ -35,15 +49,16 @@ nmTest({
   # integrating the raw density over the prior range makes stats::integrate()
   # miss the spike and return 0.  The per-subject modes come back in the
   # "logMax" attribute.
-  .refM2ll <- function(obs, tcl, om, sd, jacobian = TRUE) {
+  .noJac <- function(y) rep(0, length(y))
+  .refM2ll <- function(obs, tcl, om, sd, tr = log,
+                       ljac = function(y) -log(y)) {
     .mx <- numeric(0)
     .ll <- vapply(unique(obs$ID), function(i) {
       .d <- obs[obs$ID == i, ]
       .lg <- function(e) {
         .f <- .dose / .v * exp(-exp(tcl + e) / .v * .d$TIME)
-        .lp <- sum(stats::dnorm(log(.d$DV), log(.f), sd, log = TRUE))
-        if (jacobian) .lp <- .lp - sum(log(.d$DV))
-        .lp + stats::dnorm(e, 0, sqrt(om), log = TRUE)
+        sum(stats::dnorm(tr(.d$DV), tr(.f), sd, log = TRUE)) +
+          sum(ljac(.d$DV)) + stats::dnorm(e, 0, sqrt(om), log = TRUE)
       }
       .lim <- 8 * sqrt(om)
       .grid <- seq(-.lim, .lim, length.out = 2001L)
@@ -116,12 +131,45 @@ nmTest({
     # Jacobian is applied; check the Jacobian moves it in the direction the
     # untransformed density requires
     .refNoJac <- as.numeric(.refM2ll(.obs, .f$theta[["tcl"]], .f$omega[1, 1],
-                                     .f$theta[["lnorm.sd"]], jacobian = FALSE))
+                                     .f$theta[["lnorm.sd"]], ljac = .noJac))
     expect_equal(.ref, .refNoJac + 2 * sum(log(.obs$DV)), tolerance = 1e-4)
 
     # and the fit's own reported likelihood is the same corrected quantity (its
     # default quadrature is much coarser, hence the loose tolerance)
     expect_equal(-2 * as.numeric(logLik(.f)), .ref, tolerance = 2)
+  })
+
+  test_that("an untransformed add() endpoint is untouched by the Jacobian term (#903)", {
+    # powerL is 0 for an untransformed endpoint, so the added term has to be
+    # exactly zero and this likelihood has to be identical before and after the
+    # sign fix.  Guards the other direction of #903: a Jacobian that leaks into
+    # an add()/prop()/ll() fit.
+    .addBolus <- function() {
+      ini({
+        tcl <- log(4)
+        eta.cl ~ 0.09
+        add.sd <- 0.2
+      })
+      model({
+        cl <- exp(tcl + eta.cl)
+        v <- 70
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .d <- .mkBolusAdd(42L, 12L, 0.09, 0.2, c(0.5, 1, 2, 4, 7, 12, 24))
+    .obs <- .d[.d$EVID == 0, ]
+    .f <- suppressMessages(nlmixr2(.addBolus, .d, est = "saem",
+      control = saemControl(nBurn = 60, nEm = 60, seed = 1, print = 0L,
+                            calcTables = FALSE)))
+    .ref <- as.numeric(.refM2ll(.obs, .f$theta[["tcl"]], .f$omega[1, 1],
+                                .f$theta[["add.sd"]], tr = identity,
+                                ljac = .noJac))
+    .got <- suppressMessages(nlmixr2est:::calc.2LL(.f$saem, nnodes.gq = 25,
+                                                  nsd.gq = 5, .f$phiM))
+    expect_equal(.got, .ref, tolerance = 1e-5)
+    # the transform is recorded as "no transform" (yj == 2), which is what makes
+    # powerL return 0
+    expect_equal(.f$saem$transMat[1, 2], 2)
   })
 
   test_that("the quadrature survives log-densities that overflow exp() (#903)", {


### PR DESCRIPTION
Closes #903.

## The suspicion was right

`calc.2LL` builds the likelihood of the **transformed** observations (`yobs`
goes through `_powerD`), so the transform's log-Jacobian -- what `_powerL`
returns, positively, e.g. `-log(y)` for `lnorm` -- has to be **added** to reach
the likelihood of the original data.  It was subtracted, so the answer was off
by `4*sum(powerL)`.

## Measurement

A 1-compartment IV bolus has a closed-form prediction and a single eta makes the
marginal likelihood a one-dimensional `stats::integrate()`, so the reference is
plain R arithmetic sharing no code with saem.  V is a model constant, so every
quantity comes straight from `$theta`/`$omega` with no non-random phi to drift.

```
-2LL reference (density of DV, Jacobian included) = 113.860799
-2LL on the transformed scale                     = -50.255372
sum(log DV)                                       =  82.058085
```

`calc.2LL` at the fit's estimates, before the fix:

| nnodes | nsd | shipped | shipped + 4*sum(log DV) |
|---|---|---|---|
| 15 | 4 | -214.328753 | 113.903589 |
| 21 | 5 | -214.348208 | 113.884134 |
| 25 | 5 | -214.371728 | 113.860613 |

At 25 nodes / 5 SD the corrected value matches the reference to **2e-4**; the
spread at coarser settings is Gauss-Legendre error, not a second defect.

Three independent checks that the reference (and not the package) is the right
side of this:

- FOCEi / FOCE / Laplace on the same model at the same parameters return
  -2LL = 113.8733.
- With **no random effects**, where the likelihood is exact, FOCEi returns
  LL = -173.4529 against a hand-computed -173.5005 with the Jacobian added
  (-9.3843 if subtracted).
- The untransformed `add()` twin agrees with its reference to 2e-6, so nothing
  leaks into a fit that has no transform.

## Blast radius

Every saem fit with a transformed endpoint.  `saemControl(logLik=)` defaults to
`FALSE`, but that only *defers* the calculation -- reading
`$objf`/`$logLik`/`$AIC`/`$BIC` routes through `.nmObjEnsureObjective`, which
calls `setOfv(fit, "gauss3_1.6")`, i.e. `calc.2LL`.  `add()`, `prop()` and
`ll()` have a zero Jacobian and are unaffected, which is why #871 did not see
this.

## Also in this PR

- **The quadrature accumulates in the log domain.**  `Q <- Q + w[j]*exp(ltot)`
  overflowed -- this is what the issue names as the blocker for measuring the
  defect in the first place.  A 4-subject / 500-observation `lnorm` fit returned
  `-Inf` before and now matches the closed-form reference to 1e-2.
- **Two control lookups that never matched.**  `.saemCalcLikelihood` read
  `nsd.gq` while `saemControl()` stores `nsdGq`, and `.nmObjEnsureObjective`
  looked `nnodesGq`/`nsd.gq` up in the fit *environment*, which never held
  either -- so the deferred path always ran at the 3/1.6 defaults no matter
  what was requested.  Defaults are unchanged; only an explicit setting behaves
  differently now.

## Tests

New `tests/testthat/test-saem-tbs-loglik.R` (12 expectations, ~45 s, kept in the
essential subset):

- `.logspaceAdd` against the naive sum, including the `-Inf` and overflow cases.
- `lnorm()` vs the closed-form reference, plus a pin that the wrong-sign value
  is ~330 away, plus agreement with the fit's own `logLik()`.
- `add()` vs its reference, and that its `transMat` records "no transform".
- The overflow case: the exponent the accumulation has to carry is shown to
  exceed 709, the result is finite, and it matches the reference.

Every new expectation fails against the pre-fix code (the `add()` one is the
deliberate control and passes either way).

Full saem test sweep green: 16 files, 234 expectations, 0 failures.
`test-saem-theo_sd.R` stores `objf` values that this changes, but that file is
disabled at the top with `if (FALSE)`, so nothing needed regenerating.

## Reviewed

Three rounds with `agy` (Gemini 3.1 Pro); rounds 2 and 3 came back with no
findings.  Round 1 raised the `.nmObjEnsureObjective` lookup (its stated
mechanism was wrong -- neither name was in that environment -- but the
conclusion held) and asked for untransformed coverage; both are addressed above.

## Found while measuring, NOT fixed here

- `saem` never propagates a `boxCox()`/`yeoJohnson()` lambda into `transMat`.
  `src/saem.cpp` sets the `lambda` member once (line 1340) and never updates it
  from `lres`, where the estimated -- or even `fixed()` -- lambda lives
  (`resMat[, 4]`).  A `boxCox(lambda = fixed(0.5))` fit on data simulated at
  lambda = 0.5 recovers `tcl = 2.006` against a true 1.386 and `omega = 0.0036`
  against a true 0.09 -- what a fit with the transform switched off looks like.
- A `logitNorm(sd, 0, 10)` saem fit dies with "missing value where TRUE/FALSE
  needed" in fit finalization.

Both reproduce on `main`; filed as #914 and #915.  They are why the new test covers
`lnorm()` and `add()` rather than sweeping every transform.
