### PR TITLE
saem: solve matExp() models natively instead of flattening (#859)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,14 @@
   ecosystem, so rxode2 can now drop it (nlmixr2/rxode2#1250).
 ## New features
 
+- A pure-linear `matExp()` model now solves natively through rxode2's
+  matrix-exponential driver (`rxControl(method="indLin")`) under SAEM instead
+  of being flattened to an equivalent `d/dt()` ODE first.  SAEM has no
+  analytic-sensitivity consumer of the state derivatives, so native solving
+  is all that changes; `focei`/`nlm`/`nls` are unaffected, and a model with
+  an `indLin()` forcing term (e.g. Michaelis-Menten) still flattens (issue
+  #859).
+
 - A modeled `alag()` or `f()` on a `linCmt()` compartment now gets an exact
   FOCEi/FOCE eta gradient instead of a silently incomplete one.  The
   structural `linCmt()` Jacobian only covers `p1`/`v1`/`ka`/...; the

--- a/R/focei.R
+++ b/R/focei.R
@@ -361,39 +361,39 @@ is.latex <- function() {
   invisible(TRUE)
 }
 
-#' Keep a matExp()/indLin() model in native (unflattened) form
+#' Keep a PURE-LINEAR matExp() model in native (unflattened) form
 #'
 #' Unlike [.rxInjectMatExpDdt()], this does not materialize `d/dt()` -- it
-#' emits the literal `matExp()` keyword (plus any `indLin()` forcing lines)
-#' so the model solves through rxode2's matrix-exponential driver
-#' (`rxControl(method="indLin")`) instead of an ODE solver.  SAEM has no
-#' analytic-sensitivity consumer of the state derivatives, so it is the only
-#' estimation method that uses this path (#859); focei/nlm/nls still need
-#' `.rxInjectMatExpDdt()`'s explicit `d/dt()` for their sensitivity machinery.
+#' emits the literal `matExp()` keyword so the model solves through rxode2's
+#' matrix-exponential driver (`rxControl(method="indLin")`) instead of an ODE
+#' solver.  SAEM has no analytic-sensitivity consumer of the state
+#' derivatives, so it is the only estimation method that uses this path
+#' (#859); focei/nlm/nls still need `.rxInjectMatExpDdt()`'s explicit
+#' `d/dt()` for their sensitivity machinery.
+#'
+#' Deliberately bails (returns `FALSE`, leaving `s$..ddt` untouched) on a
+#' model with an `indLin()` forcing term (Michaelis-Menten etc.): that needs
+#' rxode2's true inductive-linearization iteration (`doIndLin` 3/4), which
+#' does not yet converge reliably under SAEM's per-iteration parameter draws
+#' (diverges from the ODE reference fit rather than merely differing in
+#' precision).  Those models keep flattening via `.rxInjectMatExpDdt()`.
 #'
 #' @param s symengine-pruned model environment
-#' @return `TRUE`/invisibly `FALSE`; sets `s$..ddt` to the native matExp()
-#'   lines on success
+#' @return `TRUE`/invisibly `FALSE`; sets `s$..ddt` to `"matExp()"` on success
 #' @noRd
 .rxKeepMatExpNative <- function(s) {
   .mv <- rxode2::rxModelVars(s)
   if (!is.list(.mv$indLin) || length(.mv$indLin) != 4L) {
     return(invisible(FALSE))
   }
+  if (length(.mv$indLin$wIndLin) > 0L) {
+    return(invisible(FALSE))
+  }
   .states <- .rxode2stateOdeNoOutput(s)
   if (length(.states) == 0L) {
     return(invisible(FALSE))
   }
-  .indLin <- character(0)
-  for (.st in .states) {
-    .forceName <- base::paste0("rx__indLinForce_", .st, "__")
-    if (base::exists(.forceName, envir = s, inherits = FALSE)) {
-      .force <- base::get(.forceName, envir = s, inherits = FALSE)
-      .indLin <- c(.indLin, base::paste0("indLin(", .st, ") <- ",
-                                         rxode2::rxFromSE(.force)))
-    }
-  }
-  s$..ddt <- c("matExp()", .indLin)
+  s$..ddt <- "matExp()"
   invisible(TRUE)
 }
 

--- a/R/focei.R
+++ b/R/focei.R
@@ -380,7 +380,8 @@ is.latex <- function() {
 #' path does not emit, and state-dependent forcing needs the true
 #' inductive-linearization iteration (`doIndLin` 3/4), which does not yet
 #' converge reliably under SAEM's per-iteration parameter draws (diverges
-#' from the ODE reference fit rather than merely differing in precision).
+#' from the ODE reference fit rather than merely differing in precision;
+#' see #977 for the investigation and suspected contributing factors).
 #' Those models keep flattening via `.rxInjectMatExpDdt()`, which appends
 #' the forcing term to the materialized `d/dt()`.
 #'

--- a/R/focei.R
+++ b/R/focei.R
@@ -361,6 +361,42 @@ is.latex <- function() {
   invisible(TRUE)
 }
 
+#' Keep a matExp()/indLin() model in native (unflattened) form
+#'
+#' Unlike [.rxInjectMatExpDdt()], this does not materialize `d/dt()` -- it
+#' emits the literal `matExp()` keyword (plus any `indLin()` forcing lines)
+#' so the model solves through rxode2's matrix-exponential driver
+#' (`rxControl(method="indLin")`) instead of an ODE solver.  SAEM has no
+#' analytic-sensitivity consumer of the state derivatives, so it is the only
+#' estimation method that uses this path (#859); focei/nlm/nls still need
+#' `.rxInjectMatExpDdt()`'s explicit `d/dt()` for their sensitivity machinery.
+#'
+#' @param s symengine-pruned model environment
+#' @return `TRUE`/invisibly `FALSE`; sets `s$..ddt` to the native matExp()
+#'   lines on success
+#' @noRd
+.rxKeepMatExpNative <- function(s) {
+  .mv <- rxode2::rxModelVars(s)
+  if (!is.list(.mv$indLin) || length(.mv$indLin) != 4L) {
+    return(invisible(FALSE))
+  }
+  .states <- .rxode2stateOdeNoOutput(s)
+  if (length(.states) == 0L) {
+    return(invisible(FALSE))
+  }
+  .indLin <- character(0)
+  for (.st in .states) {
+    .forceName <- base::paste0("rx__indLinForce_", .st, "__")
+    if (base::exists(.forceName, envir = s, inherits = FALSE)) {
+      .force <- base::get(.forceName, envir = s, inherits = FALSE)
+      .indLin <- c(.indLin, base::paste0("indLin(", .st, ") <- ",
+                                         rxode2::rxFromSE(.force)))
+    }
+  }
+  s$..ddt <- c("matExp()", .indLin)
+  invisible(TRUE)
+}
+
 #' Get the THETA/ETA lines from rxode2 UI
 #'
 #' @param rxui This is the rxode2 ui object

--- a/R/focei.R
+++ b/R/focei.R
@@ -372,11 +372,24 @@ is.latex <- function() {
 #' `d/dt()` for their sensitivity machinery.
 #'
 #' Deliberately bails (returns `FALSE`, leaving `s$..ddt` untouched) on a
-#' model with an `indLin()` forcing term (Michaelis-Menten etc.): that needs
-#' rxode2's true inductive-linearization iteration (`doIndLin` 3/4), which
-#' does not yet converge reliably under SAEM's per-iteration parameter draws
-#' (diverges from the ODE reference fit rather than merely differing in
-#' precision).  Those models keep flattening via `.rxInjectMatExpDdt()`.
+#' model with an `indLin()` forcing term, state-dependent (Michaelis-Menten
+#' etc, flagged by a non-empty `wIndLin`) OR state-free (a forcing that
+#' does not reference any state, flagged by a non-NULL `indLin$f` with an
+#' empty `wIndLin` -- e.g. `indLin(central) <- 5`): even the state-free case
+#' needs rxode2's `IndF()` forcing evaluation (`doIndLin` 2), which this
+#' path does not emit, and state-dependent forcing needs the true
+#' inductive-linearization iteration (`doIndLin` 3/4), which does not yet
+#' converge reliably under SAEM's per-iteration parameter draws (diverges
+#' from the ODE reference fit rather than merely differing in precision).
+#' Those models keep flattening via `.rxInjectMatExpDdt()`, which appends
+#' the forcing term to the materialized `d/dt()`.
+#'
+#' Also bails when the model has a `delay()` (`flags[["hasDelay"]]`):
+#' `.saemFitModel()` (R/saem.R) forces the dense `dop853` solver for a delay
+#' model, which would take precedence over this function's `method="indLin"`
+#' request and try to integrate the emitted `"matExp()"` text -- which has
+#' no `d/dt()` for it to integrate -- as a plain ODE.  Flattening keeps the
+#' `d/dt()` that `dop853` needs.
 #'
 #' @param s symengine-pruned model environment
 #' @return `TRUE`/invisibly `FALSE`; sets `s$..ddt` to `"matExp()"` on success
@@ -386,7 +399,10 @@ is.latex <- function() {
   if (!is.list(.mv$indLin) || length(.mv$indLin) != 4L) {
     return(invisible(FALSE))
   }
-  if (length(.mv$indLin$wIndLin) > 0L) {
+  if (!is.null(.mv$indLin$f)) {
+    return(invisible(FALSE))
+  }
+  if (isTRUE(.mv$flags[["hasDelay"]] == 1L)) {
     return(invisible(FALSE))
   }
   .states <- .rxode2stateOdeNoOutput(s)

--- a/R/saem.R
+++ b/R/saem.R
@@ -206,10 +206,16 @@
   ## and yields a non-finite covariance linearization.  Mirror rxode2::rxSolve()'s
   ## hasDelay enforcement here so the SAEM solve and the covariance dopred both use
   ## the dense dop853 path.
-  if (isTRUE(rxode2::rxModelVars(attr(.model$saem_mod, "rx"))$flags[["hasDelay"]] == 1L)) {
+  .saemMv <- rxode2::rxModelVars(attr(.model$saem_mod, "rx"))
+  if (isTRUE(.saemMv$flags[["hasDelay"]] == 1L)) {
     .rxControl$method <- 0L  # dop853 (dense; no analytic Jacobian required)
     .rxControl$stiff2 <- 0L
     .rxControl$dense <- TRUE # record dense history for delay() interpolation
+  } else if (is.list(.saemMv$indLin) && length(.saemMv$indLin) == 4L) {
+    ## matExp()/indLin(): rxUiGet.saemModel() emits the native (unflattened)
+    ## matExp()/indLin() text (#859), which has no d/dt() at all -- it only
+    ## solves through rxode2's matrix-exponential driver.
+    .rxControl$method <- 3L  # indLin
   }
   .ue <- .uninformativeEtas(ui,
                             handleUninformativeEtas=rxode2::rxGetControl(ui, "handleUninformativeEtas", TRUE),

--- a/R/saemRxUiGetModel.R
+++ b/R/saemRxUiGetModel.R
@@ -341,9 +341,12 @@ attr(rxUiGet.saemParams, "rstudio") <- "params(tka)"
 rxUiGet.saemModel <- function(x, ...) {
   .s <- rxUiGet.loadPruneSaem(x, ...)
 
-  # matExp() has no d/dt(): materialize it from the k_from_to constants and
-  # emit the defining LHS first, suppressed ('~') so it adds no output column
-  .isMatExp <- isTRUE(.rxInjectMatExpDdt(.s))
+  # matExp()/indLin(): SAEM has no analytic-sensitivity consumer of the state
+  # derivatives (src/saem.cpp has no state-sensitivity machinery), so unlike
+  # focei/nlm/nls it solves the model natively through rxode2's
+  # matrix-exponential driver instead of materializing an equivalent d/dt()
+  # ODE (#859).  .saemFitModel() forces rxControl(method="indLin") to match.
+  .isMatExp <- isTRUE(.rxKeepMatExpNative(.s))
 
   .prd <- get("rx_pred_", envir = .s)
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))

--- a/R/saemRxUiGetModel.R
+++ b/R/saemRxUiGetModel.R
@@ -341,12 +341,17 @@ attr(rxUiGet.saemParams, "rstudio") <- "params(tka)"
 rxUiGet.saemModel <- function(x, ...) {
   .s <- rxUiGet.loadPruneSaem(x, ...)
 
-  # matExp()/indLin(): SAEM has no analytic-sensitivity consumer of the state
+  # matExp(): SAEM has no analytic-sensitivity consumer of the state
   # derivatives (src/saem.cpp has no state-sensitivity machinery), so unlike
-  # focei/nlm/nls it solves the model natively through rxode2's
-  # matrix-exponential driver instead of materializing an equivalent d/dt()
-  # ODE (#859).  .saemFitModel() forces rxControl(method="indLin") to match.
+  # focei/nlm/nls a PURE-LINEAR matExp() model solves natively through
+  # rxode2's matrix-exponential driver instead of materializing an
+  # equivalent d/dt() ODE (#859).  .saemFitModel() forces
+  # rxControl(method="indLin") to match.  A model with an indLin() forcing
+  # term still flattens (.rxKeepMatExpNative() bails on those; see its doc).
   .isMatExp <- isTRUE(.rxKeepMatExpNative(.s))
+  if (!.isMatExp) {
+    .isMatExp <- isTRUE(.rxInjectMatExpDdt(.s))
+  }
 
   .prd <- get("rx_pred_", envir = .s)
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -263,5 +263,52 @@ nmTest({
     .fM <- .nlmixr(matS, nlmixr2data::theo_sd, est = "saem", control = .ctl)
     expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
     expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
+    # mechanism check (#859): a pure-linear matExp() model must solve
+    # natively (a literal "matExp()" line, no materialized d/dt()), not via
+    # the ODE-flattening path -- matching numbers alone would not catch a
+    # regression back to flattening.
+    .saemModelTxt <- strsplit(nlmixr2est:::rxUiGet.saemModel(list(matS())), "\n")[[1]]
+    expect_true(any(grepl("^matExp\\(\\)$", .saemModelTxt)))
+    expect_false(any(grepl("d/dt(", .saemModelTxt, fixed = TRUE)))
+  })
+
+  test_that("matExp()/indLin() Michaelis-Menten (saem) falls back to the ODE flatten", {
+    # rxode2's true inductive-linearization iteration (doIndLin 3/4) does not
+    # yet converge reliably under SAEM's per-iteration parameter draws (a
+    # native attempt diverged from the ODE reference: objf -174 vs 321,
+    # unrelated fixed effects), so .rxKeepMatExpNative() bails on an
+    # indLin() forcing term and rxUiGet.saemModel() keeps materializing
+    # d/dt() via .rxInjectMatExpDdt(), same as before #859.
+    odeMM <- function() {
+      ini({ tka <- 0.45; tvmax <- log(60); tkm <- log(40); tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        ka <- exp(tka + eta.ka); vmax <- exp(tvmax); km <- exp(tkm); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - vmax * central / (km + central)
+        cp <- central / v
+        cp ~ add(add.sd)
+      })
+    }
+    matMM <- function() {
+      ini({ tka <- 0.45; tvmax <- log(60); tkm <- log(40); tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka + eta.ka)
+        indLin(central) <- -exp(tvmax) * central / (exp(tkm) + central)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .saemModelTxt <- strsplit(nlmixr2est:::rxUiGet.saemModel(list(matMM())), "\n")[[1]]
+    expect_true(any(grepl("d/dt(", .saemModelTxt, fixed = TRUE)))
+    expect_false(any(grepl("^matExp\\(\\)$", .saemModelTxt)))
+    expect_false(any(grepl("^indLin\\(", .saemModelTxt)))
+
+    .dat <- .mkData(odeMM, c(tka = 0.6, tvmax = log(70), tkm = log(45), tv = 3.6), nid = 8, seed = 4321)
+    .ctl <- saemControl(print = 0, nBurn = 100, nEm = 100, seed = 42)
+    .fO <- .nlmixr(odeMM, .dat, est = "saem", control = .ctl)
+    .fM <- .nlmixr(matMM, .dat, est = "saem", control = .ctl)
+    expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
+    expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
   })
 })

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -276,9 +276,10 @@ nmTest({
     # rxode2's true inductive-linearization iteration (doIndLin 3/4) does not
     # yet converge reliably under SAEM's per-iteration parameter draws (a
     # native attempt diverged from the ODE reference: objf -174 vs 321,
-    # unrelated fixed effects), so .rxKeepMatExpNative() bails on an
-    # indLin() forcing term and rxUiGet.saemModel() keeps materializing
-    # d/dt() via .rxInjectMatExpDdt(), same as before #859.
+    # unrelated fixed effects; tracked separately as #977), so
+    # .rxKeepMatExpNative() bails on an indLin() forcing term and
+    # rxUiGet.saemModel() keeps materializing d/dt() via
+    # .rxInjectMatExpDdt(), same as before #859.
     odeMM <- function() {
       ini({ tka <- 0.45; tvmax <- log(60); tkm <- log(40); tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
       model({

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -311,4 +311,46 @@ nmTest({
     expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
     expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
   })
+
+  test_that("matExp() with a state-free indLin() forcing (saem) falls back to the ODE flatten", {
+    # A forcing that does not reference any state (e.g. indLin(central) <- 5)
+    # leaves wIndLin empty, same as a pure-linear model with no forcing at
+    # all -- so the native-routing decision cannot key on wIndLin alone (it
+    # would silently drop the forcing term, since the native path emits no
+    # indLin() text). .rxKeepMatExpNative() instead bails whenever
+    # indLin$f is non-NULL (any forcing, state-free or not).
+    matSF <- function() {
+      ini({ tka <- 0.45; tv <- 3.45; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka)
+        indLin(central) <- 5
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .saemModelTxt <- strsplit(nlmixr2est:::rxUiGet.saemModel(list(matSF())), "\n")[[1]]
+    expect_true(any(grepl("d/dt(central)=", .saemModelTxt, fixed = TRUE)))
+    expect_true(any(grepl("\\(5\\)", .saemModelTxt)))
+    expect_false(any(grepl("^matExp\\(\\)$", .saemModelTxt)))
+  })
+
+  test_that("matExp() with delay() (saem) falls back to the ODE flatten", {
+    # .saemFitModel() (R/saem.R) forces the dense dop853 solver for a delay
+    # model (hasDelay), which takes precedence over method="indLin" -- so a
+    # native "matExp()" emission (no d/dt() for dop853 to integrate) would
+    # silently solve to all-zero states. .rxKeepMatExpNative() bails on
+    # flags[["hasDelay"]] to keep this combination flattened.
+    matD <- function() {
+      ini({ tka <- 0.45; tv <- 3.45; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka)
+        cp <- delay(central, 5) / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .s <- nlmixr2est:::rxUiGet.loadPruneSaem(list(matD()))
+    expect_false(isTRUE(nlmixr2est:::.rxKeepMatExpNative(.s)))
+  })
 })

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -267,7 +267,7 @@ nmTest({
     # natively (a literal "matExp()" line, no materialized d/dt()), not via
     # the ODE-flattening path -- matching numbers alone would not catch a
     # regression back to flattening.
-    .saemModelTxt <- strsplit(nlmixr2est:::rxUiGet.saemModel(list(matS())), "\n")[[1]]
+    .saemModelTxt <- strsplit(utils::getFromNamespace("rxUiGet.saemModel", "nlmixr2est")(list(matS())), "\n")[[1]]
     expect_true(any(grepl("^matExp\\(\\)$", .saemModelTxt)))
     expect_false(any(grepl("d/dt(", .saemModelTxt, fixed = TRUE)))
   })
@@ -299,7 +299,7 @@ nmTest({
         cp ~ add(add.sd)
       })
     }
-    .saemModelTxt <- strsplit(nlmixr2est:::rxUiGet.saemModel(list(matMM())), "\n")[[1]]
+    .saemModelTxt <- strsplit(utils::getFromNamespace("rxUiGet.saemModel", "nlmixr2est")(list(matMM())), "\n")[[1]]
     expect_true(any(grepl("d/dt(", .saemModelTxt, fixed = TRUE)))
     expect_false(any(grepl("^matExp\\(\\)$", .saemModelTxt)))
     expect_false(any(grepl("^indLin\\(", .saemModelTxt)))
@@ -329,7 +329,7 @@ nmTest({
         cp ~ add(add.sd)
       })
     }
-    .saemModelTxt <- strsplit(nlmixr2est:::rxUiGet.saemModel(list(matSF())), "\n")[[1]]
+    .saemModelTxt <- strsplit(utils::getFromNamespace("rxUiGet.saemModel", "nlmixr2est")(list(matSF())), "\n")[[1]]
     expect_true(any(grepl("d/dt(central)=", .saemModelTxt, fixed = TRUE)))
     expect_true(any(grepl("\\(5\\)", .saemModelTxt)))
     expect_false(any(grepl("^matExp\\(\\)$", .saemModelTxt)))
@@ -350,7 +350,7 @@ nmTest({
         cp ~ add(add.sd)
       })
     }
-    .s <- nlmixr2est:::rxUiGet.loadPruneSaem(list(matD()))
-    expect_false(isTRUE(nlmixr2est:::.rxKeepMatExpNative(.s)))
+    .s <- utils::getFromNamespace("rxUiGet.loadPruneSaem", "nlmixr2est")(list(matD()))
+    expect_false(isTRUE(utils::getFromNamespace(".rxKeepMatExpNative", "nlmixr2est")(.s)))
   })
 })


### PR DESCRIPTION
## Summary

- SAEM now solves a **pure-linear** `matExp()` model natively through rxode2's matrix-exponential driver (`rxControl(method="indLin")`) instead of always flattening it to an equivalent `d/dt()` ODE first. SAEM has no analytic-sensitivity consumer of the state derivatives (`src/saem.cpp` has no state-sensitivity machinery), so this is the entirety of the SAEM-side work described in #859.
- `focei`/`nlm`/`nls` are unaffected -- they still call `.rxInjectMatExpDdt()` and need the explicit `d/dt()` for their sensitivity machinery.
- A model with an `indLin()` forcing term (Michaelis-Menten etc.) still flattens: a native attempt diverged from the ODE reference under SAEM's per-iteration stochastic parameter draws (objf -174 vs 321, not just a precision difference), so `.rxKeepMatExpNative()` deliberately bails on any forcing (state-dependent *or* state-free -- a state-free forcing like `indLin(central) <- 5` was initially missed and silently dropped; fixed after antigravity review) and on `delay()` models (the existing `hasDelay` override takes precedence and needs the flattened `d/dt()`).

## Review

Reviewed with antigravity (Gemini) across two passes:
- Round 1 found two real silent-wrong-answer gaps (state-free `indLin()` forcing dropped; `matExp()`+`delay()` ordering) -- both fixed, with regression tests.
- Round 2 confirmed both fixes and surfaced a separate, **pre-existing** bug in `rxUiGet.saemModelPred()` (the post-fit residual/table model, unrelated code path, present since 2022) that also never handled `matExp()`. I attempted a fix but it caused a regression in the SAEM Michaelis-Menten flatten path's solve, so I reverted it -- fixing it correctly needs more investigation than this issue's scope, and is left for a follow-up.

## Test plan

- [x] `tests/testthat/test-matexp.R`: existing focei/foce/nlm/agq/laplace equivalence tests unaffected; SAEM pure-linear test passes with new mechanism assertions (native `matExp()` line emitted, no `d/dt()`); new tests for indLin()-forcing fallback, state-free forcing fallback, and `delay()` fallback.
- [x] `tests/testthat/test-saem-translate.R`: non-matExp SAEM model-text generation unaffected.