### PR TITLE
fix: let post-estimation machinery accept prior-carrying models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,26 @@
   bounds and takes no L-BFGS-B settings.  Passing any of the four never changed a
   fit, so removing them changes no result.
 
+## Bug fixes
+
+- Post-estimation machinery no longer refuses a model whose `ini({})` declares
+  prior distributions (#938).  Two parts:
+
+  - The `"output"` and `"posthoc"` pseudo-methods now declare
+    `nlmixr2Priors = "all"`.  Neither estimates anything -- they evaluate an
+    already-specified model and build its tables -- so there is no prior they
+    could silently ignore.
+
+  - The internal zero-iteration `est="focei"` re-entries behind `setOfv()`,
+    `addCwres()` and the impmap objective recompute now run with the prior
+    gate bypassed (scoped, restored on exit).  By the time they run, the
+    priors were already accepted or refused by the estimation method that
+    produced the fit; refusing again only broke post-processing.  A
+    user-initiated `est="focei"` on a prior-carrying model is still refused.
+
+  This was latent while no estimation method declared prior support; it would
+  have broken assembling a finished fit for the first method that does.
+
 ## New features
 
 - Requires `rxode2` (>= 5.1.7).  The compatibility layer that also let this

--- a/R/addCwres.R
+++ b/R/addCwres.R
@@ -87,8 +87,9 @@ addCwres <- function(fit, focei=TRUE, updateObject = TRUE, envir = parent.frame(
     .foceiControl$covMethod <- 0L
     .foceiControl$interaction <- focei
     .foceiControl$nAGQ <- 0L # focei/foce objective row, not the fit's quadrature
-    .newFit <- nlmixr2(fit, data=nlme::getData(fit), est="focei",
-                       control = .foceiControl)
+    .newFit <- .nlmixr2PriorGateBypass(
+      nlmixr2(fit, data=nlme::getData(fit), est="focei",
+              control = .foceiControl))
     .extra <- setdiff(names(.newFit), names(fit))
     .extra <- as.data.frame(.newFit)[, .extra]
     .origFitEnv <- fit$env

--- a/R/cov.R
+++ b/R/cov.R
@@ -287,8 +287,14 @@
   # the nested re-fit resets mu-referencing global state (.muRefTrans$cur); save + restore.
   .savedMuRef <- .muRefTrans$cur
   on.exit(.muRefTrans$cur <- .savedMuRef, add = TRUE)
+  # fixed-parameter re-fit of an already-accepted model: run with the prior
+  # gate bypassed (#938) -- .baseEst (e.g. "focei") declares no prior support,
+  # and the try() below would otherwise silently swallow the gate error and
+  # abort the covariance step of a prior-carrying fit
   .fit2 <- try(suppressMessages(suppressWarnings(
-    nlmixr2(.ui, data = getData(fit), est = .baseEst, control = .control))), silent = TRUE)
+    .nlmixr2PriorGateBypass(
+      nlmixr2(.ui, data = getData(fit), est = .baseEst, control = .control)))),
+    silent = TRUE)
   if (inherits(.fit2, "try-error") || is.null(.fit2$cov)) return(NULL)
   .env2 <- .fit2$env
   # The base-model re-fit rendered a correct parameter table (SEs computed from its

--- a/R/covRecompute.R
+++ b/R/covRecompute.R
@@ -59,8 +59,14 @@
   # the nested re-fit resets mu-referencing global state; save + restore
   .savedMuRef <- .muRefTrans$cur
   on.exit(.muRefTrans$cur <- .savedMuRef, add = TRUE)
+  # fixed-parameter re-fit of an already-accepted model: bypass the prior gate
+  # (#938) -- .covRecomputeFo forces est="focei", which declares no prior
+  # support, and the try() below would otherwise silently return NULL for a
+  # prior-carrying fit
   .fit2 <- try(suppressMessages(suppressWarnings(
-    nlmixr2(.a$ui, data = .a$data, est = est, control = control))), silent = TRUE)
+    .nlmixr2PriorGateBypass(
+      nlmixr2(.a$ui, data = .a$data, est = est, control = control)))),
+    silent = TRUE)
   if (inherits(.fit2, "try-error")) return(NULL)
   .cov <- tryCatch(.fit2$cov, error = function(e) NULL)
   if (is.null(.cov) || !is.matrix(.cov)) return(NULL)

--- a/R/focei.R
+++ b/R/focei.R
@@ -3218,6 +3218,12 @@ nlmixr2Est.output <- function(env, ...) {
   if (!exists("est", envir=env)) env$est <- "posthoc"
   .foceiFamilyReturn(env, .ui, ..., est=env$est)
 }
