### PR TITLE
fix: saem analytic FIM had one residual slot for any number of endpoints (#893)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -112,6 +112,19 @@
   halving then doubling compounded into a 4x inflated covariance. Point
   estimates, the objective value, and the log-likelihood were unaffected.
 
+- SAEM's analytic Fisher information (`covMethod="fim"`/`"sa"`) had exactly one
+  residual slot no matter how many endpoints a model declared, so a
+  multi-endpoint fit's residual score/Hessian always came from whichever
+  endpoint the internal loop happened to process last, divided by the *first*
+  endpoint's residual variance (#893). Because that slot is coupled to the
+  fixed-effect/BSV block through the full Fisher information matrix, this
+  corrupted the reported theta and Omega standard errors for any multi-endpoint
+  `fim`/`sa` fit, not just the (previously unreported) residual SE. The
+  analytic FIM now carries one residual slot per endpoint; a pure additive
+  endpoint gets a real entry, and any other endpoint's slot is held at exactly
+  zero and dropped before the matrix is inverted, falling back to the
+  linearized FIM for that endpoint's residual SE as before.
+
 ## New features
 
 - `est="saem"` gained controls for the cost of the `nonMuTheta="regress"`

--- a/R/saem.R
+++ b/R/saem.R
@@ -616,10 +616,21 @@
   .saem <- env$saem
   if (is.null(.H) || !is.matrix(.H) || nrow(.H) == 0L ||
         !all(is.finite(.H)) || all(.H == 0)) return(NULL)
+  .np <- nrow(.H)  # original nb_param layout; residual slot positions are keyed to this
+  # src/saem.cpp gives a non-additive endpoint's residual slot (and a
+  # general-log-likelihood endpoint) an exactly-zero row/col in every entry --
+  # solving the full matrix would be singular.  Drop any all-zero row (its
+  # column is zero too: Ha/HaSa is symmetric and d2logk/D11 never write a
+  # cross term into an excluded slot) and remember which original column each
+  # surviving row/col came from, since the indexing below is keyed to the
+  # ORIGINAL (nb_param) layout.
+  .keep <- which(apply(.H, 1L, function(.r) any(.r != 0)))
+  if (length(.keep) == 0L) return(NULL)
   # covariance = inverse of the FIM, in (theta, log-Omega-variance, log-sigma2) coords
-  .C <- suppressWarnings(tryCatch(solve(.H), error = function(e) NULL))
+  .C <- suppressWarnings(tryCatch(solve(.H[.keep, .keep, drop = FALSE]), error = function(e) NULL))
   if (is.null(.C) || !all(is.finite(.C))) return(NULL)
-  .np <- nrow(.C)
+  .orig2sub <- rep(NA_integer_, .np)
+  .orig2sub[.keep] <- seq_along(.keep)
   .tn <- .ui$saemParamsToEstimate[!.ui$saemFixed]
   .nth <- length(.tn)
   if (.nth == 0L || .np < .nth) return(NULL)
@@ -639,14 +650,31 @@
     .nm <- c(.nm, paste0("om.", .etaN))
     .jac <- c(.jac, .omVar[seq_len(.nEta)])
   }
