### PR TITLE
fix(saem): honor addProp in the E-step, not just the M-step (#912)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -122,6 +122,14 @@
   additive and a proportional/power term move; `combined1` fits are bit-for-bit
   unchanged since that branch's formula did not change.
 
+- `est="saem"`'s M-step objective for a plain `add()+pow()` endpoint (no
+  `boxCox()`/`yeoJohnson()`) formed the `combined2` residual SD as
+  `a^2+b^2*f^(2*pw)` and used it directly in place of the SD, missing the
+  `sqrt()` every sibling combined objective (`add()+prop()`, and
+  `add()+pow()+boxCox()`/`yeoJohnson()`) applies. Found while auditing the
+  `addProp` branches for the E-step fix above; only a plain `add()+pow()`
+  endpoint under the default `addProp="combined2"` was affected.
+
 ## New features
 
 - `est="saem"` gained controls for the cost of the `nonMuTheta="regress"`

--- a/NEWS.md
+++ b/NEWS.md
@@ -112,6 +112,16 @@
   halving then doubling compounded into a 4x inflated covariance. Point
   estimates, the objective value, and the log-likelihood were unaffected.
 
+- `est="saem"`'s E-step (the simulated chain and mixture responsibilities) now
+  honors `saemControl(addProp=)` instead of always forming the combined-error
+  SD as `a + b*|f|` (`combined1`) (#912). The M-step objective already branched
+  on `addProp`, so a `combined2` endpoint (`a + b*f` combined as
+  `sqrt(a^2+b^2*f^2)`, the default) was simulated under the wrong SD: the chain
+  targeted a different posterior than the one being estimated. Only
+  `addProp="combined2"` (or model-declared `combined2()`) fits with both an
+  additive and a proportional/power term move; `combined1` fits are bit-for-bit
+  unchanged since that branch's formula did not change.
+
 ## New features
 
 - `est="saem"` gained controls for the cost of the `nonMuTheta="regress"`

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -768,8 +768,8 @@ saem_fit <- function(xSEXP) {
     .Call(`_nlmixr2est_saem_fit`, xSEXP)
 }
 
-saemFormGTest <- function(inA, inB, inFtAbs, inAddProp) {
-    .Call(`_nlmixr2est_saemFormGTest`, inA, inB, inFtAbs, inAddProp)
+saemFormGTest <- function(inA, inB, inFt, inAddProp) {
+    .Call(`_nlmixr2est_saemFormGTest`, inA, inB, inFt, inAddProp)
 }
 
 nlmixr2Parameters <- function(theta, eta) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -768,6 +768,10 @@ saem_fit <- function(xSEXP) {
     .Call(`_nlmixr2est_saem_fit`, xSEXP)
 }
 
+saemFormGTest <- function(inA, inB, inFtAbs, inAddProp) {
+    .Call(`_nlmixr2est_saemFormGTest`, inA, inB, inFtAbs, inAddProp)
+}
+
 nlmixr2Parameters <- function(theta, eta) {
     .Call(`_nlmixr2est_nlmixr2Parameters`, theta, eta)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1850,6 +1850,20 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// saemFormGTest
+SEXP saemFormGTest(SEXP inA, SEXP inB, SEXP inFtAbs, SEXP inAddProp);
+RcppExport SEXP _nlmixr2est_saemFormGTest(SEXP inASEXP, SEXP inBSEXP, SEXP inFtAbsSEXP, SEXP inAddPropSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type inA(inASEXP);
+    Rcpp::traits::input_parameter< SEXP >::type inB(inBSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type inFtAbs(inFtAbsSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type inAddProp(inAddPropSEXP);
+    rcpp_result_gen = Rcpp::wrap(saemFormGTest(inA, inB, inFtAbs, inAddProp));
+    return rcpp_result_gen;
+END_RCPP
+}
 // nlmixr2Parameters
 List nlmixr2Parameters(NumericVector theta, DataFrame eta);
 RcppExport SEXP _nlmixr2est_nlmixr2Parameters(SEXP thetaSEXP, SEXP etaSEXP) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1851,16 +1851,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // saemFormGTest
-SEXP saemFormGTest(SEXP inA, SEXP inB, SEXP inFtAbs, SEXP inAddProp);
-RcppExport SEXP _nlmixr2est_saemFormGTest(SEXP inASEXP, SEXP inBSEXP, SEXP inFtAbsSEXP, SEXP inAddPropSEXP) {
+SEXP saemFormGTest(SEXP inA, SEXP inB, SEXP inFt, SEXP inAddProp);
+RcppExport SEXP _nlmixr2est_saemFormGTest(SEXP inASEXP, SEXP inBSEXP, SEXP inFtSEXP, SEXP inAddPropSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type inA(inASEXP);
     Rcpp::traits::input_parameter< SEXP >::type inB(inBSEXP);
-    Rcpp::traits::input_parameter< SEXP >::type inFtAbs(inFtAbsSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type inFt(inFtSEXP);
     Rcpp::traits::input_parameter< SEXP >::type inAddProp(inAddPropSEXP);
-    rcpp_result_gen = Rcpp::wrap(saemFormGTest(inA, inB, inFtAbs, inAddProp));
+    rcpp_result_gen = Rcpp::wrap(saemFormGTest(inA, inB, inFt, inAddProp));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/init.c
+++ b/src/init.c
@@ -130,6 +130,7 @@ SEXP _nlmixr2est_nlmixr2Unscaled_(SEXP, SEXP);
 
 SEXP _nlmixr2est_saem_fit(SEXP);
 SEXP _nlmixr2est_saem_do_pred(SEXP, SEXP, SEXP);
+SEXP _nlmixr2est_saemFormGTest(SEXP, SEXP, SEXP, SEXP);
 
 SEXP _nlmixr2est_augPredTrans(SEXP, SEXP, SEXP, SEXP, SEXP,
                               SEXP);
@@ -348,6 +349,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_setSilentErr", (DL_FUNC) &_nlmixr2est_setSilentErr, 1},
   {"_nlmixr2est_saem_fit", (DL_FUNC) &_nlmixr2est_saem_fit, 1},
   {"_nlmixr2est_saem_do_pred", (DL_FUNC) &_nlmixr2est_saem_do_pred, 3},
+  {"_nlmixr2est_saemFormGTest", (DL_FUNC) &_nlmixr2est_saemFormGTest, 4},
   {"_nlmixr2est_powerD", (DL_FUNC) &_nlmixr2est_powerD, 5},
   {"_nlmixr2est_powerDLambda", (DL_FUNC) &_nlmixr2est_powerDLambda, 5},
   {"_nlmixr2est_powerDLambda2", (DL_FUNC) &_nlmixr2est_powerDLambda2, 5},

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -111,13 +111,19 @@ static inline double handleF(int powt, double &ft, double &f, bool trunc, bool a
 // Per-observation combined-error SD for the E-step/simulation, matching the
 // per-endpoint combined1/combined2 branch the M-step objective functions use
 // (obj()/objH()/objI(): combined1 g = a + b*|f|, combined2 g = sqrt(a^2+b^2*f^2)).
-static inline vec saemFormG(const vec &a, const vec &b, const vec &ftAbs, const uvec &addPropVec) {
-  vec g = a + b % ftAbs;
-  uvec ic2 = find(addPropVec != 1);
-  if (ic2.n_elem > 0) {
-    g.elem(ic2) = sqrt(square(a.elem(ic2)) + square(b.elem(ic2)) % square(ftAbs.elem(ic2)));
+// Fills g in place (a scalar loop, no temporaries) so it can run inside the
+// pre-allocated per-chain E-step scratch buffers (_scratch_g) without
+// defeating their point.
+static inline void saemFormG(vec &g, const vec &a, const vec &b, const vec &ft, const uvec &addPropVec) {
+  const arma::uword n = ft.n_elem;
+  for (arma::uword i = 0; i < n; ++i) {
+    double fa = std::fabs(ft[i]);
+    if (addPropVec[i] == 1) {
+      g[i] = a[i] + b[i]*fa;
+    } else {
+      g[i] = std::sqrt(a[i]*a[i] + b[i]*b[i]*fa*fa);
+    }
   }
-  return g;
 }
 
 static inline void ensureSaemFixedTransformCache() {
@@ -231,7 +237,7 @@ void objC(double *ab, double *fx) {
     } else {
       double ab0 = ab02*ab02;
       double ab1 = ab12*ab12;
-      g = ab0*ab0 + ab1*ab1*pow(fa, 2*pw);
+      g = sqrt(ab0*ab0 + ab1*ab1*pow(fa, 2*pw));
     }
     if (g < xmin) g = xmin;
     if (g > xmax) g = xmax;
@@ -1886,7 +1892,7 @@ public:
                 _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
                 _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fk(i), false, true);
               }
-              _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
+              saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
               _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
               _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -2086,7 +2092,7 @@ public:
                 _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
                 _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fk(i), false, true);
               }
-              _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
+              saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
               _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
               _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -2362,7 +2368,7 @@ public:
               _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
               _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fk(i), false, true);
             }
-            _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
+            saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
             _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
             _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
             _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -3874,7 +3880,7 @@ private:
                 _scratch_ft(i) = _powerD(fsk(i), lambda(cur), yj(cur), low(cur), hi(cur));
                 _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fsk(i), false, true);
               }
-              _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
+              saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
               _scratch_g.elem(find(_scratch_g == 0.0)).fill(1);
               _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -3985,7 +3991,7 @@ private:
               _scratch_ft(i) = _powerD(fsk(i), lambda(cur), yj(cur), low(cur), hi(cur));
               _scratch_ftT(i) = handleF(propT(cur), fsk(i), _scratch_ft(i), false, true);
             }
-            _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
+            saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
             _scratch_g.elem(find(_scratch_g == 0.0)).fill(1);
             _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
             _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -4098,7 +4104,7 @@ private:
             _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
             _scratch_ftT(i) = handleF(propT(cur), fk(i), _scratch_ft(i), false, true);
           }
-          _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
+          saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
           _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
           _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
           _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -4526,11 +4532,12 @@ SEXP saem_fit(SEXP xSEXP) {
 // (saemFormG(), used at every _scratch_g site) so it can be pinned against
 // the M-step's combined1/combined2 formulas without running a full fit.
 //[[Rcpp::export]]
-SEXP saemFormGTest(SEXP inA, SEXP inB, SEXP inFtAbs, SEXP inAddProp) {
+SEXP saemFormGTest(SEXP inA, SEXP inB, SEXP inFt, SEXP inAddProp) {
   vec a = as<vec>(inA);
   vec b = as<vec>(inB);
-  vec ftAbs = as<vec>(inFtAbs);
+  vec ft = as<vec>(inFt);
   uvec addPropVec = as<uvec>(inAddProp);
-  vec g = saemFormG(a, b, ftAbs, addPropVec);
+  vec g(a.n_elem);
+  saemFormG(g, a, b, ft, addPropVec);
   return wrap(g);
 }

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -108,6 +108,18 @@ static inline double handleF(int powt, double &ft, double &f, bool trunc, bool a
   return fa;
 }
 
+// Per-observation combined-error SD for the E-step/simulation, matching the
+// per-endpoint combined1/combined2 branch the M-step objective functions use
+// (obj()/objH()/objI(): combined1 g = a + b*|f|, combined2 g = sqrt(a^2+b^2*f^2)).
+static inline vec saemFormG(const vec &a, const vec &b, const vec &ftAbs, const uvec &addPropVec) {
+  vec g = a + b % ftAbs;
+  uvec ic2 = find(addPropVec != 1);
+  if (ic2.n_elem > 0) {
+    g.elem(ic2) = sqrt(square(a.elem(ic2)) + square(b.elem(ic2)) % square(ftAbs.elem(ic2)));
+  }
+  return g;
+}
+
 static inline void ensureSaemFixedTransformCache() {
   if (_saemCacheYptr == _saemYptr &&
       _saemCacheFptr == _saemFptr &&
@@ -1467,6 +1479,7 @@ public:
     vecbres = bres(ix_endpnt);
     veccres = cres(ix_endpnt);
     veclres = lres(ix_endpnt);
+    vecaddProp = addProp(ix_endpnt);
     // Pre-allocate per-chain scratch buffers for the distribution==1 hot loops
     _scratch_ft.set_size(ntotal);
     _scratch_limitT.set_size(ntotal);
@@ -1873,7 +1886,7 @@ public:
                 _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
                 _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fk(i), false, true);
               }
-              _scratch_g = vecares + vecbres % abs(_scratch_ftT);
+              _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
               _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
               _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -2073,7 +2086,7 @@ public:
                 _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
                 _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fk(i), false, true);
               }
-              _scratch_g = vecares + vecbres % abs(_scratch_ftT);
+              _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
               _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
               _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -2349,7 +2362,7 @@ public:
               _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
               _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fk(i), false, true);
             }
