### PR TITLE
Fix nlm-family covariance 4x scale bug (bobyqa/nlm/newuoa/...)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,17 @@
   This was latent while no estimation method declared prior support; it would
   have broken assembling a finished fit for the first method that does.
 
+- The Hessian-based covariance for every NLM-family method (`nlm`, `bobyqa`,
+  `newuoa`, `uobyqa`, `n1qn1`, `lbfgsb3c`, `optim`, `nlminb`, `nls`) was 4x too
+  large (SEs 2x too large), for both built-in error models and custom `ll()`
+  likelihoods. `.nlmFinalizeList()` converted the Hessian to a covariance using
+  the `R = 0.5*Hessian`, `cov = 2*solve(R)` convention that is only correct
+  when the Hessian is of a `-2*log-likelihood` objective (as FOCEI/FOCE/SAEM/
+  Laplace/AGQ use). NLM-family methods instead optimize a plain
+  `-log-likelihood`, so their Hessian already is the observed information;
+  halving then doubling compounded into a 4x inflated covariance. Point
+  estimates, the objective value, and the log-likelihood were unaffected.
+
 ## New features
 
 - `est="saem"` gained controls for the cost of the `nonMuTheta="regress"`

--- a/R/nlmShared.R
+++ b/R/nlmShared.R
@@ -206,8 +206,11 @@
     if (any(is.na(.hess))) {
       .ret$covMethod <- "failed"
     } else {
-      # r matrix
-      .r <- 0.5 * .hess
+      # r matrix: nlm-family objectives (`.nlmixrNlmFunC`/optim's `fn`) are
+      # built as a plain -1*LL, not the -2*LL scale FOCEI/SAEM/etc use -- so
+      # .hess is already the Fisher information (unlike the FOCEI R matrix,
+      # which halves a -2*LL Hessian to get there).  Do not rescale here.
+      .r <- .hess
       .ch <- try(cholSE(.r), silent = TRUE)
       .covType <- "r"
       if (inherits(.ch, "try-error")) {
@@ -233,7 +236,7 @@
       if (!inherits(.ch, "try-error")) {
         .rinv <- rxode2::rxInv(.ch)
         .rinv <- .rinv %*% t(.rinv)
-        .cov <- 2*.rinv
+        .cov <- .rinv
         dimnames(.cov) <- list(.name, .name)
         dimnames(.rinv) <- list(.name, .name)
         .ret$covMethod <- .covType

--- a/tests/testthat/test-nlm.R
+++ b/tests/testthat/test-nlm.R
@@ -308,4 +308,46 @@ nmTest({
     expect_equal(.fMat$objf, .fOde$objf, tolerance = 1e-3)
     expect_equal(unname(fixef(.fMat)), unname(fixef(.fOde)), tolerance = 1e-3)
   })
+
+  test_that("nlm-family covariance from a ll() model matches the Poisson GLM (#issue not doubled)", {
+    # A constant-hazard RTTE ll() model is, up to a constant, the same
+    # likelihood as a Poisson GLM with a log-time offset -- so their SEs
+    # should agree.  Before the fix, nlm-family covariances (bobyqa/nlm/...)
+    # were 4x too large (SE 2x too large) because the objective is built as
+    # a plain -1*LL (not -2*LL like FOCEI/SAEM), while the Hessian->cov step
+    # in `.nlmFinalizeList()` assumed a -2*LL scale.
+    set.seed(1099)
+    .n <- 60L
+    .trt <- rep(0:1, each = .n)
+    .h <- exp(-2 + -0.4 * .trt)
+    .time <- pmin(stats::rexp(length(.trt), rate = .h), 5)
+    .event <- as.integer(.time < 5)
+    .dat <- data.frame(id = seq_along(.trt), time = .time, event = .event,
+                       trt = .trt, dv = .time, evid = 0L)
+
+    .mod <- function() {
+      ini({
+        log_h0 <- log(0.2)
+        log_hr <- -0.1
+      })
+      model({
+        log_h <- log_h0 + log_hr * trt
+        h <- exp(log_h)
+        H <- h * time
+        tte_ll <- event * log_h - H
+        ll(tte) ~ tte_ll
+      })
+    }
+
+    .fit <- suppressMessages(
+      .nlmixr(.mod, .dat, est = "bobyqa", bobyqaControl(print = 0))
+    )
+
+    .glm <- glm(event ~ trt, offset = log(time), family = poisson(), data = .dat)
+
+    .seNlmixr <- .fit$parFixedDf[c("log_h0", "log_hr"), "SE"]
+    .seGlm <- summary(.glm)$coefficients[, "Std. Error"]
+
+    expect_equal(unname(.seNlmixr), unname(.seGlm), tolerance = 0.1)
+  })
 })


### PR DESCRIPTION
## Summary

- Reported by a nlmixr2 user comparing a constant-hazard RTTE `ll()` model fit with `est="bobyqa"` against the equivalent Poisson GLM: point estimates, log-likelihood, and AIC matched exactly, but `fit$cov` was exactly 4x the GLM/independent-Hessian covariance (SEs 2x too large).
- Root cause: `.nlmFinalizeList()` (`R/nlmShared.R`) converts a Hessian to a covariance via `r <- 0.5*hessian; cov <- 2*solve(r)`. That is the correct NONMEM-style step only when the Hessian is of a `-2*log-likelihood` objective, which is how FOCEI/FOCE/SAEM/Laplace/AGQ build their objective (`src/inner.cpp`: `ret(0) = -2.0 * fInd->lik[0]`). NLM-family methods instead build the objective as a plain `-log-likelihood` (`R/nlm.R:429`: `rx_pred_ <- -rx_pred_`; `src/nlm.cpp`: `ret(k) -= _llAdd`), so the Hessian computed on it is already the observed information. Halving it and then doubling the inverse compounds into a 4x inflated covariance.
- Confirmed this is **not** specific to custom `ll()` models -- a plain built-in `add()`-error model fit with `est="bobyqa"` showed the same 4x factor. It affects every NLM-family engine that shares `.nlmFinalizeList(hessianCov=TRUE)`: `nlm`, `bobyqa`, `newuoa`, `uobyqa`, `n1qn1`, `lbfgsb3c`, `optim`, `nlminb`, `nls`. FOCEI/FOCE/FO/FOI/SAEM/Laplace/AGQ are unaffected -- they are on the correct `-2*LL` scale throughout.
- Fix: since the NLM-family Hessian is already the Fisher information, use it directly (`.r <- .hess`, `.cov <- .rinv`) instead of the `0.5*`/`2*` FOCEI-style rescaling.
- Point estimates, the objective function value, and the log-likelihood are unaffected -- only the Hessian-based covariance/SE/CI for NLM-family fits.

## Test plan

- [x] Added a regression test (`test-nlm.R`) fitting a constant-hazard RTTE `ll()` model with `est="bobyqa"` and comparing its SEs against the equivalent Poisson GLM's SEs (tolerance 10%); verified it fails on the pre-fix code (SEs ~2x too large) and passes after the fix.
- [x] Ran the essential (non-`.slowBatches`) NLM-family test files (`test-nlm.R`, `test-optim.R`, `test-nlm-lik-contrib.R`, `test-nlm-ptrs.R`, `test-nlmUnscalePar.R`, `test-nlmsetup-fresh-rx.R`, `test-nls.R`) -- all pass, no regressions.
- [x] Verified against the original bug report's reproduction (exponential RTTE `ll()` model, `n_arm=150`, seed 123): nlmixr2 SEs now agree with both the Poisson GLM and an independent `optim(..., hessian=TRUE)` to ~1%, down from the prior exact 4x/2x discrepancy.