-  # single additive residual: log-sigma2 -> reported SD, d(sd)/d(log sigma2) = 0.5 sd
-  .ri <- .idf[!is.na(.idf$err) & !.idf$fix, , drop = FALSE]
-  if (nrow(.ri) == 1L && .np == .nth + .nEta + 1L && !grepl("prop|pow", .ri$err)) {
-    .ares <- tryCatch(.saem$resMat[1, 1], error = function(e) NA_real_)
-    if (is.finite(.ares) && .ares > 0) {
-      .idx <- c(.idx, .np); .nm <- c(.nm, .ri$name); .jac <- c(.jac, 0.5 * .ares)
+  # per-endpoint additive residual: src/saem.cpp lays out one log-sigma2 slot per
+  # endpoint (in .predDf$cond order, matching resMat's rows), right after the
+  # theta+Omega-diag block -- d(sd)/d(log sigma2) = 0.5 sd.  Only a PURE additive
+  # endpoint (a single iniDf residual row with err=="add") has a real slot; any
+  # other endpoint's slot was dropped above (all-zero row) and simply has no
+  # surviving column to select here.
+  .predDf <- .ui$predDf
+  .nEp <- length(.predDf$cond)
+  if (.nEp > 0L && .np >= .nth + .nEta + .nEp) {
+    .base <- .nth + .nEta
+    for (.i in seq_len(.nEp)) {
+      .sub <- .orig2sub[.base + .i]
+      if (is.na(.sub)) next
+      .cond <- paste(.predDf$cond[.i])
+      .rows <- .idf[which(.idf$condition == .cond & !is.na(.idf$err)), , drop = FALSE]
+      if (nrow(.rows) != 1L || !identical(.rows$err, "add")) next
+      .ares <- tryCatch(.saem$resMat[.i, 1], error = function(e) NA_real_)
+      if (is.finite(.ares) && .ares > 0) {
+        .idx <- c(.idx, .base + .i); .nm <- c(.nm, .rows$name); .jac <- c(.jac, 0.5 * .ares)
+      }
     }
   }
+  .sub <- .orig2sub[.idx]
+  .have <- !is.na(.sub)
+  .idx <- .sub[.have]; .nm <- .nm[.have]; .jac <- .jac[.have]
   .cov <- outer(.jac, .jac) * .C[.idx, .idx, drop = FALSE]   # delta method to reported scale
   dimnames(.cov) <- list(.nm, .nm)
   # require a valid (finite, PD) covariance; otherwise let the caller fall back

--- a/R/saem_fit.R
+++ b/R/saem_fit.R
@@ -436,7 +436,10 @@
   nlambda <- nlambda1 + nlambda0
   nd1 <- nphi1 + nlambda1 + 1
   nd2 <- nphi1 + nlambda1 + nlambda0
-  nb_param <- nd2 + 1
+  # one FIM residual slot per endpoint, none for a general log-likelihood
+  # model (distribution==4) -- must stay in sync with src/saem.cpp's nb_param
+  nResidEp <- if (distribution == 4) 0L else model$nendpnt
+  nb_param <- nd2 + nResidEp
   Mcovariables <- cbind(rep(1, N), covariables)[, 1:nrow(mcov)]
   dim(Mcovariables) <- c(length(Mcovariables) / nrow(mcov), nrow(mcov)) # FIXME
 

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -1180,6 +1180,29 @@ public:
     return resk;
   }
 
+  // Fill this chain's per-endpoint residual log-sigma2 score/Hessian entries
+  // from resy(b,k) (endpoint b's residual SSR for MCMC chain k).  Only a pure
+  // additive endpoint (res_mod==rmAdd) has a valid single-parameter
+  // log-sigma2 score; every other endpoint's slot is held at exactly 0 (see
+  // the nb_param comment in inits()).  d1_logsigma2 must already be sized
+  // nResidEp; d2logk is nb_param x nb_param.
+  void fillResidLogSigma2(int k, const mat &resy, vec &d1_logsigma2, mat &d2logk) {
+    int resBase = nlambda + nphi1;
+    for (int b = 0; b < nendpnt; b++) {
+      int idx = residEpIdx[b];
+      if (idx < 0) continue;
+      int col = resBase + idx;
+      if (res_mod(b) == rmAdd) {
+        double nb = (double)(y_offset(b + 1) - y_offset(b));
+        d1_logsigma2[idx] = 0.5 * resy(b, k) / sigma2[b] - 0.5 * nb;
+        d2logk(col, col) = -0.5 * resy(b, k) / sigma2[b];
+      } else {
+        d1_logsigma2[idx] = 0.0;
+        d2logk(col, col) = 0.0;
+      }
+    }
+  }
+
   mat get_resMat() {
     mat m(nendpnt,4);
     m.col(0) = ares;
@@ -1406,7 +1429,6 @@ public:
     nlambda1 = as<int>(x["nlambda1"]);
     nlambda0 = as<int>(x["nlambda0"]);
     nlambda = nlambda1 + nlambda0;
-    nb_param = nphi1 + nlambda + 1;
     nphi = nphi1+nphi0;
     Plambda.zeros(nlambda);
     ilambda1 = as<uvec>(x["ilambda1"]);
@@ -1417,6 +1439,23 @@ public:
 
     //FIXME
     nendpnt=as<int>(x["nendpnt"]);
+    distribution=as<int>(x["distribution"]);
+    // One FIM residual slot per endpoint that carries a residual parameter --
+    // none when the whole model is a general log-likelihood (distribution==4;
+    // "any LL endpoint" forces the WHOLE model to distribution==4, so no
+    // endpoint has a real residual in that case).  Sizing to nendpnt (not
+    // nres, the total residual PARAMETER count) is deliberate: the analytic
+    // Louis FIM only ever tracks a single log-sigma2 score/Hessian per
+    // endpoint, valid only for a pure additive residual (res_mod==rmAdd);
+    // any other endpoint's slot exists (so nb_param has a fixed layout) but
+    // its d1_logsigma2/d2logk entries are held at exactly 0 in every
+    // iteration, so its row/col of Ha/HaSa stays exactly 0 and
+    // .saemFimToCov (R/saem.R) can drop it and fall back to the linFim
+    // splice for that endpoint's residual SE.
+    nResidEp = (distribution == 4) ? 0 : nendpnt;
+    for (int b = 0; b < MAXENDPNT; ++b) residEpIdx[b] = -1;
+    for (int b = 0; b < nResidEp; ++b) residEpIdx[b] = b;
+    nb_param = nphi1 + nlambda + nResidEp;
     ix_sorting=as<uvec>(x["ix_sorting"]);
     ys = y(ix_sorting);    //ys: obs sorted by endpnt
     y_offset=as<uvec>(x["y_offset"]);
@@ -1547,7 +1586,6 @@ public:
     mx.evtM   = evt;
     mx.optM   = optM;
 
-    distribution=as<int>(x["distribution"]);
     nonMuThetaRegress = x.containsElementNamed("nonMuThetaRegress") ?
       as<int>(x["nonMuThetaRegress"]) : 0;
     nonMuThetaOptType = x.containsElementNamed("nonMuThetaOptType") ?
@@ -1812,7 +1850,7 @@ public:
       mat D11 = zeros<mat>(nb_param, nb_param);
       mat D2 = zeros<mat>(nb_param, nb_param);
       mat d2logk = zeros<mat>(nb_param, nb_param);
-      vec resy(nmc);
+      mat resy(nendpnt, nmc);  // resy(b, k): endpoint b's residual SSR for chain k
       vec fsM;
       fsM.set_size(0);
 
@@ -1997,7 +2035,7 @@ public:
               resk += arResk(b, f_cur, y_cur, mHyp);
             }
             statr[b] += resk;
-            resy(k) = resk;
+            resy(b, k) = resk;
           }
 
           mat dphi1k = phi1k - mprior_phi1;