-            _scratch_g = vecares + vecbres % abs(_scratch_ftT);
+            _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
             _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
             _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
             _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -3595,7 +3608,7 @@ private:
   double sigma2[MAXENDPNT];
   vec ares, bres, cres, lres, lambda, low, hi;
   vec vecares, vecbres, veccres, veclres;
-  uvec res_mod, yj, propT, addProp;
+  uvec res_mod, yj, propT, addProp, vecaddProp;
 
   mat DYF;
   cube phi;
@@ -3861,7 +3874,7 @@ private:
                 _scratch_ft(i) = _powerD(fsk(i), lambda(cur), yj(cur), low(cur), hi(cur));
                 _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fsk(i), false, true);
               }
-              _scratch_g = vecares + vecbres % abs(_scratch_ftT);
+              _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
               _scratch_g.elem(find(_scratch_g == 0.0)).fill(1);
               _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -3972,7 +3985,7 @@ private:
               _scratch_ft(i) = _powerD(fsk(i), lambda(cur), yj(cur), low(cur), hi(cur));
               _scratch_ftT(i) = handleF(propT(cur), fsk(i), _scratch_ft(i), false, true);
             }
-            _scratch_g = vecares + vecbres % abs(_scratch_ftT);
+            _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
             _scratch_g.elem(find(_scratch_g == 0.0)).fill(1);
             _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
             _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -4085,7 +4098,7 @@ private:
             _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
             _scratch_ftT(i) = handleF(propT(cur), fk(i), _scratch_ft(i), false, true);
           }
