### PR TITLE
Wire event (jump) sensitivities into the dose-handling theta gradients (#946)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,20 @@
 
 ## New features
 
+- Dose-handling (`alag()`/`f()`/`dur()`/`rate()`) theta sensitivities are no
+  longer silently zero (#946).  The theta-sensitivity model is now compiled
+  with rxode2's analytic event ("jump") sensitivities (following the
+  control's `eventSens`, the same source the inner model uses), and its
+  solves run under its own event shape (`OdeSwapEsBatch(odeSlotThetaSens)`
+  brackets the batch; the shape is a process global whose installer calls
+  into R, so it cannot be swapped inside the parallel region).  The inner
+  batch in the conditional-likelihood C API likewise installs the inner
+  model's shape, so an eta entering dose handling gets its jump too.  An
+  estimated `alag` theta's derivative now agrees with central differences
+  (~1e-5 relative, ODE-tolerance-limited) where it previously came back
+  identically zero -- the failure mode that made an `alag`-estimating
+  imp/advi theta update a no-op and broke gradient-based samplers.
+
 - New FOCEi conditional-likelihood C API (#937): a plain-C, non-throwing,
   gradient-returning entry-point table over the `foceiLikLoad()`-ed problem,
   exposed to downstream packages through `_nlmixr2est_foceiPtrs()` /

--- a/R/focei.R
+++ b/R/focei.R
@@ -2169,8 +2169,15 @@ attr(rxUiGet.foceiSkipCov, "rstudio") <- c(FALSE, TRUE)
   if ((rxode2::rxGetControl(ui, "est", "") %in% c("impmap", "imp", "qrpem", "advi") ||
          isTRUE(rxode2::rxGetControl(ui, "thetaSensLoad", FALSE))) &&
         is.null(env$model$thetaSens)) {
-    env$model$thetaSens <- tryCatch(.impmapThetaSensModel(ui),
-                                    error = function(e) NULL)
+    # eventSens follows the control (same source as the inner model): with
+    # "jump" a theta entering dose handling (alag/f/dur/rate) gets its jump
+    # condition at the event, so its d(f)/d(theta) column is real rather
+    # than silently zero (#946)
+    env$model$thetaSens <- tryCatch(
+      .impmapThetaSensModel(ui,
+                            eventSens = rxode2::rxGetControl(ui, "eventSens",
+                                                             "jump")),
+      error = function(e) NULL)
   }
   #} else {
   #env$model <- rxUiGet.ebe(list(ui))

--- a/R/impmapThetaSens.R
+++ b/R/impmapThetaSens.R
@@ -139,11 +139,16 @@ attr(rxUiGet.impmapThetaSens, "rstudio") <- emptyenv()
 #' Compile the impmap sensitivity model.
 #'
 #' @param ui rxode2 ui object
+#' @param eventSens event-sensitivity mode for the compiled model: "jump"
+#'   attaches rxode2's analytic event sensitivities, so a theta entering dose
+#'   handling (alag/f/dur/rate) gets its jump condition at the event and its
+#'   d(f)/d(theta) column is no longer silently zero (#946); "fd" preserves
+#'   the legacy codegen.
 #' @return a compiled rxode2 model outputting rx__sens_rx_pred__BY_THETA_j___ and
 #'   rx__sens_rx_r__BY_THETA_j___ for each estimated non-mu theta j, or NULL if
 #'   there are none.
 #' @noRd
-.impmapThetaSensModel <- function(ui) {
+.impmapThetaSensModel <- function(ui, eventSens = "fd") {
   .s <- rxUiGet.impmapThetaSens(list(ui))
   if (is.null(.s)) return(NULL)
   ## Interpolation is carried like the inner model does; splitBolus() is not --
@@ -156,9 +161,7 @@ attr(rxUiGet.impmapThetaSens, "rstudio") <- emptyenv()
     paste0(.uiGetThetaEtaParams(ui, TRUE), "\n", .cmt, "\n")
   nlmixr2global$toRxDvidCmt <- .foceiToCmtLinesAndDvid(ui)
   # Role-tagged artifact name so this sensitivity model cannot share a compiled .so
-  # with another build of the same text (nlmixr2/rxode2#1171).  eventSens is left at
-  # the default: switching it to "jump" here changes the impmap thetaSens codegen and
-  # broke 5 assertions in test-impmap.R, so that is a separate question from the
-  # artifact-name collision this fixes.
-  .toRx(.s$thetaSens, "compiling sensitivity model...", role = "rxThetaSens")
+  # with another build of the same text (nlmixr2/rxode2#1171).
+  .toRx(.s$thetaSens, "compiling sensitivity model...", role = "rxThetaSens",
+        eventSens = eventSens)
 }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -18555,6 +18555,13 @@ extern "C" int nlmixr2FoceiCondBatch(const double *etaIn, int nid, int neta,
     const arma::mat omInv = op_focei.omegaInv;
     std::vector<int> bad(nid, 0);
     {
+      // Install the inner model's event ("jump") sensitivity shape for this
+      // batch (a no-op when the model carries none, #946): the eta gradient
+      // of a model whose eta enters dose handling (alag/f/dur/rate) needs
+      // the jump injection into the eta-sensitivity states, and the shape is
+      // a process global whose installer calls into R -- so it must bracket
+      // the parallel region.
+      OdeSwapEsBatch esBatch(odeSlotInner);
       NpInnerParallelScope npScope(rx, doParallel);
 #ifdef _OPENMP
 #pragma omp parallel for num_threads(cores) schedule(dynamic) if(doParallel)
@@ -18574,22 +18581,36 @@ extern "C" int nlmixr2FoceiCondBatch(const double *etaIn, int nid, int neta,
   }
 }
 
-// One subject of nlmixr2FoceiCondThetaGrad: solve at this eta first
-// (impThetaScore consumes the sensitivity model at the current subject
-// state, same order as the advi loop), then scatter the theta score into
-// the subject's dTheta row.  Returns 1 when the value was non-finite.
+// One subject of nlmixr2FoceiCondThetaGrad.  impThetaSensCollect is
+// self-contained (it syncs the thetas and this sample's etas into the
+// subject, solves the theta-sensitivity model through its own retry/FD
+// fallback, and resets the subject's solve state for determinism), so it is
+// used directly rather than through likInner0 + impThetaScore -- which also
+// keeps this batch entirely on the theta-sensitivity model, under whose
+// event ("jump") shape the caller has bracketed the loop (#946).  Returns 1
+// when the subject's sample was unusable.
 static int foceiCondThetaGradOne(int id, const double *etaIn, int neta,
                                  int ntheta, int nSens, double *dTheta) {
+  // likInner0 first: it initializes the subject's solve/event state that
+  // impThetaSensCollect's observation walk reads (without it the walk sees
+  // no observations), and its NA refusal gives the bad-subject semantics.
+  // Its VALUE is shape-independent, so running it under the caller's
+  // theta-sensitivity event shape is safe; its eta-sensitivity side effects
+  // are unused here.
   std::vector<double> eta(neta);
   foceiCondSubjectStart(id, etaIn, neta, eta);
   double v = likInner0(&eta[0], id);
   if (ISNA(v) || !std::isfinite(v)) return 1;
   arma::mat S(1, neta);
-  for (int k = 0; k < neta; ++k) S(0, k) = eta[k];
+  for (int k = 0; k < neta; ++k) S(0, k) = etaIn[(size_t)id * neta + k];
+  impThetaSensData c;
+  impThetaSensCollect(id, S, c);
+  if (c.nobs == 0 || c.sampleOk.empty() || c.sampleOk[0] == 0) return 1;
   arma::vec zk(1); zk[0] = 1.0;
   arma::vec g(nSens, arma::fill::zeros);
   arma::mat H(nSens, nSens, arma::fill::zeros);
-  impThetaScore(id, S, zk, g, H);
+  impThetaAccumOne(c, zk, g, H);
+  if (!g.is_finite()) return 1;
   for (int s = 0; s < nSens; ++s) {
     int th = op_focei.impThetaSensIdx[s]; // 0-based ntheta index
     if (th >= 0 && th < ntheta) dTheta[(size_t)id * ntheta + th] = g[s];
@@ -18611,6 +18632,13 @@ extern "C" int nlmixr2FoceiCondThetaGrad(const double *etaIn, int nid, int neta,
     std::vector<int> bad(nid, 0);
     std::fill(dTheta, dTheta + (size_t)nid * ntheta, 0.0);
     {
+      // The theta-sensitivity model's own event ("jump") shape for this
+      // batch (#946): with it, a theta entering dose handling gets its jump
+      // condition at the event; without it the sensitivity column is
+      // silently zero.  Process-global + R-calling installer, so it
+      // brackets the parallel region (a no-op when the model carries no
+      // event sensitivities).
+      OdeSwapEsBatch esBatch(odeSlotThetaSens);
       NpInnerParallelScope npScope(rx, doParallel);
 #ifdef _OPENMP
 #pragma omp parallel for num_threads(cores) schedule(dynamic) if(doParallel)

--- a/src/odeSwap.cpp
+++ b/src/odeSwap.cpp
@@ -950,7 +950,8 @@ RObject odeSwapEsNoteInstalled_(int slot) {
 List odeSwapInfo_() {
   const OdePoolPlan &p = odeSwapPlan();
   CharacterVector nm(odeSlotN);
-  IntegerVector neq(odeSlotN), nlhs(odeSlotN), npars(odeSlotN), deny(odeSlotN);
+  IntegerVector neq(odeSlotN), nlhs(odeSlotN), npars(odeSlotN), deny(odeSlotN),
+    esActive(odeSlotN);
   LogicalVector loaded(odeSlotN), sizesPool(odeSlotN), parLayoutOk(odeSlotN);
   rx_solve *_rxl = getRxSolve_();
   for (int s = 0; s < odeSlotN; ++s) {
@@ -962,12 +963,13 @@ List odeSwapInfo_() {
     sizesPool[s] = (s == p.poolSlot);
     deny[s] = odeSwapCanPool(s);
     parLayoutOk[s] = _odeReg[s].loaded ? odeSwapParLayoutOk(s, _rxl) : NA_LOGICAL;
+    esActive[s] = _odeReg[s].esActive;
   }
   List models = List::create(_["slot"] = seq_len(odeSlotN) - 1, _["name"] = nm,
                              _["neq"] = neq, _["nlhs"] = nlhs, _["npars"] = npars,
                              _["loaded"] = loaded, _["sizesPool"] = sizesPool,
                              _["parLayoutOk"] = parLayoutOk,
-                             _["deny"] = deny);
+                             _["deny"] = deny, _["esActive"] = esActive);
   models.attr("class") = "data.frame";
   models.attr("row.names") = IntegerVector::create(NA_INTEGER, -odeSlotN);
   // op->neq / op->nlhs are only meaningful once a solve pool exists.

--- a/tests/testthat/test-focei-ptrs.R
+++ b/tests/testthat/test-focei-ptrs.R
@@ -315,3 +315,119 @@ test_that("condBatch value/gradient FD-agree across error families (#937)", {
   expect_false(isTRUE(all.equal(as.numeric(got$grad), as.numeric(fd),
                                 tolerance = 1e-3)))
 })
+
+test_that("dose-handling theta sensitivities carry the event jump (#946)", {
+  # An estimated alag theta's derivative needs a jump condition at the dose
+  # event.  The theta-sensitivity model is now compiled with rxode2's
+  # analytic event ("jump") sensitivities and solved under its own event
+  # shape (OdeSwapEsBatch), so the column is real rather than silently zero.
+  skip_on_cran()
+  .lagMod <- function() {
+    ini({
+      tcl <- 1
+      tv <- 3
+      tlag <- -1
+      add.sd <- 0.5
+      eta.cl ~ 0.1
+    })
+    model({
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      d / dt(central) <- -cl / v * central
+      alag(central) <- exp(tlag)
+      cp <- central / v
+      cp ~ add(add.sd)
+    })
+  }
+  .testSeed(42)
+  d <- do.call(rbind, lapply(1:4, function(id) {
+    rbind(data.frame(ID = id, TIME = 0, DV = NA_real_, AMT = 100, EVID = 1),
+          data.frame(ID = id, TIME = c(0.5, 1, 2, 4, 8),
+                     DV = 5 * exp(-0.05 * c(0.5, 1, 2, 4, 8)) +
+                       stats::rnorm(5, 0, 0.5),
+                     AMT = 0, EVID = 0))
+  }))
+  h <- foceiLikLoad(.lagMod, d, "focei", scale = "natural", thetaSens = TRUE)
+  on.exit(foceiLikUnload(), add = TRUE)
+  # tlag (ntheta 3) is a non-mu structural theta and carries a sensitivity
+  expect_true(3L %in% h$thetaSensIdx)
+  expect_equal(bitwAnd(foceiLikDims_()$flags, 0x40), 0x40)
+  th <- c(1, 3, -1, 0.5, h$initPar[5])
+  expect_equal(foceiLikSetThetaC_(th), 0L)
+  eta <- matrix(c(-0.1, 0.05, 0.2, -0.15), 4, 1)
+  got <- foceiLikCondThetaGrad_(eta, 1L)
+  expect_equal(got$nBad, 0L)
+  # the derivative through the event is real (nonzero) ...
+  expect_true(all(abs(got$dTheta[, 3]) > 1e-3))
+  # ... and every sensitivity column (tv, tlag, add.sd) FD-agrees
+  .h <- 1e-5
+  for (t in h$thetaSensIdx) {
+    up <- th
+    up[t] <- up[t] + .h
+    dn <- th
+    dn[t] <- dn[t] - .h
+    expect_equal(foceiLikSetThetaC_(up), 0L)
+    vUp <- foceiLikCondGrad_(eta, 1L)$value
+    expect_equal(foceiLikSetThetaC_(dn), 0L)
+    vDn <- foceiLikCondGrad_(eta, 1L)$value
+    fd <- (vUp - vDn) / (2 * .h)
+    expect_equal(as.numeric(got$dTheta[, t]), as.numeric(fd),
+                 tolerance = 1e-3, info = paste0("theta ", t))
+  }
+})
+
+test_that("an eta entering dose handling gets its jump in the eta gradient (#946)", {
+  # The inner batch installs the INNER model's event shape, so d/d(eta) of the
+  # conditional through an eta-in-alag dose event is real, not silently zero.
+  skip_on_cran()
+  .lagEtaMod <- function() {
+    ini({
+      tcl <- 1
+      tv <- 3
+      tlag <- -1
+      add.sd <- 0.5
+      eta.cl ~ 0.1
+      eta.lag ~ 0.05
+    })
+    model({
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      d / dt(central) <- -cl / v * central
+      alag(central) <- exp(tlag + eta.lag)
+      cp <- central / v
+      cp ~ add(add.sd)
+    })
+  }
+  .testSeed(42)
+  d <- do.call(rbind, lapply(1:4, function(id) {
+    rbind(data.frame(ID = id, TIME = 0, DV = NA_real_, AMT = 100, EVID = 1),
+          data.frame(ID = id, TIME = c(0.5, 1, 2, 4, 8),
+                     DV = 5 * exp(-0.05 * c(0.5, 1, 2, 4, 8)) +
+                       stats::rnorm(5, 0, 0.5),
+                     AMT = 0, EVID = 0))
+  }))
+  h <- foceiLikLoad(.lagEtaMod, d, "focei", scale = "natural")
+  on.exit(foceiLikUnload(), add = TRUE)
+  # full par vector: 4 thetas + the 2 omega parameters at their initials
+  th <- h$initPar
+  th[1:4] <- c(1, 3, -1, 0.5)
+  expect_equal(foceiLikSetThetaC_(th), 0L)
+  eta <- matrix(c(-0.1, 0.05, 0.2, -0.15,
+                  0.08, -0.04, 0.1, -0.06), 4, 2)
+  got <- foceiLikCondGrad_(eta, 1L)
+  expect_equal(got$nBad, 0L)
+  # the eta.lag column runs only through the dose event: it must be real
+  expect_true(all(abs(got$grad[, 2]) > 1e-3))
+  # and both eta columns FD-agree
+  .h <- 1e-5
+  for (k in 1:2) {
+    up <- eta
+    up[, k] <- up[, k] + .h
+    dn <- eta
+    dn[, k] <- dn[, k] - .h
+    fd <- (foceiLikCondGrad_(up, 1L)$value -
+             foceiLikCondGrad_(dn, 1L)$value) / (2 * .h)
+    expect_equal(as.numeric(got$grad[, k]), as.numeric(fd),
+                 tolerance = 1e-3, info = paste0("eta ", k))
+  }
+})


### PR DESCRIPTION
Closes #946.

The theta forward-sensitivity model advertised dose-handling thetas (`alag`/`f`/`dur`/`rate`) in `impThetaSensIdx`, but their gradient columns evaluated to zero: the dependence runs through the **event time**, not the ODE right-hand side, so the symbolic forward sensitivity missed it entirely — the true derivative needs a jump condition at the dose.

### What changed

1. **Compile the theta-sensitivity model with rxode2's analytic event ("jump") sensitivities**, following the control's `eventSens` (the same source the inner model uses). Verified standalone that rxode2's build machinery handles the pre-expanded model text and theta-named sensitivity states: jump sens vs central FD agree to ~7 digits under plain `rxSolve`, for both plain and `THETA[]`-bracketed names and classic `EVID=101` dose coding. The historical note that enabling this "broke 5 assertions in test-impmap.R" does **not** reproduce — that breakage was the compiled-artifact collision the role-tag fix (nlmixr2/rxode2#1171) already eliminated; `test-impmap.R` passes unchanged (308 tests across impmap/foceiLik/focei-ptrs).

2. **Install the theta-sensitivity model's event shape around its solve batch**: `OdeSwapEsBatch(odeSlotThetaSens)` brackets the parallel loop in `nlmixr2FoceiCondThetaGrad`. The shape is a process global whose installer calls into R, so it cannot be swapped inside the OpenMP region; it is a no-op when the model carries no event sensitivities. Without this the compiled jump code never fires — the second half of the bug.

3. **The inner batch (`nlmixr2FoceiCondBatch`) likewise installs the inner model's shape**, so an eta entering dose handling gets its jump in the eta gradient.

`foceiCondThetaGradOne` keeps its `likInner0`-first call: beyond NA screening, it initializes the subject solve/event state that `impThetaSensCollect`'s observation walk reads (without it the walk sees no observations and every subject flags bad). `likInner0`'s *value* is event-shape independent, so running it under the theta-sensitivity shape is safe. The scatter now goes through `impThetaSensCollect` + `impThetaAccumOne` directly, so an unusable sample surfaces as a bad subject instead of a silent zero. `odeSwapInfo_()` additionally reports each slot's `esActive` for diagnostics.

### Verification

- New regression tests in `test-focei-ptrs.R`:
  - an estimated `alag` theta's column is nonzero and **every** sensitivity column FD-agrees at 1e-3 (measured ~1e-5 relative, ODE-tolerance-limited) — previously the `alag` column was identically zero;
  - an **eta** entering `alag` gets its jump in the conditional eta gradient (FD agreement ~3e-5).
- Full `impmap` + `foceiLik` + `focei-ptrs` + `vi`/`advi`/`emvi`/`fbvi` + `wang2007-basic` suites: **0 failures** (610 assertions).
- Safety of solving the *inner* model while the theta-sens shape is installed: every jump write in `rxode2parseHandleEvid.h` is gated by `_rxEsNState * (1 + _rxEsNParam) <= neq` of the currently-solving problem, so a foreign shape either fits inside the solve buffer's sensitivity slots (which never feed back into the base states the value reads) or the jump is skipped — no out-of-bounds path.

Reviewed with antigravity (gemini-3.1-pro-high): its missing-test finding (no committed eta-in-alag coverage) was confirmed and is addressed by the second new test; its buffer-overflow claim was checked against the guard above and rejected.

Downstream: this unblocks nlmixr2stan's `est="stan"` dose-timing-parameter refusal — with this, models estimating `alag`/`f`/`dur`/`rate` thetas get real analytic gradients through the C API.