### PR TITLE
fix: mask saem calc.COV residual variance to its owning endpoint (#904)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -112,6 +112,14 @@
   halving then doubling compounded into a 4x inflated covariance. Point
   estimates, the objective value, and the log-likelihood were unaffected.
 
+- `calc.COV()`'s `covFull` residual-variance block (`saemix` `func_FIM.R`
+  `blocB`) is now masked to the endpoint each residual parameter belongs to
+  (#904). For a multi-endpoint SAEM model with separate residuals per
+  endpoint, every residual parameter's `dVi/d(param)` previously spanned all
+  endpoints' observation rows instead of only its own, so the reported
+  residual standard errors were wrong. Single-endpoint models, including
+  combined `add()+prop()`, were unaffected.
+
 ## New features
 
 - `est="saem"` gained controls for the cost of the `nonMuTheta="regress"`

--- a/R/saem_fit_aux.R
+++ b/R/saem_fit_aux.R
@@ -31,6 +31,23 @@
   rep(TRUE, length(ixEndpnt))
 }
 
+#' 1-based endpoint index of a residual parameter, aligned to `ix_endpnt`
+#'
+#' `ares`/`bres`/... (and so `ix_endpnt`) are built in `predDf` row order
+#' (`saemRxUiGet.R`); match a residual parameter's `iniDf$condition` to
+#' `predDf$cond` the same way rather than assuming row order lines up with
+#' `.ri`, so a residual parameter's `dVi/d(param)` can be masked to only its
+#' own endpoint's observations (#904).
+#'
+#' @param condition character vector, the `condition` of each residual `iniDf` row
+#' @param cond character vector, `predDf$cond` in endpoint (`ix_endpnt`) order
+#' @return integer vector, one 1-based endpoint index per `condition` entry;
+#'   `NA_integer_` where no endpoint matches
+#' @noRd
+.saemResEndpointIdx <- function(condition, cond) {
+  match(as.character(condition), as.character(cond))
+}
+
 #' Elementwise log(exp(a) + exp(b)) without overflowing
 #'
 #' @param a,b numeric vectors of the same length
