### PR TITLE
fix(saem): score a censored observation the way FOCEi does (#876)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -131,6 +131,21 @@
   `covMethod="linFim"` (the default) is unaffected throughout; its `calc.COV()`
   linearization was always per-endpoint.
 
+- `est="saem"` and `est="fsaem"` now score a **censored** observation the way the
+  rest of the package does.  The simulation step handed the shared censoring
+  likelihood the per-observation loss where it takes a log-likelihood, the
+  residual standard deviation where it takes a variance, and the untransformed
+  `DV`, then stored the log-likelihood it returned back as a loss.  M2 hid this,
+  since a limit well below the prediction leaves its tail probability at
+  essentially 1, but under M3/M4 the censored term arrived with its sign flipped
+  and the chain drove censored predictions to the wrong side of the limit: a
+  one-compartment M3 fit that FOCEi puts at `ke = 0.76` came back at `ke = -23`
+  with a proportional residual standard deviation in the thousands.  Censored
+  rows now score identically in the chain and in the FOCEi inner behind
+  `est="fsaem"`'s Metropolis-Hastings acceptance, so censored data stays on the
+  fast kernel rather than needing a gate.  An uncensored fit is bit-identical
+  (#876).
+
 - `est="fsaem"`'s Metropolis-Hastings proposal is now built against the residual
   variance the SAEM chain actually uses.  The FOCEi inner behind the proposal was
   built with the fit's `addProp`, whose default is `"combined2"`, while the SAEM

--- a/R/fsaemInner.R
+++ b/R/fsaemInner.R
@@ -182,6 +182,12 @@
   # mu-ref covariates are supported: non-time-varying ones are absorbed into the
   # per-subject mprior data, time-varying ones are kept as inner regressor betas
   # refreshed from the live Plambda each iteration.
+  #
+  # M2/M3/M4 censoring is supported and deliberately NOT gated (#876): the chain
+  # and the IMH acceptance both score a censored row with doCensNormal1 on the
+  # same f and variance, so the composed kernel still targets the chain's
+  # distribution.  test-fsaem-inner.R pins the inner's censored term against an
+  # independent evaluation and test-focei-cens.R pins fsaem to saem on M3 data.
   TRUE
 }
 

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -1975,10 +1975,8 @@ public:
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
               _scratch_indio = indio + (arma::uword)k * stride;
               DYFhyp(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
-              for (int j = ntotal; j--;) {
-                DYFhyp(_scratch_indio(j)) = doCensNormal1(censk[j], y[j], _scratch_limitT[j],
-                                                       DYFhyp(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
-              }
+              applyCensLoss(DYFhyp, _scratch_indio, censk, yt, _scratch_limitT,
+                            _scratch_ft, _scratch_g);
               applyLLObsLoss(DYFhyp, _scratch_indio, fk);
             }
           } else if (distribution == 2) {
@@ -2178,10 +2176,8 @@ public:
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
               _scratch_indio = indio + (arma::uword)k * stride;
               cur_DYF(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
-              for (int j = ntotal; j--;) {
-                cur_DYF(_scratch_indio(j)) = doCensNormal1(censk[j], y[j], _scratch_limitT[j],
-                                                       cur_DYF(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
-              }
+              applyCensLoss(cur_DYF, _scratch_indio, censk, yt, _scratch_limitT,
+                            _scratch_ft, _scratch_g);
               applyLLObsLoss(cur_DYF, _scratch_indio, fk);
             }
           } else if (distribution == 2) {
@@ -2461,10 +2457,8 @@ public:
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
               _scratch_indio = indio + (arma::uword)k * stride;
               DYF(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
-              for (int j = ntotal; j--;) {
-                DYF(_scratch_indio(j)) = doCensNormal1(censk[j], y[j], _scratch_limitT[j],
-                                                       DYF(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
-              }
+              applyCensLoss(DYF, _scratch_indio, censk, yt, _scratch_limitT,
+                            _scratch_ft, _scratch_g);
               applyLLObsLoss(DYF, _scratch_indio, fk);
             }
           } else if (distribution == 2){
@@ -3954,9 +3948,23 @@ private:
     }
   }
 
-  static inline void doCens(mat &DYF, vec &cens, vec &limit, vec &fc, vec &r, const vec &dv) {
-    for (int j = (int)cens.size(); j--;) {
-      DYF(j) = doCensNormal1(cens[j], dv[j], limit[j], DYF(j), fc[j], r[j], 0);
+  // Replace the normal per-observation loss in `DYFm` with the censored one.
+  //
+  // doCensNormal1 speaks the FOCEi inner's language -- it takes and returns a
+  // LOG-LIKELIHOOD, wants the VARIANCE, and reads the DV on the transformed
+  // scale -- while the SAEM chain carries the NEGATED log-likelihood (a loss),
+  // the residual SD `g`, and the untransformed y.  Translating in both
+  // directions is what makes a censored row score the same here as in
+  // likInner0; that agreement is what f-SAEM's IMH acceptance needs, and
+  // without it M3/M4 came back with the censored term's sign flipped, which
+  // drove censored predictions to the wrong side of the limit.  An uncensored
+  // row comes back untouched.
+  inline void applyCensLoss(mat &DYFm, const uvec &indioK, const vec &censk,
+                            const vec &ytk, const vec &limT, const vec &ft,
+                            const vec &g) const {
+    for (int j = ntotal; j--;) {
+      DYFm(indioK(j)) = -doCensNormal1(censk[j], ytk[j], limT[j],
+                                       -DYFm(indioK(j)), ft[j], g[j]*g[j], 0);
     }
   }
 
@@ -4136,10 +4144,8 @@ private:
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
               _scratch_indio = mx.indio + (arma::uword)k * stride;
               DYF(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
-              for (int j = ntotal; j--;) {
-                DYF(_scratch_indio(j)) = doCensNormal1(censk[j], mx.y[j], _scratch_limitT[j],
-                                                       DYF(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
-              }
+              applyCensLoss(DYF, _scratch_indio, censk, yt, _scratch_limitT,
+                            _scratch_ft, _scratch_g);
               applyLLObsLoss(DYF, _scratch_indio, fsk);
             }
           }
@@ -4252,10 +4258,8 @@ private:
             _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
             _scratch_indio = mx.indio + (arma::uword)k * stride;
             DYFm(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
-            for (int j = ntotal; j--;) {
-              DYFm(_scratch_indio(j)) = doCensNormal1(censk[j], mx.y[j], _scratch_limitT[j],
-                                                     DYFm(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
-            }
+            applyCensLoss(DYFm, _scratch_indio, censk, yt, _scratch_limitT,
+                          _scratch_ft, _scratch_g);
             applyLLObsLoss(DYFm, _scratch_indio, fsk);
           }
         }
@@ -4366,10 +4370,8 @@ private:
           _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
           _scratch_indio = indio + (arma::uword)k * stride;
           DYFhyp(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
-          for (int j = ntotal; j--;) {
-            DYFhyp(_scratch_indio(j)) = doCensNormal1(censk[j], y[j], _scratch_limitT[j],
-                                                   DYFhyp(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
-          }
+          applyCensLoss(DYFhyp, _scratch_indio, censk, yt, _scratch_limitT,
+                        _scratch_ft, _scratch_g);
           applyLLObsLoss(DYFhyp, _scratch_indio, fk);
         }
       } else if (distribution == 2) {

--- a/tests/testthat/test-focei-cens.R
+++ b/tests/testthat/test-focei-cens.R
@@ -67,6 +67,44 @@ nmTest({
     expect_no_match(as.character(f.saem2$censInformation), "\\((laplace|gauss)\\)")
   })
 
+  # M3 for the SAEM family (#876).  The chain scores a censored row with
+  # doCensNormal1 and so does the FOCEi inner that f-SAEM's IMH acceptance uses,
+  # so the two agree and fsaem needs no censoring gate -- these fits are what
+  # says so.  M2 alone would not: with limit=0 the M2 tail probability is ~1, so
+  # its term is ~0 and a wrong SIGN or SCALE on it does not show.  M3 has no such
+  # cover, and when the chain fed doCensNormal1 the loss (not the
+  # log-likelihood), the SD (not the variance), and the raw DV, these fits came
+  # back at ke = -23 with a residual SD in the thousands.
+  .m3 <- rbind(dat[, names(dat) != "Y"],
+               data.frame(ID = 1:10, Time = 1.5, DV = 3))
+  .m3$cens <- ifelse(.m3$Time == 1.5, 1, 0)
+  .m3 <- .m3[order(.m3$ID, .m3$Time), ]
+  .m3ctl <- saemControl(print = 0, nBurn = 200, nEm = 200, seed = 42)
+
+  test_that("M3 censoring - saem estimates stay on the model", {
+    f.saemM3 <- suppressWarnings(suppressMessages(nlmixr(f, .m3, "saem", control = .m3ctl)))
+    f.foceiM3 <- suppressWarnings(suppressMessages(nlmixr(f, .m3, "focei")))
+    ct(f.saemM3, "M3 censoring")
+    # both fit the same model to the same data, so the elimination rate agrees to
+    # well within 20%; the flipped-sign loss put it on the wrong side of zero
+    expect_equal(fixef(f.saemM3)[["tvK"]], fixef(f.foceiM3)[["tvK"]], tolerance = 0.2)
+    # a proportional residual SD is a fraction, not a count
+    expect_lt(fixef(f.saemM3)[["prop.sd"]], 1)
+    expect_lt(f.saemM3$omega[1, 1], 1)
+  })
+
+  test_that("M3 censoring - fsaem lands where saem does", {
+    f.saemM3 <- suppressWarnings(suppressMessages(nlmixr(f, .m3, "saem", control = .m3ctl)))
+    f.fsaemM3 <- suppressWarnings(suppressMessages(nlmixr(f, .m3, "fsaem", control = .m3ctl)))
+    ct(f.fsaemM3, "M3 censoring")
+    # the fast kernel really ran on the censored data (not degraded to saem)
+    expect_gt(f.fsaemM3$fsaemDiag$nStep, 0)
+    expect_gt(f.fsaemM3$fsaemDiag$nAcc, 0)
+    # the IMH acceptance scores a censored row the way the chain does, so
+    # preconditioning the chain with it must not move where the fit lands
+    expect_equal(fixef(f.fsaemM3), fixef(f.saemM3), tolerance = 0.05)
+    expect_equal(f.fsaemM3$omega[1, 1], f.saemM3$omega[1, 1], tolerance = 0.5)
+  })
 
   test_that("Limit affects values", {
 

--- a/tests/testthat/test-focei-cens.R
+++ b/tests/testthat/test-focei-cens.R
@@ -91,6 +91,16 @@ nmTest({
     # a proportional residual SD is a fraction, not a count
     expect_lt(fixef(f.saemM3)[["prop.sd"]], 1)
     expect_lt(f.saemM3$omega[1, 1], 1)
+
+    # M4 is its own branch (a limit turns the tail into a difference of two), so
+    # it needs its own case
+    .m4 <- .m3
+    .m4$limit <- ifelse(.m4$cens == 1, 0, NA)
+    f.saemM4 <- suppressWarnings(suppressMessages(nlmixr(f, .m4, "saem", control = .m3ctl)))
+    f.foceiM4 <- suppressWarnings(suppressMessages(nlmixr(f, .m4, "focei")))
+    ct(f.saemM4, "M4 censoring")
+    expect_equal(fixef(f.saemM4)[["tvK"]], fixef(f.foceiM4)[["tvK"]], tolerance = 0.2)
+    expect_lt(fixef(f.saemM4)[["prop.sd"]], 1)
   })
 
   test_that("M3 censoring - fsaem lands where saem does", {

--- a/tests/testthat/test-fsaem-inner.R
+++ b/tests/testthat/test-fsaem-inner.R
@@ -262,4 +262,76 @@ nmTest({
     on.exit(.fsaemInnerFree(), add = TRUE)
     expect_equal(.cfg$fsaemInnerEnv$control$addProp, "combined2")
   })
+
+  # The IMH acceptance ratio is a difference of likInner0 values, so what the
+  # kernel targets on a censored dataset is whatever likInner0 does with a
+  # censored row.  Check that against an independent R evaluation of the exact
+  # M3 term (#876): the chain scores the same row with the same doCensNormal1,
+  # so agreement here is what lets censored data through .fsaemSupported.
+  test_that("the inner objective the IMH scores carries the exact M3 term", {
+    skip_if_not_installed("nlmixr2data")
+
+    one.cmt <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.3; add.sd <- 0.7})
+      model({
+        ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .ui <- rxode2::rxUiDecompress(rxode2::rxode2(one.cmt))
+    .sd <- 0.7
+    .loq <- 3
+
+    # one dataset with the low observations flagged BQL, one with the SAME DV
+    # values and no flag.  Differencing the two objectives isolates the censored
+    # term; differencing THAT across two etas drops every eta-free constant
+    # (the adjLik offset, the transform Jacobian, the eta prior).
+    .datC <- nlmixr2data::theo_sd
+    .obs <- .datC$EVID == 0
+    .datC$cens <- 0L
+    .datC$cens[.obs & .datC$DV < .loq] <- 1L
+    .datC$DV[.datC$cens == 1L] <- .loq
+    .datN <- .datC
+    .datN$cens <- 0L
+    expect_gt(sum(.datC$cens), 0)
+
+    .N <- length(unique(.datC$ID))
+    .ctl <- list(rxControl = rxode2::rxControl(), fastCov = "jacobian", fastLik = "focei",
+                 fastInnerIt = 100L, sumProd = FALSE, optExpression = TRUE, literalFix = FALSE,
+                 addProp = "combined2", eventSens = "jump", indTolRelax = TRUE,
+                 maxOdeRecalc = 5L, odeRecalcFactor = 10^0.5)
+    .e1 <- matrix(0, .N, 1)
+    .e2 <- matrix(0.35, .N, 1)
+
+    .run <- function(d) {
+      .fsaemInnerSetup(.ui, d, matrix(0, .N, 1), .ctl)
+      on.exit(.fsaemInnerFree())
+      .a <- vaeInnerLik(.e1, 1L, FALSE, TRUE)
+      .b <- vaeInnerLik(.e2, 1L, FALSE, TRUE)
+      list(o1 = .a$obj, o2 = .b$obj, f1 = .a$f, f2 = .b$f)
+    }
+    .rC <- suppressWarnings(.run(.datC))
+    .rN <- suppressWarnings(.run(.datN))
+    # flagging a row censored must not move the prediction
+    expect_identical(.rC$f1, .rN$f1)
+    expect_identical(.rC$f2, .rN$f2)
+
+    .cens <- split(.datC$cens[.obs], .datC$ID[.obs])
+    .dv <- split(.datC$DV[.obs], .datC$ID[.obs])
+    # per subject: sum over its BQL rows of (M3 loss - the normal loss it replaces)
+    .censLoss <- function(fl) {
+      vapply(seq_len(.N), function(i) {
+        .w <- which(.cens[[i]] == 1L)
+        if (length(.w) == 0L) return(0)
+        .z <- (.dv[[i]][.w] - fl[[i]][.w]) / .sd
+        sum(-stats::pnorm(.z, log.p = TRUE) - (0.5 * .z^2 + log(.sd)))
+      }, numeric(1))
+    }
+    # tolerance: the uncensored branch reproduces from the returned predictions
+    # to the same ~1e-4 relative, so this is the reference's own accuracy, not
+    # the censored term's.  A flipped sign or an SD-for-variance swap is O(1).
+    expect_equal((.rC$o1 - .rN$o1) - (.rC$o2 - .rN$o2),
+                 .censLoss(.rC$f1) - .censLoss(.rC$f2),
+                 tolerance = 1e-3)
+  })
 })


### PR DESCRIPTION
Closes #876.

## What the verification found

#876 asked whether the SAEM chain and the FOCEi inner behind `est="fsaem"`'s IMH
acceptance agree on a censored row, and to gate censoring in `.fsaemSupported`
if they do not.  They did not -- but the disagreement was a bug in **plain
SAEM**, not something specific to the fast kernel.

`doCensNormal1` (`src/censEst.h`) speaks the FOCEi inner's language: it takes and
returns a **log-likelihood**, wants the **variance**, and reads the DV on the
**transformed** scale.  `src/nlm.cpp:432` calls it exactly that way.  All six of
the SAEM chain's DYF builders handed it the per-observation **loss**, the
residual **SD** (`_scratch_g`), and the **raw** `y`, then stored the
log-likelihood it returned back as a loss.

M2 hid this: with a limit well below the prediction the tail probability is
essentially 1, so its term is ~0 and neither a wrong sign nor a wrong scale
shows.  M3/M4 had no such cover -- the censored term arrived with its sign
flipped, and the chain drove censored predictions to the wrong side of the
limit.  On the Wang2007 M3 data:

| | tvK | prop.sd | omega |
| --- | --- | --- | --- |
| focei | 0.757 | 0.280 | 0.0014 |
| saem (before) | **-23.3** | **6627** | **8.48** |
| saem (after) | 0.683 | 0.191 | 0.00026 |
| fsaem (after) | 0.684 | 0.191 | 0.00023 |

## The fix

One `applyCensLoss` helper that translates in both directions, replacing the
repeated four-line pattern at all six sites (and the dead `doCens` it sits
where).  An uncensored row round-trips through `-doCensNormal1(..., -DYF, ...)`
unchanged, so every uncensored fit is bit-identical.

**No gate is added to `.fsaemSupported`.**  With the chain fixed, the two
likelihoods agree up to an eta-free constant, so the composed kernel targets the
chain's distribution and censored data legitimately stays on the fast kernel.
That decision is commented there so it does not get "fixed" back.

## Tests

- `test-focei-cens.R`: saem M3 **and** M4 (its own branch -- a limit turns the
  tail into a difference of two) pinned against focei's `tvK`; fsaem M3 pinned to
  saem's answer, with `fsaemDiag$nStep > 0` proving the fast kernel actually fired
  rather than degrading.
- `test-fsaem-inner.R`: the inner's M3 term checked against `pnorm` in R.
  Differencing the objective across cens/no-cens data **and** across two etas
  strips every eta-free constant (the `adjLik` offset, the transform Jacobian,
  the eta prior); what is left agrees to ~4e-5 relative, which is the reference's
  own accuracy -- the uncensored branch reproduces no better.

Run clean: `focei-cens` (50), `fsaem` (144), `fsaem-inner`, `fsaem-imh`,
`fsaem-multi`, `fsaem-es`, `fsaem-iov`, `saem-loglik`, `saem-mix`, `nlm-cens`
(87), `saem-aic`, `saem-mu`, `saem-drop`, `saem-resid-lambda`, `saem-no-pop`.

## Known gap, filed separately

Censoring is now correct in the E-step only.  The residual M-step
(`src/saem.cpp:2578`, `:2898`) still counts a BQL row's recorded DV as an
observation, so `prop.sd` comes back systematically low (0.19 against focei's
0.28 above) even though `tvK` agrees to under 10%.  That is why the new cases
pin `tvK` and only bound `prop.sd`.  Fixing it means data augmentation in the
E-step -- filed as #916.
