### PR TITLE
Bless the mixture (component-major) layout in the FOCEi conditional C API (#955)

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -398,6 +398,10 @@ foceiLikDims_ <- function() {
     .Call(`_nlmixr2est_foceiLikDims_`)
 }
 
+foceiLikNMix_ <- function() {
+    .Call(`_nlmixr2est_foceiLikNMix_`)
+}
+
 foceiLikSetThetaC_ <- function(theta) {
     .Call(`_nlmixr2est_foceiLikSetThetaC_`, theta)
 }

--- a/inst/include/nlmixr2estFoceiPtr.h
+++ b/inst/include/nlmixr2estFoceiPtr.h
@@ -50,8 +50,11 @@ extern "C" {
        0x08 some eta uses finite-difference event sensitivities (etaFD):
                                       ~1e-6 gradient noise -- refuse or
                                       accept knowingly
-       0x10 mixture model             per-id indexing is component-major;
-                                      nlmixr2FoceiCondBatch refuses (-2)
+       0x10 mixture model             per-id indexing is component-major
+                                      (id = component*nsub + subject, #955);
+                                      the batch entries ACCEPT the expanded
+                                      nid = nsub * nMix layout -- query nMix
+                                      via the table's "nMix" entry
        0x20 the ODE solve method is thread-safe (cores>1 honored;
                                       otherwise cores is clamped to 1)
        0x40 the theta-sensitivity model is wired
@@ -128,6 +131,14 @@ extern "C" {
                                              int neta, int cores,
                                              double *dTheta);
 
+  /* ---- 7. mixture component count (#955, additive) --------------------- */
+  /* 1 for a non-mixture load, K for a K-component mixture, -1 not loaded.
+     The batch entries take nid = nsub * nMix in component-major order
+     (id = component*nsub + subject); the component-conditional value and
+     gradients land in the matching rows.  NULL when the loaded nlmixr2est
+     predates the entry (treat as refuse-mixtures).                        */
+  typedef int (*nlmixr2FoceiNMix_t)(void);
+
   extern nlmixr2FoceiApiVersion_t    nlmixr2FoceiApiVersionP;
   extern nlmixr2FoceiDims_t          nlmixr2FoceiDimsP;
   extern nlmixr2FoceiSetTheta_t      nlmixr2FoceiSetThetaP;
@@ -135,6 +146,7 @@ extern "C" {
   extern nlmixr2FoceiSetOmegaInv_t   nlmixr2FoceiSetOmegaInvP;
   extern nlmixr2FoceiThetaSensIdx_t  nlmixr2FoceiThetaSensIdxP;
   extern nlmixr2FoceiCondThetaGrad_t nlmixr2FoceiCondThetaGradP;
+  extern nlmixr2FoceiNMix_t          nlmixr2FoceiNMixP;
 
   // Always refresh: a reloaded nlmixr2est hands back new addresses, and
   // keeping the first set seen would leave the caller calling into an
@@ -147,6 +159,11 @@ extern "C" {
     nlmixr2FoceiSetOmegaInvP   = (nlmixr2FoceiSetOmegaInv_t)   R_ExternalPtrAddrFn(VECTOR_ELT(p, 4));
     nlmixr2FoceiThetaSensIdxP  = (nlmixr2FoceiThetaSensIdx_t)  R_ExternalPtrAddrFn(VECTOR_ELT(p, 5));
     nlmixr2FoceiCondThetaGradP = (nlmixr2FoceiCondThetaGrad_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 6));
+    /* additive entries: read defensively so a downstream built against this
+       header still installs cleanly from an OLDER nlmixr2est's 7-entry
+       table (the missing capability reads as NULL) */
+    nlmixr2FoceiNMixP = (Rf_xlength(p) > 7) ?
+      (nlmixr2FoceiNMix_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 7)) : NULL;
     return R_NilValue;
   }
 
@@ -158,6 +175,7 @@ extern "C" {
   nlmixr2FoceiSetOmegaInv_t   nlmixr2FoceiSetOmegaInvP   = NULL;        \
   nlmixr2FoceiThetaSensIdx_t  nlmixr2FoceiThetaSensIdxP  = NULL;        \
   nlmixr2FoceiCondThetaGrad_t nlmixr2FoceiCondThetaGradP = NULL;        \
+  nlmixr2FoceiNMix_t          nlmixr2FoceiNMixP          = NULL;        \
   SEXP iniNlmixr2estFocei(SEXP p) { return iniNlmixr2estFocei0(p); }
 
 #ifdef __cplusplus

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1159,6 +1159,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// foceiLikNMix_
+int foceiLikNMix_();
+RcppExport SEXP _nlmixr2est_foceiLikNMix_() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(foceiLikNMix_());
+    return rcpp_result_gen;
+END_RCPP
+}
 // foceiLikSetThetaC_
 int foceiLikSetThetaC_(NumericVector theta);
 RcppExport SEXP _nlmixr2est_foceiLikSetThetaC_(SEXP thetaSEXP) {

--- a/src/init.c
+++ b/src/init.c
@@ -56,6 +56,7 @@ extern SEXP _nlmixr2est_foceiLikEval_(SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_foceiLikCondGrad_(SEXP, SEXP);
 extern SEXP _nlmixr2est_foceiLikCondThetaGrad_(SEXP, SEXP);
 extern SEXP _nlmixr2est_foceiLikDims_(void);
+extern SEXP _nlmixr2est_foceiLikNMix_(void);
 extern SEXP _nlmixr2est_foceiLikSetThetaC_(SEXP);
 extern SEXP _nlmixr2est_foceiLikSetOmegaInvC_(SEXP);
 extern SEXP _nlmixr2est_foceiLikThetaSensIdxC_(void);
@@ -247,6 +248,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_foceiLikCondGrad_", (DL_FUNC) &_nlmixr2est_foceiLikCondGrad_, 2},
   {"_nlmixr2est_foceiLikCondThetaGrad_", (DL_FUNC) &_nlmixr2est_foceiLikCondThetaGrad_, 2},
   {"_nlmixr2est_foceiLikDims_", (DL_FUNC) &_nlmixr2est_foceiLikDims_, 0},
+  {"_nlmixr2est_foceiLikNMix_", (DL_FUNC) &_nlmixr2est_foceiLikNMix_, 0},
   {"_nlmixr2est_foceiLikSetThetaC_", (DL_FUNC) &_nlmixr2est_foceiLikSetThetaC_, 1},
   {"_nlmixr2est_foceiLikSetOmegaInvC_", (DL_FUNC) &_nlmixr2est_foceiLikSetOmegaInvC_, 1},
   {"_nlmixr2est_foceiLikThetaSensIdxC_", (DL_FUNC) &_nlmixr2est_foceiLikThetaSensIdxC_, 0},

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -18556,15 +18556,21 @@ static void foceiCondBatchReset(rx_solving_options *op) {
 }
 
 // Shared argument/state guard for the batch entries.  0 ok, -1 not loaded,
-// -2 bad shape / FO (lp never filled) / mixture (id is component*nsub+subject;
-// refuse rather than guess).  Sets `rx` as a side effect.
+// -2 bad shape / FO (lp never filled).  Sets `rx` as a side effect.
+// Mixtures (#955): the component-major expanded layout is BLESSED --
+// nid = nsub * nMix with id = component*nsub + subject.  likInner0 pins the
+// subject's component itself on recalc (setIndMixest at the top of its
+// recalc branch, and the batch entries force recalc per subject), and the
+// batch loops run components serial-outer / subjects parallel-inner (the
+// foceiLikEval_ discipline: components share the physical subjects' solve
+// slots, so two components of one subject must never solve concurrently).
 static int foceiCondBatchCheck(const double *etaIn, const double *out,
                                int nid, int neta) {
   if (!foceiLikLoaded) return -1;
   if (etaIn == NULL || out == NULL) return -2;
   if (neta != op_focei.neta || neta <= 0 || op_focei.fo == 1) return -2;
   rx = getRxSolve_();
-  if (op_focei.mixIdxN != 0 || nid != (int)getRxNsub(rx)) return -2;
+  if (nid != (int)getRxNsub(rx) * (op_focei.mixIdxN + 1)) return -2;
   return 0;
 }
 
@@ -18651,14 +18657,20 @@ extern "C" int nlmixr2FoceiCondBatch(const double *etaIn, int nid, int neta,
       // the parallel region.
       OdeSwapEsBatch esBatch(odeSlotInner);
       NpInnerParallelScope npScope(rx, doParallel);
+      // components serial-outer (they share the physical subjects' solve
+      // slots), subjects parallel-inner; nMix == 1 reduces to the plain loop
+      const int nsub = (int)getRxNsub(rx);
+      const int nMix = op_focei.mixIdxN + 1;
+      for (int m = 0; m < nMix; ++m) {
 #ifdef _OPENMP
 #pragma omp parallel for num_threads(cores) schedule(dynamic) if(doParallel)
 #endif
-      for (int ii = 0; ii < nid; ++ii) {
-        int id = doParallel ? (getOrdId(rx, ii) - 1) : ii;
-        foceiCondEnterThread(doParallel);
-        bad[id] = foceiCondBatchOne(id, etaIn, neta, omInv, value, grad);
-        foceiCondLeaveThread(doParallel);
+        for (int ii = 0; ii < nsub; ++ii) {
+          int id = (doParallel ? (getOrdId(rx, ii) - 1) : ii) + m * nsub;
+          foceiCondEnterThread(doParallel);
+          bad[id] = foceiCondBatchOne(id, etaIn, neta, omInv, value, grad);
+          foceiCondLeaveThread(doParallel);
+        }
       }
     }
     int nbad = 0;
@@ -18728,14 +18740,21 @@ extern "C" int nlmixr2FoceiCondThetaGrad(const double *etaIn, int nid, int neta,
       // event sensitivities).
       OdeSwapEsBatch esBatch(odeSlotThetaSens);
       NpInnerParallelScope npScope(rx, doParallel);
+      // components serial-outer, subjects parallel-inner (see
+      // foceiCondBatchCheck); nMix == 1 reduces to the plain loop
+      const int nsub = (int)getRxNsub(rx);
+      const int nMix = op_focei.mixIdxN + 1;
+      for (int m = 0; m < nMix; ++m) {
 #ifdef _OPENMP
 #pragma omp parallel for num_threads(cores) schedule(dynamic) if(doParallel)
 #endif
-      for (int ii = 0; ii < nid; ++ii) {
-        int id = doParallel ? (getOrdId(rx, ii) - 1) : ii;
-        foceiCondEnterThread(doParallel);
-        bad[id] = foceiCondThetaGradOne(id, etaIn, neta, ntheta, nSens, dTheta);
-        foceiCondLeaveThread(doParallel);
+        for (int ii = 0; ii < nsub; ++ii) {
+          int id = (doParallel ? (getOrdId(rx, ii) - 1) : ii) + m * nsub;
+          foceiCondEnterThread(doParallel);
+          bad[id] = foceiCondThetaGradOne(id, etaIn, neta, ntheta, nSens,
+                                          dTheta);
+          foceiCondLeaveThread(doParallel);
+        }
       }
     }
     int nbad = 0;
@@ -18746,22 +18765,31 @@ extern "C" int nlmixr2FoceiCondThetaGrad(const double *etaIn, int nid, int neta,
   }
 }
 
+// Mixture component count for the blessed component-major layout (#955):
+// 1 for a non-mixture load, K for a K-component mixture; -1 not loaded.
+extern "C" int nlmixr2FoceiNMix(void) {
+  if (!foceiLikLoaded) return -1;
+  return op_focei.mixIdxN + 1;
+}
+
 // The external-pointer table (CRAN-preferred over R_RegisterCCallable, like
 // _nlmixr2est_likContribPtrs above); the downstream package installs it via
 // inst/include/nlmixr2estFoceiPtr.h.
 extern "C" SEXP _nlmixr2est_foceiPtrs(void) {
-  const char *nm[7] = {"apiVersion", "dims", "setTheta", "condBatch",
-                       "setOmegaInv", "thetaSensIdx", "condThetaGrad"};
-  DL_FUNC fn[7] = {(DL_FUNC) &nlmixr2FoceiApiVersion,
+  const char *nm[8] = {"apiVersion", "dims", "setTheta", "condBatch",
+                       "setOmegaInv", "thetaSensIdx", "condThetaGrad",
+                       "nMix"};
+  DL_FUNC fn[8] = {(DL_FUNC) &nlmixr2FoceiApiVersion,
                    (DL_FUNC) &nlmixr2FoceiDims,
                    (DL_FUNC) &nlmixr2FoceiSetTheta,
                    (DL_FUNC) &nlmixr2FoceiCondBatch,
                    (DL_FUNC) &nlmixr2FoceiSetOmegaInv,
                    (DL_FUNC) &nlmixr2FoceiThetaSensIdx,
-                   (DL_FUNC) &nlmixr2FoceiCondThetaGrad};
-  SEXP ret  = PROTECT(Rf_allocVector(VECSXP, 7));
-  SEXP retN = PROTECT(Rf_allocVector(STRSXP, 7));
-  for (int i = 0; i < 7; ++i) {
+                   (DL_FUNC) &nlmixr2FoceiCondThetaGrad,
+                   (DL_FUNC) &nlmixr2FoceiNMix};
+  SEXP ret  = PROTECT(Rf_allocVector(VECSXP, 8));
+  SEXP retN = PROTECT(Rf_allocVector(STRSXP, 8));
+  for (int i = 0; i < 8; ++i) {
     SET_VECTOR_ELT(ret, i, R_MakeExternalPtrFn(fn[i], R_NilValue, R_NilValue));
     SET_STRING_ELT(retN, i, Rf_mkChar(nm[i]));
   }
@@ -18819,6 +18847,11 @@ List foceiLikDims_() {
                       _["ntheta"] = ntheta, _["npars"] = npars,
                       _["flags"] = flags,
                       _["apiVersion"] = nlmixr2FoceiApiVersion());
+}
+
+//[[Rcpp::export]]
+int foceiLikNMix_() {
+  return nlmixr2FoceiNMix();
 }
 
 //[[Rcpp::export]]

--- a/tests/testthat/test-focei-ptrs.R
+++ b/tests/testthat/test-focei-ptrs.R
@@ -28,11 +28,12 @@
   }))
 }
 
-test_that("the foceiPtrs table has the documented shape (#937)", {
+test_that("the foceiPtrs table has the documented shape (#937 + #955)", {
   .p <- .nlmixr2estFoceiPtrs()
-  expect_length(.p, 7L)
+  expect_length(.p, 8L)
   expect_equal(names(.p), c("apiVersion", "dims", "setTheta", "condBatch",
-                            "setOmegaInv", "thetaSensIdx", "condThetaGrad"))
+                            "setOmegaInv", "thetaSensIdx", "condThetaGrad",
+                            "nMix"))
   for (.i in seq_along(.p)) expect_true(inherits(.p[[.i]], "externalptr"))
 })
 
@@ -590,4 +591,84 @@ test_that("the lambda column is right for censored and multi-endpoint data (#949
   expect_equal(foceiLikSetThetaC_(th), 0L)
   expect_equal(foceiLikCondThetaGrad_(eta, 4L)$dTheta, got$dTheta,
                tolerance = 1e-12)
+})
+
+test_that("mixture models: the component-major batch layout is blessed (#955)", {
+  # nid = nsub * nMix with id = component*nsub + subject; each row is the
+  # COMPONENT-conditional log-likelihood (p-free -- the mixing probability
+  # enters only the caller's mixture weights, e.g. Stan's log_sum_exp)
+  skip_on_cran()
+  .mixMod <- function() {
+    ini({
+      tcl1 <- 1
+      tcl2 <- 2
+      tv <- 3
+      p1 <- 0.3
+      add.sd <- 0.5
+      eta.cl ~ 0.1
+    })
+    model({
+      cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl))
+      v <- exp(tv)
+      cp <- 100 / v * exp(-cl / v * time)
+      cp ~ add(add.sd)
+    })
+  }
+  .testSeed(42)
+  .tt <- c(0.5, 1, 2, 4, 8)
+  d <- do.call(rbind, lapply(1:4, function(id) {
+    data.frame(ID = id, TIME = .tt,
+               DV = 5 * exp(-0.05 * .tt) + stats::rnorm(5, 0, 0.5),
+               AMT = 0, EVID = 0)
+  }))
+  h <- foceiLikLoad(.mixMod, d, "focei", scale = "natural", thetaSens = TRUE)
+  on.exit(foceiLikUnload(), add = TRUE)
+  expect_equal(foceiLikNMix_(), 2L)
+  # flags 0x10 stays set as the LAYOUT marker (no longer a refusal)
+  expect_equal(bitwAnd(foceiLikDims_()$flags, 0x10), 0x10)
+  .th <- h$initPar
+  expect_equal(foceiLikSetThetaC_(.th), 0L)
+  set.seed(7)
+  eta <- matrix(stats::rnorm(8, 0, 0.2), 8, 1) # 2 components x 4 subjects
+  got <- foceiLikCondGrad_(eta, 1L)
+  expect_equal(got$nBad, 0L)
+  # each row is the COMPONENT-conditional density: hand-computable with that
+  # component's cl, up to the adjLik constant (+nobs * 0.5*log(2pi))
+  .hand <- vapply(1:8, function(r) {
+    .i <- ((r - 1) %% 4) + 1
+    .m <- ((r - 1) %/% 4) + 1
+    .di <- d[d$ID == .i, ]
+    .cl <- exp(c(1, 2)[.m] + eta[r, 1])
+    .f <- 100 / exp(3) * exp(-.cl / exp(3) * .di$TIME)
+    sum(stats::dnorm(.di$DV, .f, 0.5, log = TRUE))
+  }, numeric(1))
+  expect_equal(got$value, .hand + 5 * 0.5 * log(2 * pi), tolerance = 1e-8)
+  # eta gradient FD-agrees per expanded row
+  .h <- 1e-5
+  fd <- (foceiLikCondGrad_(eta + .h, 1L)$value -
+           foceiLikCondGrad_(eta - .h, 1L)$value) / (2 * .h)
+  expect_equal(as.numeric(got$grad), as.numeric(fd), tolerance = 1e-4)
+  # theta gradients: component 1 rows respond to tcl1 only, component 2 to
+  # tcl2 only, and NO row responds to the mixing probability (the
+  # conditional is p-free by construction)
+  gt <- foceiLikCondThetaGrad_(eta, 1L)
+  expect_equal(gt$nBad, 0L)
+  for (t in h$thetaSensIdx) {
+    up <- .th
+    up[t] <- up[t] + .h
+    dn <- .th
+    dn[t] <- dn[t] - .h
+    expect_equal(foceiLikSetThetaC_(up), 0L)
+    vUp <- foceiLikCondGrad_(eta, 1L)$value
+    expect_equal(foceiLikSetThetaC_(dn), 0L)
+    vDn <- foceiLikCondGrad_(eta, 1L)$value
+    expect_equal(as.numeric(gt$dTheta[, t]),
+                 as.numeric((vUp - vDn) / (2 * .h)),
+                 tolerance = 1e-3, info = paste0("theta ", t))
+  }
+  expect_equal(foceiLikSetThetaC_(.th), 0L)
+  # determinism in the expanded layout
+  expect_identical(foceiLikCondGrad_(eta, 1L), foceiLikCondGrad_(eta, 1L))
+  # and the WRONG shape still refuses
+  expect_error(foceiLikCondGrad_(eta[1:4, , drop = FALSE], 1L), "-2")
 })


