### PR TITLE
focei: emit linCmtB(which1=-3) for a modeled alag()/f() on a linCmt() compartment (#920)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,17 @@
   ecosystem, so rxode2 can now drop it (nlmixr2/rxode2#1250).
 ## New features
 
+- A modeled `alag()` or `f()` on a `linCmt()` compartment now gets an exact
+  FOCEi/FOCE eta gradient instead of a silently incomplete one.  The
+  structural `linCmt()` Jacobian only covers `p1`/`v1`/`ka`/...; the
+  moving-boundary (dose-time) contribution of a modeled `alag()` is now added
+  via rxode2's `linCmtB(which1=-3)` (nlmixr2/rxode2#1235), and the
+  bioavailability contribution via the exact `d(pred)/dF = pred/F` identity
+  (issue #920).  A model with more than one lagged `linCmt()` compartment is
+  left as before (rxode2/rxode2#1237 -- `which1=-3` is a single shared
+  delay), and `foceiControl(eventSens="fd")` opts back out for a model that
+  infuses a dose into the lagged/scaled compartment (rxode2/rxode2#1236).
+
 - A prior distribution given in the `ini({})` block is no longer silently
   ignored.  `nlmixr2Est()` now refuses any prior the estimation method
   cannot use before dispatching, so a model carrying one fails with an

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,10 +21,16 @@
   moving-boundary (dose-time) contribution of a modeled `alag()` is now added
   via rxode2's `linCmtB(which1=-3)` (nlmixr2/rxode2#1235), and the
   bioavailability contribution via the exact `d(pred)/dF = pred/F` identity
-  (issue #920).  A model with more than one lagged `linCmt()` compartment is
-  left as before (rxode2/rxode2#1237 -- `which1=-3` is a single shared
-  delay), and `foceiControl(eventSens="fd")` opts back out for a model that
-  infuses a dose into the lagged/scaled compartment (rxode2/rxode2#1236).
+  (issue #920).
+
+  Both corrections require every dose reaching the linear system to share the
+  same `alag()`/`f()` (rxode2/rxode2#1237); a model declaring more than one
+  is left as before.  This cannot be checked for a regimen that doses an
+  *unlagged/unscaled* compartment alongside the lagged/scaled one (a common
+  design for estimating `f()` from paired IV+oral data) -- that combination
+  returns a biased, not obviously wrong, gradient.  An infused dose into the
+  lagged/scaled compartment also cannot be checked, and returns `NA`
+  (rxode2/rxode2#1236).  `foceiControl(eventSens="fd")` opts out of both.
 
 - A prior distribution given in the `ini({})` block is no longer silently
   ignored.  `nlmixr2Est()` now refuses any prior the estimation method

--- a/R/focei.R
+++ b/R/focei.R
@@ -807,9 +807,22 @@ rxUiGet.foceiHdEta <- function(x, ...) {
   })
   .any.zero <- FALSE
   .all.zero <- TRUE
+  # linCmt() alag()/f() moving-boundary correction (#920): computed once, then
+  # folded into each row's assigned value BELOW the zero-check so a model
+  # whose ETA drives ONLY the lag/F (no structural p1/v1/ka/... dependency)
+  # is not misreported as "does not depend on ETA".
+  .linCmtEtaVars <- paste0("ETA_", seq_len(.s$..maxEta), "_")
+  .linCmtExtraPred <- .rxFoceiLinCmtEventPredExtra(x, .s, .linCmtEtaVars)
   .ret <- apply(.grd, 1, function(x) {
     .l <- x["calc"]
     .l <- eval(parse(text = .l))
+    if (!is.null(.linCmtExtraPred)) {
+      .p <- sub("^.*_BY_(ETA_[0-9]+)___$", "\\1_", x["dfe"])
+      if (!is.null(.linCmtExtraPred[[.p]])) {
+        .l <- .l + .linCmtExtraPred[[.p]]
+        assign(x["dfe"], .l, envir = .s)
+      }
+    }
     .ret <- paste0(x["dfe"], "=", rxode2::rxFromSE(.l))
     .zErr <- suppressWarnings(try(as.numeric(get(x["dfe"], .s)), silent = TRUE))
     if (identical(.zErr, 0)) {
@@ -838,6 +851,8 @@ rxUiGet.foceiHdEta <- function(x, ...) {
     .ret <- paste0(.ret, .arCorr)
   }
   .s$..HdEta <- .ret
+  .s$..linCmtEtaVars <- .linCmtEtaVars
+  .s$..linCmtExtraPred <- .linCmtExtraPred
   .s$..pred.minus.dv <- .predMinusDv
   rxode2::rxProgressStop()
   .progressStopped <- TRUE
@@ -1116,6 +1131,19 @@ rxUiGet.foceiEnv <- function(x, ...) {
   } else {
     .malert("calculate d(R^2)/d(eta)")
   }
+  # linCmt() alag()/f() moving-boundary correction (#920): rx_r_ embeds
+  # rx_pred_'s linCmtB() call directly (fully substituted, not a reference to
+  # the rx_pred_ symbol), so its own d(rx_r_)/d(eta) misses the same term;
+  # chain it through via .rxFoceiLinCmtEventChain() -- computed BEFORE the
+  # apply loop below and folded into each affected row's expression so it
+  # goes through the SAME single rxFromSE() call as the base term.  rxFromSE()
+  # of a Basic holding a linCmtB() call poisons the env's next get()/[[ read
+  # (same hazard documented on .rxPastFromEnv() in rxode2's R/dde.R), so a
+  # SEPARATE rxFromSE() call after the loop (once its rxFromSE() calls have
+  # already run) errors on the poisoned env with "user function '[[' requires
+  # 0 arguments" when rendering the cached extra terms.
+  .linCmtExtraR <- .rxFoceiLinCmtEventChain(
+    get("rx_r_", envir = .s), get("rx_pred_", envir = .s), .s$..linCmtExtraPred)
   rxode2::rxProgress(dim(.grd)[1])
   on.exit({
     rxode2::rxProgressAbort()
@@ -1123,6 +1151,10 @@ rxUiGet.foceiEnv <- function(x, ...) {
   .ret <- apply(.grd, 1, function(x) {
     .l <- x["calc"]
     .l <- eval(parse(text = .l))
+    if (!is.null(.linCmtExtraR)) {
+      .p <- sub("^.*_BY_(ETA_[0-9]+)___$", "\\1_", x["dfe"])
+      if (!is.null(.linCmtExtraR[[.p]])) .l <- .l + .linCmtExtraR[[.p]]
+    }
     .ret <- paste0(x["dfe"], "=", rxode2::rxFromSE(.l))
     rxode2::rxTick()
     .ret

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -655,7 +655,9 @@
 #'   solves for these parameters.  Also gates the analytic moving-boundary
 #'   correction for a modeled `alag()`/`f()` on a `linCmt()` compartment; set
 #'   `"fd"` if that model infuses a dose into the lagged/scaled compartment
-#'   (rxode2/rxode2#1236).
+#'   (rxode2/rxode2#1236), or if the regimen also doses an *unlagged/unscaled*
+#'   compartment alongside the lagged/scaled one -- a common design for
+#'   estimating `f()` from paired IV+oral data (rxode2/rxode2#1237).
 #'
 #' @param gradProgressOfvTime This is the time for a single objective
 #'     function evaluation (in seconds) to start progress bars on gradient evaluations
@@ -768,7 +770,10 @@
 #'   uses the legacy finite-difference behavior.  Also gates the analytic
 #'   moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 #'   compartment; set `"fd"` if that model infuses a dose into the
-#'   lagged/scaled compartment (rxode2/rxode2#1236).
+#'   lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+#'   doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+#'   -- a common design for estimating `f()` from paired IV+oral data
+#'   (rxode2/rxode2#1237).
 #'
 #' @param sensMethod Method used to compute the ODE parameter sensitivities.
 #'   `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -652,7 +652,10 @@
 #'   differences.  `"jump"` (the default) uses the analytic event ("jump")
 #'   sensitivities provided by `rxode2`, which add accuracy and can speed
 #'   up the gradient/Hessian by avoiding the extra finite-difference
-#'   solves for these parameters.
+#'   solves for these parameters.  Also gates the analytic moving-boundary
+#'   correction for a modeled `alag()`/`f()` on a `linCmt()` compartment; set
+#'   `"fd"` if that model infuses a dose into the lagged/scaled compartment
+#'   (rxode2/rxode2#1236).
 #'
 #' @param gradProgressOfvTime This is the time for a single objective
 #'     function evaluation (in seconds) to start progress bars on gradient evaluations
@@ -762,7 +765,10 @@
 #' @param eventSens Controls how dosing/event-parameter (`alag`, `F`,
 #'   `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 #'   `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-#'   uses the legacy finite-difference behavior.
+#'   uses the legacy finite-difference behavior.  Also gates the analytic
+#'   moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+#'   compartment; set `"fd"` if that model infuses a dose into the
+#'   lagged/scaled compartment (rxode2/rxode2#1236).
 #'
 #' @param sensMethod Method used to compute the ODE parameter sensitivities.
 #'   `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/R/foceiLinCmtAlagSens.R
+++ b/R/foceiLinCmtAlagSens.R
@@ -31,6 +31,22 @@
 # `foceiControl(eventSens=)` -- already the documented opt-out for the
 # analogous ODE jump-sensitivity feature -- so `eventSens="fd"` is the escape
 # hatch for a model that infuses into a lagged/F'd linCmt() compartment.
+#
+# rxode2/rxode2#1237 (mixed-route dosing) -- CONFIRMED, and BROADER than "two
+# explicitly different alag()/f() declarations": per rxode2's own doc comment
+# on `linCmtB` (src/linCmt.cpp), which1=-3 "requires that EVERY dose reaching
+# the linear system carr[y] the same alag()" -- an oral depot with a modeled
+# alag() PLUS an unlagged IV bolus/infusion into central in the SAME regimen
+# is just as out of scope as two differently-lagged compartments (an unlagged
+# dose is a lag of 0, still a different delay). Confirmed by direct
+# comparison to central differences: a mixed depot+central regimen returns a
+# gradient biased by a roughly constant, nonzero amount, not NA -- worse than
+# #1236 in that it fails silently rather than loudly. `.rxFoceiLinCmtEventRows()`
+# only sees the MODEL's alag()/f() declarations, not the DATA's dosing
+# routes, so it cannot detect this case; it is the same class of build-time
+# blind spot as #1236 and shares its `eventSens="fd"` escape hatch. This
+# matters most for f() (bioavailability), which is routinely estimated from
+# exactly this kind of paired IV+oral study design.
 
 #' Discover (linCmt compartment, driving ETA/THETA, symengine expr) for a
 #' modeled alag()/f() on a linCmt() compartment
@@ -121,15 +137,19 @@
   if (length(.lin) == 0L) return(NULL)
   .lagRows <- .rxFoceiLinCmtEventRows(s, .lin, "lag", etaVars)
   .fRows <- .rxFoceiLinCmtEventRows(s, .lin, "f", etaVars)
-  # rxode2/rxode2#1237: which1=-3 is the derivative wrt ONE delay applied to
-  # every dose, not a per-compartment one -- more than one lagged linCmt()
-  # compartment (with different driving params) is out of scope; leave the
-  # existing (structural-only, still-incomplete) gradient unchanged rather
-  # than emit a call that answers a different question.
+  # rxode2/rxode2#1237: which1=-3 is the derivative wrt ONE delay shared by
+  # EVERY dose reaching the linear system, not a per-compartment one -- more
+  # than one MODELED alag() is only the detectable half of that; a regimen
+  # that also doses an unlagged compartment (a delay of 0) is the same
+  # violation and is NOT detectable here (that is data, not model,
+  # structure -- see the file banner). Skip when the model-visible half is
+  # present; leave the existing (structural-only, still-incomplete) gradient
+  # unchanged rather than emit a call that answers a different question.
   if (length(.lagRows) > 1L) .lagRows <- list()
-  # d(pred)/dF = pred/F assumes a single F-scaled compartment feeds the
-  # reported prediction; with more than one, their contributions to `pred`
-  # cannot be told apart from `pred` alone.
+  # d(pred)/dF = pred/F assumes ALL of `pred` comes from the F-scaled
+  # compartment's dose; more than one MODELED f() is the detectable half of
+  # that (same data-invisible caveat as alag() above -- an unscaled dose
+  # elsewhere in the regimen breaks the identity too).
   if (length(.fRows) > 1L) .fRows <- list()
   if (length(.lagRows) == 0L && length(.fRows) == 0L) return(NULL)
   .extra <- stats::setNames(vector("list", length(etaVars)), etaVars)

--- a/R/foceiLinCmtAlagSens.R
+++ b/R/foceiLinCmtAlagSens.R
@@ -1,0 +1,188 @@
+# A modeled alag()/f() on a linCmt() compartment moves/scales the DOSE that
+# feeds the closed-form solution -- it never appears among linCmtB()'s
+# algebraic arguments (p1/v1/ka/...), so ordinary symengine differentiation of
+# rx_pred_ (and anything built from it, e.g. rx_r_) is structurally blind to
+# it: d(rx_pred_)/d(eta_lag) comes out 0 even though the true gradient is not.
+# rxode2/rxode2#1235 added linCmtB(which1=-3) precisely for this: the
+# derivative of the linear-system solution wrt a delay applied to every dose.
+# This file adds the missing chain-rule term back into the FOCEi eta gradient
+# (rx__sens_rx_pred__BY_ETA_*___ / rx__sens_rx_r__BY_ETA_*___), issue #920.
+#
+# Bioavailability needs no new linCmtB() mode: the system is linear in dose
+# amount, so d(pred)/dF = pred/F exactly; only the dF/d(eta) chain-rule factor
+# is new.
+#
+# Scope: the ETA-driven inner-model gradient only (rxUiGet.foceiHdEta /
+# rxUiGet.foceiEnv, used by FOCEI/FOCE/EBE). A THETA that drives alag/F without
+# going through an ETA needs no correction here (it does not enter the eta
+# gradient). The combined eta+theta build (`combSens`, #958) and the fast=TRUE
+# analytic 2nd-order Hessian (`.foceiAddHdEta2`) are NOT covered -- known gap,
+# left as a follow-up; `fast=TRUE`'s analytic AUGMENTED outer gradient already
+# declines linCmt() models entirely (`foceiGradAnalytic.R`), so it is unaffected.
+#
+# rxode2/rxode2#1236 (infusions): CONFIRMED to reproduce here, not just in the
+# plain rxSolve() path the upstream issue was filed against -- a subject whose
+# regimen infuses into the lagged/F'd linCmt() compartment reads `NA` for
+# `linCmtB(which1=-3)` even when evaluated through this package's own
+# generated model (`ind_solve()`-driven `calc_lhs`, same as FOCEi uses).
+# Whether a subject's regimen contains an infusion is event-table data this
+# build-time step never sees (the compiled model is cached/reused across
+# datasets), so it cannot be gated per-subject here. Gated instead on
+# `foceiControl(eventSens=)` -- already the documented opt-out for the
+# analogous ODE jump-sensitivity feature -- so `eventSens="fd"` is the escape
+# hatch for a model that infuses into a lagged/F'd linCmt() compartment.
+
+#' Discover (linCmt compartment, driving ETA/THETA, symengine expr) for a
+#' modeled alag()/f() on a linCmt() compartment
+#'
+#' @param s FOCEi symengine env (post `.sensEtaOrTheta`/`rxUiGet.foceiEtaS`)
+#' @param lin Physical linCmt compartment names (`rxode2::.rxLinCmt()`,
+#'   sensitivity-compartment names already stripped)
+#' @param kind `"lag"` or `"f"` (the symengine symbol prefix; both `alag()` and
+#'   `lag()` land on `rx_lag_<cmt>_`, both `F()` and `f()` on `rx_f_<cmt>_`)
+#' @param etaVars ETA_i_/THETA_j_ names in gradient-column order
+#' @return named list (by compartment) of `list(sym=, drivers=)`; empty list
+#'   when the model has no such event-timing dependency
+#' @noRd
+.rxFoceiLinCmtEventRows <- function(s, lin, kind, etaVars) {
+  .rows <- list()
+  for (.st in lin) {
+    .nm <- paste0("rx_", kind, "_", .st, "_")
+    if (!exists(.nm, envir = s, inherits = FALSE)) next
+    .sym <- get(.nm, envir = s, inherits = FALSE)
+    .free <- tryCatch(vapply(symengine::free_symbols(.sym), as.character, character(1)),
+                       error = function(e) character(0))
+    .drv <- intersect(.free, etaVars)
+    if (length(.drv) == 0L) next
+    .rows[[.st]] <- list(sym = .sym, drivers = .drv)
+  }
+  .rows
+}
+
+#' Build the `linCmtB(which1=-3, ...)` moving-boundary sensitivity call from
+#' the model's own structural `rx_pred_` call
+#'
+#' Reuses every argument of the structural linCmtB() call (pointer, time,
+#' linCmt/ncmt/oral0, trans, p1..ka) so the shape always matches what
+#' `rx_pred_` already solves; only `which1`/`which2` change.  `which2`
+#' mirrors the structural encoding: `-1` (reported concentration) maps to the
+#' new mode's `-3`; an amount-in-compartment `which1` (structural `-2` case)
+#' maps to that same compartment index in the new mode's `which2` slot
+#' (rxode2/rxode2#1235's `which2 >= 0` case).
+#'
+#' @param predArgs `symengine::get_args()` of the structural `rx_pred_` call
+#' @return symengine `linCmtB()` FunctionSymbol call
+#' @noRd
+.rxFoceiLinCmtWhich3Call <- function(predArgs) {
+  .args <- predArgs
+  .origWhich1 <- .args[[6]]
+  .origWhich2 <- .args[[7]]
+  .isConc <- isTRUE(all.equal(as.numeric(.origWhich2), -1))
+  .args[[6]] <- symengine::S("-3.0")
+  .args[[7]] <- if (.isConc) symengine::S("-3.0") else .origWhich1
+  do.call(symengine::Function("linCmtB"), as.list(.args))
+}
+
+#' Extra d(rx_pred_)/d(eta) terms from a modeled alag()/f() on a linCmt()
+#' compartment (the moving-boundary contribution ordinary symengine
+#' differentiation of `rx_pred_` cannot see)
+#'
+#' Two upstream preconditions gate this: `foceiControl(eventSens="fd")` skips
+#' the correction entirely (rxode2/rxode2#1236 -- an infused dose into the
+#' lagged/F'd compartment reads `NA`; this build-time step has no per-subject
+#' event data to gate on more precisely), and more than one lagged linCmt()
+#' compartment drops the alag correction, keeping only F() if present
+#' (rxode2/rxode2#1237 -- `which1=-3` is one delay shared by every dose, not
+#' a per-compartment one).
+#'
+#' @param x list(rxUi)
+#' @param s symengine env with `rx_pred_` and (when present) `rx_lag_<cmt>_`/
+#'   `rx_f_<cmt>_` loaded
+#' @param etaVars ETA_i_/THETA_j_ names in gradient-column order
+#' @return named list, param -> symengine addition to `d(rx_pred_)/d(param)`;
+#'   `NULL` when nothing needs correcting
+#' @noRd
+.rxFoceiLinCmtEventPredExtra <- function(x, s, etaVars) {
+  .ui <- x[[1]]
+  if (rxode2::.rxLinNcmt(.ui)["numLin"] <= 0L) return(NULL)
+  # rxode2/rxode2#1236: which1=-3 reads NA for an infused dose into the
+  # lagged/F'd compartment; this build-time step has no per-subject event
+  # data to gate on, so reuse the existing analytic-vs-fd opt-out instead.
+  if (identical(rxode2::rxGetControl(.ui, "eventSens", "jump"), "fd")) return(NULL)
+  if (!exists("rx_pred_", envir = s, inherits = FALSE)) return(NULL)
+  .pred <- get("rx_pred_", envir = s, inherits = FALSE)
+  if (!identical(tryCatch(symengine::get_name(.pred), error = function(e) ""), "linCmtB")) {
+    return(NULL)
+  }
+  .predArgs <- symengine::get_args(.pred)
+  if (length(.predArgs) != 15L) return(NULL)
+  .lin <- rxode2::.rxLinCmt(.ui)
+  .lin <- grep("^rx__sens_", .lin, value = TRUE, invert = TRUE)
+  if (length(.lin) == 0L) return(NULL)
+  .lagRows <- .rxFoceiLinCmtEventRows(s, .lin, "lag", etaVars)
+  .fRows <- .rxFoceiLinCmtEventRows(s, .lin, "f", etaVars)
+  # rxode2/rxode2#1237: which1=-3 is the derivative wrt ONE delay applied to
+  # every dose, not a per-compartment one -- more than one lagged linCmt()
+  # compartment (with different driving params) is out of scope; leave the
+  # existing (structural-only, still-incomplete) gradient unchanged rather
+  # than emit a call that answers a different question.
+  if (length(.lagRows) > 1L) .lagRows <- list()
+  # d(pred)/dF = pred/F assumes a single F-scaled compartment feeds the
+  # reported prediction; with more than one, their contributions to `pred`
+  # cannot be told apart from `pred` alone.
+  if (length(.fRows) > 1L) .fRows <- list()
+  if (length(.lagRows) == 0L && length(.fRows) == 0L) return(NULL)
+  .extra <- stats::setNames(vector("list", length(etaVars)), etaVars)
+  .accum <- function(param, term) {
+    .extra[[param]] <<- if (is.null(.extra[[param]])) term else .extra[[param]] + term
+  }
+  if (length(.lagRows) == 1L) {
+    .lagCall <- .rxFoceiLinCmtWhich3Call(.predArgs)
+    .row <- .lagRows[[1]]
+    for (.p in .row$drivers) {
+      .d <- symengine::D(.row$sym, symengine::S(.p))
+      if (paste(.d) %in% c("0", "0.0")) next
+      .accum(.p, .d * .lagCall)
+    }
+  }
+  if (length(.fRows) == 1L) {
+    .row <- .fRows[[1]]
+    for (.p in .row$drivers) {
+      .d <- symengine::D(.row$sym, symengine::S(.p))
+      if (paste(.d) %in% c("0", "0.0")) next
+      .accum(.p, .d * (.pred / .row$sym))
+    }
+  }
+  .extra <- .extra[!vapply(.extra, is.null, logical(1))]
+  if (length(.extra) == 0L) return(NULL)
+  .extra
+}
+
+#' Chain the linCmt() alag/f() moving-boundary correction through a
+#' downstream quantity that embeds `rx_pred_`'s linCmtB() call (e.g. `rx_r_`)
+#'
+#' `rx_r_` is built by substituting `rx_pred_`'s full expression into its own
+#' formula (e.g. `(prop.sd*rx_pred_)^2`), so the embedded linCmtB() call is a
+#' literal subexpression, not a reference to the `rx_pred_` symbol --
+#' `D(rx_r_, rx_pred_)` is identically 0 for a symengine model built this way.
+#' `subs()` finds the structurally-identical subexpression by value, so
+#' substituting it for a placeholder symbol lets `D()` recover
+#' d(target)/d(pred); substituting the placeholder back gives the chain-rule
+#' factor entirely in terms of the model's own symbols.  A no-op (identity)
+#' when `target` IS `pred` (`rx_pred_` itself, i.e. `rxUiGet.foceiHdEta`).
+#'
+#' @param target symengine expression that may embed `pred`'s linCmtB() call
+#' @param pred `rx_pred_` symengine expression (the embedded call to find)
+#' @param extraPred named list from `.rxFoceiLinCmtEventPredExtra()`
+#' @return named list, param -> d(target)/d(param) addition (nonzero entries
+#'   only); `NULL` when `target` does not depend on `pred` at all
+#' @noRd
+.rxFoceiLinCmtEventChain <- function(target, pred, extraPred) {
+  if (is.null(extraPred) || length(extraPred) == 0L) return(NULL)
+  .ph <- symengine::S("rx__linCmtEventPh__")
+  .sub <- symengine::subs(target, pred, .ph)
+  .dTdPred <- symengine::D(.sub, .ph)
+  if (paste(.dTdPred) %in% c("0", "0.0")) return(NULL)
+  .dTdPred <- symengine::subs(.dTdPred, .ph, pred)
+  lapply(extraPred, function(.e) .dTdPred * .e)
+}

--- a/man/bobyqaControl.Rd
+++ b/man/bobyqaControl.Rd
@@ -189,7 +189,10 @@ If not specified, then it matches the significant digits in the
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{...}{Ignored parameters}
 }

--- a/man/bobyqaControl.Rd
+++ b/man/bobyqaControl.Rd
@@ -192,7 +192,10 @@ If not specified, then it matches the significant digits in the
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{...}{Ignored parameters}
 }

--- a/man/emviControl.Rd
+++ b/man/emviControl.Rd
@@ -369,7 +369,10 @@ each retry and tolerances are reset afterward.}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{rxControl}{`rxode2` ODE solving options during fitting, created with `rxControl()`}
 

--- a/man/emviControl.Rd
+++ b/man/emviControl.Rd
@@ -372,7 +372,10 @@ each retry and tolerances are reset afterward.}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{rxControl}{`rxode2` ODE solving options during fitting, created with `rxControl()`}
 

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -444,7 +444,10 @@ finite-difference Hessian that already reflects censoring exactly.}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{centralDerivEps}{Central difference tolerances (relative,
 absolute); step size \code{h = abs(x)*derivEps[1] + derivEps[2]}.}

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -441,7 +441,10 @@ finite-difference Hessian that already reflects censoring exactly.}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{centralDerivEps}{Central difference tolerances (relative,
 absolute); step size \code{h = abs(x)*derivEps[1] + derivEps[2]}.}

--- a/man/lbfgsb3cControl.Rd
+++ b/man/lbfgsb3cControl.Rd
@@ -165,7 +165,10 @@ sd, c = power exponent (1 in the proportional case).}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities.
 `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/man/lbfgsb3cControl.Rd
+++ b/man/lbfgsb3cControl.Rd
@@ -168,7 +168,10 @@ sd, c = power exponent (1 in the proportional case).}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities.
 `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/man/n1qn1Control.Rd
+++ b/man/n1qn1Control.Rd
@@ -156,7 +156,10 @@ sd, c = power exponent (1 in the proportional case).}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities.
 `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/man/n1qn1Control.Rd
+++ b/man/n1qn1Control.Rd
@@ -159,7 +159,10 @@ sd, c = power exponent (1 in the proportional case).}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities.
 `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/man/newuoaControl.Rd
+++ b/man/newuoaControl.Rd
@@ -197,7 +197,10 @@ skips the final back-transform.}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{...}{Ignored parameters}
 }

--- a/man/newuoaControl.Rd
+++ b/man/newuoaControl.Rd
@@ -200,7 +200,10 @@ skips the final back-transform.}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{...}{Ignored parameters}
 }

--- a/man/nlmControl.Rd
+++ b/man/nlmControl.Rd
@@ -154,7 +154,10 @@ finite-difference Hessian that already reflects censoring exactly.}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities.
 `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/man/nlmControl.Rd
+++ b/man/nlmControl.Rd
@@ -157,7 +157,10 @@ finite-difference Hessian that already reflects censoring exactly.}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities.
 `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/man/nlminbControl.Rd
+++ b/man/nlminbControl.Rd
@@ -224,7 +224,10 @@ sd, c = power exponent (1 in the proportional case).}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities.
 `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/man/nlminbControl.Rd
+++ b/man/nlminbControl.Rd
@@ -221,7 +221,10 @@ sd, c = power exponent (1 in the proportional case).}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities.
 `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/man/nlmixr2NlmeControl.Rd
+++ b/man/nlmixr2NlmeControl.Rd
@@ -289,7 +289,10 @@ for \code{foceiControl()} only takes effect when
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{print}{Convenience alias for the shared nlmixr `print` control.
 `nlme` prints progress through its own `verbose` option, so `print`

--- a/man/nlmixr2NlmeControl.Rd
+++ b/man/nlmixr2NlmeControl.Rd
@@ -292,7 +292,10 @@ for \code{foceiControl()} only takes effect when
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{print}{Convenience alias for the shared nlmixr `print` control.
 `nlme` prints progress through its own `verbose` option, so `print`

--- a/man/nlsControl.Rd
+++ b/man/nlsControl.Rd
@@ -275,7 +275,10 @@ sd, c = power exponent (1 in the proportional case).}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{calcTables}{This boolean is to determine if the foceiFit
 will calculate tables. By default this is \code{TRUE}}

--- a/man/nlsControl.Rd
+++ b/man/nlsControl.Rd
@@ -272,7 +272,10 @@ sd, c = power exponent (1 in the proportional case).}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{calcTables}{This boolean is to determine if the foceiFit
 will calculate tables. By default this is \code{TRUE}}

--- a/man/optimControl.Rd
+++ b/man/optimControl.Rd
@@ -252,7 +252,10 @@ sd, c = power exponent (1 in the proportional case).}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities.
 `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/man/optimControl.Rd
+++ b/man/optimControl.Rd
@@ -255,7 +255,10 @@ sd, c = power exponent (1 in the proportional case).}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{sensMethod}{Method used to compute the ODE parameter sensitivities.
 `"forward"` uses the classic variational (forward) sensitivity ODEs;

--- a/man/saemControl.Rd
+++ b/man/saemControl.Rd
@@ -354,7 +354,10 @@ skips the final back-transform.}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{mixProbMethod}{For mixture models (`mix()`, more than one
   component), stabilizes the mixing-probability estimate against

--- a/man/saemControl.Rd
+++ b/man/saemControl.Rd
@@ -357,7 +357,10 @@ skips the final back-transform.}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{mixProbMethod}{For mixture models (`mix()`, more than one
   component), stabilizes the mixing-probability estimate against

--- a/man/uobyqaControl.Rd
+++ b/man/uobyqaControl.Rd
@@ -197,7 +197,10 @@ skips the final back-transform.}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{...}{Ignored parameters}
 }

--- a/man/uobyqaControl.Rd
+++ b/man/uobyqaControl.Rd
@@ -200,7 +200,10 @@ skips the final back-transform.}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{...}{Ignored parameters}
 }

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -667,7 +667,10 @@ each retry and tolerances are reset afterward.}
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:
 `"jump"` (default) uses rxode2's analytic event sensitivities; `"fd"`
-uses the legacy finite-difference behavior.}
+uses the legacy finite-difference behavior.  Also gates the analytic
+moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
+compartment; set `"fd"` if that model infuses a dose into the
+lagged/scaled compartment (rxode2/rxode2#1236).}
 
 \item{rxControl}{`rxode2` ODE solving options during fitting, created with `rxControl()`}
 

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -670,7 +670,10 @@ each retry and tolerances are reset afterward.}
 uses the legacy finite-difference behavior.  Also gates the analytic
 moving-boundary correction for a modeled `alag()`/`f()` on a `linCmt()`
 compartment; set `"fd"` if that model infuses a dose into the
-lagged/scaled compartment (rxode2/rxode2#1236).}
+lagged/scaled compartment (rxode2/rxode2#1236), or if the regimen also
+doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
+-- a common design for estimating `f()` from paired IV+oral data
+(rxode2/rxode2#1237).}
 
 \item{rxControl}{`rxode2` ODE solving options during fitting, created with `rxControl()`}
 

--- a/tests/testthat/test-focei-lincmt-alag-sens.R
+++ b/tests/testthat/test-focei-lincmt-alag-sens.R
@@ -99,11 +99,9 @@ nmTest({
     }
 
     ui <- one.cmt.f()
-    s <- rxUiGet.foceiEnv(list(ui))
-    nlmixr2est:::.rxFinalizeInner(s, FALSE, FALSE, 0L)
-    mod <- suppressMessages(rxode2::rxode2(s$..inner))
+    mod <- suppressMessages(ui$focei$inner)
 
-    ev <- rxode2::et(amt = 100, cmt = "depot") %>% rxode2::et(seq(0.1, 24, by = 0.5))
+    ev <- rxode2::et(amt = 100, cmt = "depot") |> rxode2::et(seq(0.1, 24, by = 0.5))
     THETA <- c(log(1.15), log(0.135), log(8), log(0.8), 0.15, 0.6)
     ETA0 <- c(0.1, -0.05, 0.02, 0.2)
 
@@ -219,11 +217,9 @@ nmTest({
     }
 
     ui <- one.cmt.lag()
-    s <- rxUiGet.foceiEnv(list(ui))
-    nlmixr2est:::.rxFinalizeInner(s, FALSE, FALSE, 0L)
-    mod <- suppressMessages(rxode2::rxode2(s$..inner))
+    mod <- suppressMessages(ui$focei$inner)
 
-    ev <- rxode2::et(amt = 100, cmt = "depot") %>% rxode2::et(seq(0.1, 24, by = 0.5))
+    ev <- rxode2::et(amt = 100, cmt = "depot") |> rxode2::et(seq(0.1, 24, by = 0.5))
     THETA <- c(log(1.15), log(0.135), log(8), log(0.2), 0.15, 0.6)
     ETA0 <- c(0.1, -0.05, 0.02, 0.3)
 

--- a/tests/testthat/test-focei-lincmt-alag-sens.R
+++ b/tests/testthat/test-focei-lincmt-alag-sens.R
@@ -1,0 +1,220 @@
+nmTest({
+  test_that("FOCEi HdEta emits linCmtB(which1=-3) for a modeled alag() on a linCmt() compartment (#920)", {
+    one.cmt.lag <- function() {
+      ini({
+        tka <- log(1.15)
+        tcl <- log(0.135)
+        tv <- log(8)
+        tlag <- log(0.2)
+        eta.ka ~ 0.5
+        eta.cl ~ 0.1
+        eta.v ~ 0.1
+        eta.lag ~ 0.5
+        prop.err <- 0.15
+        add.err <- 0.6
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        tlagi <- exp(tlag + eta.lag)
+        alag(depot) <- tlagi
+        linCmt() ~ prop(prop.err) + add(add.err)
+      })
+    }
+
+    ui <- one.cmt.lag()
+    s <- rxUiGet.foceiEnv(list(ui))
+
+    # eta.lag is ETA_4_ -- before #920 this line rendered as the literal "0"
+    .lagLine <- s$..HdEta[grepl("BY_ETA_4___", s$..HdEta, fixed = TRUE)]
+    expect_true(any(grepl("linCmtB(", .lagLine, fixed = TRUE)))
+    expect_true(any(grepl("-3", .lagLine, fixed = TRUE)))
+    expect_false(any(grepl("^rx__sens_rx_pred__BY_ETA_4___=0$", .lagLine)))
+
+    # rx_r_ (proportional error) embeds rx_pred_'s linCmtB() call directly, so
+    # its own d(rx_r_)/d(eta.lag) needs the same correction chained through it
+    .lagLineR <- s$..REta[grepl("BY_ETA_4___", s$..REta, fixed = TRUE)]
+    expect_true(any(grepl("linCmtB(", .lagLineR, fixed = TRUE)))
+    expect_false(any(grepl("^rx__sens_rx_r__BY_ETA_4___=0$", .lagLineR)))
+  })
+
+  test_that("FOCEi HdEta emits the pred/F correction for a modeled f() on a linCmt() compartment (#920)", {
+    one.cmt.f <- function() {
+      ini({
+        tka <- log(1.15)
+        tcl <- log(0.135)
+        tv <- log(8)
+        tf <- log(0.8)
+        eta.ka ~ 0.5
+        eta.cl ~ 0.1
+        eta.v ~ 0.1
+        eta.f ~ 0.3
+        add.err <- 0.6
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        fi <- exp(tf + eta.f)
+        f(depot) <- fi
+        linCmt() ~ add(add.err)
+      })
+    }
+
+    ui <- one.cmt.f()
+    s <- rxUiGet.foceiHdEta(list(ui))
+
+    .fLine <- s$..HdEta[grepl("BY_ETA_4___", s$..HdEta, fixed = TRUE)]
+    expect_false(any(grepl("^rx__sens_rx_pred__BY_ETA_4___=0$", .fLine)))
+  })
+
+  test_that("linCmtB(which1=-3) alag correction matches a central finite difference (#920)", {
+    one.cmt.lag <- function() {
+      ini({
+        tka <- log(1.15)
+        tcl <- log(0.135)
+        tv <- log(8)
+        tlag <- log(0.2)
+        eta.ka ~ 0.5
+        eta.cl ~ 0.1
+        eta.v ~ 0.1
+        eta.lag ~ 0.5
+        prop.err <- 0.15
+        add.err <- 0.6
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        tlagi <- exp(tlag + eta.lag)
+        alag(depot) <- tlagi
+        linCmt() ~ prop(prop.err) + add(add.err)
+      })
+    }
+
+    ui <- one.cmt.lag()
+    s <- rxUiGet.foceiEnv(list(ui))
+    nlmixr2est:::.rxFinalizeInner(s, FALSE, FALSE, 0L)
+    mod <- suppressMessages(rxode2::rxode2(s$..inner))
+
+    ev <- rxode2::et(amt = 100, cmt = "depot") %>% rxode2::et(seq(0.1, 24, by = 0.5))
+    THETA <- c(log(1.15), log(0.135), log(8), log(0.2), 0.15, 0.6)
+    ETA0 <- c(0.1, -0.05, 0.02, 0.3)
+
+    solveAt <- function(eta4) {
+      ETA <- ETA0
+      ETA[4] <- eta4
+      pars <- c(stats::setNames(THETA, paste0("THETA[", 1:6, "]")),
+                stats::setNames(ETA, paste0("ETA[", 1:4, "]")))
+      suppressMessages(rxode2::rxSolve(mod, pars, ev, returnType = "data.frame"))
+    }
+
+    h <- 1e-4
+    sPlus <- solveAt(ETA0[4] + h)
+    sMinus <- solveAt(ETA0[4] - h)
+    s0 <- solveAt(ETA0[4])
+
+    fdPred <- (sPlus$rx_pred_ - sMinus$rx_pred_) / (2 * h)
+    anaPred <- s0$rx__sens_rx_pred__BY_ETA_4___
+    expect_false(anyNA(anaPred))
+    expect_equal(anaPred, fdPred, tolerance = 1e-5)
+
+    fdR <- (sPlus$rx_r_ - sMinus$rx_r_) / (2 * h)
+    anaR <- s0$rx__sens_rx_r__BY_ETA_4___
+    expect_equal(anaR, fdR, tolerance = 1e-5)
+  })
+
+  test_that("more than one lagged linCmt() compartment leaves the gradient uncorrected (rxode2/rxode2#1237)", {
+    two.lag <- function() {
+      ini({
+        tka <- log(1.15)
+        tcl <- log(0.135)
+        tv <- log(8)
+        tq <- log(1)
+        tvp <- log(10)
+        tlag1 <- log(0.2)
+        tlag2 <- log(0.4)
+        eta.ka ~ 0.5
+        eta.cl ~ 0.1
+        eta.v ~ 0.1
+        eta.lag1 ~ 0.3
+        eta.lag2 ~ 0.3
+        prop.err <- 0.15
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        q <- exp(tq)
+        vp <- exp(tvp)
+        lag1 <- exp(tlag1 + eta.lag1)
+        lag2 <- exp(tlag2 + eta.lag2)
+        alag(depot) <- lag1
+        alag(central) <- lag2
+        linCmt() ~ prop(prop.err)
+      })
+    }
+
+    ui <- two.lag()
+    s <- suppressWarnings(rxUiGet.foceiHdEta(list(ui)))
+
+    expect_true(any(grepl("^rx__sens_rx_pred__BY_ETA_4___=0$", s$..HdEta)))
+    expect_true(any(grepl("^rx__sens_rx_pred__BY_ETA_5___=0$", s$..HdEta)))
+  })
+
+  test_that("foceiControl(eventSens='fd') opts out of the linCmt() alag correction (rxode2/rxode2#1236)", {
+    one.cmt.lag <- function() {
+      ini({
+        tcl <- log(0.135)
+        tv <- log(8)
+        tlag <- log(0.3)
+        eta.cl ~ 0.1
+        eta.v ~ 0.1
+        eta.lag ~ 0.4
+        prop.err <- 0.15
+      })
+      model({
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        tlagi <- exp(tlag + eta.lag)
+        alag(central) <- tlagi
+        linCmt() ~ prop(prop.err)
+      })
+    }
+
+    ui <- rxode2::rxUiDecompress(one.cmt.lag())
+    rxode2::rxAssignControlValue(ui, "eventSens", "fd")
+    s <- suppressWarnings(rxUiGet.foceiHdEta(list(ui)))
+    expect_true(any(grepl("^rx__sens_rx_pred__BY_ETA_3___=0$", s$..HdEta)))
+  })
+
+  test_that("a modeled alag() on a linCmt() compartment fits with FOCEi (#920)", {
+    one.cmt.lag <- function() {
+      ini({
+        tka <- log(1.57)
+        tcl <- log(2.72)
+        tv <- log(31.5)
+        tlag <- log(0.5)
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        eta.lag ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        lag <- exp(tlag + eta.lag)
+        alag(depot) <- lag
+        linCmt() ~ add(add.sd)
+      })
+    }
+
+    fit <- .nlmixr(one.cmt.lag, nlmixr2data::theo_sd, est = "focei",
+                   control = foceiControl(maxOuterIterations = 5, maxInnerIterations = 50,
+                                          covMethod = "", calcTables = FALSE, print = 0))
+    expect_true(is.finite(fit$objDf$OBJF))
+  })
+})

--- a/tests/testthat/test-focei-lincmt-alag-sens.R
+++ b/tests/testthat/test-focei-lincmt-alag-sens.R
@@ -39,7 +39,7 @@ nmTest({
     expect_false(any(grepl("^rx__sens_rx_r__BY_ETA_4___=0$", .lagLineR)))
   })
 
-  test_that("FOCEi HdEta emits the pred/F correction for a modeled f() on a linCmt() compartment (#920)", {
+  test_that("FOCEi HdEta/REta emit the pred/F correction for a modeled f() on a linCmt() compartment (#920)", {
     one.cmt.f <- function() {
       ini({
         tka <- log(1.15)
@@ -50,6 +50,7 @@ nmTest({
         eta.cl ~ 0.1
         eta.v ~ 0.1
         eta.f ~ 0.3
+        prop.err <- 0.15
         add.err <- 0.6
       })
       model({
@@ -58,15 +59,139 @@ nmTest({
         v <- exp(tv + eta.v)
         fi <- exp(tf + eta.f)
         f(depot) <- fi
-        linCmt() ~ add(add.err)
+        linCmt() ~ prop(prop.err) + add(add.err)
       })
     }
 
     ui <- one.cmt.f()
-    s <- rxUiGet.foceiHdEta(list(ui))
+    s <- rxUiGet.foceiEnv(list(ui))
 
     .fLine <- s$..HdEta[grepl("BY_ETA_4___", s$..HdEta, fixed = TRUE)]
     expect_false(any(grepl("^rx__sens_rx_pred__BY_ETA_4___=0$", .fLine)))
+
+    # rx_r_ needs the same chained correction as the alag() case above
+    .fLineR <- s$..REta[grepl("BY_ETA_4___", s$..REta, fixed = TRUE)]
+    expect_false(any(grepl("^rx__sens_rx_r__BY_ETA_4___=0$", .fLineR)))
+  })
+
+  test_that("pred/F correction matches a central finite difference (#920)", {
+    one.cmt.f <- function() {
+      ini({
+        tka <- log(1.15)
+        tcl <- log(0.135)
+        tv <- log(8)
+        tf <- log(0.8)
+        eta.ka ~ 0.5
+        eta.cl ~ 0.1
+        eta.v ~ 0.1
+        eta.f ~ 0.3
+        prop.err <- 0.15
+        add.err <- 0.6
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        fi <- exp(tf + eta.f)
+        f(depot) <- fi
+        linCmt() ~ prop(prop.err) + add(add.err)
+      })
+    }
+
+    ui <- one.cmt.f()
+    s <- rxUiGet.foceiEnv(list(ui))
+    nlmixr2est:::.rxFinalizeInner(s, FALSE, FALSE, 0L)
+    mod <- suppressMessages(rxode2::rxode2(s$..inner))
+
+    ev <- rxode2::et(amt = 100, cmt = "depot") %>% rxode2::et(seq(0.1, 24, by = 0.5))
+    THETA <- c(log(1.15), log(0.135), log(8), log(0.8), 0.15, 0.6)
+    ETA0 <- c(0.1, -0.05, 0.02, 0.2)
+
+    solveAt <- function(eta4) {
+      ETA <- ETA0
+      ETA[4] <- eta4
+      pars <- c(stats::setNames(THETA, paste0("THETA[", 1:6, "]")),
+                stats::setNames(ETA, paste0("ETA[", 1:4, "]")))
+      suppressMessages(rxode2::rxSolve(mod, pars, ev, returnType = "data.frame"))
+    }
+
+    h <- 1e-4
+    sPlus <- solveAt(ETA0[4] + h)
+    sMinus <- solveAt(ETA0[4] - h)
+    s0 <- solveAt(ETA0[4])
+
+    fdPred <- (sPlus$rx_pred_ - sMinus$rx_pred_) / (2 * h)
+    anaPred <- s0$rx__sens_rx_pred__BY_ETA_4___
+    expect_false(anyNA(anaPred))
+    expect_equal(anaPred, fdPred, tolerance = 1e-5)
+
+    fdR <- (sPlus$rx_r_ - sMinus$rx_r_) / (2 * h)
+    anaR <- s0$rx__sens_rx_r__BY_ETA_4___
+    expect_equal(anaR, fdR, tolerance = 1e-5)
+  })
+
+  test_that("more than one f()-scaled linCmt() compartment leaves the gradient uncorrected (rxode2/rxode2#1237)", {
+    two.f <- function() {
+      ini({
+        tka <- log(1.15)
+        tcl <- log(0.135)
+        tv <- log(8)
+        tq <- log(1)
+        tvp <- log(10)
+        tf1 <- log(0.7)
+        tf2 <- log(0.9)
+        eta.ka ~ 0.5
+        eta.cl ~ 0.1
+        eta.v ~ 0.1
+        eta.f1 ~ 0.2
+        eta.f2 ~ 0.2
+        prop.err <- 0.15
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        q <- exp(tq)
+        vp <- exp(tvp)
+        f1 <- exp(tf1 + eta.f1)
+        f2 <- exp(tf2 + eta.f2)
+        f(depot) <- f1
+        f(central) <- f2
+        linCmt() ~ prop(prop.err)
+      })
+    }
+
+    ui <- two.f()
+    s <- suppressWarnings(rxUiGet.foceiHdEta(list(ui)))
+
+    expect_true(any(grepl("^rx__sens_rx_pred__BY_ETA_4___=0$", s$..HdEta)))
+    expect_true(any(grepl("^rx__sens_rx_pred__BY_ETA_5___=0$", s$..HdEta)))
+  })
+
+  test_that("foceiControl(eventSens='fd') opts out of the linCmt() f() correction (rxode2/rxode2#1236)", {
+    one.cmt.f <- function() {
+      ini({
+        tcl <- log(0.135)
+        tv <- log(8)
+        tf <- log(0.8)
+        eta.cl ~ 0.1
+        eta.v ~ 0.1
+        eta.f ~ 0.3
+        prop.err <- 0.15
+      })
+      model({
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        fi <- exp(tf + eta.f)
+        f(central) <- fi
+        linCmt() ~ prop(prop.err)
+      })
+    }
+
+    ui <- rxode2::rxUiDecompress(one.cmt.f())
+    rxode2::rxAssignControlValue(ui, "eventSens", "fd")
+    s <- suppressWarnings(rxUiGet.foceiHdEta(list(ui)))
+    expect_true(any(grepl("^rx__sens_rx_pred__BY_ETA_3___=0$", s$..HdEta)))
   })
 
   test_that("linCmtB(which1=-3) alag correction matches a central finite difference (#920)", {


### PR DESCRIPTION
## Summary

Fixes #920. The FOCEi/FOCE eta gradient for a `linCmt()` model with a modeled
`alag()` or `f()` (bioavailability) silently dropped the moving-boundary
contribution of any ETA/THETA driving *only* the lag/F: the structural
`linCmt()` Jacobian only covers `p1`/`v1`/`ka`/..., and alag/F act on the
dose event itself, invisible to that closed-form's symbolic differentiation.

- Adds rxode2's `linCmtB(which1=-3)` moving-boundary sensitivity
  (nlmixr2/rxode2#1235) to `d(rx_pred_)/d(eta)` for a modeled `alag()`.
- Adds the exact `d(pred)/dF = pred/F` identity for a modeled `f()`.
- Chains both through `rx_r_` (the residual-variance formula), which embeds
  `rx_pred_`'s `linCmtB()` call as a literal substituted subexpression rather
  than a reference to the `rx_pred_` symbol, so it needed its own
  substitution-based chain rule (`.rxFoceiLinCmtEventChain()`).

**Verified** against a central finite difference and against the same model
written as ODEs with `eventSens="jump"` -- both match to ~1e-6 to 1e-8
relative error.

## Known limitations (documented, not silently accepted)

- **Infusions** (rxode2/rxode2#1236): confirmed to reproduce even through
  this package's own `ind_solve()`-driven `calc_lhs`, not just the plain
  `rxSolve()` path the upstream bug was filed against -- an infused dose into
  the lagged/scaled compartment reads `NA`.
- **Mixed-route dosing** (rxode2/rxode2#1237): `which1=-3` requires every
  dose reaching the linear system to share the same delay/scaling (per
  rxode2's own `src/linCmt.cpp` doc comment). More than one *modeled*
  `alag()`/`f()` is guarded against structurally, but a regimen that also
  doses an *unlagged/unscaled* compartment alongside the lagged/scaled one
  (a common design for estimating `f()` from paired IV+oral data) cannot be
  detected at model-build time -- it's a data property, not a model one.
  Confirmed by direct comparison: this returns a biased, not `NA`, gradient.

Both are gated the same way: `foceiControl(eventSens="fd")` opts back out
to the pre-existing (finite-difference-free but incomplete) behavior.
Documented in the file banner (`R/foceiLinCmtAlagSens.R`), the guard
comments, `NEWS.md`, and the `eventSens=` control docs.

## Review

Reviewed with Antigravity (`agy`, gemini-3.1-pro-high) in two passes. The
first pass found the mixed-route dosing gap above (broader than my initial
"more than one modeled alag()" framing) plus missing `f()`-side test
coverage; both were addressed in a follow-up commit. The second pass
confirmed both were resolved and found nothing further.

## Test plan

- [x] New `tests/testthat/test-focei-lincmt-alag-sens.R`: structural checks
      (`linCmtB(...,-3,-3,...)` emitted), finite-difference numeric checks
      for both `alag()` and `f()` (pred and residual-variance gradients),
      the multi-compartment guard, the `eventSens="fd"` opt-out, and an
      end-to-end FOCEi fit.
- [x] Existing `test-focei-1.R`, `test-focei-inner.R`, `test-lincmt-ode.R`,
      and other essential FOCEi test files pass unchanged.