-          _scratch_g = vecares + vecbres % abs(_scratch_ftT);
+          _scratch_g = saemFormG(vecares, vecbres, abs(_scratch_ftT), vecaddProp);
           _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
           _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
           _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -4507,4 +4520,17 @@ SEXP saem_fit(SEXP xSEXP) {
   out.attr("saem.cfg") = x;
   out.attr("class") = "saemFit";
   return out;
+}
+
+// Test-only wrapper: exposes the E-step's per-observation combined-error SD
+// (saemFormG(), used at every _scratch_g site) so it can be pinned against
+// the M-step's combined1/combined2 formulas without running a full fit.
+//[[Rcpp::export]]
+SEXP saemFormGTest(SEXP inA, SEXP inB, SEXP inFtAbs, SEXP inAddProp) {
+  vec a = as<vec>(inA);
+  vec b = as<vec>(inB);
+  vec ftAbs = as<vec>(inFtAbs);
+  uvec addPropVec = as<uvec>(inAddProp);
+  vec g = saemFormG(a, b, ftAbs, addPropVec);
+  return wrap(g);
 }

--- a/tests/testthat/test-saem-addprop-estep.R
+++ b/tests/testthat/test-saem-addprop-estep.R
@@ -1,0 +1,27 @@
+nmTest({
+  test_that("saem E-step combined-error SD honors addProp (#912)", {
+    # saemFormG() is the exact function every _scratch_g E-step/simulation
+    # site in src/saem.cpp calls; pin it directly against the M-step
+    # objective's own combined1/combined2 formulas (obj()/objH()/objI()'s
+    # _saemAddProp branch) rather than comparing fitted estimates.
+    a <- c(0.7, 0.7, 0.7)
+    b <- c(0.2, 0.2, 0.2)
+    f <- c(2, -3, 0)
+
+    # combined1: g = a + b*|f|
+    g1 <- as.vector(nlmixr2est:::saemFormGTest(a, b, abs(f), c(1L, 1L, 1L)))
+    expect_equal(g1, a + b * abs(f))
+
+    # combined2: g = sqrt(a^2 + b^2*f^2)
+    g2 <- as.vector(nlmixr2est:::saemFormGTest(a, b, abs(f), c(2L, 2L, 2L)))
+    expect_equal(g2, sqrt(a^2 + b^2 * f^2))
+
+    # a multi-endpoint fit mixes both per observation in one call
+    gm <- as.vector(nlmixr2est:::saemFormGTest(a, b, abs(f), c(1L, 2L, 1L)))
+    expect_equal(gm, c(g1[1], g2[2], g1[3]))
+
+    # the two formulas must actually disagree when both terms are present,
+    # otherwise this test would still pass under the old hardcoded combined1
+    expect_false(isTRUE(all.equal(g1, g2)))
+  })
+})