+# "output" is not an estimation method: it takes a completed environment and
+# builds the tables/objDf for it (nlmixr2CreateOutputFromUi).  The priors were
+# already used (or refused) by whichever method actually ran, so there is
+# nothing here that could silently ignore them -- refusing at this point would
+# only break assembling a finished fit from a prior-carrying model (#938).
+attr(nlmixr2Est.output, "nlmixr2Priors") <- "all"
 
 #' Create nlmixr output from the UI
 #'

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -774,7 +774,8 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
               silent=TRUE)
   if (inherits(.ctl, "try-error")) return(invisible(FALSE))
   .f2 <- try(suppressMessages(suppressWarnings(
-    nlmixr2(.ui, data=nlme::getData(fit), est="focei", control=.ctl))),
+    .nlmixr2PriorGateBypass(
+      nlmixr2(.ui, data=nlme::getData(fit), est="focei", control=.ctl)))),
     silent=TRUE)
   if (inherits(.f2, "try-error")) return(invisible(FALSE))
   .e2 <- tryCatch(.f2$env, error=function(e) NULL)

--- a/R/ofv.R
+++ b/R/ofv.R
@@ -27,7 +27,8 @@
       return(fit)
     }
     .foceiControl <- do.call(foceiControl, .foceiControl)
-    .newFit <- nlmixr2(fit, nlme::getData(fit), "focei", control = .foceiControl)
+    .newFit <- .nlmixr2PriorGateBypass(
+      nlmixr2(fit, nlme::getData(fit), "focei", control = .foceiControl))
     .env <- fit$env
     .addFoceiInfoToFit(.env, .newFit)
     .ob1 <- .newFit$objDf

--- a/R/posthoc.R
+++ b/R/posthoc.R
@@ -112,3 +112,7 @@ nlmixr2Est.posthoc <- function(env, ...) {
 }
 attr(nlmixr2Est.posthoc, "covPresent") <- TRUE
 attr(nlmixr2Est.posthoc, "unbounded") <- FALSE
+# Like "output", posthoc does not estimate anything (maxOuterIterations=0); it
+# evaluates an already-specified model, so a prior in ini({}) is not something
+# it could silently ignore.  See #938.
+attr(nlmixr2Est.posthoc, "nlmixr2Priors") <- "all"

--- a/R/priors.R
+++ b/R/priors.R
@@ -86,6 +86,32 @@
   invisible(ui)
 }
 
+#' Evaluate `expr` with the prior gate bypassed
+#'
+#' For internal re-entries that evaluate an already-accepted model at fixed
+#' parameters: the zero-iteration focei runs behind `setOfv()`, `addCwres()`
+#' and the impmap objective recompute all re-dispatch with `est="focei"`,
+#' which declares no prior support.  By then the priors were already accepted
+#' (or refused) by the estimation method that produced the fit, and the
+#' fixed-parameter evaluation does not use them, so refusing again would only
+#' break post-processing of a prior-carrying fit (#938).
+#'
+#' Scoped: the flag is restored on exit, so a user-initiated estimation is
+#' never affected.  The field is deliberately absent from
+#' `.nlmixr2globalReset()` -- the nested `nlmixr2()` call resets
+#' `nlmixr2global`, and the flag has to survive it (reset assigns known
+#' fields; it does not clear the environment).
+#'
+#' @param expr expression to evaluate
+#' @return the value of `expr`
+#' @noRd
+.nlmixr2PriorGateBypass <- function(expr) {
+  .saved <- nlmixr2global$nlmixr2PriorGateBypass
+  nlmixr2global$nlmixr2PriorGateBypass <- TRUE
+  on.exit(assign("nlmixr2PriorGateBypass", .saved, envir=nlmixr2global))
+  force(expr)
+}
+
 #' Refuse the priors the dispatched estimation method cannot use
 #'
 #' @param env nlmixr2 estimation environment