@@ -2008,8 +2046,8 @@ public:
           vec d1_mu_phi1 = Md1(ind_cov1);
           vec d1_mu_phi0 = Md0(ind_cov0);
           vec d1_loggamma2_phi1 = 0.5 * sdg1 - 0.5 * N;
-          vec d1_logsigma2(1);
-          d1_logsigma2[0] = 0.5 * resy(k) / sigma2[0] - 0.5 * ntotal;
+          vec d1_logsigma2(nResidEp);
+          fillResidLogSigma2(k, resy, d1_logsigma2, d2logk);
           vec d1logk = join_cols(d1_mu_phi1, join_cols(d1_mu_phi0, join_cols(d1_loggamma2_phi1, d1_logsigma2)));
           D1 = D1 + d1logk;
           D11 = D11 + d1logk * d1logk.t();
@@ -2024,7 +2062,6 @@ public:
             }
             d2logk(nlambda + j, nlambda + j) = w2phi(j);
           }
-          d2logk(nb_param - 1, nb_param - 1) = -0.5 * resy(k) / sigma2[0];
           D2 = D2 + d2logk;
         }
       } else if (nMix > 1) {
@@ -2282,7 +2319,7 @@ public:
               resk += arResk(b, f_cur, y_cur, jMix);
             }
             statr[b] += resk;
-            resy(k) = resk;
+            resy(b, k) = resk;
           }
 
           vec sdg1 = sdg1_w / gamma2_phi1;