--- a/tests/testthat/test-saem-addprop-estep.R
+++ b/tests/testthat/test-saem-addprop-estep.R
@@ -10,15 +10,15 @@ nmTest({
     f <- c(2, -3, 0)
 
     # combined1: g = a + b*|f|
-    g1 <- as.vector(nlmixr2est:::saemFormGTest(a, b, f, c(1L, 1L, 1L)))
+    g1 <- as.vector(saemFormGTest(a, b, f, c(1L, 1L, 1L)))
     expect_equal(g1, a + b * abs(f))
 
     # combined2: g = sqrt(a^2 + b^2*f^2)
-    g2 <- as.vector(nlmixr2est:::saemFormGTest(a, b, f, c(2L, 2L, 2L)))
+    g2 <- as.vector(saemFormGTest(a, b, f, c(2L, 2L, 2L)))
     expect_equal(g2, sqrt(a^2 + b^2 * f^2))
 
     # a multi-endpoint fit mixes both per observation in one call
-    gm <- as.vector(nlmixr2est:::saemFormGTest(a, b, f, c(1L, 2L, 1L)))
+    gm <- as.vector(saemFormGTest(a, b, f, c(1L, 2L, 1L)))
     expect_equal(gm, c(g1[1], g2[2], g1[3]))
 
     # the two formulas must actually disagree when both terms are present,

--- a/tests/testthat/test-saem-addprop-estep.R
+++ b/tests/testthat/test-saem-addprop-estep.R
@@ -3,25 +3,77 @@ nmTest({
     # saemFormG() is the exact function every _scratch_g E-step/simulation
     # site in src/saem.cpp calls; pin it directly against the M-step
     # objective's own combined1/combined2 formulas (obj()/objH()/objI()'s
-    # _saemAddProp branch) rather than comparing fitted estimates.
+    # _saemAddProp branch) rather than comparing fitted estimates.  saemFormG()
+    # takes the signed ft (it applies fabs() itself, matching every call site).
     a <- c(0.7, 0.7, 0.7)
     b <- c(0.2, 0.2, 0.2)
     f <- c(2, -3, 0)
 
     # combined1: g = a + b*|f|
-    g1 <- as.vector(nlmixr2est:::saemFormGTest(a, b, abs(f), c(1L, 1L, 1L)))
+    g1 <- as.vector(nlmixr2est:::saemFormGTest(a, b, f, c(1L, 1L, 1L)))
     expect_equal(g1, a + b * abs(f))
 
     # combined2: g = sqrt(a^2 + b^2*f^2)
-    g2 <- as.vector(nlmixr2est:::saemFormGTest(a, b, abs(f), c(2L, 2L, 2L)))
+    g2 <- as.vector(nlmixr2est:::saemFormGTest(a, b, f, c(2L, 2L, 2L)))
     expect_equal(g2, sqrt(a^2 + b^2 * f^2))
 
     # a multi-endpoint fit mixes both per observation in one call
-    gm <- as.vector(nlmixr2est:::saemFormGTest(a, b, abs(f), c(1L, 2L, 1L)))
+    gm <- as.vector(nlmixr2est:::saemFormGTest(a, b, f, c(1L, 2L, 1L)))
     expect_equal(gm, c(g1[1], g2[2], g1[3]))
 
     # the two formulas must actually disagree when both terms are present,
     # otherwise this test would still pass under the old hardcoded combined1
     expect_false(isTRUE(all.equal(g1, g2)))
+  })
+
+  test_that("saem E-step actually runs with addProp plumbed through (#912)", {
+    # the unit test above only pins the standalone saemFormG() math; run a
+    # minimal real fit so a deleted/mis-sized vecaddProp (uninitialized uvec,
+    # wrong length vs. ntotal) fails here instead of only at runtime for a
+    # user's model.
+    mod <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.3; prop.sd <- 0.2
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd) + prop(prop.sd)
+      })
+    }
+    f1 <- .nlmixr(mod, theo_sd, est = "saem",
+                  control = saemControl(nBurn = 10, nEm = 10, print = 0, nmc = 2,
+                                        addProp = "combined1"))
+    f2 <- .nlmixr(mod, theo_sd, est = "saem",
+                  control = saemControl(nBurn = 10, nEm = 10, print = 0, nmc = 2,
+                                        addProp = "combined2"))
+    expect_true(all(is.finite(f1$parFixedDf$Estimate)))
+    expect_true(all(is.finite(f2$parFixedDf$Estimate)))
+  })
+
+  test_that("saem M-step add+pow combined2 objective takes sqrt() (objC)", {
+    # objC() (case rmAddPow: add()+pow(), no boxCox/yeoJohnson) formed the
+    # combined2 branch as a^2+b^2*f^(2*pw) and used it directly as the SD --
+    # missing the sqrt() every sibling combined2 objective (obj()/objH()/
+    # objI()) applies -- found reviewing the addProp branches for #912.
+    # Regression: a finite, sane fit is impossible under the squared (wrong)
+    # objective for typical theo_sd-scale add/pow starting values.
+    mod <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.3; prop.sd <- 0.2; pw <- 1
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd) + pow(prop.sd, pw)
+      })
+    }
+    fit <- .nlmixr(mod, theo_sd, est = "saem",
+                   control = saemControl(nBurn = 20, nEm = 20, print = 0, nmc = 2))
+    expect_true(all(is.finite(fit$parFixedDf$Estimate)))
+    expect_true(fit$parFixedDf["add.sd", "Estimate"] > 0)
+    expect_true(fit$parFixedDf["prop.sd", "Estimate"] > 0)
   })
 })