@@ -93,6 +119,7 @@
 #' @noRd
 #' @author Matthew L. Fidler
 .nlmixr2AssertPriors <- function(env) {
+  if (isTRUE(nlmixr2global$nlmixr2PriorGateBypass)) return(invisible())
   .support <- .nlmixr2PriorSupport(env)
   if (.support == "all") return(invisible())
   .ui <- get("ui", envir=env)

--- a/tests/testthat/test-priors-output.R
+++ b/tests/testthat/test-priors-output.R
@@ -1,0 +1,96 @@
+nmTest({
+  test_that("output/posthoc declare full prior support (#938)", {
+    # "output" and "posthoc" do not estimate anything; refusing a prior there
+    # would only break assembling a finished fit from a prior-carrying model.
+    for (.cls in c("output", "posthoc")) {
+      .env <- new.env(parent = emptyenv())
+      class(.env) <- c(.cls, "nlmixr2Est")
+      expect_identical(.nlmixr2PriorSupport(.env), "all")
+    }
+    # a method without the attribute still defaults to "none"
+    .env <- new.env(parent = emptyenv())
+    class(.env) <- c("focei", "nlmixr2Est")
+    expect_identical(.nlmixr2PriorSupport(.env), "none")
+  })
+
+  test_that("posthoc runs on a model whose ini({}) declares priors (#938)", {
+    skip_on_cran()
+    skip_if_not(exists("rxUiPriors", envir = asNamespace("rxode2")),
+                "rxode2 without prior support")
+
+    one.compartment <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.6
+        prior(tka) ~ dnorm(0, 10)
+        prior(add.sd) ~ dcauchy(0, 5)
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d / dt(depot) <- -ka * depot
+        d / dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+
+    # Before #938 this errored at the prior gate ("...which this estimation
+    # method cannot use"): first at the posthoc dispatch itself, then again in
+    # the automatic FOCEi-objective evaluation (.setOfvFo), which re-enters
+    # with est="focei".
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(one.compartment, nlmixr2data::theo_sd, est = "posthoc")))
+    expect_true(inherits(.fit, "nlmixr2FitData"))
+    # the priors survive onto the finished fit
+    .pri <- rxode2::rxUiPriors(.fit$ui)
+    expect_true(all(c("tka", "add.sd") %in% .pri$name))
+    # the bypass is scoped: the gate still refuses a user-initiated focei
+    expect_error(
+      suppressWarnings(suppressMessages(
+        nlmixr2(one.compartment, nlmixr2data::theo_sd, est = "focei",
+                control = foceiControl(maxOuterIterations = 0L, print = 0L)))),
+      "prior")
+    expect_false(isTRUE(nlmixr2global$nlmixr2PriorGateBypass))
+  })
+
+  test_that("addCwres() works on a prior-carrying fit (#938)", {
+    skip_on_cran()
+    skip_if_not(exists("rxUiPriors", envir = asNamespace("rxode2")),
+                "rxode2 without prior support")
+
+    one.compartment <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.6
+        prior(tka) ~ dnorm(0, 10)
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d / dt(depot) <- -ka * depot
+        d / dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+    # cwres=FALSE keeps CWRES out of the fit so addCwres() genuinely runs its
+    # nested est="focei" evaluation (with CWRES already present it returns
+    # early and the bypass is never exercised)
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(one.compartment, nlmixr2data::theo_sd, est = "posthoc",
+              table = tableControl(cwres = FALSE))))
+    expect_false("CWRES" %in% names(.fit))
+    .fit2 <- suppressWarnings(suppressMessages(addCwres(.fit)))
+    expect_true("CWRES" %in% names(.fit2))
+    expect_false(isTRUE(nlmixr2global$nlmixr2PriorGateBypass))
+  })
+})


### PR DESCRIPTION
Closes #938.

## What

Two-part fix so post-estimation machinery accepts a model whose `ini({})` declares prior distributions:

1. **`nlmixr2Est.output` and `nlmixr2Est.posthoc` now declare `nlmixr2Priors = "all"`.** Neither estimates anything — they evaluate an already-specified model and build its tables — so there is no prior they could silently ignore, and refusing broke `nlmixr2CreateOutputFromUi()` (the finalize step of every external backend) for prior-carrying models.

2. **Internal fixed-parameter re-entries run with the prior gate bypassed.** Five sites re-dispatch with `est="focei"` (which rightly declares no prior support) to evaluate an *already-accepted* model at fixed parameters: the automatic FOCEi objective row (`.setOfvFo`, fired from `.foceiFamilyReturn` whenever CWRES exists), `addCwres()`, the impmap objective recompute, `.foceiRecomputeMuCov` and `.covRecomputeNative` (the last two wrap the nested call in `try(silent=TRUE)`, so the gate error was *silently swallowed* and the covariance step just produced nothing). They now run inside `.nlmixr2PriorGateBypass()`, a scoped flag restored on exit. A user-initiated `est="focei"` on a prior-carrying model is still refused, and the tests assert that.

The bypass flag survives the nested `nlmixr2()` call's `.nlmixr2globalReset()` because reset assigns known fields rather than clearing the environment — the flag is deliberately not among them.

## Why now

Latent while no estimation method declares prior support (none does today); it breaks the first method that sets `nlmixr2Priors`, which `est="stan"` (nlmixr2/nlmixr2stan) will be.

## Review

Independently reviewed by Antigravity (gemini-3.1-pro-high). Its findings — the two silently-swallowed covariance sites and missing `addCwres()` coverage — are verified and fixed in this PR; it also confirmed no state-leak path (error/interrupt restores the flag, and the impmap whole-global snapshot/restore composes correctly).

## Tests

`tests/testthat/test-priors-output.R`: prior-support attributes; a full `est="posthoc"` fit on a prior-carrying model (previously died at the gate, then again in `.setOfvFo`); prior round-trip onto the finished fit; the scoped-bypass property (user focei still refused, flag not left set); `addCwres()` on a prior-carrying fit built with `tableControl(cwres=FALSE)` so the nested `est="focei"` evaluation genuinely runs.
