### PR TITLE
saem: fix the rank-deficient non-mu theta back-solve and make that refinement affordable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,24 @@
   by other packages -- `babelmixr2`'s `nonmem`, `monolix`, `saemix` and
   the rest -- are covered without any change of their own.
 
+## Changed defaults
+
+- `est="saem"` now refines a population theta that carries no random effect with
+  `newuoa` over all such thetas at once, under a budget of 25 objective
+  evaluations per iteration (`saemControl(nonMuThetaOpt="newuoa",
+  nonMuThetaMaxEval=25)`), rather than with sweeps of golden-section coordinate
+  descent.  That refinement is where such a model spends most of its time -- each
+  of its evaluations re-solves every subject and chain -- and the sweeps solved it
+  far more precisely than a stochastic-approximation step that then moves a
+  fraction of the way there can use.  Fits of models that have a non-mu theta
+  will report slightly different estimates.  Measured by the FOCEi conditional
+  objective at each run's converged estimates: on the nimotuzumab target-mediated
+  model 1.6x faster at an indistinguishable objective (143.53 vs 143.48), and on
+  the mavoglurant PBPK model 1.9x faster at a clearly better one (1977.0 vs
+  2055.8), where the cheaper refinement escapes a poor additive-error basin the
+  old default settles into.  Pass `saemControl(nonMuThetaOpt="optimize")` for the
+  previous behavior.
+
 ## Breaking changes
 
 - `saemControl(lbfgsLmm=, lbfgsFactr=, lbfgsPgtol=, lbfgsMaxIter=)` have been
@@ -67,6 +85,23 @@
   have broken assembling a finished fit for the first method that does.
 
 ## New features
+
+- `est="saem"` gained controls for the cost of the `nonMuTheta="regress"`
+  refinement, which estimates population thetas that carry no random effect:
+  `saemControl(nonMuThetaOpt=, nonMuThetaSweeps=, nonMuThetaMaxEval=,
+  nonMuThetaTol=, nonMuThetaEvery=)`.  That refinement runs every iteration of
+  the second half of the fit, and when the non-mu thetas are structural (they
+  drive the ODE) each of its objective evaluations is a full re-solve of every
+  subject and chain, so it can cost more than the rest of the algorithm put
+  together -- on the nimotuzumab target-mediated example and the mavoglurant
+  PBPK example (both with five non-mu thetas) it is around 60% of the run time.
+  `nonMuThetaOpt="newuoa"` (the new default, see **Changed defaults**) and
+  `nonMuThetaOpt="nelderMead"` run one clamped multivariate optimization over
+  all free `phi0` coordinates under a fixed evaluation budget
+  (`nonMuThetaMaxEval`); both see the coupling between those coordinates, which
+  the previous coordinate descent (`nonMuThetaOpt="optimize"`, still available)
+  cannot.  `nonMuThetaEvery` additionally runs the refinement only every k-th
+  iteration.
 
 - An estimated transform-both-sides `lambda` (`boxCox()`/`yeoJohnson()`) now
   carries a real theta-sensitivity column instead of a silent zero (#949).
@@ -172,6 +207,19 @@
 ## Bug fixes
 
 ### Estimation
+
+- `est="saem"` no longer prints `solve(): system is singular; attempting approx
+  solution` **on every iteration of the second half of the fit** when the model
+  has more than one population theta without a random effect.  The
+  `nonMuTheta="regress"` refinement (the default) wrote its result back with one
+  least-squares against the whole `phi0` design, but that design is block
+  structured -- each coefficient belongs to exactly one `phi0` theta -- and with
+  no `phi0` covariate every one of its columns is the same intercept column, so
+  the normal equations are exactly rank deficient.  The back-solve is now done
+  per `phi0` theta against its own columns.  The rank-deficient solution also
+  filled the coefficient matrix off-structure, which is why a `fix()`ed non-mu
+  theta of a general log-likelihood model did not reproduce its fixed value;
+  that is fixed with it.  Estimates are otherwise unchanged.
 
 - Fixed the analytic-gradient methods (`est="foceif"` and the rest of the `*f`
   family, or `foceiControl(fast=TRUE)`) **stopping short of the optimum**, after

--- a/R/saem.R
+++ b/R/saem.R
@@ -34,6 +34,18 @@
   return(.ret)
 }
 