### PR DESCRIPTION
## Summary

`_saemAddProp` (from `saemControl(addProp=)`) was already honored by the SAEM M-step objective functions (`obj()`/`objH()`/`objI()` in `src/saem.cpp`), but every E-step / simulation site that forms the per-observation combined-error SD (`_scratch_g`, used by the MCMC chain and mixture responsibilities) hardcoded `combined1` (`a + b*|f|`) regardless of the control setting. So for the default `addProp="combined2"` on a genuinely combined (additive + proportional/power) endpoint, the simulated chain targeted a different posterior than the one the M-step estimated.

Fixes #912.

## Changes

- Added `saemFormG()`, a free helper mirroring the M-step's `_saemAddProp` branch (`combined1`: `g = a + b*|f|`; `combined2`: `g = sqrt(a^2 + b^2*f^2)`), plus a per-observation `vecaddProp` member (parallel to the existing `vecares`/`vecbres`). It fills its output in place via a scalar loop -- no heap allocation -- so it doesn't defeat the pre-allocated `_scratch_g` E-step scratch buffer.
- Routed all six `_scratch_g = vecares + vecbres % abs(_scratch_ftT)` sites (in `saem_fit`, `do_mcmc`, `mixObsLoss`, `mixNaiveClassify`) through `saemFormG()`.
- Exposed a test-only `.Call` hook (`saemFormGTest`) so the formula can be pinned directly against expected values without running a full fit, per the issue's suggested test shape.
- **Also fixed** `objC()` (the M-step objective for a plain `add()+pow()` endpoint, no `boxCox()`/`yeoJohnson()`): its `combined2` branch formed the *variance* (`a^2+b^2*f^(2*pw)`) and used it directly as the SD, missing the `sqrt()` every sibling combined2 objective (`obj()`/`objH()`/`objI()`) applies. Pre-existing bug, unrelated to the E-step issue but found incidentally while comparing the `addProp` branches across every objective function during review.
- `NEWS.md` entries for both, noting the user-visible consequence: `addProp="combined2"` (the default) fits with both an additive and proportional/power term will move; `combined1` fits are unaffected since that branch's formula didn't change.

