### PR TITLE
fix(saem): degrade instead of erroring on a singular final omega (#923)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -246,6 +246,18 @@
 
 ### Crashes and stability
 
+- An over-parameterized `est="saem"` fit no longer dies with "nearest PD
+  calculation failed" after the last iteration (#923).  A singular final Omega
+  was already projected to the nearest positive-definite matrix before the
+  residual/table step, but that projection itself errors on the fully degenerate
+  cases -- an all-zero, non-finite, or negative-definite Omega -- which is
+  exactly what an over-parameterized model produces.  Those now fall back to a
+  floored diagonal so the completed run is returned as a fit, with a `$runInfo`
+  note saying the Omega was singular; the reported Omega is left as estimated.
+  A collapsed or non-finite `saem` Omega is also reported in `$runInfo` on its
+  own, and a failure while assembling the fit object retries once without the
+  table step rather than throwing the finished run away.  When `nmNearPD()` does
+  error it now says which degenerate case it hit.
 - The shared solve pool's lhs-width probe could **segfault** instead of
   declining.  It verifies a model by calling that model's `calc_lhs`, and
   generated `calc_lhs` dereferences per-subject pointers that are bound by a

--- a/R/focei.R
+++ b/R/focei.R
@@ -1724,6 +1724,40 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
   }
 }
 
+#' Repair a non-positive-definite omega so post-fit processing can continue
+#'
+#' `nmNearPD()` itself fails (and errors) on the fully degenerate cases -- an
+#' all-zero omega, one holding NaN/Inf, or a negative-definite one -- which is
+#' exactly what an over-parameterized fit produces (#923).  Fall back to a
+#' floored diagonal there so the fit degrades instead of aborting.
+#'
+#' @param om omega matrix
+#' @return positive-definite matrix with the dimnames of `om`
+#' @author Matthew L. Fidler
+#' @noRd
+.foceiRepairOmega <- function(om) {
+  .om <- om
+  .bad <- !is.finite(.om)
+  .om[.bad] <- 0
+  .r <- try(nmNearPD(.om), silent=TRUE)
+  if (!inherits(.r, "try-error") &&
+        !inherits(try(chol(.r), silent=TRUE), "try-error")) {
+    dimnames(.r) <- dimnames(om)
+    if (any(.bad)) {
+      warning("non-finite omega values zeroed for tables", call.=FALSE)
+    }
+    return(.r)
+  }
+  .d <- diag(.om)
+  .pos <- .d[is.finite(.d) & .d > 0]
+  .floor <- if (length(.pos) > 0L) max(1e-8, 1e-6 * max(.pos)) else 1e-6
+  .d[!is.finite(.d) | .d < .floor] <- .floor
+  .ret <- diag(.d, nrow=length(.d))
+  dimnames(.ret) <- dimnames(om)
+  warning("singular omega; used a floored diagonal for tables", call.=FALSE)
+  .ret
+}
+
 #'  This sets up the initial omega/eta estimates and the boundaries for the whole system
 #'
 #' @param ui rxode2 UI object
@@ -1784,10 +1818,10 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
     # A degenerate fit can collapse an uninformative random-effect variance to
     # exactly 0 (e.g. SAEM with very few subjects), leaving a singular omega
     # whose inverse/chol fails when building the sym-inv-chol env and aborts the
-    # whole fit at the residual/table step.  nearPD the omega in that case so
+    # whole fit at the residual/table step.  Repair the omega in that case so
     # post-fit diagnostics still run; the reported fit omega is left unchanged.
     if (inherits(try(chol(.om0), silent=TRUE), "try-error")) {
-      .om0 <- nmNearPD(.om0)
+      .om0 <- .foceiRepairOmega(.om0)
     }
     env$rxInv <- rxode2::rxSymInvCholCreate(mat = .om0, diag.xform = .diagXform)
     env$xType <- env$rxInv$xType

--- a/R/saem.R
+++ b/R/saem.R
@@ -448,12 +448,6 @@
   }
   invisible()
 }
-#' Get SAEM omega
-#'
-#' @param env Environment that has ui and saem in it
-#' @return Nothing, environment is assigned the omega
-#' @author Matthew L. Fidler
-#' @noRd
 #' Note a degenerate final SAEM omega in the fit's $runInfo
 #'
 #' A collapsed (zero) or non-finite variance is the visible signature of an
@@ -488,6 +482,12 @@
   invisible()
 }
 