### PR DESCRIPTION
Closes #955.  The batch entries accept `nid = nsub * nMix` in component-major order (`id = component*nsub + subject`) instead of refusing mixtures.

- `likInner0` already pins the subject's component on recalc, and the batch entries force recalc per subject, so the only structural change is the loop discipline: **components serial-outer, subjects parallel-inner** (`foceiLikEval_`'s pattern — components share the physical subjects' solve slots).  `nMix == 1` reduces to the exact previous loop.
- Additive 8th table entry `nlmixr2FoceiNMix()`; the header installer reads it defensively by table length, so every old/new × old/new combination of upstream and downstream binaries behaves correctly.  flags 0x10 re-documented as the layout marker, not a refusal.
- **Gate**: a 2-component closed-form `mix()` fixture — every expanded row's value ties to a hand-written density with *that* component's parameters (up to the adjLik constant); the mixing probability provably never enters the conditional (FD zero — exactly what lets a Bayesian caller own the weights via `log_sum_exp`); eta + theta gradients FD-agree with per-component selectivity; bitwise determinism in the expanded layout; the wrong shape still refuses.  focei-ptrs + foceiLik suites: 344 pass.

Antigravity-reviewed (gemini-3.1-pro-high): no findings — the serial-outer barrier, pseudo-id↔physical-ind mapping (`getRxId = id %% nsub`), the guaranteed recalc pinning, all four header compatibility combinations, and the gate's non-vacuousness (component swap and duplicate-evaluation scenarios both break the hand-density anchor) verified clean.

Downstream: nlmixr2/nlmixr2stan finite mixtures (log-sum-exp marginalization over these component-conditional rows).