### PR TITLE
IOV magnitude theta: exact sensitivity via sqrt(theta^2) (fixes #952)

### DIFF
--- a/R/foceiLik.R
+++ b/R/foceiLik.R
@@ -64,6 +64,10 @@
 #'   parameter vector remain in the internal `diagXform` parameterization of
 #'   `chol(Omega^-1)`; `"natural"` leaves them unscaled but does not change
 #'   that parameterization.
+#' @param iovXform Transformation carrying the IOV magnitude theta (the
+#'   `.uiApplyIov` hook): `"sd"` (default), `"var"`, `"logsd"`,
+#'   `"logvar"`.  The presence of this argument also marks the loaded
+#'   nlmixr2est as carrying the exact IOV magnitude sensitivity (#952)
 #' @param combSens When `TRUE`, use the combined eta+theta sensitivity
 #'   build (#958): the INNER model itself carries the theta-sensitivity
 #'   columns (appended after the FOCEi block), so one ODE integration per
@@ -143,6 +147,7 @@ foceiLikLoad <- function(object, data,
                          scale = c("focei", "natural"),
                          thetaSens = FALSE,
                          combSens = FALSE,
+                         iovXform = c("sd", "var", "logsd", "logvar"),
                          est = "focei", ...) {
   likelihood <- match.arg(likelihood)
   scale <- match.arg(scale)
@@ -153,14 +158,17 @@ foceiLikLoad <- function(object, data,
          call. = FALSE)
   }
   .ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(object))
+  iovXform <- match.arg(iovXform)
   if (identical(scale, "natural")) {
     # identity scale/unscale: scaleType="mult" with scaleTo=0 returns the
     # parameter unchanged in both directions (see unscalePar()/scalePar(),
     # src/inner.cpp), so the estimation scale IS the natural scale (#939)
     .control <- .foceiLikControl(likelihood, rxControl,
-                                 scaleType = "mult", scaleTo = 0, ...)
+                                 scaleType = "mult", scaleTo = 0,
+                                 iovXform = iovXform, ...)
   } else {
-    .control <- .foceiLikControl(likelihood, rxControl, ...)
+    .control <- .foceiLikControl(likelihood, rxControl,
+                                 iovXform = iovXform, ...)
   }
   .control$est <- "focei"
   # Run the standard pre-process hooks (bounded transforms, covariates,

--- a/R/foceiLik.R
+++ b/R/foceiLik.R
@@ -17,7 +17,7 @@
                              eventSens = "jump", indTolRelax = TRUE,
                              maxOdeRecalc = 5L, odeRecalcFactor = 10^0.5,
                              scaleType = "nlmixr2", scaleTo = 1.0,
-                             fallbackFD = FALSE) {
+                             fallbackFD = FALSE, iovXform = "sd") {
   .interaction <- if (likelihood %in% c("foce", "focep")) 0L else 1L
   .foce <- if (identical(likelihood, "focep")) "foce+" else "nonmem"
   foceiControl(rxControl = rxControl, maxOuterIterations = 0L,
@@ -29,7 +29,7 @@
                indTolRelax = indTolRelax, maxOdeRecalc = maxOdeRecalc,
                odeRecalcFactor = odeRecalcFactor, print = 0L,
                scaleType = scaleType, scaleTo = scaleTo,
-               fallbackFD = fallbackFD)
+               fallbackFD = fallbackFD, iovXform = iovXform)
 }
 
 #' Load a general FOCE-family likelihood into memory