+#' Get SAEM omega
+#'
+#' @param env Environment that has ui and saem in it
+#' @return Nothing, environment is assigned the omega
+#' @author Matthew L. Fidler
+#' @noRd
 .getSaemOmega <- function(env) {
   ## Reorder based on translation
   .saem <- env$saem
@@ -1178,13 +1178,6 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
   invisible()
 }
 
-#' Fit the saem family of models
-#'
-#' @param env Environment from nlmixr2Est
-#' @param ... Other arguments
-#' @return fit environment with $saem, $saemControl, $dataSav, $origData, $ui
-#' @author Matthew L. Fidler
-#' @noRd
 #' Build the saem fit object, degrading to a table-free fit on failure
 #'
 #' The SAEM run itself is finished by this point (thetas, omega and the
@@ -1220,6 +1213,13 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
   .ret
 }
 
+#' Fit the saem family of models
+#'
+#' @param env Environment from nlmixr2Est
+#' @param ... Other arguments
+#' @return fit environment with $saem, $saemControl, $dataSav, $origData, $ui
+#' @author Matthew L. Fidler
+#' @noRd
 .saemFamilyFit <- function(env, ...) {
   .ui <- env$ui
   .control <- .ui$control

--- a/R/saem.R
+++ b/R/saem.R
@@ -454,6 +454,40 @@
 #' @return Nothing, environment is assigned the omega
 #' @author Matthew L. Fidler
 #' @noRd
+#' Note a degenerate final SAEM omega in the fit's $runInfo
+#'
+#' A collapsed (zero) or non-finite variance is the visible signature of an
+#' over-parameterized model; the downstream repair (`.foceiRepairOmega`) keeps
+#' the fit running, so without this the fit looks healthy (#923).
+#'
+#' @param ome final SAEM omega
+#' @param fixed names of eta variances that were fixed by the user (a fixed
+#'   zero is a modeling choice, not a collapse)
+#' @return Nothing, called for the warning side effect
+#' @author Matthew L. Fidler
+#' @noRd
+.saemWarnDegenerateOmega <- function(ome, fixed=character(0)) {
+  if (!is.matrix(ome) || nrow(ome) == 0L) return(invisible())
+  if (any(!is.finite(ome))) {
+    warning("omega has non-finite values; model may be over-parameterized",
+            call.=FALSE)
+    return(invisible())
+  }
+  .d <- diag(ome)
+  .d <- .d[!(names(.d) %in% fixed)]
+  if (length(.d) == 0L) return(invisible())
+  .zero <- names(.d)[.d <= 0]
+  if (length(.zero) == 0L) return(invisible())
+  if (length(.zero) == length(.d)) {
+    warning("all omega variances are zero; model may be over-parameterized",
+            call.=FALSE)
+  } else {
+    .pre <- "omega variance collapsed to zero: "
+    warning(paste0(.pre, .vaeTruncList(.zero, prefix=.pre)), call.=FALSE)
+  }
+  invisible()
+}
+
 .getSaemOmega <- function(env) {
   ## Reorder based on translation
   .saem <- env$saem
@@ -481,6 +515,8 @@
     .ome[.e2, .e1] <- .curOme[.o2, .o1]
   }
   env$omega <- .ome
+  .saemWarnDegenerateOmega(.ome,
+                           fixed=.eta[.eta$neta1 == .eta$neta2 & .eta$fix, "name"])
   # Always save the N-row (per-subject) etaMat so FOCEi post-processing
   # gets the correct number of rows, even for mixture models.
   env$.etaMatBase <- .mat2
@@ -1149,6 +1185,41 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
 #' @return fit environment with $saem, $saemControl, $dataSav, $origData, $ui
 #' @author Matthew L. Fidler
 #' @noRd
+#' Build the saem fit object, degrading to a table-free fit on failure
+#'
+#' The SAEM run itself is finished by this point (thetas, omega and the
+#' objective function are already in `env`), so a failure while assembling the
+#' output should not throw the completed run away (#923).  Retry once with the
+#' table/residual step off; only a second failure is an error, and it reports
+#' the original one.
+#'
+#' @param env saem environment ready for `nlmixr2CreateOutputFromUi()`
+#' @return the fit object
+#' @author Matthew L. Fidler
+#' @noRd
+.saemCreateOutput <- function(env) {
+  .snap <- as.list(env, all.names=TRUE)
+  .build <- function() {
+    nlmixr2CreateOutputFromUi(env$ui, data=env$origData, control=env$control,
+                              table=env$table, env=env, est="saem")
+  }
+  .ret <- try(.build(), silent=TRUE)
+  if (!inherits(.ret, "try-error")) return(.ret)
+  .msg <- attr(.ret, "condition")$message
+  # the failed attempt has already written into env; put it back the way it was
+  rm(list=ls(envir=env, all.names=TRUE), envir=env)
+  list2env(.snap, envir=env)
+  env$control$calcTables <- FALSE
+  env$table$cwres <- FALSE
+  env$table$npde <- FALSE
+  .ret <- try(.build(), silent=TRUE)
+  if (inherits(.ret, "try-error")) stop(.msg, call.=FALSE)
+  .pre <- "fit degraded, no tables: "
+  warning(paste0(.pre, .vaeTruncList(gsub("[\r\n]+", " ", .msg), prefix=.pre)),
+          call.=FALSE)
+  .ret
+}
+
 .saemFamilyFit <- function(env, ...) {
   .ui <- env$ui
   .control <- .ui$control
@@ -1204,7 +1275,7 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
     .ret$message <- "" # no message for now
     .ret$est <- "saem"
     .saemControlToFoceiControl(.ret)
-    .ret <- nlmixr2CreateOutputFromUi(.ret$ui, data=.ret$origData, control=.ret$control, table=.ret$table, env=.ret, est="saem")
+    .ret <- .saemCreateOutput(.ret)
     # covFull/sa: swap in the stashed full theta+residual+Omega covariance now that
     # the theta-dimensioned fit table has been built.
     .saemInstallFullCov(.ret)

--- a/src/nearPD.cpp
+++ b/src/nearPD.cpp
@@ -42,11 +42,19 @@ RObject nmNearPD_(RObject x
                   , bool trace = false // set to TRUE (or 1 ..) to trace iterations
                   ){
   arma::mat ret;
-  if (nmNearPD(ret, as<arma::mat>(x), keepDiag, do2eigen,
+  arma::mat xM = as<arma::mat>(x);
+  if (nmNearPD(ret, xM, keepDiag, do2eigen,
                doDykstra, only_values, eig_tol, conv_tol, posd_tol, maxit, trace)) {
     return wrap(ret);
   } else {
-    stop("nearest PD calculation failed");
+    // say which degenerate case it was; "failed" alone gives the caller nothing
+    // to act on (#923)
+    if (!xM.is_finite()) {
+      stop("nearest PD calculation failed: matrix has non-finite values");
+    } else if (arma::all(arma::vectorise(xM) == 0.0)) {
+      stop("nearest PD calculation failed: matrix is all zero");
+    }
+    stop("nearest PD calculation failed: matrix may be negative definite");
   }
   return R_NilValue;
 }

--- a/tests/testthat/test-saem-degraded-fit.R
+++ b/tests/testthat/test-saem-degraded-fit.R
@@ -1,0 +1,127 @@
+nmTest({
+  # #923: an over-parameterized saem run can end with a singular (all-zero,
+  # non-finite or negative-definite) Omega.  nmNearPD() itself errors on those,
+  # which aborted the completed fit at the post-processing step.  The fit now
+  # degrades (with a $runInfo note) instead of erroring.
+
+  .om <- function(x, nm=c("eta.ka", "eta.cl")) {
+    matrix(x, 2, 2, dimnames=list(nm, nm))
+  }
+
+  test_that(".foceiRepairOmega always returns a cholesky-able omega", {
+    # the fully degenerate cases: nmNearPD() errors on all three
+    .want <- c("singular omega", "non-finite", "singular omega")
+    .degs <- list(.om(0), .om(c(0.4, NaN, NaN, 0.2)), .om(c(-1, 0, 0, -2)))
+    for (.i in seq_along(.degs)) {
+      .deg <- .degs[[.i]]
+      expect_error(nmNearPD(.deg))
+      expect_warning(.r <- .foceiRepairOmega(.deg), .want[.i])
+      expect_false(inherits(try(chol(.r), silent=TRUE), "try-error"))
+      expect_equal(dimnames(.r), dimnames(.deg))
+    }
+    # a merely singular omega is still repaired by nearPD (no fallback warning)
+    expect_warning(.r <- .foceiRepairOmega(.om(c(0.5, 0, 0, 0))), NA)
+    expect_false(inherits(try(chol(.r), silent=TRUE), "try-error"))
+    expect_equal(dimnames(.r), dimnames(.om(0)))
+    # a good omega is returned unchanged
+    expect_equal(.foceiRepairOmega(.om(c(0.5, 0, 0, 0.2))), .om(c(0.5, 0, 0, 0.2)))
+  })
+
+  test_that("the focei post-processing env survives an all-zero omega (#923)", {
+    .mod <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .ui <- rxode2::rxUiDecompress(rxode2::rxode2(.mod))
+    # what a collapsed saem Omega looks like coming out of .getSaemOmega()
+    .iniDf <- .ui$iniDf
+    .iniDf$est[!is.na(.iniDf$neta1)] <- 0
+    assign("iniDf", .iniDf, envir=.ui)
+    assign("control", foceiControl(), envir=.ui)
+    expect_error(nmNearPD(.ui$omega))
+
+    .env <- new.env(parent=emptyenv())
+    .env$etaNames <- c("eta.ka", "eta.cl")
+    expect_warning(.foceiOptEnvSetupBounds(.ui, .env), "singular omega")
+    # the mechanism that used to abort the fit now produced a usable inverse
+    expect_false(is.null(.env$rxInv))
+  })
+
+  test_that(".saemWarnDegenerateOmega notes a collapsed omega in $runInfo", {
+    expect_warning(.saemWarnDegenerateOmega(.om(0)), "all omega variances are zero")
+    expect_warning(.saemWarnDegenerateOmega(.om(c(0.5, 0, 0, 0))),
+                   "omega variance collapsed to zero: eta.cl")
+    expect_warning(.saemWarnDegenerateOmega(.om(c(0.5, NaN, NaN, 0.2))), "non-finite")
+    # a user-fixed zero variance is a modeling choice, not a collapse
+    expect_warning(.saemWarnDegenerateOmega(.om(c(0.5, 0, 0, 0)), fixed="eta.cl"), NA)
+    expect_warning(.saemWarnDegenerateOmega(.om(c(0.5, 0, 0, 0.2))), NA)
+    expect_warning(.saemWarnDegenerateOmega(matrix(numeric(0), 0, 0)), NA)
+  })
+
+  test_that(".saemCreateOutput degrades to a table-free fit", {
+    .calls <- new.env(parent=emptyenv())
+    .calls$n <- 0L
+    .calls$calcTables <- logical(0)
+    .mockBuild <- function(nFail) {
+      function(ui, data, control, table, env, est) {
+        .calls$n <- .calls$n + 1L
+        .calls$calcTables <- c(.calls$calcTables, control$calcTables)
+        env$leftBehind <- TRUE
+        if (.calls$n <= nFail) stop("build failure ", .calls$n)
+        "fit"
+      }
+    }
+    .mkEnv <- function() {
+      .e <- new.env(parent=emptyenv())
+      .e$ui <- NULL
+      .e$origData <- NULL
+      .e$control <- list(calcTables=TRUE)
+      .e$table <- list(cwres=TRUE, npde=TRUE)
+      .e
+    }
+
+    # first attempt fails -> retried without tables, warns, keeps the fit
+    local_mocked_bindings(nlmixr2CreateOutputFromUi=.mockBuild(1L))
+    .env <- .mkEnv()
+    expect_warning(.ret <- .saemCreateOutput(.env), "fit degraded, no tables")
+    expect_equal(.ret, "fit")
+    expect_equal(.calls$n, 2L)
+    # the retry really did turn the table step off ...
+    expect_equal(.calls$calcTables, c(TRUE, FALSE))
+    expect_false(.env$table$cwres)
+    expect_false(.env$table$npde)
+
+    # ... and the failed attempt's writes into the environment were rolled back
+    # before the retry (`leftBehind` only comes from the successful second call)
+    .calls$n <- 0L
+    .calls$calcTables <- logical(0)
+    .env2 <- .mkEnv()
+    local_mocked_bindings(nlmixr2CreateOutputFromUi=function(ui, data, control, table, env, est) {
+      .calls$n <- .calls$n + 1L
+      if (.calls$n == 1L) {
+        env$leftBehind <- TRUE
+        stop("build failure")
+      }
+      exists("leftBehind", envir=env, inherits=FALSE)
+    })
+    expect_warning(.ret2 <- .saemCreateOutput(.env2), "fit degraded")
+    expect_false(.ret2)
+
+    # both attempts fail -> the original error is what the user sees
+    .calls$n <- 0L
+    local_mocked_bindings(nlmixr2CreateOutputFromUi=.mockBuild(2L))
+    expect_error(.saemCreateOutput(.mkEnv()), "build failure 1")
+  })
+})


### PR DESCRIPTION
Fixes #923.

An over-parameterized `est="saem"` run could die after the last iteration with

```
nearest PD calculation failed
```

which threw the completed fit away and stopped an `nlmixr2targets` pipeline.

## Root cause

`nmNearPD_()` (`src/nearPD.cpp`) is reachable from R at exactly one place on the
SAEM path: the singular-omega guard in `.foceiOptEnvSetupBounds()`
(`R/focei.R`), which builds the FOCEi post-processing environment used for the
residual/table step:

```r
if (inherits(try(chol(.om0), silent=TRUE), "try-error")) {
  .om0 <- nmNearPD(.om0)          # <- threw here
}
```

So a repair for a singular omega already existed -- it just assumed `nearPD`
always succeeds.  It does not.  `lotriNearPDarma()` declines (and the R wrapper
turns that into an error) on the fully degenerate cases:

| omega | nearPD |
|---|---|
| one zero variance among nonzero ones | ok (repaired) |
| rank deficient | ok |
| **all zero** | **fails** (no positive eigenvalue) |
| **any NaN/Inf** | **fails** (`eig_sym` fails) |
| **negative definite** | **fails** |

An over-parameterized fit lands in exactly the failing set: either every
uninformative variance collapses to 0, or `Gamma2_phi1` goes non-finite.  The
objective function is computed before this point, so what the error threw away
was a finished run.

## Changes

- **`.foceiRepairOmega()` (`R/focei.R`)** replaces the bare `nmNearPD()` call.
  It zeroes non-finite entries, tries `nearPD`, and falls back to a floored
  diagonal when `nearPD` declines.  Dimnames are preserved on both routes and
  each notes itself in `$runInfo` ("singular omega; used a floored diagonal for
  tables" / "non-finite omega values zeroed for tables").  This covers every
  method that builds a FOCEi post-processing environment, not only SAEM.  The
  reported fit omega is left as estimated -- the zeros are diagnostic
  information.
- **`.saemWarnDegenerateOmega()` (`R/saem.R`)**, called from `.getSaemOmega()`,
  reports a non-finite omega, an all-zero omega, or the specific etas whose
  variance collapsed, so a degraded fit says why instead of looking healthy
  after the silent repair.  A user `fix()`ed zero variance is excluded (a
  modeling choice, not a collapse).
- **`.saemCreateOutput()` (`R/saem.R`)** wraps the fit assembly: on failure it
  restores the environment the failed attempt wrote into, retries once with the
  table/residual step off, and warns with the truncated original message.  If
  the retry also fails, the ORIGINAL error is raised -- nothing is hidden.
  (The `addTable()` step itself was already guarded upstream; this covers the
  assembly stage above it.)
- **`nmNearPD()` (`src/nearPD.cpp`)** now says which degenerate case it hit
  (non-finite / all zero / possibly negative definite) instead of just
  "failed".  No signature change, so `src/init.c` is untouched.

## Tests

New `tests/testthat/test-saem-degraded-fit.R` (34 assertions, no fits, so it
stays in the essential push/PR subset):

- all three degenerate omegas are confirmed to error under `nmNearPD()` and to
  come back cholesky-able from `.foceiRepairOmega()`;
- the real call site: a ui with an all-zero omega now builds `env$rxInv`
  through `.foceiOptEnvSetupBounds()` with the warning, where it previously
  threw;
- `.saemWarnDegenerateOmega()` messages, including the fixed-eta exclusion and
  the cases that must stay silent;
- `.saemCreateOutput()` through `local_mocked_bindings`: the retry happens,
  `calcTables` really is `FALSE` on the second call, the failed attempt's writes
  to the environment are rolled back, and a double failure surfaces the first
  error.

`test-saem-no-pop`, `test-saem-drop` pass and a full fixture recompute
(saem/focei/foce/fo/foi/posthoc) is clean with no spurious `$runInfo` note on a
normal fit.

## Known gap

I could not cheaply construct a genuinely over-parameterized SAEM run that
reproduces the original failure end to end (aliased etas break mu-referencing
before the fit starts), so the regression test drives the exact call site rather
than a full fit.  A reproducing model from #923 would let that be tightened.
