### PR TITLE
A covariate forced on the model is not required from the data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Internal
 
+- A covariate whose value is carried on the model in `rxode2::rxForcedPars()` is
+  no longer required to be a column of the data.  Such a covariate is supplied
+  by the model itself, so demanding it from the data rejected a well-specified
+  fit and forced the caller to add a placeholder column.  This is the same rule
+  rxode2 applies when resolving solve parameters, and it lets a model own
+  parameters the user never sees -- for example neural-network weights.
+
 - `ini()` on a fit now calls `rxode2::.iniHandleLine()` rather than the
   `rxode2::.iniHandleFixOrUnfix()` alias for it.  They are the same
   function; this was the last caller of the old name anywhere in the

--- a/R/preProcessCovariatesPresent.R
+++ b/R/preProcessCovariatesPresent.R
@@ -19,7 +19,14 @@
     .covNames <- ui$covariates
     .newNames <- .nmUpcaseNonCov(names(data), .covNames)
     colnames(data) <- .newNames
-    requiredCols <- c("TIME", .covNames)
+    ## A covariate whose value is FORCED on the model (rxForcedPars) is supplied
+    ## by the model itself, so requiring it from the data would reject a perfectly
+    ## well-specified fit.  This is how a model can own parameters the user never
+    ## sees -- e.g. neural-network weights carried on the ui -- without making
+    ## them placeholder data columns.  Same rule rxode2 applies when resolving
+    ## solve parameters.
+    .forced <- tryCatch(names(rxode2::rxForcedPars(ui)), error = function(e) NULL)
+    requiredCols <- c("TIME", setdiff(.covNames, .forced))
     checkmate::assert_names(.newNames, must.include = requiredCols)
   }
   NULL


### PR DESCRIPTION
`.nlmixr0preProcessCovariatesPresent()` requires every `ui$covariates` to be a
column of the data. A covariate whose value is carried on the model in
`rxode2::rxForcedPars()` is supplied *by the model itself*, so requiring it from
the data rejects a well-specified fit.

This check runs in the preprocessing hooks, i.e. before the estimation method
dispatches, so there is no way for a package to satisfy it after the fact. The
practical effect is that a package which gives a model parameters the user never
sees cannot get past it without asking the user to add placeholder columns to
their dataset — which is exactly the kind of ritual that makes a feature feel
bolted on. (The case that prompted this is neural-network weights carried on the
model in `nlmixr2nn`, but nothing here is specific to that.)

This is the same rule rxode2 applies when resolving solve parameters
(nlmixr2/rxode2#1267).

## Behaviour

- **No-op** for any model with no forced parameters: `.forced` is `NULL` and
  `setdiff(.covNames, NULL)` is `.covNames`, so `requiredCols` is unchanged.
- A covariate that is **genuinely missing** is still rejected, with the same
  message — verified directly.
- The `rxForcedPars()` lookup is wrapped in `tryCatch()`, so an older rxode2
  without it degrades to today's behaviour rather than erroring.

Depends on nothing in the rxode2 PR — `rxForcedPars()` already exists — but the
two together are what let a model own parameters end to end.