--- a/R/iov.R
+++ b/R/iov.R
@@ -260,14 +260,22 @@ nlmixr2iovVarSd <- function(val) {
                                                    collapse="+"),
                                              ")"))
                          } else if (.xform == "sd") {
-                           str2lang(paste0("rx.", v, " <- abs(", v, ")*(",
+                           # |theta| written as sqrt(theta^2): identical value,
+                           # but symengine differentiates it EXACTLY
+                           # (theta/sqrt(theta^2) = sign) -- abs() is rewritten
+                           # to an indicator form whose derivative is a
+                           # tanh-SMOOTHED step, making the theta-sensitivity
+                           # column wrong by a theta-dependent factor (#952)
+                           str2lang(paste0("rx.", v, " <- sqrt((", v, ")^2)*(",
                                            paste(paste0("rx.", v, ".", .lvls[[l1]],
                                                         "*(", l1,
                                                         " == ", .lvls[[l1]], ")"),
                                                  collapse="+"),
                                            ")"))
                          } else if (.xform == "var") {
-                           str2lang(paste0("rx.", v, " <- sqrt(abs(", v, "))*(",
+                           # sqrt(|theta|) as (theta^2)^(1/4), same reasoning
+                           # as the "sd" branch above (#952)
+                           str2lang(paste0("rx.", v, " <- ((", v, ")^2)^0.25*(",
                                            paste(paste0("rx.", v, ".", .lvls[[l1]],
                                                         "*(", l1,
                                                         " == ", .lvls[[l1]], ")"),

--- a/man/foceiLikLoad.Rd
+++ b/man/foceiLikLoad.Rd
@@ -12,6 +12,7 @@ foceiLikLoad(
   scale = c("focei", "natural"),
   thetaSens = FALSE,
   combSens = FALSE,
+  iovXform = c("sd", "var", "logsd", "logvar"),
   est = "focei",
   ...
 )
@@ -58,6 +59,11 @@ batch entry `nlmixr2FoceiCondBatchThetaGrad` reads all three from a
 single solve (~2x cheaper per evaluation than the two-model path).
 Implies a theta-sensitivity request; the separate theta-sensitivity
 model is neither built nor compiled.}
+
+\item{iovXform}{Transformation carrying the IOV magnitude theta (the
+`.uiApplyIov` hook): `"sd"` (default), `"var"`, `"logsd"`,
+`"logvar"`.  The presence of this argument also marks the loaded
+nlmixr2est as carrying the exact IOV magnitude sensitivity (#952)}
 
 \item{est}{Estimation-method name the standard pre-process hooks run
 against (default `"focei"`).  The hooks read the named method's

--- a/tests/testthat/test-focei-ptrs.R
+++ b/tests/testthat/test-focei-ptrs.R
@@ -793,3 +793,51 @@ test_that("combined build: sigma-only theta set adds columns, no states (#958)",
   expect_equal(.f$nBad, 0L)
   expect_true(all(is.finite(.f$value)))
 })
+
+test_that("IOV magnitude theta sensitivity column FD-agrees (#952)", {
+  skip_on_cran()
+  # the sd/var transforms used abs(theta), whose symengine rewrite carries
+  # an indicator with a tanh-SMOOTHED derivative -- the column came out
+  # wrong by 1 + 10*theta*(1 - tanh(10*theta)^2) (x1.42 at theta=0.1).
+  # |theta| is now emitted as sqrt(theta^2) (identical value, exact
+  # derivative), and this locks the FD agreement in for every transform.
+  .mod <- function() {
+    ini({
+      tcl <- 1.05; tv <- 2.95; add.sd <- 0.55
+      eta.cl ~ 0.1
+      iov.cl ~ 0.02 | OCC
+    })
+    model({
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv)
+      cp <- 100 / v * exp(-cl / v * time)
+      cp ~ add(add.sd)
+    })
+  }
+  .testSeed(7)
+  .d <- expand.grid(ID = 1:4, OCC = 1:2, TIME = c(1, 2, 4))
+  .d <- .d[order(.d$ID, .d$OCC, .d$TIME), ]
+  .d$DV <- 3 + stats::rnorm(nrow(.d), 0, 0.5)
+  .d$AMT <- 0; .d$EVID <- 0
+  for (.xf in c("sd", "logsd", "var", "logvar")) {
+    .h <- foceiLikLoad(.mod, .d, "focei", scale = "natural",
+                       thetaSens = TRUE, iovXform = .xf)
+    .th <- .h$initPar
+    .iov <- grep("iov", .h$thetaNames)
+    .testSeed(3)
+    .eta <- matrix(stats::rnorm(.h$nid * .h$neta, 0, 0.3), .h$nid, .h$neta)
+    .th2 <- .th
+    .th2[.iov] <- if (.xf %in% c("logsd", "logvar")) -1.5 else 0.15
+    foceiLikSetTheta_(.th2)
+    .an <- foceiLikCondThetaGrad_(.eta, 1L)$dTheta[, .iov]
+    .hs <- 1e-5
+    .tp <- .th2; .tp[.iov] <- .tp[.iov] + .hs
+    .tm <- .th2; .tm[.iov] <- .tm[.iov] - .hs
+    foceiLikSetTheta_(.tp); .vp <- foceiLikCondGrad_(.eta, 1L)$value
+    foceiLikSetTheta_(.tm); .vm <- foceiLikCondGrad_(.eta, 1L)$value
+    .fd <- (.vp - .vm) / (2 * .hs)
+    expect_lt(max(abs(.an / .fd - 1)), 1e-6,
+              label = paste0("iovXform=", .xf, " analytic/FD"))
+    foceiLikUnload()
+  }
+})


### PR DESCRIPTION
Fixes #952. The iov hook emitted `abs(iov.cl)` ("sd") / `sqrt(abs(iov.cl))` ("var"); rxode2's abs rewrite carried a tanh-smoothed indicator derivative, scaling the theta-sensitivity column by `1 + 10*theta*(1 - tanh(10*theta)^2)` — exactly the ×1.41997/×1.14130/×1.00536 factors measured in the issue at theta = 0.1/0.2/0.4.

`|theta|` is now emitted as `sqrt(theta^2)` (and `sqrt|theta|` as `(theta^2)^0.25`): identical values, exact symengine derivatives via the power rules, and — unlike bare `abs()` even after nlmixr2/rxode2#1269 — no non-differentiable point in the chain at theta = 0. Likelihood semantics unchanged for every estimator (the density is even in theta; the reporting layer applies `abs()` independently).

Also: `foceiLikLoad()`/`.foceiLikControl` gain an `iovXform` pass-through (needed by the test; useful to external callers).

FD gates on the issue fixture through the C API: analytic/FD = 1 ± 2e-10 ("sd"), 1.2e-9 ("logsd"), 3.0e-9 ("var"), 1.3e-9 ("logvar") — was ×1.42. Regression test locks all four transforms in. iov/focei-ptrs/saem suites: 741 passing.

Complementary to nlmixr2/rxode2#1269 (merged), which fixes `abs()`'s derivative for every other model; this PR's form additionally avoids the |0| kink for the IOV magnitude specifically. Downstream: nlmixr2/nlmixr2stan flips first-class IOV on against this (probe: the `iovXform` formal on `foceiLikLoad`).