### PR TITLE
fix: allow method="indLin" in post-fit table and residual solves (#858)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -112,10 +112,11 @@
   halving then doubling compounded into a 4x inflated covariance. Point
   estimates, the objective value, and the log-likelihood were unaffected.
 
-- `method="indLin"` is no longer excluded from the ODE-method fallback list
-  used by post-fit table/residual solves (#858). rxode2/#1183-#1185 restored
-  `indLin()`/matrix-exponential correctness, which was the reason for the
-  exclusion.
+- `"indLin"` is no longer excluded from the ODE-method fallback candidates a
+  post-fit table/residual solve tries when the fit's own ODE method is
+  neither `"dop853"`, `"liblsoda"`, nor `"lsoda"` (#858). rxode2/#1183-#1185
+  restored `indLin()`/matrix-exponential correctness, which was the reason
+  for the exclusion.
 
 ## New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -112,6 +112,11 @@
   halving then doubling compounded into a 4x inflated covariance. Point
   estimates, the objective value, and the log-likelihood were unaffected.
 
+- `method="indLin"` is no longer excluded from the ODE-method fallback list
+  used by post-fit table/residual solves (#858). rxode2/#1183-#1185 restored
+  `indLin()`/matrix-exponential correctness, which was the reason for the
+  exclusion.
+
 ## New features
 
 - `est="saem"` gained controls for the cost of the `nonMuTheta="regress"`

--- a/R/resid.R
+++ b/R/resid.R
@@ -89,12 +89,7 @@ nmObjGet.foceiThetaEtaParameters <- function(x, ...) {
     attr(cur, "class") <- "factor"
     currentOdeMethod <- as.character(cur)
   }
-  allOdeMethods <-
-    setdiff(
-      eval(formals(rxode2::rxSolve)$method),
-      # ignore indLin for now
-      "indLin"
-    )
+  allOdeMethods <- eval(formals(rxode2::rxSolve)$method)
   # Fallback ODE methods, see nlmixr2/nlmixr2est#254
   if (currentOdeMethod %in% "dop853") {
     allOdeMethods <- "liblsoda"

--- a/R/resid.R
+++ b/R/resid.R
@@ -63,6 +63,28 @@ nmObjGet.foceiThetaEtaParameters <- function(x, ...) {
 }
 
 
+#' Build the ODE-method fallback list for a post-fit table/residual solve
+#'
+#' @param currentOdeMethod character ODE method the fit itself used
+#'   (`fit$methodOde`, coerced to a name)
+#' @return list of candidate `method=` values to try in order,
+#'   `currentOdeMethod` first
+#' @author Matthew Fidler
+#' @noRd
+.residOdeFallbackMethods <- function(currentOdeMethod) {
+  allOdeMethods <- eval(formals(rxode2::rxSolve)$method)
+  # Fallback ODE methods, see nlmixr2/nlmixr2est#254
+  if (currentOdeMethod %in% "dop853") {
+    allOdeMethods <- "liblsoda"
+  } else if (currentOdeMethod %in% c("liblsoda", "lsoda")) {
+    allOdeMethods <- "dop853"
+  } # otherwise, use all the methods (nlmixr2/nlmixr2est#858 stopped excluding "indLin" here)
+  append(
+    list(currentOdeMethod),
+    as.list(setdiff(allOdeMethods, currentOdeMethod))
+  )
+}
+
 #' Solve for pred/ipred types of calculations (including residuals)
 #'
 #' @param fit focei style fit
@@ -89,18 +111,7 @@ nmObjGet.foceiThetaEtaParameters <- function(x, ...) {
     attr(cur, "class") <- "factor"
     currentOdeMethod <- as.character(cur)
   }
-  allOdeMethods <- eval(formals(rxode2::rxSolve)$method)
-  # Fallback ODE methods, see nlmixr2/nlmixr2est#254
-  if (currentOdeMethod %in% "dop853") {
-    allOdeMethods <- "liblsoda"
-  } else if (currentOdeMethod %in% c("liblsoda", "lsoda")) {
-    allOdeMethods <- "dop853"
-  } # otherwise, use all the methods
-  odeMethods <-
-    append(
-      list(currentOdeMethod),
-      as.list(setdiff(allOdeMethods, currentOdeMethod))
-    )
+  odeMethods <- .residOdeFallbackMethods(currentOdeMethod)
   failedMethods <- character()
   isFirstFit <- TRUE
   recalc <- TRUE

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -264,4 +264,46 @@ nmTest({
     expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
     expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
   })
+
+  test_that("matExp()/indLin() table and residual generation (#858)", {
+    # R/resid.R excluded "indLin" from the ODE-method fallback list used by
+    # post-fit table/residual solves; nlmixr2/nlmixr2est#858 removed that
+    # exclusion once rxode2/#1183-#1185 restored indLin() correctness.  This
+    # is a plain regression check that table/residual generation for a
+    # matExp()/indLin() fit still works with the exclusion gone.
+    matLin <- function() {
+      ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka + eta.ka)
+        k_central_output <- exp(tcl) / exp(tv)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    matMM <- function() {
+      ini({ tka <- 0.45; tvmax <- log(60); tkm <- log(40); tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka + eta.ka)
+        indLin(central) <- -exp(tvmax) * central / (exp(tkm) + central)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .datLin <- .mkData(matLin, c(tka = 0.6, tcl = 1.1, tv = 3.6))
+    .datMM <- .mkData(matMM, c(tka = 0.6, tvmax = log(70), tkm = log(45), tv = 3.6))
+
+    .fLin <- .nlmixr(matLin, .datLin, est = "focei", control = foceiControl(print = 0))
+    expect_true(all(c("PRED", "IPRED") %in% names(.fLin)))
+    expect_false(any(is.na(.fLin$IPRED)))
+    suppressMessages(expect_error(addCwres(.fLin), NA))
+    suppressMessages(expect_error(addNpde(.fLin), NA))
+
+    .fMM <- .nlmixr(matMM, .datMM, est = "focei", control = foceiControl(print = 0, sigdig = 6))
+    expect_true(all(c("PRED", "IPRED") %in% names(.fMM)))
+    expect_false(any(is.na(.fMM$IPRED)))
+    suppressMessages(expect_error(addCwres(.fMM), NA))
+    suppressMessages(expect_error(addNpde(.fMM), NA))
+  })
 })

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -266,11 +266,11 @@ nmTest({
   })
 
   test_that("matExp()/indLin() table and residual generation (#858)", {
-    # R/resid.R excluded "indLin" from the ODE-method fallback list used by
-    # post-fit table/residual solves; nlmixr2/nlmixr2est#858 removed that
-    # exclusion once rxode2/#1183-#1185 restored indLin() correctness.  This
-    # is a plain regression check that table/residual generation for a
-    # matExp()/indLin() fit still works with the exclusion gone.
+    # General regression check (issue #858's stated test) that table/residual
+    # generation for a matExp()/indLin() fit works. This does NOT exercise the
+    # setdiff() removal in R/resid.R itself -- see
+    # test-resid-ode-fallback.R for that (the default ODE methods used here
+    # never reach the branch the removal changed).
     matLin <- function() {
       ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
       model({

--- a/tests/testthat/test-resid-ode-fallback.R
+++ b/tests/testthat/test-resid-ode-fallback.R
@@ -1,0 +1,22 @@
+test_that("indLin() is available in the post-fit ODE-method fallback list (#858)", {
+  # "dop853"/"liblsoda"/"lsoda" primaries hard-override the candidate list to a
+  # single named fallback, so "indLin" never appears there regardless.
+  expect_equal(.residOdeFallbackMethods("dop853"), list("dop853", "liblsoda"))
+  expect_equal(.residOdeFallbackMethods("liblsoda"), list("liblsoda", "dop853"))
+  expect_equal(.residOdeFallbackMethods("lsoda"), list("lsoda", "dop853"))
+
+  # A primary of "indLin" itself always tries "indLin" first; it can never
+  # also appear later in its own fallback list (setdiff), so this is
+  # unaffected by the #858 change -- confirm the invariant directly.
+  .indLinCandidates <- .residOdeFallbackMethods("indLin")
+  expect_equal(.indLinCandidates[[1]], "indLin")
+  expect_equal(sum(unlist(.indLinCandidates) == "indLin"), 1L)
+
+  # Any other explicitly-requested ODE method (e.g. an obscure integrator set
+  # via rxControl(method=)) falls through to the "use all the methods"
+  # branch -- this is the only branch #858's setdiff removal affects, and
+  # "indLin" must now be a candidate there.
+  .rk4Candidates <- .residOdeFallbackMethods("rk4")
+  expect_equal(.rk4Candidates[[1]], "rk4")
+  expect_true("indLin" %in% unlist(.rk4Candidates))
+})


### PR DESCRIPTION
## Summary

- Removes the `setdiff(..., "indLin")` exclusion in `R/resid.R` that kept `"indLin"` out of the ODE-method fallback candidates used by post-fit table/residual solves. That exclusion is no longer needed now that rxode2/#1183, rxode2/#1184, and rxode2/#1185 (all closed) restored `indLin()`/matrix-exponential correctness.
- Extracts the candidate-list construction into a new `.residOdeFallbackMethods()` helper so the change is directly unit-testable (the default ODE methods `dop853`/`liblsoda`/`lsoda` hard-override the candidate list before the exclusion ever mattered, and a fit whose own method already is `"indLin"` drops it from its own fallback list either way -- the exclusion only ever affected a fit using some other explicitly-requested ODE method).
- Adds `tests/testthat/test-resid-ode-fallback.R`, a fast unit test that exercises the exact branch the removal changed (verified to fail if the exclusion is restored).
- Adds a regression test to `tests/testthat/test-matexp.R` (issue #858's stated "Test": table/residual generation for a matExp() fit) covering `addCwres()`/`addNpde()` on both a pure `matExp()` model and a `matExp()` + `indLin()` Michaelis-Menten model.
- NEWS.md entry.

Closes #858.

## Review

Reviewed with Antigravity (`agy`, Gemini 3.1 Pro) across two passes:
- First pass correctly flagged that the initial regression test didn't exercise the changed line, and that the NEWS.md wording overstated the change's scope.
- Both were addressed (helper extraction + targeted unit test + narrowed NEWS.md wording); the second pass confirmed the refactor is behavior-preserving, the new test genuinely targets the changed branch, and found no remaining correctness issues.

## Test plan

- [x] `testthat::test_file("tests/testthat/test-resid-ode-fallback.R")` -- 7/7 pass; fails as expected when the exclusion is restored (manually verified)
- [x] `testthat::test_file("tests/testthat/test-matexp.R")` -- 52/52 pass (full file, including the new `matExp()`/`indLin()` table/residual test)
- [x] `devtools::document()` -- no doc changes needed (both new functions are `@noRd`)