@@ -540,10 +557,9 @@ calc.COV <- function(fit0) {
     if (nrow(.ri) > 0L) {
       .resNames <- .ri$name
       .resType  <- ifelse(grepl("prop|pow", .ri$err), 2L, 1L)   # 1 = additive (a), 2 = proportional (b)
-      # dVi/d(residual param) is only nonzero on its OWN endpoint's rows (#904); match
-      # each residual parameter's condition to predDf's row order, which is what
-      # ix_endpnt numbers against.  Fail rather than guess a wrong endpoint (#856).
-      .resEndpnt <- match(as.character(.ri$condition), as.character(.ui$predDf$cond))
+      # dVi/d(residual param) is only nonzero on its OWN endpoint's rows (#904).
+      # Fail rather than guess a wrong endpoint (#856).
+      .resEndpnt <- .saemResEndpointIdx(.ri$condition, .ui$predDf$cond)
       if (anyNA(.resEndpnt)) {
         warning("saem covFull: residual parameter endpoint unknown; variance block dropped",
                 call. = FALSE)

--- a/R/saem_fit_aux.R
+++ b/R/saem_fit_aux.R
@@ -1,5 +1,3 @@
-## FIXME: g by endpoint
-
 #' Per-observation mask of general log-likelihood (`ll()`) rows
 #'
 #' `res.mod == 0` marks an `ll()` endpoint and `ix_endpnt` maps each observation
@@ -528,6 +526,7 @@ calc.COV <- function(fit0) {
   .ui <- if (is.environment(.env)) .env$ui else NULL
   .covFull <- !is.null(.ui) && isTRUE(rxode2::rxGetControl(.ui, "covFull", TRUE))
   .omPairs <- NULL; .omNames <- character(0); .resNames <- character(0); .resType <- integer(0)
+  .resEndpnt <- integer(0)
   if (.covFull) {
     .idf <- .ui$iniDf
     .etaN <- tryCatch(.foceiEtaThetaMap(.ui)$etaNames, error = function(e) NULL)
@@ -541,6 +540,15 @@ calc.COV <- function(fit0) {
     if (nrow(.ri) > 0L) {
       .resNames <- .ri$name
       .resType  <- ifelse(grepl("prop|pow", .ri$err), 2L, 1L)   # 1 = additive (a), 2 = proportional (b)
+      # dVi/d(residual param) is only nonzero on its OWN endpoint's rows (#904); match
+      # each residual parameter's condition to predDf's row order, which is what
+      # ix_endpnt numbers against.  Fail rather than guess a wrong endpoint (#856).
+      .resEndpnt <- match(as.character(.ri$condition), as.character(.ui$predDf$cond))
+      if (anyNA(.resEndpnt)) {
+        warning("saem covFull: residual parameter endpoint unknown; variance block dropped",
+                call. = FALSE)
+        .resNames <- character(0); .resType <- integer(0); .resEndpnt <- integer(0)
+      }
     }
   }
   .nom <- if (is.null(.omPairs)) 0L else nrow(.omPairs)
@@ -581,12 +589,13 @@ calc.COV <- function(fit0) {
     .b <- NULL
     if (.doVar) {
       invVi <- crossprod(invVi.5)                            # Vi^{-1}
-      .gix <- g[ix]; .fix <- .absF0[ix]
+      .gix <- g[ix]; .fix <- .absF0[ix]; .eix <- ix_endpnt[ix]
       # A_k = Vi^{-1} dVi/d(param_k) for each variance parameter
       .A <- vector("list", .nvar); .k <- 0L
       for (r in seq_along(.resNames)) {
         .k <- .k + 1L
         .dv <- if (.resType[r] == 1L) 2 * .gix else 2 * .gix * .fix   # dVi/da = 2 diag(g); dVi/db = 2 diag(g|f|)
+        .dv[.eix != .resEndpnt[r]] <- 0                       # mask to the owning endpoint (#904)
         .A[[.k]] <- sweep(invVi, 2L, .dv, "*")               # Vi^{-1} diag(.dv)
       }
       if (.nom > 0L) for (pp in seq_len(.nom)) {

--- a/R/saem_fit_aux.R
+++ b/R/saem_fit_aux.R
@@ -561,9 +561,15 @@ calc.COV <- function(fit0) {
       # Fail rather than guess a wrong endpoint (#856).
       .resEndpnt <- .saemResEndpointIdx(.ri$condition, .ui$predDf$cond)
       if (anyNA(.resEndpnt)) {
+        # drop the WHOLE variance block, not just the residual rows: leaving
+        # .omPairs in place would still invert an Omega-only blocB submatrix,
+        # silently discarding its (generally nonzero) correlation with the
+        # residual parameters this cfg cannot place -- an unflagged, degraded
+        # Omega covariance is worse than reporting no variance block at all.
         warning("saem covFull: residual parameter endpoint unknown; variance block dropped",
                 call. = FALSE)
         .resNames <- character(0); .resType <- integer(0); .resEndpnt <- integer(0)
+        .omPairs <- NULL; .omNames <- character(0)
       }
     }
   }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -73,7 +73,7 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
     "focei-wang2007-bounded", "saem-loglik", "mu-timevarying", "saem-nearpd",
     "saem-nonmutheta", "focei-theta-reset-bounds",
     "saem-cov-analytic", "focei-shi21-bounds", "splitbolus-interp",
-    "optexpression-saem-nlme"),
+    "optexpression-saem-nlme", "saem-cov-multi-endpoint-904"),
 
   # batches 4-7 -- the former batches 4 (13 files) and 5 (15 files), each split
   # in two.  Both TIMED OUT on the weekly runner (run 30688874991, 2026-08-01):

--- a/tests/testthat/test-saem-cov-multi-endpoint-904.R
+++ b/tests/testthat/test-saem-cov-multi-endpoint-904.R
@@ -1,0 +1,98 @@
+# calc.COV's covFull residual variance block used to build dVi/d(residual param)
+# from every observation row of the subject, across ALL endpoints, instead of only
+# the endpoint that residual parameter belongs to (#904).  Two unrelated endpoints
+# (sharing no theta/eta) make this directly checkable: masked to its own endpoint,
+# a residual parameter's SE from the joint fit must reproduce the SE from fitting
+# that endpoint alone, since nothing about the other endpoint's data or parameters
+# should be able to leak in.  Multi-iteration fits -- weekly batch.
+
+nmTest({
+  test_that("saem covFull residual variance is masked to its own endpoint (#904)", {
+    skip_on_cran()
+
+    twoEp <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.7
+        tbio <- 5
+        eta.bio ~ 0.25
+        pdadd.sd <- 0.3
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        bio <- tbio + eta.bio                # unrelated endpoint: no shared theta/eta with cp
+        cp ~ add(add.sd)
+        bio ~ add(pdadd.sd) | bio
+      })
+    }
+    cpOnly <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+    bioOnly <- function() {
+      ini({ tbio <- 5; eta.bio ~ 0.25; pdadd.sd <- 0.3 })
+      model({ bio <- tbio + eta.bio; bio ~ add(pdadd.sd) })
+    }
+
+    .testSeed(2); rxode2::rxSetSeed(2)
+    .N <- 30
+    .ev <- rxode2::et(amt = 100, cmt = "depot", id = 1:.N)
+    .ev <- rxode2::et(.ev, seq(0.5, 24, by = 3), cmt = "cp")
+    .ev <- rxode2::et(.ev, seq(0.5, 24, by = 3), cmt = "bio")
+    .d <- as.data.frame(rxode2::rxSolve(twoEp, .ev, addDosing = TRUE))
+    .dose <- .d[.d$evid != 0, c("id", "time", "CMT", "amt", "evid")]
+    .dose$dv <- NA_real_
+    .obs <- .d[.d$evid == 0, c("id", "time", "CMT", "sim")]
+    .obs$amt <- 0; .obs$evid <- 0
+    names(.obs)[names(.obs) == "sim"] <- "dv"
+    .dat <- rbind(.dose[, c("id", "time", "dv", "CMT", "amt", "evid")],
+                  .obs[, c("id", "time", "dv", "CMT", "amt", "evid")])
+    .dat <- .dat[order(.dat$id, .dat$time, -.dat$evid), ]
+
+    # dosing + cp observations are exactly the rows the cp-only model sees -- "the
+    # first endpoint's data is unchanged" (issue #904's verification recipe)
+    .datCp <- .dat[.dat$CMT %in% c(1L, 3L), ]
+    .datBio <- .dat[.dat$CMT == 4L, ]
+
+    .ctl <- saemControl(nBurn = 150, nEm = 200, print = 0, seed = 1L,
+                        calcTables = FALSE, covMethod = "linFim")
+    .fJoint <- .nlmixr(twoEp, .dat, est = "saem", control = .ctl)
+    .fCp    <- .nlmixr(cpOnly, .datCp, est = "saem", control = .ctl)
+    .fBio   <- .nlmixr(bioOnly, .datBio, est = "saem", control = .ctl)
+
+    .getVarCov <- function(f) {
+      .s <- f$saem
+      attr(.s, "env") <- f$env
+      attr(suppressWarnings(calc.COV(.s)), "varCov")
+    }
+    .vcJoint <- .getVarCov(.fJoint)
+    .vcCp    <- .getVarCov(.fCp)
+    .vcBio   <- .getVarCov(.fBio)
+
+    expect_true(all(c("add.sd", "pdadd.sd") %in% rownames(.vcJoint)))
+    expect_true(all(is.finite(diag(.vcJoint))))
+    expect_true(all(diag(.vcJoint) > 0))
+
+    # the mechanism: masked to its own endpoint, each residual parameter's SE from
+    # the joint fit reproduces the single-endpoint reference (tight tolerance --
+    # nothing about the OTHER endpoint should be able to move this at all)
+    expect_equal(sqrt(.vcJoint["add.sd", "add.sd"]), sqrt(.vcCp["add.sd", "add.sd"]),
+                 tolerance = 0.1)
+    expect_equal(sqrt(.vcJoint["pdadd.sd", "pdadd.sd"]), sqrt(.vcBio["pdadd.sd", "pdadd.sd"]),
+                 tolerance = 0.1)
+  })
+})

--- a/tests/testthat/test-saem-cov-multi-endpoint-904.R
+++ b/tests/testthat/test-saem-cov-multi-endpoint-904.R
@@ -9,6 +9,11 @@
 nmTest({
   test_that("saem covFull residual variance is masked to its own endpoint (#904)", {
     skip_on_cran()
+    # pin threads: the simulated data and the fits themselves must be
+    # reproducible regardless of the runner's core count
+    .oldThreads <- rxode2::getRxThreads()
+    on.exit(rxode2::setRxThreads(.oldThreads), add = TRUE)
+    rxode2::setRxThreads(1L)
 
     twoEp <- function() {
       ini({
@@ -17,7 +22,7 @@ nmTest({
         add.sd <- 0.7
         tbio <- 5
         eta.bio ~ 0.25
-        pdadd.sd <- 0.3
+        pdadd.sd <- 0.15
       })
       model({
         ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
@@ -26,7 +31,13 @@ nmTest({
         cp <- center / v
         bio <- tbio + eta.bio                # unrelated endpoint: no shared theta/eta with cp
         cp ~ add(add.sd)
-        bio ~ add(pdadd.sd) | bio
+        # deliberately a DIFFERENT residual type (proportional, not additive) than cp's:
+        # with matching types the unmasked pre-fix dVi/da columns for both parameters
+        # were numerically identical, making the old code's blocB exactly singular and
+        # solve() fail -- so the fix only showed up as a missing row, not a wrong value.
+        # A mismatched type makes the pre-fix result wrong-but-present, so this test
+        # actually exercises the SE comparison below rather than an earlier NULL guard.
+        bio ~ prop(pdadd.sd) | bio
       })
     }
     cpOnly <- function() {
@@ -44,8 +55,8 @@ nmTest({
       })
     }
     bioOnly <- function() {
-      ini({ tbio <- 5; eta.bio ~ 0.25; pdadd.sd <- 0.3 })
-      model({ bio <- tbio + eta.bio; bio ~ add(pdadd.sd) })
+      ini({ tbio <- 5; eta.bio ~ 0.25; pdadd.sd <- 0.15 })
+      model({ bio <- tbio + eta.bio; bio ~ prop(pdadd.sd) })
     }
 
     .testSeed(2); rxode2::rxSetSeed(2)
@@ -89,10 +100,14 @@ nmTest({
 
     # the mechanism: masked to its own endpoint, each residual parameter's SE from
     # the joint fit reproduces the single-endpoint reference (tight tolerance --
-    # nothing about the OTHER endpoint should be able to move this at all)
-    expect_equal(sqrt(.vcJoint["add.sd", "add.sd"]), sqrt(.vcCp["add.sd", "add.sd"]),
-                 tolerance = 0.1)
-    expect_equal(sqrt(.vcJoint["pdadd.sd", "pdadd.sd"]), sqrt(.vcBio["pdadd.sd", "pdadd.sd"]),
-                 tolerance = 0.1)
+    # nothing about the OTHER endpoint should be able to move this at all).  These
+    # SEs are ~0.01 in magnitude, well under a naive absolute tolerance -- compare
+    # the RATIO to 1 so the check is genuinely relative (expect_equal(x, y, tolerance=)
+    # falls back to an absolute difference once both values are small, which would
+    # make a tolerance chosen for O(1) numbers pass almost regardless of x vs y).
+    expect_equal(sqrt(.vcJoint["add.sd", "add.sd"]) / sqrt(.vcCp["add.sd", "add.sd"]),
+                 1, tolerance = 0.15)
+    expect_equal(sqrt(.vcJoint["pdadd.sd", "pdadd.sd"]) / sqrt(.vcBio["pdadd.sd", "pdadd.sd"]),
+                 1, tolerance = 0.15)
   })
 })

--- a/tests/testthat/test-saem-cov-sa.R
+++ b/tests/testthat/test-saem-cov-sa.R
@@ -261,4 +261,13 @@ nmTest({
     # no distribution at all (an old cfg) must not error
     expect_equal(.saemLlObsMask(list(opt = list()), .ix), rep(FALSE, 4))
   })
+
+  test_that(".saemResEndpointIdx matches a residual parameter to its ix_endpnt endpoint (#904)", {
+    # predDf$cond is in ix_endpnt (endpoint) order; a residual parameter's condition
+    # is matched positionally against it, not assumed to line up with .ri's row order
+    expect_equal(.saemResEndpointIdx(c("cp", "effect", "cp"), c("cp", "effect")), c(1L, 2L, 1L))
+    # a condition naming no endpoint fails rather than being silently attributed
+    # to the wrong (or first) one
+    expect_equal(.saemResEndpointIdx(c("cp", "bogus"), c("cp", "effect")), c(1L, NA_integer_))
+  })
 })


### PR DESCRIPTION
## Summary

- `calc.COV()`'s `covFull` residual-variance block (`saemix` `func_FIM.R` `blocB`) built `dVi/d(residual param)` from every observation row of a subject, across **all** endpoints, instead of only the endpoint that residual parameter belongs to. For a multi-endpoint SAEM model with separate residuals per endpoint, this made the reported residual standard errors wrong. Single-endpoint models (including combined `add()+prop()`) were unaffected -- the defect is specific to multiple endpoints.
- Fixes it by matching each residual parameter's `iniDf$condition` to `predDf$cond` (the same row order `ix_endpnt` numbers against, following the existing precedent in `R/saemRxUiGet.R`) and zeroing `dVi` outside the owning endpoint's rows. If the match is ambiguous, the whole variance block (residual **and** Omega) is dropped with a warning rather than guessing.

Closes #904.

## Review

Ran an independent Antigravity (Gemini) review against the diff. Two findings were real and are fixed here:

- The `anyNA` fallback only cleared the residual rows, leaving `.omPairs` in place -- that silently inverted an Omega-only `blocB` submatrix, discarding its correlation with the residual parameters that couldn't be placed. Now the whole block is dropped.
- The original regression test used `expect_equal(x, y, tolerance = 0.1)` on ~0.01-magnitude SEs, which testthat/`all.equal` treats as an absolute bound once both values are small, so it passed almost regardless of the actual values, and both endpoints used the same residual type, which made the pre-fix unmasked `dVi` columns coincidentally identical (an exactly singular `blocB`), so the old test only caught a missing row, not a wrong value. Reworked to compare SE ratios to 1 (a genuine relative check) with mismatched residual types (add vs prop) across endpoints. Verified by hand that the test now fails against the pre-fix code and passes against the fix.

One finding was correct but out of scope: endpoint matching assumes `predDf` row (declaration) order equals the data's ascending-CMT-value order, which `ix_endpnt` sorts by. This is a real potential divergence, but it's a pre-existing assumption shared by `ares[ix_endpnt]`, `bres[ix_endpnt]`, `lambda[ix_endpnt]`, etc. throughout this file -- not a new regression from this fix. Matching that same (imperfect) convention was deliberate: an independently "more correct" endpoint lookup for just the residual mask would only make things worse by disagreeing with how `g` itself is already computed. Left as a known limitation for a future fix.

Other findings (3+ endpoint / covariate-conditioned residual test coverage, and a separate pre-existing miscasting of `boxCox`/`yeoJohnson`/`ar` rows as additive residual params in the same `.resType` computation) are real but unrelated to this issue's defect and out of scope here.

## Test plan

- New weekly-batch test `test-saem-cov-multi-endpoint-904.R`: a 2-endpoint SAEM model whose endpoints share no theta/eta; each residual parameter's `linFim` SE from the joint fit is checked against the SE from fitting that endpoint alone (issue's verification recipe). Manually confirmed it fails on the pre-fix code and passes on the fix.
- New unit test for `.saemResEndpointIdx()` alongside the existing `.saemLlObsMask` tests (essential/always-run).
- `test-saem-cov-sa.R` and `test-saem-cov-analytic.R` (existing covariance suites, including the ll()-endpoint and Omega-splice tests) re-run clean.