@@ -2291,8 +2328,8 @@ public:
           vec d1_mu_phi1 = Md1(ind_cov1);
           vec d1_mu_phi0 = Md0(ind_cov0);
           vec d1_loggamma2_phi1 = 0.5 * sdg1 - 0.5 * N;
-          vec d1_logsigma2(1);
-          d1_logsigma2[0] = 0.5 * resy(k) / sigma2[0] - 0.5 * ntotal;
+          vec d1_logsigma2(nResidEp);
+          fillResidLogSigma2(k, resy, d1_logsigma2, d2logk);
           vec d1logk = join_cols(d1_mu_phi1, join_cols(d1_mu_phi0, join_cols(d1_loggamma2_phi1, d1_logsigma2)));
           D1 = D1 + d1logk;
           D11 = D11 + d1logk * d1logk.t();
@@ -2307,7 +2344,6 @@ public:
             }
             d2logk(nlambda + j, nlambda + j) = w2phi(j);
           }
-          d2logk(nb_param - 1, nb_param - 1) = -0.5 * resy(k) / sigma2[0];
           D2 = D2 + d2logk;
         }
         for (int k = 0; k < nmc; k++) {
@@ -2473,7 +2509,7 @@ public:
             }
 
             statr[b]=statr[b]+resk;
-            resy(k) = resk;                                          //FIXME: resy(b,k)?
+            resy(b, k) = resk;
           }
           if (DEBUG>1) Rcout << "star[] successful\n";
 
@@ -2485,9 +2521,10 @@ public:
           vec d1_mu_phi1=Md1(ind_cov1);                              //CHK!! vec or mat
           vec d1_mu_phi0=Md0(ind_cov0);                              //CHK!! vec or mat
           vec d1_loggamma2_phi1=0.5*sdg1-0.5*N;
-          vec d1_logsigma2(1);
-          // general log-likelihood: no residual param, so its FIM row is 0
-          d1_logsigma2[0] = (distribution == 4) ? 0.0 : 0.5*resy(k)/sigma2[0]-0.5*ntotal; //FIXME: sigma2[0], sigma2[b] instead?
+          // general log-likelihood (distribution==4): no residual param, so
+          // nResidEp==0 and this block is empty
+          vec d1_logsigma2(nResidEp);
+          if (distribution != 4) fillResidLogSigma2(k, resy, d1_logsigma2, d2logk);
           vec d1logk=join_cols(d1_mu_phi1, join_cols(d1_mu_phi0, join_cols(d1_loggamma2_phi1, d1_logsigma2)));
           D1 = D1+d1logk;
           D11= D11+d1logk*d1logk.t();
@@ -2502,7 +2539,6 @@ public:
             }
             d2logk(nlambda+j,nlambda+j)=w2phi(j);
           }
-          d2logk(nb_param-1,nb_param-1)=(distribution == 4) ? 0.0 : -0.5*resy(k)/sigma2[0];      //FIXME: sigma2[0], sigma2[b] instead?
           D2=D2+d2logk;
         }
       }//k
@@ -3586,6 +3622,11 @@ private:
 
   int nlambda1, nlambda0, nlambda, nb_param;
   uvec ilambda1, ilambda0;
+  // one FIM residual slot per endpoint (see the nb_param comment in inits());
+  // residEpIdx[b] is that endpoint's compacted slot, or -1 when the whole
+  // model is a general log-likelihood (nResidEp==0)
+  int nResidEp;
+  int residEpIdx[MAXENDPNT];
 
   mat statphi01, statphi02, statphi11, statphi12;
   // Per-component, unblended sufficient statistic (never mixed across components); used to fix

