### PR TITLE
Call rxode2::.iniHandleLine() instead of the old alias

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # nlmixr2est 7.0.3
 
+## Internal
+
+- `ini()` on a fit now calls `rxode2::.iniHandleLine()` rather than the
+  `rxode2::.iniHandleFixOrUnfix()` alias for it.  They are the same
+  function; this was the last caller of the old name anywhere in the
+  ecosystem, so rxode2 can now drop it (nlmixr2/rxode2#1250).
+
 ## Breaking changes
 
 - `saemControl(lbfgsLmm=, lbfgsFactr=, lbfgsPgtol=, lbfgsMaxIter=)` have been

--- a/R/ini.R
+++ b/R/ini.R
@@ -5,7 +5,7 @@ ini.nlmixr2FitCore <- function(x, ..., envir = parent.frame()) {
   .iniLines <- rxode2::.quoteCallInfoLines(match.call(expand.dots = TRUE)[-(1:2)],
                                            envir = envir)
   lapply(.iniLines, function(line) {
-    rxode2::.iniHandleFixOrUnfix(line, .ret, envir = envir)
+    rxode2::.iniHandleLine(line, .ret, envir = envir)
   })
   .ret
 }


### PR DESCRIPTION
First half of nlmixr2/rxode2#1250.

`ini()` on a fit called `rxode2::.iniHandleFixOrUnfix()`, an alias rxode2
kept **only** for this one call — it carried a `# TODO: while nlmixr2est is
changed` comment saying so.

They are the same function:

```r
identical(rxode2::.iniHandleLine, rxode2::.iniHandleFixOrUnfix)   #> TRUE
identical(formals(...), formals(...))                            #> TRUE
```

so this is a rename with no behaviour change.

This was the **only** caller left anywhere: `nlmixr2est`, `nlmixr2extra`,
`babelmixr2`, `nlmixr2`, `nlmixr2lib` and `nlmixr2plot` were all checked and
none of the others use the old name.

Once this is merged, rxode2 can drop the alias — that is the other half of
#1250 and must land **after** this, since rxode2's revdep CI installs
nlmixr2est from GitHub.