+# newuoa refinement of the non-mu (phi0) thetas, saemControl(nonMuThetaOpt="newuoa").
+# Warnings are suppressed because this runs once per SAEM iteration and stopping on
+# the evaluation budget is the expected outcome, not a problem to report -- an
+# unsuppressed warning here would be collected into the fit's $runInfo every
+# iteration.
+.saemPhi0Newuoa <- function(par, fn, maxfun, rhobeg, rhoend, npt) {
+  suppressWarnings(
+    .newuoa(par = par, fn = fn,
+            control = list(maxfun = maxfun, rhobeg = rhobeg,
+                           rhoend = rhoend, npt = npt)))
+}
+
 .saemCheckCfg <- function(cfg) {
   checkmate::assertIntegerish(cfg$itmax, lower=1, len=1, .var.name="saem.cfg$itmax")
   checkmate::assertNumeric(cfg$tol, lower=0, len=1, .var.name="saem.cfg$tol")
@@ -267,6 +279,17 @@
     # estimated by the bounded direct optimizer (bounds from phi0Lower/Upper)
     # for normal models too, not just general-likelihood.
     .cfg$nonMuThetaRegress <- as.integer(identical(.cfg$nonMuTheta, "regress"))
+    # cost controls for that refinement; it re-solves the ODE per objective
+    # evaluation, so it is the dominant per-iteration cost for a model whose
+    # non-mu thetas are structural
+    .cfg$nonMuThetaOptType <- as.integer(match(
+      rxode2::rxGetControl(ui, "nonMuThetaOpt", "newuoa"),
+      c("optimize", "nelderMead", "newuoa"), nomatch = 1L) - 1L)
+    .cfg$nonMuThetaSweeps <- as.integer(rxode2::rxGetControl(ui, "nonMuThetaSweeps", 2L))
+    .cfg$nonMuThetaMaxEval <- as.integer(rxode2::rxGetControl(ui, "nonMuThetaMaxEval", 25L))
+    .cfg$nonMuThetaTol <- as.numeric(rxode2::rxGetControl(ui, "nonMuThetaTol",
+                                                          .Machine$double.eps^0.25))
+    .cfg$nonMuThetaEvery <- as.integer(rxode2::rxGetControl(ui, "nonMuThetaEvery", 1L))
     # warm-start residual params from observed per-endpoint moments (npag-style)
     .cfg$residWarmStart <- as.integer(rxode2::rxGetControl(ui, "residWarmStart", TRUE))
     # mixProbMethod="regress": fix per-subject mixture membership (hard classify

--- a/R/saemControl.R
+++ b/R/saemControl.R
@@ -271,6 +271,33 @@
 #'   * `"eta"`: the historic SAEM treatment (the parameter is carried through
 #'     the stochastic `phi0` block).
 #'
+#' @param nonMuThetaOpt Optimizer for the `nonMuTheta="regress"` refinement.
+#'   `"newuoa"` (default) and `"nelderMead"` each run one clamped multivariate
+#'   optimization over all free `phi0` coordinates under the `nonMuThetaMaxEval`
+#'   evaluation budget; `"optimize"` is the historic coordinate descent with R's
+#'   golden-section `optimize()`.  When the non-mu thetas drive the ODE, every
+#'   objective evaluation is a full re-solve, so this refinement can dominate the
+#'   run time; the multivariate options spend a much smaller fixed budget and
+#'   account for the coupling between coordinates that coordinate descent cannot
+#'   see.
+#'
+#' @param nonMuThetaSweeps Number of coordinate-descent sweeps per refinement
+#'   for `nonMuThetaOpt="optimize"` (default 2).
+#'
+#' @param nonMuThetaMaxEval Objective-evaluation budget of one refinement for
+#'   `nonMuThetaOpt="newuoa"` or `"nelderMead"` (default 25); 0 means ten
+#'   evaluations per free non-mu theta instead.  `"newuoa"` needs `2n+3`
+#'   evaluations to build its first quadratic model, and is raised to that when
+#'   the budget is smaller.
+#'
+#' @param nonMuThetaTol Convergence tolerance of the `nonMuTheta="regress"`
+#'   refinement (`newuoa`'s `rhoend`, the nelder-mead relative objective
+#'   tolerance, or the `optimize()` `tol`).
+#'
+#' @param nonMuThetaEvery Run the `nonMuTheta="regress"` refinement every
+#'   `nonMuThetaEvery` iterations instead of every iteration (default 1).  In
+#'   between, `phi0` keeps its last refined value.
+#'
 #' @param residWarmStart Boolean (default `TRUE`); warm-start the residual-error
 #'   parameters from the observed per-endpoint moments at the initial predictions
 #'   (additive SD from `sqrt(mean(err^2))`, proportional SD from
@@ -344,6 +371,11 @@ saemControl <- function(seed = 99,
                         mixProbPriorN = 20,
                         mixSampleMethod = c("parallel", "msaem"),
                         nonMuTheta = c("regress", "eta"),
+                        nonMuThetaOpt = c("newuoa", "optimize", "nelderMead"),
+                        nonMuThetaSweeps = 2L,
+                        nonMuThetaMaxEval = 25L,
+                        nonMuThetaTol = .Machine$double.eps^0.25,
+                        nonMuThetaEvery = 1L,
                         residWarmStart = TRUE,
                         censOption = c("gauss", "laplace"),
                         ...) {
@@ -417,6 +449,11 @@ saemControl <- function(seed = 99,
   checkmate::assertNumeric(mixProbPriorN, any.missing=FALSE, len=1, lower=0, finite=TRUE)
   mixSampleMethod <- match.arg(mixSampleMethod)
   nonMuTheta <- match.arg(nonMuTheta)
+  nonMuThetaOpt <- match.arg(nonMuThetaOpt)
+  checkmate::assertIntegerish(nonMuThetaSweeps, any.missing=FALSE, len=1, lower=1)
+  checkmate::assertIntegerish(nonMuThetaMaxEval, any.missing=FALSE, len=1, lower=0)
+  checkmate::assertNumeric(nonMuThetaTol, any.missing=FALSE, len=1, lower=0, finite=TRUE)
+  checkmate::assertIntegerish(nonMuThetaEvery, any.missing=FALSE, len=1, lower=1)
   checkmate::assertLogical(residWarmStart, any.missing=FALSE, len=1)
 
 
@@ -537,6 +574,11 @@ saemControl <- function(seed = 99,
     mixProbPriorN=mixProbPriorN,
     mixSampleMethod=mixSampleMethod,
     nonMuTheta=nonMuTheta,
+    nonMuThetaOpt=nonMuThetaOpt,
+    nonMuThetaSweeps=as.integer(nonMuThetaSweeps),
+    nonMuThetaMaxEval=as.integer(nonMuThetaMaxEval),
+    nonMuThetaTol=nonMuThetaTol,
+    nonMuThetaEvery=as.integer(nonMuThetaEvery),
     residWarmStart=residWarmStart
   )
   class(.ret) <- "saemControl"

--- a/man/saemControl.Rd
+++ b/man/saemControl.Rd
@@ -54,6 +54,11 @@ saemControl(
   mixProbPriorN = 20,
   mixSampleMethod = c("parallel", "msaem"),
   nonMuTheta = c("regress", "eta"),
+  nonMuThetaOpt = c("newuoa", "optimize", "nelderMead"),
+  nonMuThetaSweeps = 2L,
+  nonMuThetaMaxEval = 25L,
+  nonMuThetaTol = .Machine$double.eps^0.25,
+  nonMuThetaEvery = 1L,
   residWarmStart = TRUE,
   censOption = c("gauss", "laplace"),
   ...
@@ -432,6 +437,33 @@ the estimate more and need more `nBurn`/`nEm`. Default 20.}
 
   * `"eta"`: the historic SAEM treatment (the parameter is carried through
     the stochastic `phi0` block).}
+
+\item{nonMuThetaOpt}{Optimizer for the `nonMuTheta="regress"` refinement.
+`"newuoa"` (default) and `"nelderMead"` each run one clamped multivariate
+optimization over all free `phi0` coordinates under the `nonMuThetaMaxEval`
+evaluation budget; `"optimize"` is the historic coordinate descent with R's
+golden-section `optimize()`.  When the non-mu thetas drive the ODE, every
+objective evaluation is a full re-solve, so this refinement can dominate the
+run time; the multivariate options spend a much smaller fixed budget and
+account for the coupling between coordinates that coordinate descent cannot
+see.}
+
+\item{nonMuThetaSweeps}{Number of coordinate-descent sweeps per refinement
+for `nonMuThetaOpt="optimize"` (default 2).}
+
+\item{nonMuThetaMaxEval}{Objective-evaluation budget of one refinement for
+`nonMuThetaOpt="newuoa"` or `"nelderMead"` (default 25); 0 means ten
+evaluations per free non-mu theta instead.  `"newuoa"` needs `2n+3`
+evaluations to build its first quadratic model, and is raised to that when
+the budget is smaller.}
+
+\item{nonMuThetaTol}{Convergence tolerance of the `nonMuTheta="regress"`
+refinement (`newuoa`'s `rhoend`, the nelder-mead relative objective
+tolerance, or the `optimize()` `tol`).}
+
+\item{nonMuThetaEvery}{Run the `nonMuTheta="regress"` refinement every
+`nonMuThetaEvery` iterations instead of every iteration (default 1).  In
+between, `phi0` keeps its last refined value.}
 
 \item{residWarmStart}{Boolean (default `TRUE`); warm-start the residual-error
 parameters from the observed per-endpoint moments at the initial predictions

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -565,6 +565,19 @@ static int gPhi0Coord = 0;
 static arma::vec gPhi0Full;
 static std::vector<int> gPhi0FreeIx;
 static double gPhi0Obj1DR(double x);
+// Shared state for the multivariate phi0 refinements (nelder-mead and newuoa).
+// Both are unbounded, so the objective clamps each candidate into the trust
+// region before evaluating it, and both need their evaluation budget enforced
+// here: nelder_fn's itmax counts IMPROVING iterations rather than evaluations,
+// and newuoa's own maxfun stop still returns whatever point it was holding.  The
+// objective therefore tracks the best point it actually saw, and the caller
+// takes that rather than whatever the optimizer reports.
+static arma::vec gPhi0Lo, gPhi0Hi, gPhi0RefBest;
+static int gPhi0RefEvalMax = 0, gPhi0RefEvalN = 0;
+static double gPhi0RefBestF = 0.0;
+static double gPhi0RefObj(const double *p);
+static void gPhi0NmFn(double *p, double *fx);
+static double gPhi0RefObjR(Rcpp::NumericVector p);
 
 // Fill an armadillo mat/vec from rxode2's threefry engine (the current seeded
 // stream).  Used for the MCMC proposals; the saem ODE solve does not draw from
@@ -894,25 +907,87 @@ public:
     if (localTrust) {
       // Normal-model phi0 objective is extremely ill-conditioned (a tiny
       // proportional-error SD makes it change by orders of magnitude over a
-      // small phi0 step), which breaks bobyqa's quadratic model.  Use robust
-      // coordinate descent with R's golden-section optimize() (no quadratic
-      // model), a few sweeps, within the local trust bounds.
+      // small phi0 step), which breaks bobyqa's quadratic model.  Two
+      // derivative-free options within the local trust bounds:
+      //   nonMuThetaOpt="optimize"   -- coordinate descent with R's golden-section
+      //     optimize(); exact per coordinate but costs sweeps*nphi0*~20 objective
+      //     evaluations, each a full ODE re-solve when phi0 drives the model.
+      //   nonMuThetaOpt="nelderMead" -- one clamped nelder-mead over all free
+      //     coordinates; a fixed, much smaller budget, and it sees the coupling
+      //     between coordinates that coordinate descent cannot.
+      //   nonMuThetaOpt="newuoa"     -- the same, with newuoa's quadratic model
+      //     built from those evaluations instead of a simplex.
+      // Both spend at most nonMuThetaMaxEval objective evaluations (enforced by
+      // gPhi0RefObj) and both are clamped into the trust region.
       gPhi0Self = this;
       gPhi0Work.set_size(nphi0);
       for (int c = 0; c < nphi0; c++) gPhi0Work[c] = par0[c];
-      Rcpp::Environment stats = Rcpp::Environment::namespace_env("stats");
-      Rcpp::Function optimize = stats["optimize"];
-      Rcpp::InternalFunction fn1d(&gPhi0Obj1DR);
-      for (int sweep = 0; sweep < 2; sweep++) {
-        for (int c = 0; c < nphi0; c++) {
-          if (phi0Fix[(size_t)c]) continue;
-          if (!(hi[c] > lo[c])) continue;
-          gPhi0Coord = c;
-          Rcpp::List o = optimize(Rcpp::_["f"] = fn1d,
-                                  Rcpp::_["lower"] = lo[c],
-                                  Rcpp::_["upper"] = hi[c]);
-          double xm = Rcpp::as<double>(o["minimum"]);
-          gPhi0Work[c] = xm;
+      int nFree = (int)gPhi0FreeIx.size();
+      if (nonMuThetaOptType > 0 && nFree > 1) {
+        gPhi0Lo.set_size(nphi0);
+        gPhi0Hi.set_size(nphi0);
+        for (int c = 0; c < nphi0; c++) { gPhi0Lo(c) = lo[c]; gPhi0Hi(c) = hi[c]; }
+        gPhi0RefBest.set_size(nFree);
+        gPhi0RefEvalN = 0;
+        gPhi0RefBestF = 0.0;
+        gPhi0RefEvalMax = (nonMuThetaMaxEval > 0) ? nonMuThetaMaxEval : 10*nFree;
+        if (nonMuThetaOptType == 1) {
+          std::vector<double> st((size_t)nFree), stp((size_t)nFree), xm((size_t)nFree);
+          for (int fi = 0; fi < nFree; fi++) {
+            int c = gPhi0FreeIx[(size_t)fi];
+            st[(size_t)fi] = par0[c];
+            xm[(size_t)fi] = par0[c];
+            double span = hi[c] - lo[c];
+            stp[(size_t)fi] = (R_finite(span) && span > 0.0) ? 0.1*span : 0.1;
+          }
+          int iconv, it, nfcall, iprint = 0;
+          double ynewlo;
+          // itmax is deliberately generous; gPhi0RefObj owns the real budget
+          nelder_fn(gPhi0NmFn, nFree, st.data(), stp.data(), 100*nFree,
+                    nonMuThetaTol, 1.0, 2.0, 0.5,
+                    &iconv, &it, &nfcall, &ynewlo, xm.data(), &iprint);
+        } else {
+          // newuoa needs npt = 2n+1 interpolation points before it can move, so
+          // a budget below that leaves it no working evaluations at all.
+          int npt = 2*nFree + 1;
+          if (gPhi0RefEvalMax < npt + 2) gPhi0RefEvalMax = npt + 2;
+          Rcpp::Environment nlmixr2 = Rcpp::Environment::namespace_env("nlmixr2est");
+          Rcpp::Function phi0Newuoa = nlmixr2[".saemPhi0Newuoa"];
+          Rcpp::InternalFunction fnRef(&gPhi0RefObjR);
+          Rcpp::NumericVector parFree(nFree);
+          double rhobeg = R_PosInf;
+          for (int fi = 0; fi < nFree; fi++) {
+            int c = gPhi0FreeIx[(size_t)fi];
+            parFree[fi] = par0[c];
+            double span = hi[c] - lo[c];
+            if (R_finite(span) && span > 0.0 && 0.2*span < rhobeg) rhobeg = 0.2*span;
+          }
+          if (!R_finite(rhobeg) || rhobeg <= 0.0) rhobeg = 0.2;
+          phi0Newuoa(Rcpp::_["par"] = parFree, Rcpp::_["fn"] = fnRef,
+                     Rcpp::_["maxfun"] = gPhi0RefEvalMax,
+                     Rcpp::_["rhobeg"] = rhobeg,
+                     Rcpp::_["rhoend"] = nonMuThetaTol,
+                     Rcpp::_["npt"] = npt);
+        }
+        for (int fi = 0; fi < nFree; fi++) {
+          gPhi0Work[gPhi0FreeIx[(size_t)fi]] = gPhi0RefBest(fi);
+        }
+      } else {
+        Rcpp::Environment stats = Rcpp::Environment::namespace_env("stats");
+        Rcpp::Function optimize = stats["optimize"];
+        Rcpp::InternalFunction fn1d(&gPhi0Obj1DR);
+        for (int sweep = 0; sweep < nonMuThetaSweeps; sweep++) {
+          for (int c = 0; c < nphi0; c++) {
+            if (phi0Fix[(size_t)c]) continue;
+            if (!(hi[c] > lo[c])) continue;
+            gPhi0Coord = c;
+            Rcpp::List o = optimize(Rcpp::_["f"] = fn1d,
+                                    Rcpp::_["lower"] = lo[c],
+                                    Rcpp::_["upper"] = hi[c],
+                                    Rcpp::_["tol"] = nonMuThetaTol);
+            double xm = Rcpp::as<double>(o["minimum"]);
+            gPhi0Work[c] = xm;
+          }
         }
       }
       for (int c = 0; c < nphi0; c++) xmin[c] = gPhi0Work[c];
@@ -943,7 +1018,22 @@ public:
       double cur = mprior_phi0(0, c);
       mprior_phi0.col(c).fill(cur + pas(kiter) * (xmin[c] - cur));
     }
-    MCOV0 = solve(COV0.t() * COV0, COV0.t() * mprior_phi0);
+    // MCOV0 is BLOCK structured by LCOV0 -- each lambda row belongs to exactly one
+    // phi0 column -- so a single least-squares against all of COV0 is rank
+    // deficient whenever nphi0 > 1: with no phi0 covariate every column of COV0 is
+    // the same intercept column, and arma warns "solve(): system is singular"
+    // every iteration from niter_phi0 on.  It also fills MCOV0 off-structure, so a
+    // FIXED phi0 no longer reproduces its value through COV0*MCOV0.  Back-solve
+    // each phi0 column against only its own design columns instead.
+    for (int c = 0; c < nphi0; c++) {
+      uvec li = arma::find(LCOV0.col(c) == 1);
+      if (li.n_elem == 0) continue;
+      mat Xc = COV0.cols(li);
+      vec bc;
+      if (arma::solve(bc, Xc.t() * Xc, Xc.t() * mprior_phi0.col(c))) {
+        for (unsigned int j = 0; j < li.n_elem; ++j) MCOV0(li(j), c) = bc(j);
+      }
+    }
     if (fixedIx0.n_elem > 0) MCOV0(jcov0(fixedIx0)) = mcov0Fixed;
   }
 
@@ -1460,6 +1550,17 @@ public:
     distribution=as<int>(x["distribution"]);
     nonMuThetaRegress = x.containsElementNamed("nonMuThetaRegress") ?
       as<int>(x["nonMuThetaRegress"]) : 0;
+    nonMuThetaOptType = x.containsElementNamed("nonMuThetaOptType") ?
+      as<int>(x["nonMuThetaOptType"]) : 0;
+    nonMuThetaMaxEval = x.containsElementNamed("nonMuThetaMaxEval") ?
+      as<int>(x["nonMuThetaMaxEval"]) : 25;
+    nonMuThetaSweeps = x.containsElementNamed("nonMuThetaSweeps") ?
+      as<int>(x["nonMuThetaSweeps"]) : 2;
+    nonMuThetaEvery = x.containsElementNamed("nonMuThetaEvery") ?
+      as<int>(x["nonMuThetaEvery"]) : 1;
+    if (nonMuThetaEvery < 1) nonMuThetaEvery = 1;
+    nonMuThetaTol = x.containsElementNamed("nonMuThetaTol") ?
+      as<double>(x["nonMuThetaTol"]) : 1.0e-4;
     residWarmStart = x.containsElementNamed("residWarmStart") ?
       as<int>(x["residWarmStart"]) : 1;
     mixProbRegress = x.containsElementNamed("mixProbRegress") ?
@@ -2502,8 +2603,12 @@ public:
       // (distribution==4) and, via nonMuTheta="regress", for normal models --
       // keeping non-mu thetas as directly-optimized, bound-respecting regressors
       // instead of stochastic phi0 draws.
+      // nonMuThetaEvery>1 refines only every k-th iteration; mprior_phi0 holds its
+      // last refined value in between (the SA step pas(kiter) moves it a fraction
+      // of one optimizer step anyway, so refining every iteration buys little).
       if ((distribution == 4 || nonMuThetaRegress) &&
-          nphi0 > 0 && kiter >= (unsigned int)niter_phi0) {
+          nphi0 > 0 && kiter >= (unsigned int)niter_phi0 &&
+          (kiter - (unsigned int)niter_phi0) % (unsigned int)nonMuThetaEvery == 0) {
         refinePhi0Lik(kiter, pas);
       }
       mprior_phi0.set_size(N, nphi0);                              // deal w/ nphi0=0
@@ -3534,6 +3639,19 @@ private:
   // with directly-optimized, bound-respecting values (no shrinking phi0
   // variance).  0 = classic phi0, 1 = direct-optimize.
   int nonMuThetaRegress;
+  // Cost controls for that refinement (it is the dominant per-iteration cost when
+  // the phi0 thetas drive the ODE): nonMuThetaOptType picks the optimizer
+  // (0 = coordinate descent, 1 = nelder-mead, 2 = newuoa -- the latter two over
+  // all free coordinates at once), nonMuThetaMaxEval is their objective-
+  // evaluation budget (0 means 10 per free coordinate), nonMuThetaSweeps the
+  // coordinate-descent sweep count,
+  // nonMuThetaTol the inner convergence tolerance and nonMuThetaEvery how often
+  // (in iterations) the refinement runs at all.
+  int nonMuThetaOptType;
+  int nonMuThetaMaxEval;
+  int nonMuThetaSweeps;
+  int nonMuThetaEvery;
+  double nonMuThetaTol;
   // Cached: does any phi0 param change the structural prediction f?  -1 unknown,
   // 0 no (residual/likelihood only -> freeze the ODE during the phi0 opt like
   // npag), 1 yes (structural, e.g. ka/V -> keep the ODE live).
@@ -4093,6 +4211,36 @@ static double gPhi0ObjR(Rcpp::NumericVector p) {
 static double gPhi0Obj1DR(double x) {
   gPhi0Work[gPhi0Coord] = x;
   return gPhi0Self->phi0Objective(gPhi0Work.memptr());
+}
+
+static double gPhi0RefObj(const double *p) {
+  if (gPhi0RefEvalN >= gPhi0RefEvalMax) {
+    // Out of budget: report a value worse than anything seen so the optimizer
+    // collapses onto the best point instead of wandering.
+    return gPhi0RefBestF + 1.0e10;
+  }
+  for (size_t i = 0; i < gPhi0FreeIx.size(); ++i) {
+    int c = gPhi0FreeIx[i];
+    double v = p[i];
+    if (v < gPhi0Lo(c)) v = gPhi0Lo(c);
+    if (v > gPhi0Hi(c)) v = gPhi0Hi(c);
+    gPhi0Work[c] = v;
+  }
+  double f = gPhi0Self->phi0Objective(gPhi0Work.memptr());
+  gPhi0RefEvalN++;
+  if (gPhi0RefEvalN == 1 || f < gPhi0RefBestF) {
+    gPhi0RefBestF = f;
+    for (size_t i = 0; i < gPhi0FreeIx.size(); ++i) {
+      gPhi0RefBest(i) = gPhi0Work[gPhi0FreeIx[i]];
+    }
+  }
+  return f;
+}
+
+static void gPhi0NmFn(double *p, double *fx) { *fx = gPhi0RefObj(p); }
+
+static double gPhi0RefObjR(Rcpp::NumericVector p) {
+  return gPhi0RefObj(&(p[0]));
 }
 
 

--- a/tests/testthat/test-saem-nonmutheta.R
+++ b/tests/testthat/test-saem-nonmutheta.R
@@ -65,3 +65,89 @@ test_that("saemControl(nonMuTheta='regress') recovers no-eta thetas and engages 
   expect_lte(abs(.eReg[["tka"]] - .truth[["tka"]]),
              abs(.eEta[["tka"]] - .truth[["tka"]]) + 0.05)
 })
+
+test_that("the non-mu theta refinement back-solve is per phi0 column (no singular solve)", {
+  skip_on_cran()
+
+  # Two thetas with no eta (tka, tv) make nphi0 = 2.  With no phi0 covariate
+  # every column of COV0 is the same intercept column, so a back-solve against
+  # all of COV0 at once is exactly rank deficient and armadillo printed
+  # "solve(): system is singular" on every iteration from niter_phi0 on.
+  .mod <- function() {
+    ini({
+      tka <- log(1.57)
+      tcl <- log(2.72)
+      tv  <- log(31.5)
+      eta.cl ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl)
+      v  <- exp(tv)
+      d/dt(depot)  <- -ka * depot
+      d/dt(center) <-  ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  # niter_phi0 is half of nBurn+nEm, so this runs 10 refined iterations.
+  .msg <- capture.output(
+    .fit <- suppressWarnings(
+      nlmixr2(.mod, nlmixr2data::theo_sd, est = "saem",
+              control = saemControl(nBurn = 10, nEm = 10, print = 0,
+                                    calcTables = FALSE, covMethod = ""))),
+    type = "message")
+
+  expect_false(any(grepl("singular", .msg, fixed = TRUE)))
+  expect_true(all(is.finite(fixef(.fit))))
+})
+
+test_that("the multivariate nonMuThetaOpt= optimizers refine the non-mu thetas", {
+  skip_on_cran()
+
+  .mod <- function() {
+    ini({
+      tka <- log(1.57)
+      tcl <- log(2.72)
+      tv  <- log(31.5)
+      eta.cl ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl)
+      v  <- exp(tv)
+      d/dt(depot)  <- -ka * depot
+      d/dt(center) <-  ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  .ctl <- function(...) {
+    saemControl(nBurn = 100, nEm = 100, print = 0, calcTables = FALSE,
+                covMethod = "", seed = 1042, ...)
+  }
+  .fitNm  <- suppressWarnings(nlmixr2(.mod, nlmixr2data::theo_sd, est = "saem",
+                                      control = .ctl(nonMuThetaOpt = "nelderMead")))
+  .fitNu  <- suppressWarnings(nlmixr2(.mod, nlmixr2data::theo_sd, est = "saem",
+                                      control = .ctl(nonMuThetaOpt = "newuoa")))
+  .fitOpt <- suppressWarnings(nlmixr2(.mod, nlmixr2data::theo_sd, est = "saem",
+                                      control = .ctl(nonMuThetaOpt = "optimize")))
+  .fitEta <- suppressWarnings(nlmixr2(.mod, nlmixr2data::theo_sd, est = "saem",
+                                      control = .ctl(nonMuTheta = "eta")))
+
+  for (.f in list(.fitNm, .fitNu)) {
+    expect_true(all(is.finite(fixef(.f))))
+    # each is a different optimizer, so it must not reproduce the unrefined phi0
+    # path bit-for-bit -- that would mean the refinement never ran
+    expect_false(isTRUE(all.equal(fixef(.f), fixef(.fitEta), tolerance = 1e-8)))
+    # but it refines to the same place as the coordinate-descent default
+    expect_equal(fixef(.f)[["tka"]], fixef(.fitOpt)[["tka"]], tolerance = 0.1)
+    expect_equal(fixef(.f)[["tv"]],  fixef(.fitOpt)[["tv"]],  tolerance = 0.1)
+  }
+  # nelder-mead and newuoa are distinct optimizers under the same budget
+  expect_false(isTRUE(all.equal(fixef(.fitNm), fixef(.fitNu), tolerance = 1e-8)))
+})


### PR DESCRIPTION
Both problems live in `refinePhi0Lik` (`src/saem.cpp`), the `nonMuTheta="regress"` refinement that estimates population thetas carrying no random effect. Found while investigating the nimotuzumab and mavoglurant PBPK vignettes, which run slowly and emit a constant stream of singular-solve warnings after ~250 iterations.

## The warning

The refinement wrote its result back with a single least-squares against the whole `phi0` design:

```cpp
MCOV0 = solve(COV0.t() * COV0, COV0.t() * mprior_phi0);
```

`COV0` is block structured -- each coefficient belongs to exactly one `phi0` theta -- and with no `phi0` covariate every one of its columns is the same intercept column. So with more than one non-mu theta the normal equations are exactly rank deficient, and armadillo printed

```
warning: solve(): system is singular; attempting approx solution
```

every iteration from `niter_phi0 = round(niter/2)` on -- iteration 250 of the default 500, which is exactly where the vignettes start complaining. Both models have five non-mu thetas.

The back-solve is now done per `phi0` theta against its own design columns. The rank-deficient solution also filled `MCOV0` off-structure, which is why a `fix()`ed non-mu theta of a general log-likelihood model stopped reproducing its fixed value; that is fixed with it. Otherwise estimates are bit-identical -- verified on a nimotuzumab fit before and after.

## The cost

Same function. It runs every iteration of the second half of the fit, and when the non-mu thetas are structural (they drive the ODE) each objective evaluation is a full re-solve of every subject and chain. The coordinate descent spent `sweeps * nphi0 * ~20` of them per iteration -- around 60% of total run time on both models, and it was solving the inner problem far more precisely than a stochastic-approximation step that then moves a fraction of the way there can use.

`saemControl()` gains `nonMuThetaOpt=`, `nonMuThetaSweeps=`, `nonMuThetaMaxEval=`, `nonMuThetaTol=` and `nonMuThetaEvery=`. `nonMuThetaOpt="newuoa"` (new default) and `"nelderMead"` run one clamped multivariate optimization over all free `phi0` coordinates under a fixed evaluation budget, and see the coupling between those coordinates that coordinate descent cannot. Neither optimizer's own stopping rule bounds evaluations usefully -- `nelder_fn`'s `itmax` counts improving iterations, and newuoa's `maxfun` returns whatever point it was holding -- so the objective enforces the budget and tracks the best point it actually saw, and the caller takes that rather than what the optimizer reports.

## Changed default

`nonMuThetaOpt="newuoa"`, `nonMuThetaMaxEval=25`. **Fits of models with a non-mu theta will report slightly different estimates.** `saemControl(nonMuThetaOpt="optimize")` restores the previous behavior exactly.

Measured by the FOCEi conditional objective at each run's converged estimates (200 burn / 300 EM, all configs under equal machine load; lower is better):

| model | old default | new default | speedup | objective |
|---|---|---|---|---|
| nimotuzumab (TMDD) | 1263 s | 809 s | 1.6x | 143.53 vs 143.48 -- indistinguishable |
| mavoglurant (PBPK) | 2110 s | 1102 s | 1.9x | 1977.0 vs 2055.8 -- clearly better |

The PBPK gain is not only speed: the old default settles into an `add.err` ~ 12.3 basin while the cheaper refinement finds ~ 3.5 and a 79-point better objective. A wider sweep (Nelder-Mead and newuoa at 25/50/100 evaluations, `nonMuThetaEvery=5`, and `nonMuTheta="eta"` with the refinement off entirely) is what picked this point; newuoa was at least as good as the old default on both models at every budget tried.

## Tests

Added to `tests/testthat/test-saem-nonmutheta.R`:

- a regression test that captures the message stream of a fit with two non-mu thetas run past `niter_phi0` and asserts no singular-solve message; and
- a test that each multivariate optimizer actually refines (its estimates differ from the unrefined `phi0` path) and lands where the coordinate-descent default does.

133 assertions across 9 saem/control test files pass under the new defaults. The shipping default was separately confirmed to take the newuoa path by counting `stats::optimize` calls, which is reachable only from the coordinate-descent branch: 0 under the default, 200 under `nonMuThetaOpt="optimize"`.

Note the fixtures under `tests/testthat/fixtures/` will regenerate -- the cache keys on a hash of `R/` + `src/`, and the default change moves the numbers anyway. Warm the cache with one serial run before going parallel.