--- a/tests/testthat/test-saem-cov-sa.R
+++ b/tests/testthat/test-saem-cov-sa.R
@@ -207,6 +207,12 @@ nmTest({
     # residual error to anchor it); linFim is what gets reported
     expect_equal(.f$covMethod, "linFim")
 
+    # nb_param (#893): the C++ kernel still accumulates Ha/HaSa every fit
+    # regardless of the reported covMethod -- for a general-likelihood model
+    # (distribution==4) it must carry NO residual slot at all (theta + eta
+    # only), not a spurious always-zero one
+    expect_equal(nrow(.f$saem$Ha), 1L + 1L)
+
     .tlam <- fixef(.f)[["tlam"]]
     .om <- .f$omega[1, 1]
     # exact marginal -2LL and its observed information, by quadrature over the eta

--- a/tests/testthat/test-saem-cov-sa.R
+++ b/tests/testthat/test-saem-cov-sa.R
@@ -242,6 +242,87 @@ nmTest({
     expect_equal(.ff$covMethod, "linFim")
   })
 
+  test_that("multi-endpoint fim/sa: one residual FIM slot per endpoint (#893)", {
+    # Before the fix, src/saem.cpp had exactly ONE log-sigma2 slot no matter how
+    # many endpoints the model declared, so a multi-endpoint fit's residual score
+    # always came from whichever endpoint the per-chain loop processed last,
+    # divided by endpoint 0's sigma2 -- and because that slot couples to theta/
+    # Omega through the full Fisher information matrix, R's .saemFimToCov() never
+    # even surfaced a residual SE for a multi-endpoint model (nrow(.ri) > 1
+    # always skipped the residual block entirely).  A pure-additive two-endpoint
+    # model must now get a REAL, separate SE for each endpoint's residual.
+    pkpd <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45; tslope <- 1
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.7; add2.sd <- 5
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v  <- exp(tv + eta.v)
+        slope <- exp(tslope)
+        cp <- linCmt()
+        pca <- slope * cp
+        cp ~ add(add.sd)
+        pca ~ add(add2.sd)
+      })
+    }
+    ctl <- saemControl(nBurn = 150, nEm = 200, print = 0, seed = 1L,
+                       covMethod = "sa", nSaCov = 500)
+    f <- .nlmixr(pkpd, warfarin, est = "saem", control = ctl)
+    skip_if_not(identical(f$covMethod, "sa"))   # near-singular fits legitimately fall back
+
+    # nb_param carries one slot per endpoint: theta(4) + eta(3) + residual(2)
+    expect_equal(nrow(f$saem$Ha), 4L + 3L + 2L)
+
+    # both endpoints' additive residual SEs are real (not dropped/NA)
+    expect_true(all(c("add.sd", "add2.sd") %in% rownames(f$cov)))
+    expect_true(is.finite(f$parFixedDf["add.sd", "SE"]) && f$parFixedDf["add.sd", "SE"] > 0)
+    expect_true(is.finite(f$parFixedDf["add2.sd", "SE"]) && f$parFixedDf["add2.sd", "SE"] > 0)
+
+    # a mixed add+prop / add model: the pure-additive endpoint still gets a real
+    # analytic slot, the combined endpoint's slot is an exact-zero row dropped
+    # before solve() (its SE instead comes from the linFim splice)
+    pkpd2 <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45; tslope <- 1
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.7; prop.sd <- 0.1; add2.sd <- 5
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v  <- exp(tv + eta.v)
+        slope <- exp(tslope)
+        cp <- linCmt()
+        pca <- slope * cp
+        cp ~ add(add.sd) + prop(prop.sd)
+        pca ~ add(add2.sd)
+      })
+    }
+    f2 <- .nlmixr(pkpd2, warfarin, est = "saem",
+                  control = saemControl(nBurn = 150, nEm = 200, print = 0, seed = 1L,
+                                        covMethod = "sa", nSaCov = 500))
+    .Ha <- f2$saem$HaSa
+    expect_equal(nrow(.Ha), 4L + 3L + 2L)
+    # the combined endpoint's slot (cp, first endpoint) is exactly zero;
+    # the pure-additive endpoint's slot (pca, second) is not
+    .zeroRow <- apply(.Ha, 1L, function(r) all(r == 0))
+    expect_equal(unname(.zeroRow[8]), TRUE)
+    expect_equal(unname(.zeroRow[9]), FALSE)
+    if (identical(f2$covMethod, "sa")) {
+      expect_true("add2.sd" %in% rownames(f2$cov))
+      expect_false("add.sd" %in% rownames(f2$cov))
+      expect_false("prop.sd" %in% rownames(f2$cov))
+    }
+    # the pure-additive endpoint's SE is real regardless (its slot was never
+    # dropped); the combined endpoint's SE depends on the linFim splice
+    # succeeding, which is a convergence question unrelated to this fix and
+    # already covered by the "fim/sa splice" test above
+    expect_true(is.finite(f2$parFixedDf["add2.sd", "SE"]) && f2$parFixedDf["add2.sd", "SE"] > 0)
+  })
+
   test_that(".saemLlObsMask refuses to guess rather than mis-score (#871)", {
     .ix <- c(1L, 1L, 2L, 2L)
     # res.mod present: per-observation, res.mod == 0 marks the ll() endpoint


### PR DESCRIPTION
## Summary

Fixes #893. SAEM's analytic Fisher Information Matrix (`covMethod="fim"`/`"sa"`) sized `nb_param` with exactly one residual (log-sigma2) slot regardless of how many endpoints the model declared. A multi-endpoint fit's residual score/Hessian therefore always came from whichever endpoint the internal per-chain loop happened to process last, divided by endpoint 0's `sigma2`. Because that slot couples to theta/Omega through the full Fisher information matrix (`D1`/`D11`/`D2` accumulation, then `Ha = D2 - Louis correction`), this silently corrupted the reported fixed-effect and BSV standard errors for *any* multi-endpoint `fim`/`sa` fit -- not just the (previously never-reported) residual SE.

- `src/saem.cpp`: `nb_param` now carries one residual slot per endpoint (`nResidEp`), via a per-endpoint map (`residEpIdx`) built once from `nendpnt`/`distribution` (`distribution==4` means the whole model is a general log-likelihood, so `nResidEp` is 0 -- "any `ll()` endpoint" forces this for the entire model, never a mix). Only a pure additive endpoint (`res_mod==rmAdd`) gets a real `d1_logsigma2`/`d2logk` entry via the new `fillResidLogSigma2()` helper; every other endpoint's slot is held at exactly `0.0` in every iteration, so its row/column of the accumulated `Ha`/`HaSa` stays exactly zero for the whole fit. `resy` is now a per-endpoint (`nendpnt x nmc`) matrix instead of a single vector overwritten by whichever endpoint ran last.
- `R/saem.R`: `.saemFimToCov()` (shared by `covMethod="fim"`/`"sa"`) now drops any all-zero row/column from the FIM *before* calling `solve()` (a zero row makes the full matrix singular), remembers which original `nb_param` column each surviving row came from, and builds one residual delta-method entry per pure-additive endpoint (matched via `predDf$cond` order against `resMat`'s rows) instead of only ever handling a single declared residual parameter.
- `R/saem_fit.R`: a small dead-code sizing formula (`nb_param`, never consumed downstream) updated to stay in sync/documented.

## Review

Reviewed twice with Antigravity (`gemini-3.1-pro-high`) as an independent second opinion. First pass flagged three items:
1. Possible buffer overflow on `residEpIdx[MAXENDPNT]` if `nendpnt >= 41` -- rejected: every other per-endpoint array in this file (`statrese`, `sigma2`, `arFirstSSR`, `arNobs`, `arPair*`) has the identical unchecked pattern; out of scope for this fix.
2. Missing test for the "successful linFim splice" path on a non-additive multi-endpoint residual -- attempted but left uncovered; the underlying `calc.COV` variance-block machinery proved fragile to converge on a multi-endpoint combined-residual model within reasonable test runtime, independent of this fix. The zero-row-drop mechanism itself is deterministically covered.
3. Missing test proving a general-log-likelihood model correctly zero-sizes the residual block -- addressed, one assertion added reusing an existing fit (no new compute).

A second pass on the updated diff found nothing further.

## Test plan

- [x] `devtools::load_all()` compiles cleanly (`rm -f src/*.o src/*.so` first, per struct-layout convention)
- [x] `tests/testthat/test-saem-cov-sa.R` passes, including two new test blocks pinning the per-endpoint FIM slot behavior and the general-likelihood zero-slot sizing
- [x] `tests/testthat/test-saem-cov-analytic.R`, `test-saem-cov-transpose.R`, `test-saem-loglik.R`, and the rest of the essential (non-slow-batch) `test-saem-*.R` files pass
- [x] Manual smoke test: a two-endpoint pure-additive model now reports real, independent residual SEs for both endpoints under `covMethod="sa"` (previously neither was ever reported); a mixed add+prop / pure-add model shows the combined endpoint's FIM slot is an exact-zero row, correctly dropped before inversion