### PR TITLE
Combined eta+theta sensitivity model + fused single-solve tier-2 entry (#958)

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -402,6 +402,10 @@ foceiLikCondGrad_ <- function(etaMat, cores) {
     .Call(`_nlmixr2est_foceiLikCondGrad_`, etaMat, cores)
 }
 
+foceiLikCondBatchThetaGrad_ <- function(etaMat, cores) {
+    .Call(`_nlmixr2est_foceiLikCondBatchThetaGrad_`, etaMat, cores)
+}
+
 foceiLikCondThetaGrad_ <- function(etaMat, cores) {
     .Call(`_nlmixr2est_foceiLikCondThetaGrad_`, etaMat, cores)
 }

--- a/R/focei.R
+++ b/R/focei.R
@@ -673,7 +673,7 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
 #' @author Matthew L. Fidler
 #' @export
 #' @keywords internal
-.sensEtaOrTheta <- function(s, theta=FALSE) {
+.sensEtaOrTheta <- function(s, theta=FALSE, extraThetaVars=NULL) {
   .etaVars <- NULL
   if (theta && exists("..maxTheta", s)) {
     .etaVars <- paste0("THETA_", seq(1, s$..maxTheta), "_")
@@ -683,6 +683,11 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
   if (length(.etaVars) == 0L) {
     stop("cannot identify parameters for sensitivity analysis\n   with nlmixr2 an 'eta' initial estimate must use '~'", call. = FALSE)
   }
+  # combined eta+theta build (#958): the UNION goes through the same single
+  # .rxJacobian/.rxSens pair (proven to accept a mixed ETA_/THETA_ list by
+  # the augmented-outer builder); eta-sens states keep their positions, the
+  # theta-sens states append after them
+  .etaVars <- c(.etaVars, extraThetaVars)
   .stateVars <- .rxode2stateOdeNoOutput(s)
   # matExp() models are handled transparently here: rxode2::.rxJacobian calls
   # .rxInjectMatExpOdes(), which materializes the implied d/dt() from the
@@ -697,7 +702,23 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
 #' @export
 rxUiGet.foceiEtaS <- function(x, ..., theta=FALSE) {
   .s <- rxUiGet.loadPruneSens(x, ...)
-  .sensEtaOrTheta(.s)
+  .extra <- NULL
+  if (isTRUE(rxode2::rxGetControl(x[[1]], "combSens", FALSE))) {
+    # combined eta+theta sensitivity build (#958): the inner model also
+    # carries d/d(theta) forward sensitivities for the estimated non-mu
+    # thetas, so one solve serves value + d/d(eta) + d/d(theta)
+    .idx <- .impmapEstTheta(x[[1]])
+    if (length(.idx$all) > 0L) {
+      # paste0 recycles a zero-length index to "" (R >= 4.0), which would
+      # fabricate a malformed "THETA__" sensitivity variable
+      if (length(.idx$struct) > 0L) {
+        .extra <- paste0("THETA_", .idx$struct, "_")
+      }
+      assign("..combThetaStruct", .idx$struct, envir = .s)
+      assign("..combThetaIdx", .idx$all, envir = .s)
+    }
+  }
+  .sensEtaOrTheta(.s, extraThetaVars = .extra)
 }
 #attr(rxUiGet.foceiEtaS, "desc") <- "Get symengine environment with eta sensitivities"
 attr(rxUiGet.foceiEtaS, "rstudio") <- emptyenv()
@@ -948,6 +969,39 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   # rx_pred_ so the FOCEi column block stays contiguous.
   .arEtaSens <- .s$..arEtaSens
   if (is.null(.arEtaSens)) .arEtaSens <- character(0)
+  # Combined eta+theta sensitivity columns (#958): computed against THIS
+  # env (whose union .rxSens defined the rx__sens_<state>_BY_THETA_j___
+  # symbols) with the impmap chain rule, and APPENDED after the FOCEi
+  # eta block -- likInner0 reads predOffset+k arithmetically, so the
+  # block through rx__sens_rx_r__BY_ETA_<neta>___ must stay untouched;
+  # the theta consumers resolve their offsets by name.
+  .combTheta <- character(0)
+  if (!is.null(.s$..combThetaIdx)) {
+    .stV <- .rxode2stateOdeNoOutput(.s)
+    .idxAll <- .s$..combThetaIdx
+    .idxStruct <- .s$..combThetaStruct
+    .combDf <- vapply(.idxAll, function(j) {
+      paste0("rx__sens_rx_pred__BY_THETA_", j, "___=",
+             .impmapChainRule(.s, "rx_pred_", j, .stV, .idxStruct))
+    }, character(1))
+    .combDv <- vapply(.idxAll, function(j) {
+      paste0("rx__sens_rx_r__BY_THETA_", j, "___=",
+             .impmapChainRule(.s, "rx_r_", j, .stV, .idxStruct))
+    }, character(1))
+    .combDl <- character(0)
+    .lambdaSym <- get("rx_lambda_", envir = .s)
+    if (inherits(.lambdaSym, "Basic")) {
+      .dl <- vapply(.idxAll,
+                    function(j) .impmapChainRule(.s, "rx_lambda_", j, .stV,
+                                                 .idxStruct),
+                    character(1))
+      if (any(!(.dl %in% c("0", "0.0", "-0")))) {
+        .combDl <- paste0("rx__sens_rx_lambda__BY_THETA_", .idxAll, "___=",
+                          .dl)
+      }
+    }
+    .combTheta <- c(.combDf, .combDv, .combDl)
+  }
   .s$..inner <- paste(c(
     .preLhs,
     .ddt,
@@ -966,6 +1020,7 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
     .s$..HdEta,
     .r,
     .s$..REta,
+    .combTheta,
     .adjLhs,
     .s$..stateInfo["statef"],
     .s$..stateInfo["dvid"],
@@ -1585,7 +1640,9 @@ rxUiGet.foceiModelDigest <- function(x, ...) {
   ## text, so they must key the persisted cache too, else two fits of the same model
   ## whose datasets differ only in covariate-constancy would collide.
   .constCovs <- paste(sort(rxode2::rxGetControl(.ui, "foceiConstCovs", NULL)), collapse=",")
-  digest::digest(c(all(is.na(.iniDf$neta1)),
+  ## combined eta+theta sensitivity build (#958) changes the inner model text
+  .combSens <- isTRUE(rxode2::rxGetControl(.ui, "combSens", FALSE))
+  digest::digest(c(all(is.na(.iniDf$neta1)), .combSens,
                    rxode2::rxGetControl(.ui, "interaction", 1L),
                    .iniDf$name,
                    .sumProd, .optExpression, .predMinusDv,
@@ -2202,7 +2259,10 @@ attr(rxUiGet.foceiSkipCov, "rstudio") <- c(FALSE, TRUE)
   # wants the same model without being an imp/advi estimation.
   if ((rxode2::rxGetControl(ui, "est", "") %in% c("impmap", "imp", "qrpem", "advi") ||
          isTRUE(rxode2::rxGetControl(ui, "thetaSensLoad", FALSE))) &&
+        !isTRUE(rxode2::rxGetControl(ui, "combSens", FALSE)) &&
         is.null(env$model$thetaSens)) {
+    # (combSens (#958): the INNER model carries the theta columns, so the
+    # separate theta-sensitivity model is neither built nor compiled)
     # eventSens follows the control (same source as the inner model): with
     # "jump" a theta entering dose handling (alag/f/dur/rate) gets its jump
     # condition at the event, so its d(f)/d(theta) column is real rather

--- a/R/foceiLik.R
+++ b/R/foceiLik.R
@@ -85,7 +85,9 @@
 #'   `initPar` (the parameter vector at the model's initial estimates on the
 #'   requested `scale`, a ready `theta` for [foceiLikRun()]), `npars`,
 #'   `ntheta`, `neta`, `nid`, `thetaNames`, `etaNames`, `idLvl`,
-#'   `likelihood`, `scale`, `thetaSens` and `thetaSensIdx`.
+#'   `likelihood`, `scale`, `thetaSens` (theta sensitivities wired, by
+#'   either build), `combSens` (the #958 combined build) and
+#'   `thetaSensIdx`.
 #' @seealso [foceiLikRun()], [foceiLikUnload()]
 #'
 #' @examples
@@ -216,7 +218,11 @@ foceiLikLoad <- function(object, data,
   # report what was actually wired, not what was asked for: the sensitivity
   # model build is a tryCatch(NULL) in .foceiOptEnvLik, so a request can fail
   # (and with no eligible thetas there is nothing to differentiate)
-  .thetaSensBuilt <- isTRUE(thetaSens) && !is.null(.env$model$thetaSens)
+  # handle$thetaSens reports whether theta sensitivities are WIRED, however
+  # they are carried: the separate theta-sensitivity model, or (#958) the
+  # combined build whose inner model holds the columns
+  .thetaSensBuilt <- (isTRUE(thetaSens) && !is.null(.env$model$thetaSens)) ||
+    (isTRUE(combSens) && length(.thetaSensIdx) > 0L)
   if (isTRUE(thetaSens) && !.thetaSensBuilt && length(.thetaSensIdx) > 0L) {
     warning("the theta-sensitivity model could not be built; handle$thetaSens is FALSE",
             call. = FALSE)
@@ -233,6 +239,7 @@ foceiLikLoad <- function(object, data,
                   likelihood = likelihood,
                   scale = scale,
                   thetaSens = .thetaSensBuilt,
+                  combSens = isTRUE(combSens),
                   thetaSensIdx = .thetaSensIdx)
   nlmixr2global$foceiLikEnv <- .handle
   invisible(.handle)

--- a/R/foceiLik.R
+++ b/R/foceiLik.R
@@ -132,6 +132,7 @@ foceiLikLoad <- function(object, data,
                          rxControl = rxode2::rxControl(),
                          scale = c("focei", "natural"),
                          thetaSens = FALSE,
+                         combSens = FALSE,
                          est = "focei", ...) {
   likelihood <- match.arg(likelihood)
   scale <- match.arg(scale)
@@ -176,6 +177,17 @@ foceiLikLoad <- function(object, data,
     .control$thetaSensLoad <- TRUE
     .control$impThetaSensIdx <- .thetaSensIdx - 1L
   }
+  # combined eta+theta sensitivity build (#958): the INNER model carries the
+  # theta columns, so one solve serves value + d/d(eta) + d/d(theta); implies
+  # a theta-sensitivity request
+  if (isTRUE(combSens)) {
+    if (!isTRUE(thetaSens)) {
+      .thetaSensIdx <- as.integer(.impmapEstTheta(.ui)$all)
+      .control$thetaSensLoad <- TRUE
+      .control$impThetaSensIdx <- .thetaSensIdx - 1L
+    }
+    .control$combSens <- TRUE
+  }
   # vi-style inner setup on the hooked ui
   .ui$control <- .control
   .env <- .ui$foceiOptEnv
@@ -184,12 +196,13 @@ foceiLikLoad <- function(object, data,
   .env$table <- NULL
   .foceiPreProcessData(.data, .env, .ui, .control$rxControl)
   .env$control$est <- "focei"
-  if (isTRUE(thetaSens)) {
+  if (isTRUE(thetaSens) || isTRUE(combSens)) {
     # foceiSetup_ reads thetaSensLoad/impThetaSensIdx from e$control (foceiO);
     # make sure both are present there (not only on the pre-build .control) so
     # op_focei wires the offsets -- same defensive re-set as .adviInnerSetup.
     .env$control$thetaSensLoad <- TRUE
     .env$control$impThetaSensIdx <- .thetaSensIdx - 1L
+    if (isTRUE(combSens)) .env$control$combSens <- TRUE
   }
   .env$control$printTop <- FALSE
   if (is.null(.env$control$nF)) .env$control$nF <- 0L

--- a/R/foceiLik.R
+++ b/R/foceiLik.R
@@ -64,6 +64,14 @@
 #'   parameter vector remain in the internal `diagXform` parameterization of
 #'   `chol(Omega^-1)`; `"natural"` leaves them unscaled but does not change
 #'   that parameterization.
+#' @param combSens When `TRUE`, use the combined eta+theta sensitivity
+#'   build (#958): the INNER model itself carries the theta-sensitivity
+#'   columns (appended after the FOCEi block), so one ODE integration per
+#'   subject serves the value, `d/d(eta)` AND `d/d(theta)` -- the fused
+#'   batch entry `nlmixr2FoceiCondBatchThetaGrad` reads all three from a
+#'   single solve (~2x cheaper per evaluation than the two-model path).
+#'   Implies a theta-sensitivity request; the separate theta-sensitivity
+#'   model is neither built nor compiled.
 #' @param thetaSens When `TRUE`, also build and wire the theta-sensitivity
 #'   model (`d(f)/d(theta)`, `d(V)/d(theta)` forward sensitivities for the
 #'   estimated non-mu structural and residual-error thetas), the model the

--- a/R/impmapThetaSens.R
+++ b/R/impmapThetaSens.R
@@ -78,7 +78,14 @@ rxUiGet.impmapThetaSens <- function(x, ...) {
   if (!exists("..maxTheta", .s)) return(NULL)
   .stateVars <- .rxode2stateOdeNoOutput(.s)
   # State sensitivities only for the structural thetas.
-  .thetaVars <- paste0("THETA_", .idx$struct, "_")
+  # paste0 recycles a zero-length struct index to "" (R >= 4.0), which
+  # would fabricate a malformed "THETA__" sensitivity variable when every
+  # structural theta is mu-referenced and only sigma thetas remain
+  .thetaVars <- if (length(.idx$struct) > 0L) {
+    paste0("THETA_", .idx$struct, "_")
+  } else {
+    character(0)
+  }
   if (length(.thetaVars) > 0L) {
     rxode2::.rxJacobian(.s, c(.stateVars, .thetaVars))
     rxode2::.rxSens(.s, .thetaVars)

--- a/inst/include/nlmixr2estFoceiPtr.h
+++ b/inst/include/nlmixr2estFoceiPtr.h
@@ -148,6 +148,23 @@ extern "C" {
   typedef int (*nlmixr2FoceiIterPrintRow_t)(const double *par, int npars,
                                             double objf);
 
+  /* #958 fused tier-2 entry: value + d/d(eta) + d/d(theta) from ONE
+     combined-model solve per subject.  Same contracts as condBatch +
+     condThetaGrad merged: value/gradEta as condBatch (row-major
+     nid x neta, -Inf + zeroed rows on rejection), dTheta as condThetaGrad
+     (row-major nid x ntheta; sensitivity columns filled, mu-referenced
+     columns zero for the caller's identity).  >=0 bad-subject count;
+     -4 theta sensitivities not wired; -5 the loaded problem is not a
+     combined build (foceiLikLoad(combSens=TRUE)).  NULL when the loaded
+     nlmixr2est predates the entry.  */
+  /* dims flag 0x80: the loaded problem is a combined-sensitivity build
+     (foceiLikLoad(combSens=TRUE)) and the fused entry below works. */
+  typedef int (*nlmixr2FoceiCondBatchThetaGrad_t)(const double *eta, int nid,
+                                                  int neta, int cores,
+                                                  double *value,
+                                                  double *gradEta,
+                                                  double *dTheta);
+
   extern nlmixr2FoceiApiVersion_t    nlmixr2FoceiApiVersionP;
   extern nlmixr2FoceiDims_t          nlmixr2FoceiDimsP;
   extern nlmixr2FoceiSetTheta_t      nlmixr2FoceiSetThetaP;
@@ -157,6 +174,7 @@ extern "C" {
   extern nlmixr2FoceiCondThetaGrad_t nlmixr2FoceiCondThetaGradP;
   extern nlmixr2FoceiNMix_t          nlmixr2FoceiNMixP;
   extern nlmixr2FoceiIterPrintRow_t  nlmixr2FoceiIterPrintRowP;
+  extern nlmixr2FoceiCondBatchThetaGrad_t nlmixr2FoceiCondBatchThetaGradP;
 
   // Always refresh: a reloaded nlmixr2est hands back new addresses, and
   // keeping the first set seen would leave the caller calling into an
@@ -176,6 +194,8 @@ extern "C" {
       (nlmixr2FoceiNMix_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 7)) : NULL;
     nlmixr2FoceiIterPrintRowP = (Rf_xlength(p) > 8) ?
       (nlmixr2FoceiIterPrintRow_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 8)) : NULL;
+    nlmixr2FoceiCondBatchThetaGradP = (Rf_xlength(p) > 9) ?
+      (nlmixr2FoceiCondBatchThetaGrad_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 9)) : NULL;
     return R_NilValue;
   }
 
@@ -189,6 +209,7 @@ extern "C" {
   nlmixr2FoceiCondThetaGrad_t nlmixr2FoceiCondThetaGradP = NULL;        \
   nlmixr2FoceiNMix_t          nlmixr2FoceiNMixP          = NULL;        \
   nlmixr2FoceiIterPrintRow_t  nlmixr2FoceiIterPrintRowP  = NULL;        \
+  nlmixr2FoceiCondBatchThetaGrad_t nlmixr2FoceiCondBatchThetaGradP = NULL; \
   SEXP iniNlmixr2estFocei(SEXP p) { return iniNlmixr2estFocei0(p); }
 
 #ifdef __cplusplus

--- a/man/dot-sensEtaOrTheta.Rd
+++ b/man/dot-sensEtaOrTheta.Rd
@@ -4,7 +4,7 @@
 \alias{.sensEtaOrTheta}
 \title{Calculate d(state)/d(eta) or d(state)/d(theta) sensitivities}
 \usage{
-.sensEtaOrTheta(s, theta = FALSE)
+.sensEtaOrTheta(s, theta = FALSE, extraThetaVars = NULL)
 }
 \arguments{
 \item{s}{symengine environment (from `.loadSymengine()`)}

--- a/man/foceiLikLoad.Rd
+++ b/man/foceiLikLoad.Rd
@@ -11,6 +11,7 @@ foceiLikLoad(
   rxControl = rxode2::rxControl(),
   scale = c("focei", "natural"),
   thetaSens = FALSE,
+  combSens = FALSE,
   est = "focei",
   ...
 )
@@ -65,7 +66,9 @@ Invisibly, a handle list with the loaded system's dimensions:
   `initPar` (the parameter vector at the model's initial estimates on the
   requested `scale`, a ready `theta` for [foceiLikRun()]), `npars`,
   `ntheta`, `neta`, `nid`, `thetaNames`, `etaNames`, `idLvl`,
-  `likelihood`, `scale`, `thetaSens` and `thetaSensIdx`.
+  `likelihood`, `scale`, `thetaSens` (theta sensitivities wired, by
+  either build), `combSens` (the #958 combined build) and
+  `thetaSensIdx`.
 }
 \description{
 Compiles the inner (FOCEi sensitivity) model from an rxode2 UI model,

--- a/man/foceiLikLoad.Rd
+++ b/man/foceiLikLoad.Rd
@@ -50,6 +50,15 @@ should not pay (#939).  The handle's `thetaSensIdx` reports which
 `ntheta` indices carry sensitivities (`integer(0)` when none do, e.g.
 when every theta is mu-referenced).}
 
+\item{combSens}{When `TRUE`, use the combined eta+theta sensitivity
+build (#958): the INNER model itself carries the theta-sensitivity
+columns (appended after the FOCEi block), so one ODE integration per
+subject serves the value, `d/d(eta)` AND `d/d(theta)` -- the fused
+batch entry `nlmixr2FoceiCondBatchThetaGrad` reads all three from a
+single solve (~2x cheaper per evaluation than the two-model path).
+Implies a theta-sensitivity request; the separate theta-sensitivity
+model is neither built nor compiled.}
+
 \item{est}{Estimation-method name the standard pre-process hooks run
 against (default `"focei"`).  The hooks read the named method's
 capability attributes (for example whether a bounded-transform

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1174,6 +1174,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// foceiLikCondBatchThetaGrad_
+List foceiLikCondBatchThetaGrad_(NumericMatrix etaMat, int cores);
+RcppExport SEXP _nlmixr2est_foceiLikCondBatchThetaGrad_(SEXP etaMatSEXP, SEXP coresSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type etaMat(etaMatSEXP);
+    Rcpp::traits::input_parameter< int >::type cores(coresSEXP);
+    rcpp_result_gen = Rcpp::wrap(foceiLikCondBatchThetaGrad_(etaMat, cores));
+    return rcpp_result_gen;
+END_RCPP
+}
 // foceiLikCondThetaGrad_
 List foceiLikCondThetaGrad_(NumericMatrix etaMat, int cores);
 RcppExport SEXP _nlmixr2est_foceiLikCondThetaGrad_(SEXP etaMatSEXP, SEXP coresSEXP) {

--- a/src/imp.h
+++ b/src/imp.h
@@ -110,7 +110,11 @@ struct impThetaSensData {
   // DV side is applied here because the sensitivity model never sees the DV.
   arma::mat ddvmat, dlimmat;
 };
-void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out);
+// reuseSolve (#958): the caller has JUST solved the combined inner model at
+// this exact (theta, eta) point on this thread (single-sample case), so the
+// read pass consumes that solution instead of re-solving.
+void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out,
+                         bool reuseSolve = false);
 void impThetaAccumOne(const impThetaSensData& c, const arma::vec& zk,
                       arma::vec& g, arma::mat& H);
 

--- a/src/init.c
+++ b/src/init.c
@@ -55,6 +55,7 @@ extern SEXP _nlmixr2est_foceiLikSetTheta_(SEXP);
 extern SEXP _nlmixr2est_foceiLikEval_(SEXP, SEXP, SEXP);
 extern SEXP _nlmixr2est_foceiLikCondGrad_(SEXP, SEXP);
 extern SEXP _nlmixr2est_foceiLikCondThetaGrad_(SEXP, SEXP);
+extern SEXP _nlmixr2est_foceiLikCondBatchThetaGrad_(SEXP, SEXP);
 extern SEXP _nlmixr2est_foceiLikDims_(void);
 extern SEXP _nlmixr2est_foceiLikNMix_(void);
 extern SEXP _nlmixr2est_foceiLikIterPrintStart_(SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -250,6 +251,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_foceiLikEval_", (DL_FUNC) &_nlmixr2est_foceiLikEval_, 3},
   {"_nlmixr2est_foceiLikCondGrad_", (DL_FUNC) &_nlmixr2est_foceiLikCondGrad_, 2},
   {"_nlmixr2est_foceiLikCondThetaGrad_", (DL_FUNC) &_nlmixr2est_foceiLikCondThetaGrad_, 2},
+  {"_nlmixr2est_foceiLikCondBatchThetaGrad_", (DL_FUNC) &_nlmixr2est_foceiLikCondBatchThetaGrad_, 2},
   {"_nlmixr2est_foceiLikDims_", (DL_FUNC) &_nlmixr2est_foceiLikDims_, 0},
   {"_nlmixr2est_foceiLikNMix_", (DL_FUNC) &_nlmixr2est_foceiLikNMix_, 0},
   {"_nlmixr2est_foceiLikIterPrintStart_", (DL_FUNC) &_nlmixr2est_foceiLikIterPrintStart_, 5},

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -1337,8 +1337,139 @@ static inline double scalePar(double *x, int i){
 // covariance's foceiFdSetOmega() is its variance-covariance-scale, pure-C++ sibling.
 // Shared by updateTheta(), the final-Omega refresh and the per-individual FD's omega phase,
 // which all used to inline the same five lines.
+// Memo of the last omega tail updateTheta() rebuilt Omega from: the
+// rebuild goes through rxode2's symbolic-inverse machinery (R-level
+// symengine environment calls, ~1 ms), and within an outer iteration's
+// gradient evaluations -- and for EVERY est="stan" evaluation, where Stan
+// owns Omega -- the tail does not change.  Cleared whenever the omega
+// state is rebuilt or set outside updateTheta (setup, direct
+// setOmegaTheta callers, the external SetOmegaInv), so a stale skip can
+// never leave the caller's omega in force by accident.
+static std::vector<double> _updateThetaOmegaTail;
+
+// ---- C-side Omega rebuild (#958 follow-on) --------------------------------
+// The omega tail parameterizes chol(Omega^-1) directly (one tail entry per
+// factor entry; diagonals stored through sqrt/log/identity), but the values
+// were fetched by evaluating rxode2's precomputed R closure -- an R round
+// trip (~1 ms) in the per-evaluation hot path.  The map {tail k -> (i,j),
+// diagonal transform} is discovered EMPIRICALLY on first use by probing the
+// env one entry at a time and then VERIFIED against the env at a displaced
+// tail; any mismatch, ambiguity, or unsupported structure falls back to the
+// R path permanently for the loaded problem.  fo==1 (needs omega itself)
+// keeps the R path.
+static std::vector<int> _omFastRow, _omFastCol, _omFastXf; // xf: 0 id, 1 sqrt, 2 log, -1 offdiag
+static int _omFastNeta = 0;
+static int _omFastState = 0; // 0 untried, 1 ok, -1 unavailable
+void foceiOmegaFastReset(void) { _omFastState = 0; }
+
+// Under the fast path updateTheta() no longer pushes the tail into the
+// _rxInv env each evaluation, so any argument-less env read (the "omega"
+// matrix, the d(omegaInv) lists, ...) must sync the env itself first.
+// One R call at OUTER-iteration frequency; a no-op-cost guard elsewhere.
+static void foceiOmegaEnvSyncFromTail(void) {
+  if (op_focei.omegan == 0) return;
+  NumericVector ot((int)op_focei.omegan);
+  std::copy(&op_focei.fullTheta[0] + op_focei.ntheta,
+            &op_focei.fullTheta[0] + op_focei.ntheta + op_focei.omegan,
+            ot.begin());
+  setOmegaTheta(ot);
+}
+void foceiOmegaTailMemoClear(void) { _updateThetaOmegaTail.clear(); }
+
+static void foceiOmegaFastCompute(const double *omBlock) {
+  const int n = _omFastNeta;
+  arma::mat U(n, n, arma::fill::zeros);
+  double ld = 0.0;
+  for (unsigned int k = 0; k < op_focei.omegan; ++k) {
+    double v = omBlock[k];
+    switch (_omFastXf[k]) {
+    case 1: v = v * v; break;
+    case 2: v = std::exp(v); break;
+    default: break;
+    }
+    U(_omFastRow[k], _omFastCol[k]) = v;
+  }
+  for (int i = 0; i < n; ++i) ld += std::log(U(i, i));
+  op_focei.cholOmegaInv = U;
+  op_focei.omegaInv = U.t() * U;
+  op_focei.logDetOmegaInv5 = ld;
+}
+
+static void foceiOmegaFastTry(const double *omBlock) {
+  _omFastState = -1; // pessimistic until verified
+  const int n = (int)op_focei.neta;
+  const unsigned int m = op_focei.omegan;
+  if (n <= 0 || m == 0) return;
+  std::vector<double> t0(omBlock, omBlock + m);
+  NumericVector ot((int)m);
+  std::copy(t0.begin(), t0.end(), ot.begin());
+  setOmegaTheta(ot);
+  arma::mat U0 = getCholOmegaInv();
+  if ((int)U0.n_rows != n) return;
+  _omFastNeta = n;
+  _omFastRow.assign(m, -1); _omFastCol.assign(m, -1); _omFastXf.assign(m, -1);
+  const double dlt = 0.25;
+  for (unsigned int k = 0; k < m; ++k) {
+    NumericVector tp((int)m);
+    std::copy(t0.begin(), t0.end(), tp.begin());
+    tp[(int)k] += dlt;
+    setOmegaTheta(tp);
+    arma::mat Uk = getCholOmegaInv();
+    int nz = 0, ri = -1, ci = -1;
+    for (int i = 0; i < n; ++i) {
+      for (int jj = 0; jj < n; ++jj) {
+        if (std::fabs(Uk(i, jj) - U0(i, jj)) > 1e-12) { nz++; ri = i; ci = jj; }
+      }
+    }
+    if (nz != 1) return; // not a one-entry-per-theta parameterization
+    _omFastRow[k] = ri; _omFastCol[k] = ci;
+    if (ri != ci) {
+      // off-diagonal must be the raw theta (linear, coefficient 1)
+      if (std::fabs((Uk(ri, ci) - U0(ri, ci)) - dlt) > 1e-9) return;
+      _omFastXf[k] = 0;
+    } else {
+      const double th = t0[k], b0 = U0(ri, ci), b1 = Uk(ri, ci);
+      if (std::fabs(b1 - (th + dlt)) < 1e-9 && std::fabs(b0 - th) < 1e-9) {
+        _omFastXf[k] = 0;
+      } else if (std::fabs(b1 - (th + dlt) * (th + dlt)) < 1e-9 &&
+                 std::fabs(b0 - th * th) < 1e-9) {
+        _omFastXf[k] = 1;
+      } else if (std::fabs(b1 - std::exp(th + dlt)) < 1e-9 &&
+                 std::fabs(b0 - std::exp(th)) < 1e-9) {
+        _omFastXf[k] = 2;
+      } else {
+        return; // unrecognized diagonal transform
+      }
+    }
+  }
+  // verification at a displaced tail: the C-side rebuild must reproduce the
+  // env exactly (up to numerical noise) for omegaInv, chol and logdet
+  std::vector<double> tv(t0);
+  for (unsigned int k = 0; k < m; ++k) tv[k] += 0.1 + 0.03 * (double)k;
+  NumericVector tvv((int)m);
+  std::copy(tv.begin(), tv.end(), tvv.begin());
+  setOmegaTheta(tvv);
+  arma::mat oiR = getOmegaInv();
+  arma::mat chR = getCholOmegaInv();
+  double ldR = getOmegaDet();
+  _omFastState = 1; // arm so the compute below uses the map
+  foceiOmegaFastCompute(tv.data());
+  bool ok = arma::approx_equal(op_focei.omegaInv, oiR, "absdiff", 1e-10) &&
+    arma::approx_equal(op_focei.cholOmegaInv, chR, "absdiff", 1e-10) &&
+    std::fabs(op_focei.logDetOmegaInv5 - ldR) < 1e-10;
+  if (!ok) { _omFastState = -1; return; }
+  _omFastState = 1;
+}
+
 static void foceiOmegaFromTheta(const double *omBlock) {
   if (op_focei.omegan == 0) return;
+  if (getenv("NLMIXR2_NO_FAST_OMEGA") == NULL && op_focei.fo != 1) {
+    if (_omFastState == 0) foceiOmegaFastTry(omBlock);
+    if (_omFastState == 1) {
+      foceiOmegaFastCompute(omBlock);
+      return;
+    }
+  }
   NumericVector omegaTheta(op_focei.omegan);
   std::copy(omBlock, omBlock + op_focei.omegan, omegaTheta.begin());
   setOmegaTheta(omegaTheta);
@@ -1393,9 +1524,21 @@ void updateTheta(double *theta){
     NumericVector mixJac = f(curTheta, mixIdx);
     std::copy(mixJac.begin(), mixJac.end(), &op_focei.mixProbGrad[0]);
   }
-  // Update setOmegaTheta
+  // Update setOmegaTheta -- skipped when the omega tail is UNCHANGED
+  // since the last rebuild (the symbolic-inverse rebuild costs ~1 ms of
+  // R-level calls; a sampler that owns Omega, or an outer gradient
+  // varying one theta at a time, pays it only when the tail moves)
   if (op_focei.neta > 0 && !op_focei.covFdDirect) {
-    foceiOmegaFromTheta(&op_focei.fullTheta[0] + op_focei.ntheta);
+    const double *omTail = &op_focei.fullTheta[0] + op_focei.ntheta;
+    const size_t omN = (size_t)op_focei.omegan;
+    bool same = getenv("NLMIXR2_NO_OMEGA_MEMO") == NULL &&
+      _updateThetaOmegaTail.size() == omN && omN > 0 &&
+      std::memcmp(_updateThetaOmegaTail.data(), omTail,
+                  sizeof(double) * omN) == 0;
+    if (!same) {
+      foceiOmegaFromTheta(omTail);
+      _updateThetaOmegaTail.assign(omTail, omTail + omN);
+    }
   }
   //Now Setup Last theta
   if (!op_focei.calcGrad){
@@ -4207,6 +4350,7 @@ void innerOpt() {
   rx_solving_options *op = getSolvingOptions(rx);
   int cores = getOpCores(op);
   if (op_focei.neta > 0 && !op_focei.covFdDirect) {   // covFdDirect: keep the FD-perturbed Omega
+    foceiOmegaEnvSyncFromTail(); // fast omega path leaves the env theta stale
     op_focei.omegaInv=getOmegaInv();
     op_focei.logDetOmegaInv5 = getOmegaDet();
   }
@@ -6408,6 +6552,10 @@ NumericVector foceiSetup_(const RObject &obj,
   // #958 combined build: same process-global hygiene as thetaSensLoad
   op_focei.combSens = foceiO.containsElementNamed("combSens") &&
     as<bool>(foceiO["combSens"]);
+  // fresh problem: never inherit a previous fit's omega-tail memo or its
+  // fast chol(Omega^-1) map (the _rxInv env is new)
+  foceiOmegaTailMemoClear();
+  foceiOmegaFastReset();
 
   op_focei.zeroGrad = false;
   op_focei.resetThetaCheckPer = as<double>(foceiO["resetThetaCheckPer"]);
@@ -10530,6 +10678,7 @@ double impGetOmegaThetaVal(int m) { return op_focei.fullTheta[op_focei.ntheta + 
 // updateTheta() takes), so likInner0's prior term and the objective normalizer
 // both reflect it.
 void impSetOmegaThetaAll(int m, double val) {
+  foceiOmegaTailMemoClear(); // omega state moves outside updateTheta
   op_focei.fullTheta[op_focei.ntheta + m] = val;
   NumericVector omegaTheta(op_focei.omegan);
   std::copy(&op_focei.fullTheta[0] + op_focei.ntheta,
@@ -10551,6 +10700,7 @@ void impSetEta(int id, const arma::vec& eta) {
 
 // Current Omega matrix (its zero pattern gives the estimated-element structure).
 void impGetOmega(arma::mat& Om) {
+  foceiOmegaEnvSyncFromTail(); // fast omega path leaves the env theta stale
   Om = getOmegaMat();
 }
 
@@ -10678,6 +10828,8 @@ void impReMap() {
 // determinant, and copy the new Omega thetas into fullTheta so the next MAP and
 // the output see them.
 void impSetOmega(const arma::mat& Omega, const std::string& diagXform) {
+  foceiOmegaFastReset(); // the _rxInv env is replaced; the map may change
+  foceiOmegaTailMemoClear();
   Environment rxode2ns = Environment::namespace_env("rxode2");
   Function f = rxode2ns["rxSymInvCholCreate"];
   // positive-definite guard: a support-point covariance can be numerically
@@ -13175,6 +13327,7 @@ static std::vector<double> _fdOmTheta0;
 // _fdOmBlock0 when it is done.
 static bool fdOmegaBuild(const std::vector<double> &blk, arma::mat &oiOut, double &ldOut) {
   if (op_focei.omegan == 0) return false;
+  foceiOmegaTailMemoClear(); // _rxInv moves outside updateTheta
   NumericVector ot((int)op_focei.omegan);
   for (unsigned int q = 0; q < op_focei.omegan; ++q) ot[(int)q] = blk[(size_t)q];
   setOmegaTheta(ot);
@@ -15392,6 +15545,7 @@ static bool gradDirectEbes(int nsub, int neta, arma::mat &ebes) {
 static bool gradDirectOmega(const FoceiGradPooledSetup &G, int neta, arma::mat &Oi,
                             arma::cube &dOiEst, arma::vec &tr28) {
   try {
+    foceiOmegaEnvSyncFromTail(); // fast omega path leaves the env theta stale
     Oi = getOmegaInv();
     List dOiL = getDOmegaInvL();
     NumericVector tr = getTr28V();
@@ -18578,6 +18732,9 @@ extern "C" int nlmixr2FoceiSetOmegaInv(const double *omegaInv, int neta) {
     op_focei.omegaInv = oi;
     op_focei.cholOmegaInv = ch;
     op_focei.logDetOmegaInv5 = 0.5 * val;
+    // preserve pre-memo semantics: the next updateTheta rebuilds Omega
+    // from the theta tail even if the tail is unchanged
+    foceiOmegaTailMemoClear();
     // the memoized per-subject inner state was computed against the old
     // Omega; force a recompute
     rx = getRxSolve_();

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -760,6 +760,10 @@ struct focei_options {
   bool thetaSensLoad = false; // foceiLikLoad(thetaSens=TRUE) (#939): wire the
                               // theta-sensitivity model for an external caller
                               // without being an imp/advi estimation
+  bool combSens = false; // #958: the INNER model carries the theta-sensitivity
+                         // columns too (appended after the FOCEi block), so the
+                         // theta gradient reads the inner solve -- no separate
+                         // theta-sensitivity model, one integration per subject
   double npResidScale = 1.0; // npag/npb residual-error magnitude multiplier (gamma):
                              // likInner0 scales the residual variance r by this^2,
                              // so the conditional likelihood (incl. censoring via
@@ -6401,6 +6405,9 @@ NumericVector foceiSetup_(const RObject &obj,
       op_focei.impThetaSensIdx = as<IntegerVector>(foceiO["impThetaSensIdx"]);
     else op_focei.impThetaSensIdx = IntegerVector(0);
   }
+  // #958 combined build: same process-global hygiene as thetaSensLoad
+  op_focei.combSens = foceiO.containsElementNamed("combSens") &&
+    as<bool>(foceiO["combSens"]);
 
   op_focei.zeroGrad = false;
   op_focei.resetThetaCheckPer = as<double>(foceiO["resetThetaCheckPer"]);
@@ -10809,17 +10816,23 @@ static void impThetaSensFD(int id, arma::vec& curTheta,
 //   sum_j [ -(f-dv)/V d(f)/d(theta) + 0.5 ((dv-f)^2/V^2 - 1/V) d(V)/d(theta) ]
 // and the (mean+variance) Fisher information is
 //   sum_j [ d(f)/d(theta) d(f)/d(theta)'/V + 0.5 d(V)/d(theta) d(V)/d(theta)'/V^2 ].
-void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
+void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out,
+                         bool reuseSolve) {
   out.nobs = 0; out.fvec.clear(); out.Vvec.clear(); out.dfmat.clear();
   out.dVmat.clear(); out.sampleOk.clear(); out.dvv.clear(); out.limv.clear();
   out.censv.clear(); out.distv.clear();
+  // #958 combined build: the theta columns live on the INNER model (appended
+  // after the FOCEi block), so the whole read pass runs against the inner
+  // slot/model; otherwise the separate theta-sensitivity model as before.
+  const int tsSlot = op_focei.combSens ? odeSlotInner : odeSlotThetaSens;
+  rxSolveF &tsModel = op_focei.combSens ? rxInner : rxThetaSens;
   int nSens = op_focei.impThetaSensIdx.size();
   // thetaSensNlhs is the sensitivity model's true lhs width (set at setup); it sizes
   // the calc_lhs output buffer below.  If it is unset (<=0) we cannot size the buffer
   // to the width calc_lhs will write, so bail rather than risk a buffer overflow.
   if (nSens == 0 || op_focei.thetaSensOffset < 0 || op_focei.thetaSensDvOffset < 0 ||
       op_focei.thetaSensPredOffset < 0 || op_focei.thetaSensROffset < 0 ||
-      op_focei.thetaSensNlhs <= 0 || rxThetaSens.calc_lhs == NULL) return;
+      op_focei.thetaSensNlhs <= 0 || tsModel.calc_lhs == NULL) return;
   rx = getRxSolve_();
   rx_solving_options *op = getSolvingOptions(rx);
   int _rxId = getRxId(id);
@@ -10834,7 +10847,7 @@ void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
   // structure); the inner MAP runs with ind->neqOverride = innerNeq, so switch it
   // to thetaSensNeq for these solves and restore on exit (mirrors the predNeq FD
   // pattern).
-  OdeSwapScope neqGuard(odeSlotThetaSens, ind, op);
+  OdeSwapScope neqGuard(tsSlot, ind, op);
   // Sync the current thetas into this subject before solving (etas set per sample).
   arma::vec curTheta((unsigned int)op_focei.ntheta);
   for (int t = 0; t < (int)op_focei.ntheta; ++t) {
@@ -10945,9 +10958,11 @@ void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
     // re-solve.  Deterministic for a fixed thread count, though not bit-identical
     // to the serial global-relaxation path.
     FoceiRetryHooks _hk;
-    odeSwapSolveRetry(op, ind, fInd->stickyRecalcN2,
-                      [&]{ odeSwapSolveInd(odeSlotThetaSens, _rxId); },
-                      foceiRetryOpts(odeRelaxInd), _hk);
+    if (!(reuseSolve && nsamp == 1)) {
+      odeSwapSolveRetry(op, ind, fInd->stickyRecalcN2,
+                        [&]{ odeSwapSolveInd(tsSlot, _rxId); },
+                        foceiRetryOpts(odeRelaxInd), _hk);
+    }
     bool okRow = true;
     if (!indHasBadSolve(op, ind)) {
       // Re-point this subject's per-thread pointers (ind->lhs etc.) for the
@@ -10955,10 +10970,10 @@ void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
       // likInner0 / shi21ThetaGeneral do (iniSubjectE with inLhs=1).  Serially this
       // is a no-op (thread 0), but under the parallel M-step it is what makes the
       // lhs reads land in this thread's slice instead of a stale one.
-      iniSubjectE(_rxId, 1, ind, op, rx, rxThetaSens.update_inis);
+      iniSubjectE(_rxId, 1, ind, op, rx, tsModel.update_inis);
       // pooled table -> the theta-sensitivity model's own CMT basis.  A no-op while
       // thetaSens IS the pool (est="impmap"/"advi"), but not if a wider peer sizes it.
-      OdeSwapCmtScope _tsCmt(odeSlotThetaSens, op, ind);
+      OdeSwapCmtScope _tsCmt(tsSlot, op, ind);
       // Read through the scope's buffer: it is rxode2's per-thread slice when the
       // pool is at least this wide, and a private buffer when this model is wider
       // -- writing past the slice would spill into the neighbouring thread's,
@@ -10970,10 +10985,10 @@ void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
       for (int jj = 0; jj < getIndNallTimes(ind) && ko < nobs; ++jj) {
         setIndIdx(ind, jj); kk = getIndIx(ind, jj); curT = getTime(kk, ind);
         if (isDose(getIndEvid(ind, kk))) {
-          rxThetaSens.calc_lhs(_rxId, curT, getOpIndSolve(op, ind, jj), lhs);
+          tsModel.calc_lhs(_rxId, curT, getOpIndSolve(op, ind, jj), lhs);
           continue;
         } else if (getIndEvid(ind, kk) == 0) {
-          rxThetaSens.calc_lhs(_rxId, curT, getOpIndSolve(op, ind, jj), lhs);
+          tsModel.calc_lhs(_rxId, curT, getOpIndSolve(op, ind, jj), lhs);
           // ind->yj / ind->lambda now describe THIS row -- the only point in the
           // subject where that is true, so take the per-obs DV transform and
           // distribution here (once; they do not vary across samples).
@@ -11011,15 +11026,15 @@ void impThetaSensCollect(int id, const arma::mat& S, impThetaSensData& out) {
     // rx_yj_/rx_lambda_, which are functions of CMT and the thetas and NOT of the ODE
     // state -- so the values are right even though the sensitivity solve behind this
     // buffer failed.  f/V/df/dV are not read here; they come from the FD fallback.
-    iniSubjectE(_rxId, 1, ind, op, rx, rxThetaSens.update_inis);
-    OdeSwapCmtScope _riCmt(odeSlotThetaSens, op, ind);
+    iniSubjectE(_rxId, 1, ind, op, rx, tsModel.update_inis);
+    OdeSwapCmtScope _riCmt(tsSlot, op, ind);
     double *lhs = neqGuard.lhs();
     int ko = 0, kk;
     double curT;
     for (int jj = 0; jj < getIndNallTimes(ind) && ko < nobs; ++jj) {
       setIndIdx(ind, jj); kk = getIndIx(ind, jj); curT = getTime(kk, ind);
       if (!isDose(getIndEvid(ind, kk)) && getIndEvid(ind, kk) != 0) continue;
-      rxThetaSens.calc_lhs(_rxId, curT, getOpIndSolve(op, ind, jj), lhs);
+      tsModel.calc_lhs(_rxId, curT, getOpIndSolve(op, ind, jj), lhs);
       if (getIndEvid(ind, kk) == 0) {
         rowInfoAt(ko, lhs);
         ko++;
@@ -11413,7 +11428,28 @@ Environment foceiFitCpp_(Environment e){
       op_focei.thetaSensLambdaOffset = -1;
       op_focei.thetaSensNlhs = 0;
       op_focei.thetaSensNeq = 0;
-      if ((op_focei.isImpmap || op_focei.isAdvi || op_focei.thetaSensLoad) &&
+      if (op_focei.combSens) {
+        // #958 combined build: the INNER model carries the theta-sensitivity
+        // columns (appended after the FOCEi block), so every offset resolves
+        // against odeSlotInner and there is no separate model to register or
+        // pin around (the inner IS the largest peer).
+        op_focei.thetaSensNeq = 0;
+        op_focei.thetaSensNlhs = odeSwapNlhs(odeSlotInner);
+        if (op_focei.impThetaSensIdx.size() > 0) {
+          std::string j0 = std::to_string(op_focei.impThetaSensIdx[0] + 1);
+          std::string firstF = "rx__sens_rx_pred__BY_THETA_" + j0 + "___";
+          std::string firstV = "rx__sens_rx_r__BY_THETA_" + j0 + "___";
+          int _if = odeSwapLhsIndex(odeSlotInner, firstF.c_str());
+          int _iv = odeSwapLhsIndex(odeSlotInner, firstV.c_str());
+          if (_if >= 0) op_focei.thetaSensOffset = _if;
+          if (_iv >= 0) op_focei.thetaSensDvOffset = _iv;
+          op_focei.thetaSensPredOffset = odeSwapLhsIndex(odeSlotInner, "rx_pred_");
+          op_focei.thetaSensROffset = odeSwapLhsIndex(odeSlotInner, "rx_r_");
+          std::string firstL = "rx__sens_rx_lambda__BY_THETA_" + j0 + "___";
+          op_focei.thetaSensLambdaOffset =
+            odeSwapLhsIndex(odeSlotInner, firstL.c_str());
+        }
+      } else if ((op_focei.isImpmap || op_focei.isAdvi || op_focei.thetaSensLoad) &&
       model.containsElementNamed("thetaSens")) {
         RObject ts = model["thetaSens"];
         if (odeSwapRegister(odeSlotThetaSens, "thetaSens", ts, &rxThetaSens)) {
@@ -11965,7 +12001,27 @@ RObject vaeInnerSetup_(Environment e) {
   op_focei.thetaSensLambdaOffset = -1;
   op_focei.thetaSensNlhs = 0;
   op_focei.thetaSensNeq = 0;
-  if ((op_focei.isImpmap || op_focei.isAdvi || op_focei.thetaSensLoad) &&
+  if (op_focei.combSens) {
+    // #958 combined build: the INNER model carries the theta columns
+    // (appended after the FOCEi block); resolve against odeSlotInner --
+    // there is no separate model to register or pin around.
+    op_focei.thetaSensNeq = 0;
+    op_focei.thetaSensNlhs = odeSwapNlhs(odeSlotInner);
+    if (op_focei.impThetaSensIdx.size() > 0) {
+      std::string j0 = std::to_string(op_focei.impThetaSensIdx[0] + 1);
+      std::string firstF = "rx__sens_rx_pred__BY_THETA_" + j0 + "___";
+      std::string firstV = "rx__sens_rx_r__BY_THETA_" + j0 + "___";
+      int _if = odeSwapLhsIndex(odeSlotInner, firstF.c_str());
+      int _iv = odeSwapLhsIndex(odeSlotInner, firstV.c_str());
+      if (_if >= 0) op_focei.thetaSensOffset = _if;
+      if (_iv >= 0) op_focei.thetaSensDvOffset = _iv;
+      op_focei.thetaSensPredOffset = odeSwapLhsIndex(odeSlotInner, "rx_pred_");
+      op_focei.thetaSensROffset = odeSwapLhsIndex(odeSlotInner, "rx_r_");
+      std::string firstL = "rx__sens_rx_lambda__BY_THETA_" + j0 + "___";
+      op_focei.thetaSensLambdaOffset =
+        odeSwapLhsIndex(odeSlotInner, firstL.c_str());
+    }
+  } else if ((op_focei.isImpmap || op_focei.isAdvi || op_focei.thetaSensLoad) &&
       model.containsElementNamed("thetaSens")) {
     RObject ts = model["thetaSens"];
     if (odeSwapRegister(odeSlotThetaSens, "thetaSens", ts, &rxThetaSens)) {
@@ -18436,7 +18492,8 @@ static bool foceiThetaSensWired(void) {
   return op_focei.impThetaSensIdx.size() > 0 &&
     op_focei.thetaSensOffset >= 0 && op_focei.thetaSensDvOffset >= 0 &&
     op_focei.thetaSensPredOffset >= 0 && op_focei.thetaSensROffset >= 0 &&
-    op_focei.thetaSensNlhs > 0 && rxThetaSens.calc_lhs != NULL;
+    op_focei.thetaSensNlhs > 0 &&
+    (op_focei.combSens ? rxInner.calc_lhs : rxThetaSens.calc_lhs) != NULL;
 }
 
 // Capability/hazard flag word for nlmixr2FoceiDims (bit meanings documented in
@@ -18452,6 +18509,8 @@ static int foceiDimsFlags(rx_solving_options *op) {
   if (op_focei.mixIdxN != 0)     f |= 0x10;
   if (solveMethodThreadSafe(op)) f |= 0x20;
   if (foceiThetaSensWired())     f |= 0x40;
+  // #958: combined build loaded -- the fused condBatchThetaGrad entry works
+  if (op_focei.combSens && foceiThetaSensWired()) f |= 0x80;
   return f;
 }
 
@@ -18615,11 +18674,13 @@ static void foceiCondSubjectStart(int id, const double *etaIn, int neta,
 // Returns 1 when the value was non-finite (gradient row zeroed).
 static int foceiCondBatchOne(int id, const double *etaIn, int neta,
                              const arma::mat &omInv,
-                             double *value, double *grad) {
+                             double *value, double *grad,
+                             int *usedFD = NULL) {
   std::vector<double> eta(neta);
   foceiCondSubjectStart(id, etaIn, neta, eta);
   double v = npEvalCondLik(&eta[0], id);
   focei_ind *fIndF = &(inds_focei[id]);
+  if (usedFD != NULL) *usedFD = 0;
   if (!std::isfinite(v) && op_focei.canDoFD && op_focei.fallbackFD) {
     // the inner SENSITIVITY solve failed even after likInner0's tolerance
     // retry ladder; fall back to the simpler prediction model with shi21
@@ -18631,6 +18692,7 @@ static int foceiCondBatchOne(int id, const double *etaIn, int neta,
     fIndF->doFD = 1;
     v = npEvalCondLik(&eta[0], id);
     fIndF->doFD = 0;
+    if (usedFD != NULL) *usedFD = 1;
   }
   value[id] = v;
   if (!std::isfinite(v)) {
@@ -18781,7 +18843,10 @@ extern "C" int nlmixr2FoceiCondThetaGrad(const double *etaIn, int nid, int neta,
       // silently zero.  Process-global + R-calling installer, so it
       // brackets the parallel region (a no-op when the model carries no
       // event sensitivities).
-      OdeSwapEsBatch esBatch(odeSlotThetaSens);
+      // #958 combined build: the theta columns ride the inner model, so
+      // the inner event-sensitivity shape is the right one for this batch
+      OdeSwapEsBatch esBatch(op_focei.combSens ? odeSlotInner
+                                               : odeSlotThetaSens);
       NpInnerParallelScope npScope(rx, doParallel);
       // components serial-outer, subjects parallel-inner (see
       // foceiCondBatchCheck); nMix == 1 reduces to the plain loop
@@ -18932,6 +18997,85 @@ int foceiLikRowTick_(NumericVector par, double objf) {
   return nlmixr2FoceiIterPrintRow(&par[0], (int)par.size(), objf);
 }
 
+// #958 fused tier-2 entry: value + d/d(eta) + d/d(theta) from ONE inner
+// solve per subject.  Requires the combined-sensitivity build
+// (foceiLikLoad(combSens=TRUE)): the inner model carries the theta columns,
+// so the theta read pass consumes the SAME solution likInner0 just
+// produced (impThetaSensCollect reuseSolve).  When the value came from the
+// prediction-model FD fallback the inner solution is not populated, so the
+// theta pass re-solves (and falls back to impThetaSensFD if that fails).
+static int foceiCondBatchThetaGradOne(int id, const double *etaIn, int neta,
+                                      int ntheta, int nSens,
+                                      const arma::mat &omInv,
+                                      double *value, double *gradEta,
+                                      double *dTheta) {
+  int usedFD = 0;
+  int bad = foceiCondBatchOne(id, etaIn, neta, omInv, value, gradEta,
+                              &usedFD);
+  for (int t = 0; t < ntheta; ++t) dTheta[(size_t)id * ntheta + t] = 0.0;
+  if (bad != 0) return bad;
+  arma::mat S(1, neta);
+  for (int k = 0; k < neta; ++k) S(0, k) = etaIn[(size_t)id * neta + k];
+  impThetaSensData c;
+  impThetaSensCollect(id, S, c, /*reuseSolve=*/usedFD == 0);
+  if (c.nobs == 0 || c.sampleOk.empty() || c.sampleOk[0] == 0) return 1;
+  arma::vec zk(1); zk[0] = 1.0;
+  arma::vec g(nSens, arma::fill::zeros);
+  arma::mat H(nSens, nSens, arma::fill::zeros);
+  impThetaAccumOne(c, zk, g, H);
+  if (!g.is_finite()) return 1;
+  for (int ss = 0; ss < nSens; ++ss) {
+    int th = op_focei.impThetaSensIdx[ss];
+    if (th >= 0 && th < ntheta) dTheta[(size_t)id * ntheta + th] = g[ss];
+  }
+  return 0;
+}
+
+extern "C" int nlmixr2FoceiCondBatchThetaGrad(const double *etaIn, int nid,
+                                              int neta, int cores,
+                                              double *value, double *gradEta,
+                                              double *dTheta) {
+  int rc = foceiCondBatchCheck(etaIn, value, nid, neta);
+  if (rc != 0 || gradEta == NULL || dTheta == NULL) return rc != 0 ? rc : -2;
+  if (!op_focei.combSens) return -5; // needs the combined build
+  if (!foceiThetaSensWired()) return -4;
+  try {
+    rx_solving_options *op = getSolvingOptions(rx);
+    const int ntheta = (int)op_focei.ntheta;
+    const int nSens = op_focei.impThetaSensIdx.size();
+    foceiCondBatchReset(op);
+    const bool doParallel = foceiCondBatchParallel(cores, op);
+    const arma::mat omInv = op_focei.omegaInv;
+    std::vector<int> bad(nid, 0);
+    {
+      // ONE event-sensitivity shape for the whole fused batch: the combined
+      // model owns both the eta and theta jump sensitivities
+      OdeSwapEsBatch esBatch(odeSlotInner);
+      NpInnerParallelScope npScope(rx, doParallel);
+      const int nsub = (int)getRxNsub(rx);
+      const int nMix = op_focei.mixIdxN + 1;
+      for (int m = 0; m < nMix; ++m) {
+#ifdef _OPENMP
+#pragma omp parallel for num_threads(cores) schedule(dynamic) if(doParallel)
+#endif
+        for (int ii = 0; ii < nsub; ++ii) {
+          int id = (doParallel ? (getOrdId(rx, ii) - 1) : ii) + m * nsub;
+          foceiCondEnterThread(doParallel);
+          bad[id] = foceiCondBatchThetaGradOne(id, etaIn, neta, ntheta,
+                                               nSens, omInv, value, gradEta,
+                                               dTheta);
+          foceiCondLeaveThread(doParallel);
+        }
+      }
+    }
+    int nbad = 0;
+    for (int i = 0; i < nid; ++i) nbad += bad[i];
+    return nbad;
+  } catch (...) {
+    return -3;
+  }
+}
+
 // Mixture component count for the blessed component-major layout (#955):
 // 1 for a non-mixture load, K for a K-component mixture; -1 not loaded.
 extern "C" int nlmixr2FoceiNMix(void) {
@@ -18943,21 +19087,22 @@ extern "C" int nlmixr2FoceiNMix(void) {
 // _nlmixr2est_likContribPtrs above); the downstream package installs it via
 // inst/include/nlmixr2estFoceiPtr.h.
 extern "C" SEXP _nlmixr2est_foceiPtrs(void) {
-  const char *nm[9] = {"apiVersion", "dims", "setTheta", "condBatch",
-                       "setOmegaInv", "thetaSensIdx", "condThetaGrad",
-                       "nMix", "iterPrintRow"};
-  DL_FUNC fn[9] = {(DL_FUNC) &nlmixr2FoceiApiVersion,
-                   (DL_FUNC) &nlmixr2FoceiDims,
-                   (DL_FUNC) &nlmixr2FoceiSetTheta,
-                   (DL_FUNC) &nlmixr2FoceiCondBatch,
-                   (DL_FUNC) &nlmixr2FoceiSetOmegaInv,
-                   (DL_FUNC) &nlmixr2FoceiThetaSensIdx,
-                   (DL_FUNC) &nlmixr2FoceiCondThetaGrad,
-                   (DL_FUNC) &nlmixr2FoceiNMix,
-                   (DL_FUNC) &nlmixr2FoceiIterPrintRow};
-  SEXP ret  = PROTECT(Rf_allocVector(VECSXP, 9));
-  SEXP retN = PROTECT(Rf_allocVector(STRSXP, 9));
-  for (int i = 0; i < 9; ++i) {
+  const char *nm[10] = {"apiVersion", "dims", "setTheta", "condBatch",
+                        "setOmegaInv", "thetaSensIdx", "condThetaGrad",
+                        "nMix", "iterPrintRow", "condBatchThetaGrad"};
+  DL_FUNC fn[10] = {(DL_FUNC) &nlmixr2FoceiApiVersion,
+                    (DL_FUNC) &nlmixr2FoceiDims,
+                    (DL_FUNC) &nlmixr2FoceiSetTheta,
+                    (DL_FUNC) &nlmixr2FoceiCondBatch,
+                    (DL_FUNC) &nlmixr2FoceiSetOmegaInv,
+                    (DL_FUNC) &nlmixr2FoceiThetaSensIdx,
+                    (DL_FUNC) &nlmixr2FoceiCondThetaGrad,
+                    (DL_FUNC) &nlmixr2FoceiNMix,
+                    (DL_FUNC) &nlmixr2FoceiIterPrintRow,
+                    (DL_FUNC) &nlmixr2FoceiCondBatchThetaGrad};
+  SEXP ret  = PROTECT(Rf_allocVector(VECSXP, 10));
+  SEXP retN = PROTECT(Rf_allocVector(STRSXP, 10));
+  for (int i = 0; i < 10; ++i) {
     SET_VECTOR_ELT(ret, i, R_MakeExternalPtrFn(fn[i], R_NilValue, R_NilValue));
     SET_STRING_ELT(retN, i, Rf_mkChar(nm[i]));
   }
@@ -18987,6 +19132,31 @@ List foceiLikCondGrad_(NumericMatrix etaMat, int cores) {
     for (int j = 0; j < neta; ++j) grad(i, j) = g[(size_t)i * neta + j];
   }
   return List::create(_["value"] = value, _["grad"] = grad, _["nBad"] = rc);
+}
+
+//[[Rcpp::export]]
+List foceiLikCondBatchThetaGrad_(NumericMatrix etaMat, int cores) {
+  const int nid = etaMat.nrow();
+  const int neta = etaMat.ncol();
+  int ntheta = 0;
+  int rc0 = nlmixr2FoceiDims(NULL, NULL, &ntheta, NULL, NULL);
+  if (rc0 < 0) stop("nlmixr2FoceiDims failed with status %d", rc0);
+  std::vector<double> eta((size_t)nid * neta), v(nid),
+    gE((size_t)nid * neta), dTh((size_t)nid * ntheta);
+  for (int i = 0; i < nid; ++i)
+    for (int j = 0; j < neta; ++j) eta[(size_t)i * neta + j] = etaMat(i, j);
+  int rc = nlmixr2FoceiCondBatchThetaGrad(eta.data(), nid, neta, cores,
+                                          v.data(), gE.data(), dTh.data());
+  if (rc < 0) stop("nlmixr2FoceiCondBatchThetaGrad failed with status %d", rc);
+  NumericVector value(nid);
+  NumericMatrix gradEta(nid, neta), dTheta(nid, ntheta);
+  for (int i = 0; i < nid; ++i) {
+    value[i] = v[i];
+    for (int j = 0; j < neta; ++j) gradEta(i, j) = gE[(size_t)i * neta + j];
+    for (int t = 0; t < ntheta; ++t) dTheta(i, t) = dTh[(size_t)i * ntheta + t];
+  }
+  return List::create(_["value"] = value, _["gradEta"] = gradEta,
+                      _["dTheta"] = dTheta, _["nBad"] = rc);
 }
 
 //[[Rcpp::export]]

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -1395,6 +1395,70 @@ static void foceiOmegaFastCompute(const double *omBlock) {
   op_focei.logDetOmegaInv5 = ld;
 }
 
+// Classify the diagonal transform at (probe) tail value th, given the base
+// and displaced factor entries; -1 when no candidate matches.
+static int foceiOmegaFastXfClassify(double th, double dlt, double b0,
+                                    double b1) {
+  if (std::fabs(b1 - (th + dlt)) < 1e-9 && std::fabs(b0 - th) < 1e-9) {
+    return 0; // identity
+  }
+  if (std::fabs(b1 - (th + dlt) * (th + dlt)) < 1e-9 &&
+      std::fabs(b0 - th * th) < 1e-9) {
+    return 1; // sqrt storage: factor entry = theta^2
+  }
+  if (std::fabs(b1 - std::exp(th + dlt)) < 1e-9 &&
+      std::fabs(b0 - std::exp(th)) < 1e-9) {
+    return 2; // log storage: factor entry = exp(theta)
+  }
+  return -1;
+}
+
+// Probe tail entry k: displace it, locate the ONE factor entry that moved,
+// and record its position + transform.  FALSE aborts the fast path (not a
+// one-entry-per-theta parameterization, or an unrecognized transform).
+static bool foceiOmegaFastProbeOne(unsigned int k, const std::vector<double> &t0,
+                                   const arma::mat &U0, double dlt) {
+  const int n = _omFastNeta;
+  NumericVector tp((int)t0.size());
+  std::copy(t0.begin(), t0.end(), tp.begin());
+  tp[(int)k] += dlt;
+  setOmegaTheta(tp);
+  arma::mat Uk = getCholOmegaInv();
+  int nz = 0, ri = -1, ci = -1;
+  for (int i = 0; i < n; ++i) {
+    for (int jj = 0; jj < n; ++jj) {
+      if (std::fabs(Uk(i, jj) - U0(i, jj)) > 1e-12) { nz++; ri = i; ci = jj; }
+    }
+  }
+  if (nz != 1) return false;
+  _omFastRow[k] = ri; _omFastCol[k] = ci;
+  if (ri != ci) {
+    // off-diagonal must be the raw theta (linear, coefficient 1)
+    if (std::fabs((Uk(ri, ci) - U0(ri, ci)) - dlt) > 1e-9) return false;
+    _omFastXf[k] = 0;
+    return true;
+  }
+  _omFastXf[k] = foceiOmegaFastXfClassify(t0[k], dlt, U0(ri, ci), Uk(ri, ci));
+  return _omFastXf[k] >= 0;
+}
+
+// Verify the mapped C-side rebuild against the env at a displaced tail:
+// omegaInv, chol and logdet must agree to numerical noise.
+static bool foceiOmegaFastVerify(const std::vector<double> &t0) {
+  std::vector<double> tv(t0);
+  for (size_t k = 0; k < tv.size(); ++k) tv[k] += 0.1 + 0.03 * (double)k;
+  NumericVector tvv((int)tv.size());
+  std::copy(tv.begin(), tv.end(), tvv.begin());
+  setOmegaTheta(tvv);
+  arma::mat oiR = getOmegaInv();
+  arma::mat chR = getCholOmegaInv();
+  double ldR = getOmegaDet();
+  foceiOmegaFastCompute(tv.data());
+  return arma::approx_equal(op_focei.omegaInv, oiR, "absdiff", 1e-10) &&
+    arma::approx_equal(op_focei.cholOmegaInv, chR, "absdiff", 1e-10) &&
+    std::fabs(op_focei.logDetOmegaInv5 - ldR) < 1e-10;
+}
+
 static void foceiOmegaFastTry(const double *omBlock) {
   _omFastState = -1; // pessimistic until verified
   const int n = (int)op_focei.neta;
@@ -1408,57 +1472,10 @@ static void foceiOmegaFastTry(const double *omBlock) {
   if ((int)U0.n_rows != n) return;
   _omFastNeta = n;
   _omFastRow.assign(m, -1); _omFastCol.assign(m, -1); _omFastXf.assign(m, -1);
-  const double dlt = 0.25;
   for (unsigned int k = 0; k < m; ++k) {
-    NumericVector tp((int)m);
-    std::copy(t0.begin(), t0.end(), tp.begin());
-    tp[(int)k] += dlt;
-    setOmegaTheta(tp);
-    arma::mat Uk = getCholOmegaInv();
-    int nz = 0, ri = -1, ci = -1;
-    for (int i = 0; i < n; ++i) {
-      for (int jj = 0; jj < n; ++jj) {
-        if (std::fabs(Uk(i, jj) - U0(i, jj)) > 1e-12) { nz++; ri = i; ci = jj; }
-      }
-    }
-    if (nz != 1) return; // not a one-entry-per-theta parameterization
-    _omFastRow[k] = ri; _omFastCol[k] = ci;
-    if (ri != ci) {
-      // off-diagonal must be the raw theta (linear, coefficient 1)
-      if (std::fabs((Uk(ri, ci) - U0(ri, ci)) - dlt) > 1e-9) return;
-      _omFastXf[k] = 0;
-    } else {
-      const double th = t0[k], b0 = U0(ri, ci), b1 = Uk(ri, ci);
-      if (std::fabs(b1 - (th + dlt)) < 1e-9 && std::fabs(b0 - th) < 1e-9) {
-        _omFastXf[k] = 0;
-      } else if (std::fabs(b1 - (th + dlt) * (th + dlt)) < 1e-9 &&
-                 std::fabs(b0 - th * th) < 1e-9) {
-        _omFastXf[k] = 1;
-      } else if (std::fabs(b1 - std::exp(th + dlt)) < 1e-9 &&
-                 std::fabs(b0 - std::exp(th)) < 1e-9) {
-        _omFastXf[k] = 2;
-      } else {
-        return; // unrecognized diagonal transform
-      }
-    }
+    if (!foceiOmegaFastProbeOne(k, t0, U0, 0.25)) return;
   }
-  // verification at a displaced tail: the C-side rebuild must reproduce the
-  // env exactly (up to numerical noise) for omegaInv, chol and logdet
-  std::vector<double> tv(t0);
-  for (unsigned int k = 0; k < m; ++k) tv[k] += 0.1 + 0.03 * (double)k;
-  NumericVector tvv((int)m);
-  std::copy(tv.begin(), tv.end(), tvv.begin());
-  setOmegaTheta(tvv);
-  arma::mat oiR = getOmegaInv();
-  arma::mat chR = getCholOmegaInv();
-  double ldR = getOmegaDet();
-  _omFastState = 1; // arm so the compute below uses the map
-  foceiOmegaFastCompute(tv.data());
-  bool ok = arma::approx_equal(op_focei.omegaInv, oiR, "absdiff", 1e-10) &&
-    arma::approx_equal(op_focei.cholOmegaInv, chR, "absdiff", 1e-10) &&
-    std::fabs(op_focei.logDetOmegaInv5 - ldR) < 1e-10;
-  if (!ok) { _omFastState = -1; return; }
-  _omFastState = 1;
+  if (foceiOmegaFastVerify(t0)) _omFastState = 1;
 }
 
 static void foceiOmegaFromTheta(const double *omBlock) {

--- a/tests/testthat/test-focei-ptrs.R
+++ b/tests/testthat/test-focei-ptrs.R
@@ -30,10 +30,10 @@
 
 test_that("the foceiPtrs table has the documented shape (#937 + #955)", {
   .p <- .nlmixr2estFoceiPtrs()
-  expect_length(.p, 9L)
+  expect_length(.p, 10L)
   expect_equal(names(.p), c("apiVersion", "dims", "setTheta", "condBatch",
                             "setOmegaInv", "thetaSensIdx", "condThetaGrad",
-                            "nMix", "iterPrintRow"))
+                            "nMix", "iterPrintRow", "condBatchThetaGrad"))
   for (.i in seq_along(.p)) expect_true(inherits(.p[[.i]], "externalptr"))
 })
 
@@ -718,4 +718,78 @@ test_that("sampler iteration print: scale.h rows + parHistData over the residenc
   expect_true(all(c("tcl", "tv", "add.sd", "om.eta.cl") %in% names(.ph)))
   # inactive after End
   expect_equal(foceiLikRowTick_(h$initPar, -1), -1L)
+})
+
+test_that("combined eta+theta sensitivity build (#958): layout, parity, fused entry", {
+  skip_on_cran()
+  .mod <- function() {
+    ini({
+      tka <- 0.45; tcl <- 1; tv <- 3.45
+      kout <- 0.2
+      eta.ka ~ 0.6; eta.cl ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center - kout * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+  .d <- nlmixr2data::theo_sd
+  .testSeed(11)
+  .eta <- matrix(stats::rnorm(24, 0, 0.2), 12, 2)
+  # reference: the two-model path
+  .h1 <- foceiLikLoad(.mod, .d, "focei", scale = "natural", thetaSens = TRUE)
+  .v1 <- foceiLikCondGrad_(.eta, 1L)
+  .t1 <- foceiLikCondThetaGrad_(.eta, 1L)
+  foceiLikUnload()
+  # combined build
+  .h2 <- foceiLikLoad(.mod, .d, "focei", scale = "natural", combSens = TRUE)
+  on.exit(foceiLikUnload(), add = TRUE)
+  .d2 <- foceiLikDims_()
+  expect_true(bitwAnd(.d2[["flags"]], 0x40L) != 0L) # theta sens wired
+  expect_true(bitwAnd(.d2[["flags"]], 0x80L) != 0L) # combined build
+  .v2 <- foceiLikCondGrad_(.eta, 1L)
+  .t2 <- foceiLikCondThetaGrad_(.eta, 1L)
+  # value/eta grad agree at solver tolerance (the theta-sens states ride the
+  # same adaptive integration, so bit-parity is impossible by construction)
+  expect_equal(.v1$value, .v2$value, tolerance = 1e-6)
+  expect_equal(.v1$grad, .v2$grad, tolerance = 1e-5)
+  # theta gradient from the combined solve == two-model path (solver tol)
+  expect_equal(.t1$dTheta, .t2$dTheta, tolerance = 1e-5)
+  # fused entry: one solve per subject, all three outputs; value/etaGrad
+  # BITWISE equal to the separate combined-path calls, dTheta bitwise too
+  # (the reuse pass reads the very solve the value pass produced)
+  .f <- foceiLikCondBatchThetaGrad_(.eta, 1L)
+  expect_identical(.f$value, .v2$value)
+  expect_identical(.f$gradEta, .v2$grad)
+  expect_identical(.f$dTheta, .t2$dTheta)
+  expect_equal(.f$nBad, 0L)
+})
+
+test_that("combined build: sigma-only theta set adds columns, no states (#958)", {
+  skip_on_cran()
+  # every structural theta mu-referenced; only add.sd (sigma) remains -- the
+  # paste0-recycling guard keeps a malformed THETA__ variable out of the build
+  .mod <- function() {
+    ini({
+      tcl <- 1
+      eta.cl ~ 0.1
+      add.sd <- 0.5
+    })
+    model({
+      cl <- exp(tcl + eta.cl)
+      cp <- 100 * exp(-cl * time)
+      cp ~ add(add.sd)
+    })
+  }
+  .d <- data.frame(ID = rep(1:4, each = 3), TIME = rep(c(1, 2, 4), 4),
+                   DV = 3, AMT = 0, EVID = 0)
+  .h <- foceiLikLoad(.mod, .d, "focei", scale = "natural", combSens = TRUE)
+  on.exit(foceiLikUnload(), add = TRUE)
+  .f <- foceiLikCondBatchThetaGrad_(matrix(0, 4, 1), 1L)
+  expect_equal(.f$nBad, 0L)
+  expect_true(all(is.finite(.f$value)))
 })


### PR DESCRIPTION
Implements #958. **Stacked on #957** (base branch `fix/cond-batch-nan-value`) — merge that first, then rebase/retarget this to main.

## What

`est="stan"`'s tier-2 gradient previously cost **three ODE integrations per subject per evaluation** (inner solve for value + d/d(eta); condThetaGrad's likInner0 pre-pass; the separate theta-sensitivity-model solve). With `foceiLikLoad(combSens=TRUE)` it costs **one**:

- **R**: the inner generator derives the eta+theta union in a single `.rxJacobian`/`.rxSens` pair and appends the theta columns (impmap chain rule, identical naming) **after** the FOCEi eta block — `likInner0`'s arithmetic `predOffset` reads stay byte-identical. State sensitivities only for etas + structural non-mu thetas; sigma thetas get columns only. Opt-in (`combSens` control), keyed into the model digest; the separate theta-sensitivity model is not built under it.
- **C**: theta offsets resolve by name against `odeSlotInner` (both setup paths); `impThetaSensCollect` gains a slot switch plus `reuseSolve` (skips its re-solve when the caller just solved the combined model at the same point); new fused entry `nlmixr2FoceiCondBatchThetaGrad` (table entry 10, additive/defensive install) fills value + gradEta + dTheta from one solve under **one** event-sensitivity shape (the combined model owns both jump-sensitivity sets). Dims flag `0x80` advertises the capability.

## Measurements

theo_sd, dense `dop853`, 4 threads: **0.62 ms** per full-population gradient vs 1.26 ms two-model (**2.03×**) — and below the native-Stan coupled solve (1.98 ms). Fused outputs are **bitwise identical** to the separate combined-path calls; vs the two-model path agreement is at solver tolerance (~1e-6), inherent since the theta states ride the same adaptive integration.

## Drive-by fix

`paste0()` recycles a zero-length index to `""` (R ≥ 4.0), so a sigma-only theta set fabricated a malformed `THETA__` sensitivity variable — guarded in the new path **and** in the pre-existing impmap builder, where the same latent bug existed.

## Tests

focei/nlm/imp suites: 8,136 passing, 0 failed. focei-ptrs golden updated to the 10-entry table; new tests cover the combined layout, two-path parity, the fused entry's bitwise contract, and the sigma-only build.

Downstream: nlmixr2/nlmixr2stan#12's follow-up will consume the fused entry (projected to take the linked ODE tier past native ESS/s together with the forked chains already landed there).