### PR TITLE
fix: give an estimated transform-both-sides lambda a real conditional theta-sensitivity column (#949)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,20 @@
 
 ## New features
 
+- An estimated transform-both-sides `lambda` (`boxCox()`/`yeoJohnson()`) now
+  carries a real theta-sensitivity column instead of a silent zero (#949).
+  The conditional depends on `lambda` through both sides of the residual
+  `h(y; lambda) - h(f; lambda)`: the prediction side now comes from the
+  sensitivity model (the direct partial is taken for residual-error thetas
+  too, not hard-coded to zero, so `rx_pred_`'s `rxTBS()` is differentiated),
+  and the DV side from a new `d(lambda)/d(theta)` output multiplied by the
+  analytic `d(h(y; lambda))/d(lambda)` where the DV transform is applied.
+  The censored (M2/M3/M4) score picks up the matching DV and `LIMIT` partials.
+  The column agrees with central differences to ~1e-9 relative on Box-Cox and
+  Yeo-Johnson fixtures where it was previously identically zero -- the failure
+  mode that made an estimated `lambda` an imp/advi M-step no-op and gave
+  gradient-based callers a wrong direction.
+
 - Dose-handling (`alag()`/`f()`/`dur()`/`rate()`) theta sensitivities are no
   longer silently zero (#946).  The theta-sensitivity model is now compiled
   with rxode2's analytic event ("jump") sensitivities (following the

--- a/R/impmapThetaSens.R
+++ b/R/impmapThetaSens.R
@@ -10,13 +10,20 @@
 #
 # Only NON-MU thetas get sensitivities: mu-referenced thetas are updated by the EM
 # closed form.  Among those, structural thetas (which enter the ODE states / f)
-# carry a sensitivity ODE; residual-error (sigma) thetas enter only V algebraically
-# and need no state sensitivity, so restricting the sensitivity ODEs to the
-# structural thetas also keeps the state count bounded for the shared solve buffer.
+# carry a sensitivity ODE; residual-error (sigma) thetas reach f and V only
+# algebraically and need no state sensitivity, so restricting the sensitivity ODEs
+# to the structural thetas also keeps the state count bounded for the shared solve
+# buffer.
 #
 # d(f)/d(theta_j) and d(V)/d(theta_j) share the chain rule
 #   d(g)/d(theta_j) = D(g, THETA_j) + sum_state rx__sens_state_BY_THETA_j * D(g, state)
 # where the state-sensitivity term is present only for the structural thetas.
+#
+# An ESTIMATED transform-both-sides lambda is a residual-error theta that DOES
+# reach f (rx_pred_ applies rxTBS()), and it moves the transformed DV as well.
+# The model therefore also outputs rx__sens_rx_lambda__BY_THETA_j___ =
+# d(lambda)/d(theta_j) -- but only when some column is non-zero -- which the
+# M-step multiplies by the analytic d(h(y; lambda))/d(lambda) on the DV side (#949).
 #
 # rx_pred_ / rx_r_ are retrieved with the `$` accessor via an intermediate
 # variable (the sensitivity setup shadows base get/:: and the `$` NSE misbehaves
@@ -57,6 +64,13 @@
   rxode2::rxFromSE(.l)
 }
 
+#' Direct partial D(target, THETA_j_) with no state-sensitivity chain term.
+#' @noRd
+.impmapDirectD <- function(s, target, j) {
+  .l <- eval(parse(text = paste0("with(s, D(", target, ", THETA_", j, "_))")))
+  rxode2::rxFromSE(.l)
+}
+
 # Build the symengine env carrying the impmap sensitivity model
 # (\code{..thetaSens}).  For each estimated non-mu theta j it outputs
 # rx__sens_rx_pred__BY_THETA_j___ = d(f)/d(theta_j) and
@@ -91,31 +105,47 @@ rxUiGet.impmapThetaSens <- function(x, ...) {
   .lambda <- .s$`rx_lambda_`
   .hi <- .s$`rx_hi_`
   .low <- .s$`rx_low_`
+  .lambdaStr <- rxode2::rxFromSE(.lambda)
   .tbs <- c(paste0("rx_yj_~", rxode2::rxFromSE(.yj)),
-            paste0("rx_lambda_~", rxode2::rxFromSE(.lambda)),
+            paste0("rx_lambda_~", .lambdaStr),
             paste0("rx_hi_~", rxode2::rxFromSE(.hi)),
             paste0("rx_low_~", rxode2::rxFromSE(.low)))
   # Also output the residual variance V so the M-step gradient reads f and V from
   # this one solve (no separate inner solve / context interleave).
   .rvar <- .s$`rx_r_`
   .rr <- paste0("rx_r_=", rxode2::rxFromSE(.rvar))
-  # d(f)/d(theta_j): chain rule for structural thetas, 0 for sigma thetas.
+  # d(f)/d(theta_j): chain rule (state sensitivities only for the structural
+  # thetas; .impmapChainRule already restricts them).  A residual-error theta
+  # usually drops out of rx_pred_, but an ESTIMATED transform-both-sides lambda
+  # does not -- it enters through rx_pred_'s rxTBS(), so hard-coding 0 here made
+  # its column silently zero (#949).
   .dfOut <- vapply(.idx$all, function(j) {
-    if (j %in% .idx$struct) {
-      paste0("rx__sens_rx_pred__BY_THETA_", j, "___=",
-             .impmapChainRule(.s, "rx_pred_", j, .stateVars, .idx$struct))
-    } else {
-      paste0("rx__sens_rx_pred__BY_THETA_", j, "___=0")
-    }
+    paste0("rx__sens_rx_pred__BY_THETA_", j, "___=",
+           .impmapChainRule(.s, "rx_pred_", j, .stateVars, .idx$struct))
   }, character(1))
   # d(V)/d(theta_j): chain rule (structural) or direct partial (sigma).
   .dvOut <- vapply(.idx$all, function(j) {
     paste0("rx__sens_rx_r__BY_THETA_", j, "___=",
            .impmapChainRule(.s, "rx_r_", j, .stateVars, .idx$struct))
   }, character(1))
+  # d(lambda)/d(theta_j), emitted only when some column is non-zero (an estimated
+  # transform-both-sides lambda).  The conditional depends on lambda through the
+  # TRANSFORMED DV as well, err = h(y; lambda) - h(f; lambda), and h(y) is applied
+  # in C++ (it needs the DV), so the M-step multiplies this column by
+  # d(h(y; lambda))/d(lambda) there (#949).
+  # A constant rx_lambda_ is a plain number here, not a symengine expression, so
+  # guard the D() by looking for a THETA in it first.
+  .dlOut <- character(0)
+  if (grepl("THETA", .lambdaStr, fixed = TRUE)) {
+    .dl <- vapply(.idx$all, function(j) .impmapDirectD(.s, "rx_lambda_", j),
+                  character(1))
+    if (any(!(.dl %in% c("0", "0.0", "-0")))) {
+      .dlOut <- paste0("rx__sens_rx_lambda__BY_THETA_", .idx$all, "___=", .dl)
+    }
+  }
   .ddt <- .s$..ddt; if (is.null(.ddt)) .ddt <- character(0)
   .sens <- .s$..sens; if (is.null(.sens)) .sens <- character(0)
-  .s$..thetaSens <- paste(c(.ddt, .sens, .tbs, .prd, .rr, .dfOut, .dvOut, ""),
+  .s$..thetaSens <- paste(c(.ddt, .sens, .tbs, .prd, .rr, .dfOut, .dvOut, .dlOut, ""),
                           collapse = "\n")
   .s$..thetaSensIdx <- .idx$all
   ## Return ONLY the lightweight result -- NEVER the symengine environment `.s`.
@@ -145,8 +175,9 @@ attr(rxUiGet.impmapThetaSens, "rstudio") <- emptyenv()
 #'   d(f)/d(theta) column is no longer silently zero (#946); "fd" preserves
 #'   the legacy codegen.
 #' @return a compiled rxode2 model outputting rx__sens_rx_pred__BY_THETA_j___ and
-#'   rx__sens_rx_r__BY_THETA_j___ for each estimated non-mu theta j, or NULL if
-#'   there are none.
+#'   rx__sens_rx_r__BY_THETA_j___ for each estimated non-mu theta j (plus
+#'   rx__sens_rx_lambda__BY_THETA_j___ when the transform-both-sides lambda is
+#'   itself estimated), or NULL if there are none.
 #' @noRd
 .impmapThetaSensModel <- function(ui, eventSens = "fd") {
   .s <- rxUiGet.impmapThetaSens(list(ui))

--- a/R/impmapThetaSens.R
+++ b/R/impmapThetaSens.R
@@ -64,13 +64,6 @@
   rxode2::rxFromSE(.l)
 }
 
-#' Direct partial D(target, THETA_j_) with no state-sensitivity chain term.
-#' @noRd
-.impmapDirectD <- function(s, target, j) {
-  .l <- eval(parse(text = paste0("with(s, D(", target, ", THETA_", j, "_))")))
-  rxode2::rxFromSE(.l)
-}
-
 # Build the symengine env carrying the impmap sensitivity model
 # (\code{..thetaSens}).  For each estimated non-mu theta j it outputs
 # rx__sens_rx_pred__BY_THETA_j___ = d(f)/d(theta_j) and
@@ -105,9 +98,8 @@ rxUiGet.impmapThetaSens <- function(x, ...) {
   .lambda <- .s$`rx_lambda_`
   .hi <- .s$`rx_hi_`
   .low <- .s$`rx_low_`
-  .lambdaStr <- rxode2::rxFromSE(.lambda)
   .tbs <- c(paste0("rx_yj_~", rxode2::rxFromSE(.yj)),
-            paste0("rx_lambda_~", .lambdaStr),
+            paste0("rx_lambda_~", rxode2::rxFromSE(.lambda)),
             paste0("rx_hi_~", rxode2::rxFromSE(.hi)),
             paste0("rx_low_~", rxode2::rxFromSE(.low)))
   # Also output the residual variance V so the M-step gradient reads f and V from
@@ -133,11 +125,16 @@ rxUiGet.impmapThetaSens <- function(x, ...) {
   # TRANSFORMED DV as well, err = h(y; lambda) - h(f; lambda), and h(y) is applied
   # in C++ (it needs the DV), so the M-step multiplies this column by
   # d(h(y; lambda))/d(lambda) there (#949).
-  # A constant rx_lambda_ is a plain number here, not a symengine expression, so
-  # guard the D() by looking for a THETA in it first.
+  # A constant rx_lambda_ is a plain number here, not a symengine expression, and
+  # D() would dispatch to stats::D and error.  Test the CLASS rather than grepping
+  # the rendered string for "THETA": boxCox()/yeoJohnson() accept a model variable,
+  # so lambda can be any expression (exp(theta), or one reaching a state).  The
+  # chain rule, not the direct partial, for the same reason.
   .dlOut <- character(0)
-  if (grepl("THETA", .lambdaStr, fixed = TRUE)) {
-    .dl <- vapply(.idx$all, function(j) .impmapDirectD(.s, "rx_lambda_", j),
+  if (inherits(.lambda, "Basic")) {
+    .dl <- vapply(.idx$all,
+                  function(j) .impmapChainRule(.s, "rx_lambda_", j, .stateVars,
+                                               .idx$struct),
                   character(1))
     if (any(!(.dl %in% c("0", "0.0", "-0")))) {
       .dlOut <- paste0("rx__sens_rx_lambda__BY_THETA_", .idx$all, "___=", .dl)

--- a/src/censEst.h
+++ b/src/censEst.h
@@ -649,6 +649,46 @@ static inline void censNormalPartials(double cens, double limDv, double lim,
     }
   }
 }
+
+// Partials of the SAME rho = -logLik-per-obs w.r.t. the observed value dv and the
+// LIMIT, given rho_f (censNormalPartials' out[0]).  Needed when the transformed DV
+// itself moves with a parameter -- an estimated transform-both-sides lambda, whose
+// h(y; lambda) shifts dv and limit as well as f (#949).
+//
+// rho depends on (dv, lim, f) only through (dv - f) and (lim - f), so
+// rho_dv + rho_lim = -rho_f; the dv half is closed form per method and the limit
+// half is the remainder:
+//   M2 (cens 0, finite lim): dv enters only the ordinary normal density
+//   M3 (cens +/-1, no lim):  the whole density is Phi(cens (dv-f)/sd), so rho_dv = -rho_f
+//   M4 (cens +/-1, finite lim): dv enters only the upper cumulative of Phi1 - Phi2
+// An uncensored observation returns the plain normal rho_dv (and no limit term).
+static inline void censNormalDvPartials(double cens, double limDv, double lim,
+                                        double f, double r, double rhoF,
+                                        double* rhoDv, double* rhoLim) {
+  double dv = limDv;
+  int hasFin = (R_FINITE(lim) && !ISNA(lim));
+  double rd;
+  if (cens == 0.0) {
+    rd = (dv - f) / _safe_zero(r);
+  } else if (!hasFin) {
+    rd = -rhoF;
+  } else {
+    // ll = log|Phi(z1) - Phi(z2)| - log tail; logspace_sub returns the magnitude, so
+    // restore the sign of the difference (= sign of z1 - z2) before dividing by it.
+    double sd = _safe_sqrt(r);
+    double z1 = cens * (dv - f) / sd;
+    double z2 = cens * (lim - f) / sd;
+    double ld = logspace_sub(Rf_pnorm5(z1, 0.0, 1.0, 1, 1),
+                             Rf_pnorm5(z2, 0.0, 1.0, 1, 1));
+    double sgn = (z1 >= z2) ? 1.0 : -1.0;
+    // z1 is already standardized, so the log density is exact inline (no dnorm call)
+    double ldn = -0.5 * z1 * z1 - M_LN_SQRT_2PI;
+    rd = -sgn * cens * exp(ldn - ld) / sd;
+  }
+  if (!R_FINITE(rd)) rd = 0.0;
+  *rhoDv = rd;
+  *rhoLim = (cens == 0.0 && !hasFin) ? 0.0 : (-rhoF - rd);
+}
 #undef hasFiniteLimit
 #undef isM2
 #undef isM3orM4

--- a/src/censEst.h
+++ b/src/censEst.h
@@ -686,8 +686,14 @@ static inline void censNormalDvPartials(double cens, double limDv, double lim,
     rd = -sgn * cens * exp(ldn - ld) / sd;
   }
   if (!R_FINITE(rd)) rd = 0.0;
+  // With no finite LIMIT (M3, and an uncensored row) there is no limit term at all.
+  // Taking it as -rhoF - rd instead would be 0 only while rhoF is finite: a
+  // non-finite rhoF leaves rhoLim non-finite, and dlim is identically zero on
+  // those rows, so the score picks up Inf*0 = NaN for the whole subject.
+  double rl = hasFin ? (-rhoF - rd) : 0.0;
+  if (!R_FINITE(rl)) rl = 0.0;
   *rhoDv = rd;
-  *rhoLim = (cens == 0.0 && !hasFin) ? 0.0 : (-rhoF - rd);
+  *rhoLim = rl;
 }
 #undef hasFiniteLimit
 #undef isM2

--- a/src/imp.h
+++ b/src/imp.h
@@ -104,6 +104,11 @@ struct impThetaSensData {
   std::vector<arma::vec> fvec, Vvec;    // [nsamp], each length nobs
   std::vector<arma::mat> dfmat, dVmat;  // [nsamp], each nobs x nSens
   std::vector<char> sampleOk;           // [nsamp], 0 = drop this sample
+  // d(transformed DV)/d(theta) and d(transformed LIMIT)/d(theta), nobs x nSens.
+  // Empty unless the transform-both-sides lambda is itself estimated (#949): then
+  // the residual err = h(y; lambda) - h(f; lambda) moves on BOTH sides, and the
+  // DV side is applied here because the sensitivity model never sees the DV.
+  arma::mat ddvmat, dlimmat;
 };
 void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out);
 void impThetaAccumOne(const impThetaSensData& c, const arma::vec& zk,

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -11073,6 +11073,39 @@ static void impThetaAccumGauss(const impThetaSensData &c, int jo, double f, doub
   H += w * ((de.t() * de) / V + 0.5 * (dV.t() * dV) / (V * V));
 }
 
+// One (sample k, observation jo) contribution to the theta score/information.
+// Returns without touching g/H when that observation's outputs are unusable.
+// `zeroDir` stands in for the DV/limit directions when the transform lambda is
+// not estimated (#949).
+static void impThetaAccumObs(const impThetaSensData &c, int k, int jo,
+                             bool hasDvSens, const arma::rowvec &zeroDir,
+                             double w, arma::vec &g, arma::mat &H) {
+  const arma::mat &dfmat = c.dfmat[k];
+  double f = c.fvec[k][jo], V = c.Vvec[k][jo];
+  // General (non-normal) log-likelihood endpoint: rx_pred_ IS the per-obs
+  // log-likelihood and rx_r_ == 0, so the Gauss-Newton (f/V) score below does
+  // not apply.  The theta score is d(ll)/d(theta) (dfmat already holds it) and
+  // the empirical (BHHH) Fisher information is its outer product -- PSD, so the
+  // Newton step ascends the likelihood.  This must run BEFORE the V<=0 guard,
+  // which would otherwise drop every LL obs (V==0) and freeze the M-step.
+  if (jo < (int)c.distv.size() && c.distv[jo] != rxDistributionNorm) {
+    arma::rowvec dll = dfmat.row(jo);
+    if (!R_finite(f) || !dll.is_finite()) return;
+    g += w * dll.t();
+    H += w * (dll.t() * dll);
+    return;
+  }
+  if (!R_finite(V) || V <= 0.0 || !R_finite(f)) return;
+  arma::rowvec df = dfmat.row(jo), dV = c.dVmat[k].row(jo);
+  if (!df.is_finite() || !dV.is_finite()) return;
+  if (hasDvSens) {
+    impThetaAccumGauss(c, jo, f, V, df, dV, c.ddvmat.row(jo), c.dlimmat.row(jo),
+                       true, w, g, H);
+  } else {
+    impThetaAccumGauss(c, jo, f, V, df, dV, zeroDir, zeroDir, false, w, g, H);
+  }
+}
+
 // Cheap arithmetic half of the theta score: accumulate the IS-weighted score `g`
 // and Gauss-Newton Hessian `H` from a subject's collected per-sample sensitivity
 // outputs, in the original (sample, obs) order.  g/H must be pre-sized (nSens).
@@ -11082,40 +11115,13 @@ void impThetaAccumOne(const impThetaSensData& c, const arma::vec& zk,
   if (nSens == 0 || c.nobs == 0) return;
   int nobs = c.nobs;
   int nsamp = (int)c.sampleOk.size();
-  // stand-in DV/limit directions when the transform lambda is not estimated (#949)
   const bool hasDvSens = ((int)c.ddvmat.n_rows == nobs &&
                           (int)c.ddvmat.n_cols == nSens);
   const arma::rowvec zeroDir(nSens, arma::fill::zeros);
   for (int k = 0; k < nsamp; ++k) {
     if (!c.sampleOk[k]) continue;
-    const arma::vec& fvec = c.fvec[k];
-    const arma::vec& Vvec = c.Vvec[k];
-    const arma::mat& dfmat = c.dfmat[k];
-    const arma::mat& dVmat = c.dVmat[k];
     for (int jo = 0; jo < nobs; ++jo) {
-      double f = fvec[jo], V = Vvec[jo];
-      // General (non-normal) log-likelihood endpoint: rx_pred_ IS the per-obs
-      // log-likelihood and rx_r_ == 0, so the Gauss-Newton (f/V) score below does
-      // not apply.  The theta score is d(ll)/d(theta) (dfmat already holds it) and
-      // the empirical (BHHH) Fisher information is its outer product -- PSD, so the
-      // Newton step ascends the likelihood.  This must run BEFORE the V<=0 guard,
-      // which would otherwise drop every LL obs (V==0) and freeze the M-step.
-      if (jo < (int)c.distv.size() && c.distv[jo] != rxDistributionNorm) {
-        arma::rowvec dll = dfmat.row(jo);
-        if (!R_finite(f) || !dll.is_finite()) continue;
-        g += zk[k] * dll.t();
-        H += zk[k] * (dll.t() * dll);
-        continue;
-      }
-      if (!R_finite(V) || V <= 0.0 || !R_finite(f)) continue;
-      arma::rowvec df = dfmat.row(jo), dV = dVmat.row(jo);
-      if (!df.is_finite() || !dV.is_finite()) continue;
-      if (hasDvSens) {
-        impThetaAccumGauss(c, jo, f, V, df, dV, c.ddvmat.row(jo), c.dlimmat.row(jo),
-                           true, zk[k], g, H);
-      } else {
-        impThetaAccumGauss(c, jo, f, V, df, dV, zeroDir, zeroDir, false, zk[k], g, H);
-      }
+      impThetaAccumObs(c, k, jo, hasDvSens, zeroDir, zk[k], g, H);
     }
   }
 }
@@ -17155,6 +17161,9 @@ List adviThetaSensInfo_() {
                       _["rOffset"] = op_focei.thetaSensROffset,
                       _["fOffset"] = op_focei.thetaSensOffset,
                       _["dvOffset"] = op_focei.thetaSensDvOffset,
+                      // >= 0 only when the transform-both-sides lambda is
+                      // estimated, i.e. the DV-side term is wired (#949)
+                      _["lambdaOffset"] = op_focei.thetaSensLambdaOffset,
                       _["neq"] = op_focei.thetaSensNeq,
                       _["calcLhsNull"] = (rxThetaSens.calc_lhs == NULL),
                       _["isAdvi"] = op_focei.isAdvi,

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -11396,8 +11396,16 @@ Environment foceiFitCpp_(Environment e){
       // est="impmap": load the theta-sensitivity model (peer of rxInner/rxPred)
       // and record its ODE state count + the lhs offset of the first
       // d(f)/d(theta) output rx__sens_rx_pred__BY_THETA_1___.
+      // Every offset resets here, not just thetaSensOffset: the resolves below are
+      // guarded by `if (_iv >= 0)`, so a fit whose firstV name does not resolve
+      // would otherwise keep the PREVIOUS fit's offset -- which impThetaSensCollect's
+      // `< 0` guard cannot catch, and reads land in the wrong lhs columns.
       op_focei.thetaSensOffset = -1;
+      op_focei.thetaSensDvOffset = -1;
+      op_focei.thetaSensPredOffset = -1;
+      op_focei.thetaSensROffset = -1;
       op_focei.thetaSensLambdaOffset = -1;
+      op_focei.thetaSensNlhs = 0;
       op_focei.thetaSensNeq = 0;
       if ((op_focei.isImpmap || op_focei.isAdvi || op_focei.thetaSensLoad) &&
       model.containsElementNamed("thetaSens")) {
@@ -11943,8 +11951,13 @@ RObject vaeInnerSetup_(Environment e) {
   // the first d(f)/d(theta) / d(V)/d(theta) columns) so impThetaScore can supply
   // the outer population gradient -- mirrors the impmap full-fit path (which sets
   // these in foceiFitCpp_, a code path vaeInnerSetup_ does not go through).
+  // all offsets, for the stale-read reason in foceiFitCpp_ above
   op_focei.thetaSensOffset = -1;
+  op_focei.thetaSensDvOffset = -1;
+  op_focei.thetaSensPredOffset = -1;
+  op_focei.thetaSensROffset = -1;
   op_focei.thetaSensLambdaOffset = -1;
+  op_focei.thetaSensNlhs = 0;
   op_focei.thetaSensNeq = 0;
   if ((op_focei.isImpmap || op_focei.isAdvi || op_focei.thetaSensLoad) &&
       model.containsElementNamed("thetaSens")) {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -319,6 +319,8 @@ struct focei_options {
   int thetaSensDvOffset = -1; // lhs offset of the first d(V)/d(theta) output (impmap)
   int thetaSensPredOffset = -1; // lhs offset of rx_pred_ (f) in the sensitivity model
   int thetaSensROffset = -1;    // lhs offset of rx_r_ (V) in the sensitivity model
+  int thetaSensLambdaOffset = -1; // lhs offset of the first d(lambda)/d(theta) output;
+                              // -1 unless the transform-both-sides lambda is estimated (#949)
   int thetaSensNeq = 0;       // ODE state count of the sensitivity model (impmap)
   int thetaSensNlhs = 0;      // lhs output count of the sensitivity model (impmap).  Whether
                               // reads need a private buffer is decided by OdeSwapScope: the
@@ -10871,6 +10873,15 @@ void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
   out.dvv.assign(dvRaw.begin(), dvRaw.end());
   out.limv.assign(limRaw.begin(), limRaw.end());
   out.distv.assign(nobs, rxDistributionNorm);
+  // DV-side lambda sensitivity, only when the model emits d(lambda)/d(theta) (#949).
+  const bool doDvSens = (op_focei.thetaSensLambdaOffset >= 0);
+  if (doDvSens) {
+    out.ddvmat.zeros(nobs, nSens);
+    out.dlimmat.zeros(nobs, nSens);
+  } else {
+    out.ddvmat.reset();
+    out.dlimmat.reset();
+  }
   bool rowInfoDone = false;
   out.fvec.resize(nsamp); out.Vvec.resize(nsamp);
   out.dfmat.resize(nsamp); out.dVmat.resize(nsamp);
@@ -10894,12 +10905,30 @@ void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
   // Transform observation ko's DV/limit and read its endpoint distribution.  Call ONLY
   // from a pass that has just run calc_lhs for that row: rx_yj_/rx_lambda_/rx_low_/
   // rx_hi_ are model assignments, so ind->yj / ind->lambda describe the row only then.
-  auto rowInfoAt = [&](int ko) {
+  auto rowInfoAt = [&](int ko, const double *lhs) {
     out.dvv[ko] = tbs(dvRaw[ko]);
     if (R_FINITE(limRaw[ko])) out.limv[ko] = tbs(limRaw[ko]);
     int _yj = getIndYj(ind), _dist = rxDistributionNorm, _yj0 = 0;
     _splitYj(&_yj, &_dist, &_yj0);
     out.distv[ko] = _dist;
+    if (!doDvSens) return;
+    // d(h(y; lambda))/d(theta) = d(h)/d(lambda) * d(lambda)/d(theta): the transform is
+    // applied to the DV here in C++, so the sensitivity model cannot carry this half.
+    double _dY = _powerDLambda(dvRaw[ko], getIndLambda(ind), getIndLambdaYj(ind),
+                               getIndLogitLow(ind), getIndLogitHi(ind));
+    if (!R_FINITE(_dY)) _dY = 0.0;
+    double _dL = 0.0;
+    if (R_FINITE(limRaw[ko])) {
+      _dL = _powerDLambda(limRaw[ko], getIndLambda(ind), getIndLambdaYj(ind),
+                          getIndLogitLow(ind), getIndLogitHi(ind));
+      if (!R_FINITE(_dL)) _dL = 0.0;
+    }
+    for (int s = 0; s < nSens; ++s) {
+      double _dl = lhs[op_focei.thetaSensLambdaOffset + s];
+      if (!R_FINITE(_dl)) _dl = 0.0;
+      out.ddvmat(ko, s) = _dY * _dl;
+      out.dlimmat(ko, s) = _dL * _dl;
+    }
   };
   for (int k = 0; k < nsamp; ++k) {
     for (int j = 0; j < (int)op_focei.neta; ++j) {
@@ -10948,7 +10977,7 @@ void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
           // ind->yj / ind->lambda now describe THIS row -- the only point in the
           // subject where that is true, so take the per-obs DV transform and
           // distribution here (once; they do not vary across samples).
-          if (!rowInfoDone) rowInfoAt(ko);
+          if (!rowInfoDone) rowInfoAt(ko, lhs);
           fvec[ko] = lhs[op_focei.thetaSensPredOffset];
           Vvec[ko] = lhs[op_focei.thetaSensROffset];
           for (int s = 0; s < nSens; ++s) {
@@ -10992,7 +11021,7 @@ void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
       if (!isDose(getIndEvid(ind, kk)) && getIndEvid(ind, kk) != 0) continue;
       rxThetaSens.calc_lhs(_rxId, curT, getOpIndSolve(op, ind, jj), lhs);
       if (getIndEvid(ind, kk) == 0) {
-        rowInfoAt(ko);
+        rowInfoAt(ko, lhs);
         ko++;
       }
     }
@@ -11007,23 +11036,41 @@ void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
 // log-likelihood score is -rho_f, -rho_r and the information is the rho second
 // derivatives.  An uncensored observation takes the Gauss-Newton form, which is what
 // the censored one reduces to.
+//
+// `ddv`/`dlim` are d(transformed DV)/d(theta) and d(transformed LIMIT)/d(theta),
+// non-zero only for an estimated transform-both-sides lambda (#949).  Uncensored,
+// the residual direction is then d(err)/d(theta) = d(f)/d(theta) - d(h(y))/d(theta);
+// censored, the dv/limit partials of rho come from censNormalDvPartials (the Hessian
+// keeps the same residual direction -- exact for M3, a Gauss-Newton surrogate
+// otherwise, and H is only the Newton step's information).
 static void impThetaAccumGauss(const impThetaSensData &c, int jo, double f, double V,
                                const arma::rowvec &df, const arma::rowvec &dV,
+                               const arma::rowvec &ddv, const arma::rowvec &dlim,
+                               bool hasDvSens,
                                double w, arma::vec &g, arma::mat &H) {
   const bool isCens = (c.censv[jo] != 0) || (R_FINITE(c.limv[jo]) && !ISNA(c.limv[jo]));
+  arma::rowvec _deBuf;
+  if (hasDvSens) _deBuf = df - ddv;
+  const arma::rowvec &de = hasDvSens ? _deBuf : df;   // d(err)/d(theta)
   if (isCens) {
     double cp[9]; for (int _i = 0; _i < 9; ++_i) cp[_i] = 0.0;
     censNormalPartials((double)c.censv[jo], c.dvv[jo], c.limv[jo], f, V, 2, cp);
     g += w * (-cp[0] * df.t() - cp[1] * dV.t());
-    H += w * (cp[2] * (df.t() * df) +
-              cp[3] * (df.t() * dV + dV.t() * df) +
+    if (hasDvSens) {
+      double rhoDv = 0.0, rhoLim = 0.0;
+      censNormalDvPartials((double)c.censv[jo], c.dvv[jo], c.limv[jo], f, V, cp[0],
+                           &rhoDv, &rhoLim);
+      g += w * (-rhoDv * ddv.t() - rhoLim * dlim.t());
+    }
+    H += w * (cp[2] * (de.t() * de) +
+              cp[3] * (de.t() * dV + dV.t() * de) +
               cp[4] * (dV.t() * dV));
     return;
   }
   const double err = f - c.dvv[jo];
-  g += w * ((-err / V) * df.t() +
+  g += w * ((-err / V) * de.t() +
             (0.5 * (err * err / (V * V) - 1.0 / V)) * dV.t());
-  H += w * ((df.t() * df) / V + 0.5 * (dV.t() * dV) / (V * V));
+  H += w * ((de.t() * de) / V + 0.5 * (dV.t() * dV) / (V * V));
 }
 
 // Cheap arithmetic half of the theta score: accumulate the IS-weighted score `g`
@@ -11035,6 +11082,10 @@ void impThetaAccumOne(const impThetaSensData& c, const arma::vec& zk,
   if (nSens == 0 || c.nobs == 0) return;
   int nobs = c.nobs;
   int nsamp = (int)c.sampleOk.size();
+  // stand-in DV/limit directions when the transform lambda is not estimated (#949)
+  const bool hasDvSens = ((int)c.ddvmat.n_rows == nobs &&
+                          (int)c.ddvmat.n_cols == nSens);
+  const arma::rowvec zeroDir(nSens, arma::fill::zeros);
   for (int k = 0; k < nsamp; ++k) {
     if (!c.sampleOk[k]) continue;
     const arma::vec& fvec = c.fvec[k];
@@ -11059,7 +11110,12 @@ void impThetaAccumOne(const impThetaSensData& c, const arma::vec& zk,
       if (!R_finite(V) || V <= 0.0 || !R_finite(f)) continue;
       arma::rowvec df = dfmat.row(jo), dV = dVmat.row(jo);
       if (!df.is_finite() || !dV.is_finite()) continue;
-      impThetaAccumGauss(c, jo, f, V, df, dV, zk[k], g, H);
+      if (hasDvSens) {
+        impThetaAccumGauss(c, jo, f, V, df, dV, c.ddvmat.row(jo), c.dlimmat.row(jo),
+                           true, zk[k], g, H);
+      } else {
+        impThetaAccumGauss(c, jo, f, V, df, dV, zeroDir, zeroDir, false, zk[k], g, H);
+      }
     }
   }
 }
@@ -11341,6 +11397,7 @@ Environment foceiFitCpp_(Environment e){
       // and record its ODE state count + the lhs offset of the first
       // d(f)/d(theta) output rx__sens_rx_pred__BY_THETA_1___.
       op_focei.thetaSensOffset = -1;
+      op_focei.thetaSensLambdaOffset = -1;
       op_focei.thetaSensNeq = 0;
       if ((op_focei.isImpmap || op_focei.isAdvi || op_focei.thetaSensLoad) &&
       model.containsElementNamed("thetaSens")) {
@@ -11365,6 +11422,11 @@ Environment foceiFitCpp_(Environment e){
             if (_iv >= 0) op_focei.thetaSensDvOffset = _iv;
             op_focei.thetaSensPredOffset = odeSwapLhsIndex(odeSlotThetaSens, "rx_pred_");
             op_focei.thetaSensROffset = odeSwapLhsIndex(odeSlotThetaSens, "rx_r_");
+            // d(lambda)/d(theta): present only when the model emits it (an estimated
+            // transform-both-sides lambda), absent -> -1 and the DV-side term is skipped
+            std::string firstL = "rx__sens_rx_lambda__BY_THETA_" + j0 + "___";
+            op_focei.thetaSensLambdaOffset =
+              odeSwapLhsIndex(odeSlotThetaSens, firstL.c_str());
           }
         }
         // The pool is sized for the theta-sensitivity model (the largest); pin the
@@ -11882,6 +11944,7 @@ RObject vaeInnerSetup_(Environment e) {
   // the outer population gradient -- mirrors the impmap full-fit path (which sets
   // these in foceiFitCpp_, a code path vaeInnerSetup_ does not go through).
   op_focei.thetaSensOffset = -1;
+  op_focei.thetaSensLambdaOffset = -1;
   op_focei.thetaSensNeq = 0;
   if ((op_focei.isImpmap || op_focei.isAdvi || op_focei.thetaSensLoad) &&
       model.containsElementNamed("thetaSens")) {
@@ -11901,6 +11964,9 @@ RObject vaeInnerSetup_(Environment e) {
         if (_iv >= 0) op_focei.thetaSensDvOffset = _iv;
         op_focei.thetaSensPredOffset = odeSwapLhsIndex(odeSlotThetaSens, "rx_pred_");
         op_focei.thetaSensROffset = odeSwapLhsIndex(odeSlotThetaSens, "rx_r_");
+        std::string firstL = "rx__sens_rx_lambda__BY_THETA_" + j0 + "___";
+        op_focei.thetaSensLambdaOffset =
+          odeSwapLhsIndex(odeSlotThetaSens, firstL.c_str());
       }
     }
     if (op_focei.thetaSensOffset >= 0 && op_focei.innerNeq > 0) {

--- a/tests/testthat/test-focei-ptrs.R
+++ b/tests/testthat/test-focei-ptrs.R
@@ -507,6 +507,9 @@ test_that("the lambda column is right for censored and multi-endpoint data (#949
   .tbsMod <- rxode2::rxode2(.foceiPtrMod) |>
     rxode2::model(cp ~ add(add.sd) + boxCox(lambda)) |>
     rxode2::ini(lambda = 0.5)
+  .tbsYj <- rxode2::rxode2(.foceiPtrMod) |>
+    rxode2::model(cp ~ add(add.sd) + yeoJohnson(lambda)) |>
+    rxode2::ini(lambda = 0.5)
   eta <- matrix(c(-0.1, 0.05, 0.2, -0.15), 4, 1)
   .fdCheck <- function(h, th, info) {
     expect_equal(foceiLikSetThetaC_(th), 0L, info = info)
@@ -534,14 +537,18 @@ test_that("the lambda column is right for censored and multi-endpoint data (#949
   .cases$M2 <- .censData(TRUE)
   .cases$M2$DV <- .cases$M3$DV
   .cases$M2$CENS <- NULL
-  for (.nm in names(.cases)) {
-    h <- foceiLikLoad(.tbsMod, .cases[[.nm]], "focei", scale = "natural",
-                      thetaSens = TRUE)
-    th <- h$initPar
-    th[1:4] <- c(1, 3, 0.5, 0.5)
-    got <- .fdCheck(h, th, .nm)
-    expect_true(all(abs(got$dTheta[, 4]) > 1e-3), info = .nm)
-    foceiLikUnload()
+  # both transform families: the DV/LIMIT partials run through _powerDLambda, whose
+  # branch differs per transform
+  for (.tr in c("boxCox", "yeoJohnson")) {
+    for (.nm in names(.cases)) {
+      h <- foceiLikLoad(if (.tr == "boxCox") .tbsMod else .tbsYj, .cases[[.nm]],
+                        "focei", scale = "natural", thetaSens = TRUE)
+      th <- h$initPar
+      th[1:4] <- c(1, 3, 0.5, 0.5)
+      got <- .fdCheck(h, th, paste0(.tr, " ", .nm))
+      expect_true(all(abs(got$dTheta[, 4]) > 1e-3), info = paste0(.tr, " ", .nm))
+      foceiLikUnload()
+    }
   }
   # two endpoints, only the first transformed
   .multiMod <- function() {

--- a/tests/testthat/test-focei-ptrs.R
+++ b/tests/testthat/test-focei-ptrs.R
@@ -431,3 +431,156 @@ test_that("an eta entering dose handling gets its jump in the eta gradient (#946
                  tolerance = 1e-3, info = paste0("eta ", k))
   }
 })
+
+test_that("an estimated transform-both-sides lambda carries its column (#949)", {
+  # lambda is a residual-error theta, so the sensitivity model hard-coded
+  # d(f)/d(lambda) = 0 -- but the conditional depends on lambda through BOTH
+  # sides of err = h(y; lambda) - h(f; lambda).  The f side now comes from the
+  # model (rxTBSdL) and the DV side from d(lambda)/d(theta) times the analytic
+  # d(h(y))/d(lambda), applied where the DV transform is (in C++).
+  skip_on_cran()
+  d <- .foceiPtrData()
+  .base <- rxode2::rxode2(.foceiPtrMod)
+  .fam <- list(
+    boxCox = .base |> rxode2::model(cp ~ add(add.sd) + boxCox(lambda)) |>
+      rxode2::ini(lambda = 0.5),
+    yeoJohnson = .base |> rxode2::model(cp ~ add(add.sd) + yeoJohnson(lambda)) |>
+      rxode2::ini(lambda = 0.5),
+    boxCoxProp = .base |> rxode2::model(cp ~ prop(prop.sd) + boxCox(lambda)) |>
+      rxode2::ini(prop.sd = 0.1, lambda = 0.5),
+    # composed transforms: lambda applies to the logit/probit-mapped scale
+    logitYj = .base |>
+      rxode2::model(cp ~ logitNorm(lg.sd, 0, 10) + yeoJohnson(lambda)) |>
+      rxode2::ini(lg.sd = 0.4, lambda = 0.5),
+    probitYj = .base |>
+      rxode2::model(cp ~ probitNorm(pb.sd, 0, 10) + yeoJohnson(lambda)) |>
+      rxode2::ini(pb.sd = 0.4, lambda = 0.5))
+  eta <- matrix(c(-0.1, 0.05, 0.2, -0.15), 4, 1)
+  for (.n in names(.fam)) {
+    h <- foceiLikLoad(.fam[[.n]], d, "focei", scale = "natural", thetaSens = TRUE)
+    expect_true(isTRUE(h$thetaSens), info = .n)
+    # lambda is ntheta 4 (tcl, tv, <resid sd>, lambda); tcl is mu-referenced
+    expect_equal(h$thetaSensIdx, c(2L, 3L, 4L), info = .n)
+    th <- h$initPar
+    th[1:4] <- c(1, 3, switch(.n, boxCoxProp = 0.1, logitYj = 0.4,
+                              probitYj = 0.4, 0.5), 0.5)
+    expect_equal(foceiLikSetThetaC_(th), 0L, info = .n)
+    got <- foceiLikCondThetaGrad_(eta, 1L)
+    expect_equal(got$nBad, 0L, info = .n)
+    # the historical zero is gone
+    expect_true(all(abs(got$dTheta[, 4]) > 1e-3), info = .n)
+    .h <- 1e-5
+    for (t in h$thetaSensIdx) {
+      up <- th
+      up[t] <- up[t] + .h
+      dn <- th
+      dn[t] <- dn[t] - .h
+      expect_equal(foceiLikSetThetaC_(up), 0L)
+      vUp <- foceiLikCondGrad_(eta, 1L)$value
+      expect_equal(foceiLikSetThetaC_(dn), 0L)
+      vDn <- foceiLikCondGrad_(eta, 1L)$value
+      fd <- (vUp - vDn) / (2 * .h)
+      expect_equal(as.numeric(got$dTheta[, t]), as.numeric(fd),
+                   tolerance = 1e-4, info = paste0(.n, " theta ", t))
+    }
+    foceiLikUnload()
+  }
+})
+
+test_that("the lambda column is right for censored and multi-endpoint data (#949)", {
+  # The DV-side term also moves the censoring bounds (M3/M4 read the TRANSFORMED
+  # DV and LIMIT), and with several endpoints rx_lambda_ is a CMT switch so only
+  # the transformed endpoint's rows may pick the term up.
+  skip_on_cran()
+  .testSeed(42)
+  .censData <- function(limit = FALSE) {
+    do.call(rbind, lapply(1:4, function(id) {
+      tt <- c(0.5, 1, 2, 4, 8)
+      dv <- 5 * exp(-0.05 * tt) + stats::rnorm(5, 0, 0.5)
+      d <- data.frame(ID = id, TIME = tt, DV = dv, AMT = 0, EVID = 0,
+                      CENS = c(0, 0, 0, -1, -1))
+      d$DV[d$CENS == -1] <- 4.6
+      if (limit) d$LIMIT <- ifelse(d$CENS == -1, 3.5, NA_real_)
+      d
+    }))
+  }
+  .tbsMod <- rxode2::rxode2(.foceiPtrMod) |>
+    rxode2::model(cp ~ add(add.sd) + boxCox(lambda)) |>
+    rxode2::ini(lambda = 0.5)
+  eta <- matrix(c(-0.1, 0.05, 0.2, -0.15), 4, 1)
+  .fdCheck <- function(h, th, info) {
+    expect_equal(foceiLikSetThetaC_(th), 0L, info = info)
+    got <- foceiLikCondThetaGrad_(eta, 1L)
+    expect_equal(got$nBad, 0L, info = info)
+    .h <- 1e-5
+    for (t in h$thetaSensIdx) {
+      up <- th
+      up[t] <- up[t] + .h
+      dn <- th
+      dn[t] <- dn[t] - .h
+      expect_equal(foceiLikSetThetaC_(up), 0L)
+      vUp <- foceiLikCondGrad_(eta, 1L)$value
+      expect_equal(foceiLikSetThetaC_(dn), 0L)
+      vDn <- foceiLikCondGrad_(eta, 1L)$value
+      expect_equal(as.numeric(got$dTheta[, t]),
+                   as.numeric((vUp - vDn) / (2 * .h)),
+                   tolerance = 1e-4, info = paste0(info, " theta ", t))
+    }
+    got
+  }
+  # M3 (CENS only), M4 (CENS + LIMIT) and M2 (finite LIMIT, CENS 0): each takes a
+  # different branch of the dv/limit partials
+  .cases <- list(M3 = .censData(FALSE), M4 = .censData(TRUE))
+  .cases$M2 <- .censData(TRUE)
+  .cases$M2$DV <- .cases$M3$DV
+  .cases$M2$CENS <- NULL
+  for (.nm in names(.cases)) {
+    h <- foceiLikLoad(.tbsMod, .cases[[.nm]], "focei", scale = "natural",
+                      thetaSens = TRUE)
+    th <- h$initPar
+    th[1:4] <- c(1, 3, 0.5, 0.5)
+    got <- .fdCheck(h, th, .nm)
+    expect_true(all(abs(got$dTheta[, 4]) > 1e-3), info = .nm)
+    foceiLikUnload()
+  }
+  # two endpoints, only the first transformed
+  .multiMod <- function() {
+    ini({
+      tcl <- 1
+      tv <- 3
+      add.sd <- 0.5
+      lambda <- c(-2, 0.5, 2)
+      ef.sd <- 0.7
+      eta.cl ~ 0.1
+    })
+    model({
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- 100 / v * exp(-cl / v * time)
+      ef <- 10 - cp
+      cp ~ add(add.sd) + boxCox(lambda)
+      ef ~ add(ef.sd)
+    })
+  }
+  .testSeed(42)
+  dm <- do.call(rbind, lapply(1:4, function(id) {
+    tt <- c(0.5, 1, 2, 4, 8)
+    rbind(data.frame(ID = id, TIME = tt, DVID = "cp",
+                     DV = 5 * exp(-0.05 * tt) + stats::rnorm(5, 0, 0.5)),
+          data.frame(ID = id, TIME = tt, DVID = "ef",
+                     DV = 5 + 0.05 * tt + stats::rnorm(5, 0, 0.7)))
+  }))
+  dm$AMT <- 0
+  dm$EVID <- 0
+  h <- foceiLikLoad(.multiMod, dm, "focei", scale = "natural", thetaSens = TRUE)
+  on.exit(foceiLikUnload(), add = TRUE)
+  expect_equal(h$thetaSensIdx, c(2L, 3L, 4L, 5L))
+  th <- h$initPar
+  th[1:5] <- c(1, 3, 0.5, 0.5, 0.7)
+  got <- .fdCheck(h, th, "multi")
+  expect_true(all(abs(got$dTheta[, 4]) > 1e-3))
+  # and thread-count invariant with the extra per-row term
+  expect_equal(foceiLikSetThetaC_(th), 0L)
+  expect_equal(foceiLikCondThetaGrad_(eta, 4L)$dTheta, got$dTheta,
+               tolerance = 1e-12)
+})

--- a/tests/testthat/test-impmap.R
+++ b/tests/testthat/test-impmap.R
@@ -355,6 +355,44 @@ nmTest({
     expect_equal(unname(fixef(.fi)["prop.sd"]), unname(fixef(.ff)["prop.sd"]), tolerance = 0.02)
   })
 
+  test_that("M6b: an estimated transform-both-sides lambda converges to FOCEI (#949)", {
+    # lambda is a residual-error theta, but unlike a sigma it reaches the MEAN:
+    # the conditional depends on it through both sides of h(y; lambda) - h(f; lambda).
+    # Its sensitivity column used to be identically zero, which left the M-step
+    # Newton update singular in that direction and pinned lambda at its initial
+    # value (measured: exactly 0.8 in, exactly 0.8 out, objf 106.2 vs FOCEI's -9.2).
+    mbc <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        eta.ka ~ 0.6
+        add.sd <- 0.7
+        lambda <- c(-2, 0.8, 2)
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - cl / v * central
+        cp <- central / v
+        cp ~ add(add.sd) + boxCox(lambda)
+      })
+    }
+    .d <- nlmixr2data::theo_sd
+    .ff <- suppressWarnings(nlmixr2(mbc, .d, "focei", foceiControl(print = 0L, covMethod = "")))
+    rxode2::rxSetSeed(42)
+    .fi <- suppressWarnings(nlmixr2(mbc, .d, "impmap",
+                                    impmapControl(print = 0L, nIter = 30L, isample = 300L)))
+    expect_true(inherits(.fi, "nlmixr2FitCore"))
+    # it MOVED (the historical failure was a fit stuck at the initial estimate) ...
+    expect_true(abs(unname(fixef(.fi)["lambda"]) - 0.8) > 0.1)
+    # ... and it moved to where FOCEI puts it
+    expect_equal(unname(fixef(.fi)["lambda"]), unname(fixef(.ff)["lambda"]),
+                 tolerance = 0.15)
+    expect_equal(unname(fixef(.fi)["add.sd"]), unname(fixef(.ff)["add.sd"]),
+                 tolerance = 0.1)
+  })
+
   test_that("M7: multiple endpoints with more structural thetas than etas (pool sized for theta-sens)", {
     # 2-endpoint PK/PD (indirect response).  Only eta.cl is random, so the inner
     # model has few states while the theta-sensitivity model (tka, tv, tec50, tkout,

--- a/tests/testthat/test-vi-grad.R
+++ b/tests/testthat/test-vi-grad.R
@@ -76,6 +76,69 @@ nmTest({
     }
   })
 
+  test_that("adviElboGrad_ gTheta is right for an ESTIMATED boxCox lambda (#949)", {
+    ## lambda is a residual-error theta that nevertheless reaches the MEAN: the
+    ## ELBO depends on it through both sides of err = h(y; lambda) - h(f; lambda).
+    ## Its theta-sensitivity column used to be identically zero, so the advi outer
+    ## gradient had no lambda direction at all.  This is the advi-side counterpart
+    ## of the C-API check in test-focei-ptrs.R -- adviElboGradCore reaches the same
+    ## impThetaScore/impThetaAccumOne path the impmap M-step uses.
+    mod <- function() {
+      ini({ lka <- log(1.5); lcl <- log(0.09); lv <- log(32)
+        eta.ka ~ 0.3; add.err <- 0.6; lambda <- c(-2, 0.8, 2) })
+      model({ ka <- exp(lka + eta.ka); cl <- exp(lcl); v <- exp(lv)
+        d/dt(depot) = -ka * depot; d/dt(central) = ka * depot - cl / v * central
+        cp <- central / v; cp ~ add(add.err) + boxCox(lambda) })
+    }
+    ui <- rxode2::assertRxUi(mod)
+    ctl <- emviControl(rxControl = rxode2::rxControl(atol = 1e-8, rtol = 1e-8))
+    ## a boxCox endpoint floors a non-positive DV, which puts a kink in the
+    ## objective that no finite difference can resolve -- theo_sd carries 9 such
+    ## rows (DV == 0 pre-dose), really a censoring case.  Drop them for the check.
+    dat <- nlmixr2data::theo_sd
+    dat <- dat[!(dat$EVID == 0 & dat$DV <= 0), ]
+    prep <- .adviDataPrep(ui, dat)
+    N <- prep$N; neta <- 1L
+    muRefIdx <- as.integer(prep$muRefThetaIdx)
+    ntheta <- prep$ntheta
+    ## which theta is lambda (do not hard-code the ini order)
+    .th <- ui$iniDf[!is.na(ui$iniDf$ntheta), ]
+    lamIdx <- .th$ntheta[.th$name == "lambda"]
+    expect_length(lamIdx, 1L)
+
+    .testSeed(11)
+    mu <- matrix(rnorm(N * neta, 0, 0.2), N, neta)
+    omega <- matrix(rnorm(N * neta, -0.7, 0.1), N, neta)
+    theta <- prep$theta
+    logPopOmega <- log(prep$omega)
+    eps <- matrix(rnorm(N * neta), N, neta)
+
+    .adviInnerSetup(ui, dat, mu, ctl)
+    on.exit(.adviInnerFree(), add = TRUE)
+
+    ## the DV-side term is actually WIRED, not merely giving the right number:
+    ## lambdaOffset is >= 0 only when the model emits d(lambda)/d(theta)
+    .info <- adviThetaSensInfo_()
+    expect_true(.info$nSens > 0L)
+    expect_true(.info$lambdaOffset >= 0L)
+
+    elboFun <- function(theta)
+      adviElboGrad_(mu, omega, theta, logPopOmega, eps, muRefIdx)$elbo
+    a <- adviElboGrad_(mu, omega, theta, logPopOmega, eps, muRefIdx)
+    h <- 1e-4
+    relOk <- function(x, fd, tol = 2e-3) abs(x - fd) < tol * (1 + abs(x))
+    for (p in seq_len(ntheta)) {
+      xp <- theta; xp[p] <- theta[p] + h
+      xm <- theta; xm[p] <- theta[p] - h
+      gfd <- (elboFun(xp) - elboFun(xm)) / (2 * h)
+      expect_true(relOk(a$gTheta[p], gfd),
+                  info = paste0("theta ", p, ": analytic ", a$gTheta[p],
+                                " fd ", gfd))
+    }
+    ## and the historical failure -- a lambda direction of exactly zero -- is gone
+    expect_true(abs(a$gTheta[lamIdx]) > 1e-3)
+  })
+
   test_that("adviElboGradFR_ full-rank gradient matches finite differences", {
     ## two correlated etas so the off-diagonal L entries are exercised
     mod <- function() {


### PR DESCRIPTION
Closes #949.

An estimated transform-both-sides `lambda` (`boxCox()`/`yeoJohnson()`) was advertised in `impThetaSensIdx` but its gradient column evaluated to identically zero. Reproduced exactly at the numbers in the issue, through `nlmixr2FoceiCondThetaGrad` + central differences at `theta=(1, 3, 0.5, 0.5)`:

| column | analytic (before) | FD |
|---|---|---|
| tv | exact | -- |
| add.sd | exact | -- |
| **lambda** | **0, 0, 0, 0** | **-8.63, -14.17, -13.01, -7.37** |

## Why it was zero

The conditional depends on lambda through *both* sides of `err = h(y; lambda) - h(f; lambda)`, and each half was missing for its own reason.

**Prediction side.** `rx_pred_` applies `rxTBS()`, so `d(f)/d(lambda)` is just the direct partial -- but the codegen hard-coded `d(f)/d(theta) = 0` for every residual-error theta, on the otherwise-correct reasoning that a sigma reaches only `V`. lambda is the one residual-error theta that reaches the *mean*. The chain-rule helper already restricts state-sensitivity terms to structural thetas, so taking it for every theta emits exactly the direct partial here; rxode2 already carries `d(rxTBS)/d(lambda)` as `rxTBSdL`.

**DV side.** `h(y; lambda)` is applied in C++ -- the sensitivity model never sees the DV -- so no model output could carry it. The model now emits `rx__sens_rx_lambda__BY_THETA_j___ = d(lambda)/d(theta_j)`, and the M-step multiplies it by rxode2's analytic `_powerDLambda(y)` at the row's own lambda/yj/low/hi. Reading it inside `rowInfoAt` keeps it on the one pass where `ind->lambda` describes the row (the #838 discipline), which is also what makes a multi-endpoint CMT-switched `rx_lambda_` come out right.

The residual direction is then `d(f)/d(theta) - d(h(y))/d(theta)`. Censored rows shift their bounds too, so `censNormalDvPartials` adds the exact dv/`LIMIT` partials of rho, decomposed per method (M3 has `rho_dv = -rho_f`; M2's dv half is the plain normal term; M4's is the upper cumulative of `Phi1 - Phi2`, whose sign must be restored because `logspace_sub` returns the magnitude), with the limit half fixed by `rho_dv + rho_lim = -rho_f`.

The DV-transform Jacobian is deliberately still omitted, as the issue specifies: `likInner0` leaves it out of the conditional and a Bayesian caller adds it on its side.

## Verification

FD agreement at the C API level is ~1e-10 relative across boxCox, yeoJohnson (positive and negative DV), boxCox+prop, logitNorm+yeoJohnson, probitNorm+yeoJohnson, M2/M3/M4 censoring in both transform families, and a two-endpoint model where only one endpoint is transformed; thread-count invariant.

The generated sensitivity model is **byte-identical to main** for add/prop/add+prop/pow/propT/lnorm/logitNorm -- nothing changes for a model with no estimated lambda.

End to end, `est="impmap"` on `theo_sd` with an estimated boxCox lambda used to return the initial value untouched -- 0.8 in, exactly 0.8 out, objf 106.2 -- because the zero column left the M-step Newton update singular in that direction. It now moves to 0.427 against FOCEI's 0.388, objf -6.4 against -9.2. (Measured by reverting only the R codegen, which reproduces the old path exactly.)

Tests added to `test-focei-ptrs.R` and `test-vi-grad.R` (both in the essential push/PR subset) and `test-impmap.R` (weekly batch 4).

The advi fixture is in `test-vi-grad.R`: `adviElboGradCore` reaches the same `impThetaScore` -> `impThetaAccumOne` path as the impmap M-step, and that file already FD-checks `adviElboGrad_`'s `gTheta` against central differences of the ELBO. It asserts the *mechanism*, not just the number -- `adviThetaSensInfo_()` now reports `lambdaOffset`, which is `>= 0` only when the model emits `d(lambda)/d(theta)`, i.e. only when the DV-side term is wired. Confirmed it catches the bug: with `R/impmapThetaSens.R` reverted to `origin/main` (which reproduces the old zero-column path exactly) it fails 3 assertions; with the fix it passes all 9.

Passing locally: `test-focei-ptrs`, `test-impmap`, `test-foceiLik`, `test-vi-grad`, `test-vi-fit`, `test-vi-fullrank`, `test-vi-repro`, `test-vi-cores`, `test-vae-nonmutheta`, `test-vae-nonmutheta-grad`, `test-imp-auto`, `test-npag-error-models`, plus the imp/vae/npag sweep.

## Found by review, also fixed here

Four rounds of independent review (Antigravity/Gemini) produced three real items:

- **Stale theta-sens offsets across fits (pre-existing).** `foceiFitCpp_`/`vaeInnerSetup_` reset only `thetaSensOffset`, but the resolves are guarded by `if (_iv >= 0)`. A second fit whose `rx__sens_rx_r__BY_THETA_<j0>___` name failed to resolve kept the *first* fit's `thetaSensDvOffset` -- a stale positive value that `impThetaSensCollect`'s `< 0` guard cannot catch, so `d(V)/d(theta)` is read from the wrong lhs columns. All offsets now reset unconditionally.
- **A NaN path in the new censored partials.** Deriving the LIMIT partial as `-rhoF - rhoDv` gives exactly 0 for M3 only while `rhoF` is finite; a non-finite `rhoF` left `rhoLim` non-finite against an identically-zero `dlim`, so the score accumulated `Inf*0 = NaN` and poisoned the subject's gradient. Returns 0 directly when there is no finite LIMIT now, both outputs guarded.
- **A string test where a class test belonged.** The lambda block was gated on `grepl("THETA", <rendered rx_lambda_>)` and used the direct partial. `boxCox()`/`yeoJohnson()` accept a *model variable*, so lambda can be any expression. Now gated on `inherits(.lambda, "Basic")` -- the actual condition the guard exists for -- and derived with the chain rule, so a lambda variable reaching an ODE state picks up its state-sensitivity term. On `lamv <- exp(tlam) + 0.001*central`, the structural theta's lambda column is `0.001*rx__sens_central_BY_THETA_2___` where the direct partial gave 0, and all columns FD-agree.

Three further findings were rejected after measurement, recorded in the commit messages: an unreachable `impThetaSensIdx` staleness path, a claimed row-ordering mismatch between the two observation walks (refuted by reversing every subject's rows: values bit-identical, gradient FD-agreeing at 2.7e-09), and a claimed `logspace_sub` clamping defect (the clamp fires only where `ld` is `-Inf`, and the existing finiteness guard already yields the flat objective's derivative).

`impThetaAccumOne` is decomposed into a per-observation `impThetaAccumObs` to stay under the CodeFactor complexity gate (the `hasDvSens` dispatch pushed it to 17). Pure refactor -- every FD harness reproduces its previous numbers exactly.

## Follow-on

With this column real, the estimated-lambda refusal in nlmixr2stan's `est="stan"` can flip to an FD-verified supported path, adding the DV-transform Jacobian on its side -- mirroring how #946/#947 flipped the dose-handling refusal.