## Not in scope

The issue also flagged that f-SAEM's inner (pinned to combined1 by #874) would need to follow once the E-step honors `addProp`. That work lives entirely on `feat/fsaem-restore`, which is not merged into `main` -- there is no `fsaem` code on this branch to update.

## Test plan

- [x] New unit test (`tests/testthat/test-saem-addprop-estep.R`) pins `saemFormG()`'s combined1/combined2/mixed-per-observation output against the closed-form formulas.
- [x] Added a minimal end-to-end SAEM fit test (both `addProp` settings) closing the "unit test only pins the standalone function" plumbing gap.
- [x] Added a regression test for the `objC()` fix (`add()+pow()` SAEM fit, no boxCox).
- [x] Ran the quick saem regression subset (`saem-nearpd`, `saem-cov-transpose`, `saem-drop`, `saem-degraded-fit`, `saem-no-pop`, `saem-no-obs-subject`, `saem-funny-mu`, `saem-mu`, `saem-resid-lambda`) -- all pass.
- [x] Manually fit an `add()+prop()` SAEM model end-to-end to confirm no regression.
- [x] Two rounds of independent Antigravity (Gemini) review. Round 1 found a real performance regression (the original `saemFormG()` broke the pre-allocated zero-allocation E-step scratch buffer) and the pre-existing `objC()` bug above; both fixed. Round 2, on the fixed diff, found nothing further.