### PR TITLE
saem: score censored AR(1) rows against the conditional distribution (#918)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,14 @@
 
 ## Bug fixes
 
+- `est="saem"` scored a censored (M2/M3/M4) row on an `ar()` endpoint against
+  the marginal normal distribution instead of the AR(1) conditional one that
+  its uncensored neighbors already used (#918). `arDYFhyp` whitened a
+  discarded copy of the prediction/SD to build the uncensored loss, then
+  handed the censored-loss calculation the original marginal values. The
+  whitened prediction/SD are now kept and passed through, so a BQL row after
+  an AR-active observation is scored consistently with the rest of its chain.
+
 - Post-estimation machinery no longer refuses a model whose `ini({})` declares
   prior distributions (#938).  Two parts:
 

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -1064,11 +1064,16 @@ public:
   }
 
   // Per-observation Gaussian -LL contribution with the AR(1) whitening applied
-  // (reduces to the independent 0.5*((yt-ft)/g)^2 + log(g) when no AR).
+  // (reduces to the independent 0.5*((yt-ft)/g)^2 + log(g) when no AR).  Also
+  // writes the whitened (conditional) prediction/SD into _scratch_ftAr/_scratch_gAr
+  // so a censored row on the SAME chain can be scored against the AR(1)
+  // conditional distribution, not the marginal (ft, g) -- see #918.
   vec arDYFhyp(const vec &yt, const vec &ft, const vec &g) {
     vec e = yt - ft;
     vec gg = g;
     arWhiten(e, gg);
+    _scratch_ftAr = yt - e;
+    _scratch_gAr = gg;
     return 0.5*(e/gg)%(e/gg) + log(gg);
   }
 
@@ -1472,6 +1477,8 @@ public:
     _scratch_limitT.set_size(ntotal);
     _scratch_ftT.set_size(ntotal);
     _scratch_g.set_size(ntotal);
+    _scratch_ftAr.set_size(ntotal);
+    _scratch_gAr.set_size(ntotal);
     _scratch_indio = indio;  // same length as indio, initialise from it
     _arRorig.set_size(ntotal);
     for (int b=0; b<nendpnt; ++b) {
@@ -1881,7 +1888,7 @@ public:
               DYFhyp(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
               for (int j = ntotal; j--;) {
                 DYFhyp(_scratch_indio(j)) = doCensNormal1(censk[j], y[j], _scratch_limitT[j],
-                                                       DYFhyp(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
+                                                       DYFhyp(_scratch_indio(j)), _scratch_ftAr[j], _scratch_gAr[j], 0);
               }
             }
           } else if (distribution == 2) {
@@ -2081,7 +2088,7 @@ public:
               cur_DYF(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
               for (int j = ntotal; j--;) {
                 cur_DYF(_scratch_indio(j)) = doCensNormal1(censk[j], y[j], _scratch_limitT[j],
-                                                       cur_DYF(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
+                                                       cur_DYF(_scratch_indio(j)), _scratch_ftAr[j], _scratch_gAr[j], 0);
               }
             }
           } else if (distribution == 2) {
@@ -2357,7 +2364,7 @@ public:
             DYF(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
             for (int j = ntotal; j--;) {
               DYF(_scratch_indio(j)) = doCensNormal1(censk[j], y[j], _scratch_limitT[j],
-                                                     DYF(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
+                                                     DYF(_scratch_indio(j)), _scratch_ftAr[j], _scratch_gAr[j], 0);
             }
           }
         } else if (distribution == 2){
@@ -3700,6 +3707,8 @@ private:
   vec _scratch_ftT;     // handleF output per chain (replaces ftTk/fcTk)
   vec _scratch_g;       // residual SD per chain (replaces gk/gck)
   uvec _scratch_indio;  // DYF row indices per chain (replaces indio_k)
+  vec _scratch_ftAr;    // AR(1)-conditional prediction, filled by arDYFhyp()
+  vec _scratch_gAr;     // AR(1)-conditional SD, filled by arDYFhyp()
 
   uvec obs_subject;
 
@@ -3869,7 +3878,7 @@ private:
               DYF(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
               for (int j = ntotal; j--;) {
                 DYF(_scratch_indio(j)) = doCensNormal1(censk[j], mx.y[j], _scratch_limitT[j],
-                                                       DYF(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
+                                                       DYF(_scratch_indio(j)), _scratch_ftAr[j], _scratch_gAr[j], 0);
               }
             }
           }
@@ -3980,7 +3989,7 @@ private:
             DYFm(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
             for (int j = ntotal; j--;) {
               DYFm(_scratch_indio(j)) = doCensNormal1(censk[j], mx.y[j], _scratch_limitT[j],
-                                                     DYFm(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
+                                                     DYFm(_scratch_indio(j)), _scratch_ftAr[j], _scratch_gAr[j], 0);
             }
           }
         }
@@ -4093,7 +4102,7 @@ private:
           DYFhyp(_scratch_indio) = arDYFhyp(yt, _scratch_ft, _scratch_g);
           for (int j = ntotal; j--;) {
             DYFhyp(_scratch_indio(j)) = doCensNormal1(censk[j], y[j], _scratch_limitT[j],
-                                                   DYFhyp(_scratch_indio(j)), _scratch_ft[j], _scratch_g[j], 0);
+                                                   DYFhyp(_scratch_indio(j)), _scratch_ftAr[j], _scratch_gAr[j], 0);
           }
         }
       } else if (distribution == 2) {

--- a/tests/testthat/test-focei-cens.R
+++ b/tests/testthat/test-focei-cens.R
@@ -191,41 +191,70 @@ nmTest({
   test_that("ar() + M3 censoring scores the AR(1) conditional distribution (#918)", {
     # Plain est="saem" only -- an ar() endpoint always fails .fsaemSupported, so
     # fsaem degrades to standard SAEM and this exercises arDYFhyp/doCensNormal1
-    # directly.  With 2 obs/subject only the 2nd (Time=1) record has a previous
-    # same-subject record to whiten against; censoring it below the LLOQ is
-    # exactly the "censored row following an uncensored previous record" case
-    # from #918.  Per the issue's caveat, e_prev accuracy for a RUN of censored
-    # records is still approximate (#916 fixes that), so this only checks the
-    # fit runs sanely -- not a tight comparison against an uncensored/focei fit.
-    datAr <- dat
-    datAr$cens <- 0L
-    loqIds <- c(1, 3, 4)
-    datAr$cens[datAr$ID %in% loqIds & datAr$Time == 1] <- 1L
-    datAr$DV[datAr$ID %in% loqIds & datAr$Time == 1] <- 6
-
-    fAr <- function() {
+    # directly.
+    #
+    # Every population parameter is fix()ed (no outer optimization), so the
+    # reported objf is a deterministic function of (fixed params, data) via
+    # the final Gaussian-quadrature -2LL step -- not confounded by SAEM's
+    # stochastic parameter search.  3 of 8 subjects have their LAST (of 4)
+    # observations M3-censored, each with a real, uncensored previous record
+    # to whiten against -- the "censored row following an uncensored previous
+    # record" case from #918.
+    #
+    # This objf is a REGRESSION PIN, not a tolerance check: a marginal-vs-
+    # conditional scoring bug does not merely perturb it, it changes which
+    # distribution is being evaluated, so pre-fix code returns a completely
+    # different value (verified by hand: 4.5103307107 marginal vs
+    # -7.2012761860 conditional) rather than one within a few % of this one.
+    .m <- function() {
       ini({
-        tvK <- 0.5
-        bsvK ~ 0.04
-        prop.sd <- sqrt(0.1)
-        ar1.cor <- 0.3
+        tka <- log(1.2); tcl <- log(0.2); tv <- log(5)
+        eta.cl ~ 0.09; add.sd <- 0.4; ar1.cor <- 0.6
       })
       model({
-        ke <- tvK * exp(bsvK)
-        v <- 1
-        ipre <- 10 * exp(-ke * t)
-        ipre ~ prop(prop.sd) + ar(ar1.cor)
+        ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - cl / v * central
+        cp <- central / v
+        cp ~ add(add.sd) + ar(ar1.cor)
       })
     }
+    .ev <- rxode2::et(rxode2::et(amt = 100), c(0.5, 1.5, 2.5, 3.5))
+    .sim <- rxode2::rxWithSeed(2026, rxode2::rxSolve(.m, .ev, nSub = 8,
+                                     returnType = "data.frame", addDosing = TRUE))
+    .idc <- if ("sim.id" %in% names(.sim)) "sim.id" else "id"
+    datAr <- data.frame(ID = .sim[[.idc]], TIME = .sim$time,
+                       EVID = ifelse(is.na(.sim$evid), 0, .sim$evid),
+                       AMT = ifelse(is.na(.sim$amt), 0, .sim$amt),
+                       DV = ifelse(is.na(.sim$evid) | .sim$evid == 0, .sim$sim, NA))
+    datAr$EVID[datAr$AMT > 0] <- 1
 
+    .obs <- which(datAr$EVID == 0)
+    datAr$cens <- 0L
+    .w <- .obs[datAr$ID[.obs] %in% c(1, 2, 3) & datAr$TIME[.obs] == 3.5]
+    datAr$DV[.w] <- min(datAr$DV[.w]) + 1
+    datAr$cens[.w] <- 1L
+
+    .mFix <- function() {
+      ini({
+        tka <- fix(log(1.2)); tcl <- fix(log(0.2)); tv <- fix(log(5))
+        eta.cl ~ 0.09
+        add.sd <- fix(0.4); ar1.cor <- fix(0.6)
+      })
+      model({
+        ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - cl / v * central
+        cp <- central / v
+        cp ~ add(add.sd) + ar(ar1.cor)
+      })
+    }
     f.saemAr <- suppressWarnings(suppressMessages(
-      nlmixr(fAr, datAr, "saem", control = saemControl(print = 0, seed = 42))
+      nlmixr(.mFix, datAr, "saem",
+             control = saemControl(nBurn = 50, nEm = 0, print = 0, seed = 42))
     ))
-    expect_true(is.finite(f.saemAr$objf))
     ct(f.saemAr, "M3 censoring")
-
-    .corAr <- unname(f.saemAr$parFixedDf["ar1.cor", "Estimate"])
-    expect_true(is.finite(.corAr) && .corAr >= 0 && .corAr < 1)
+    expect_equal(f.saemAr$objf, -7.2012761860, tolerance = 1e-4)
   })
 
 })

--- a/tests/testthat/test-focei-cens.R
+++ b/tests/testthat/test-focei-cens.R
@@ -188,4 +188,44 @@ nmTest({
 
   })
 
+  test_that("ar() + M3 censoring scores the AR(1) conditional distribution (#918)", {
+    # Plain est="saem" only -- an ar() endpoint always fails .fsaemSupported, so
+    # fsaem degrades to standard SAEM and this exercises arDYFhyp/doCensNormal1
+    # directly.  With 2 obs/subject only the 2nd (Time=1) record has a previous
+    # same-subject record to whiten against; censoring it below the LLOQ is
+    # exactly the "censored row following an uncensored previous record" case
+    # from #918.  Per the issue's caveat, e_prev accuracy for a RUN of censored
+    # records is still approximate (#916 fixes that), so this only checks the
+    # fit runs sanely -- not a tight comparison against an uncensored/focei fit.
+    datAr <- dat
+    datAr$cens <- 0L
+    loqIds <- c(1, 3, 4)
+    datAr$cens[datAr$ID %in% loqIds & datAr$Time == 1] <- 1L
+    datAr$DV[datAr$ID %in% loqIds & datAr$Time == 1] <- 6
+
+    fAr <- function() {
+      ini({
+        tvK <- 0.5
+        bsvK ~ 0.04
+        prop.sd <- sqrt(0.1)
+        ar1.cor <- 0.3
+      })
+      model({
+        ke <- tvK * exp(bsvK)
+        v <- 1
+        ipre <- 10 * exp(-ke * t)
+        ipre ~ prop(prop.sd) + ar(ar1.cor)
+      })
+    }
+
+    f.saemAr <- suppressWarnings(suppressMessages(
+      nlmixr(fAr, datAr, "saem", control = saemControl(print = 0, seed = 42))
+    ))
+    expect_true(is.finite(f.saemAr$objf))
+    ct(f.saemAr, "M3 censoring")
+
+    .corAr <- unname(f.saemAr$parFixedDf["ar1.cor", "Estimate"])
+    expect_true(is.finite(.corAr) && .corAr >= 0 && .corAr < 1)
+  })
+
 })


### PR DESCRIPTION
## Summary

Fixes #918. On an `ar()` endpoint, `est="saem"` scored a censored (M2/M3/M4)
row against the **marginal** normal distribution instead of the AR(1)
**conditional** one its uncensored neighbors on the same chain already used.

`arDYFhyp()` (`src/saem.cpp`) whitened a discarded copy of `(ft, g)` to build
the uncensored loss, then handed `doCensNormal1()` the original marginal
`(ft, g)` at all six call sites. `arDYFhyp()` now also writes the whitened
(conditional) prediction/SD into two new scratch member vectors
(`_scratch_ftAr`/`_scratch_gAr`), and the six `doCensNormal1()` call sites use
those instead of the marginal `_scratch_ft`/`_scratch_g`. No-op when `hasAr`
is unset or a row has no AR-active endpoint/previous record (`arWhiten`
leaves `e`/`g` untouched in that case), so non-AR fits are unaffected.

Scope, per the issue: plain `est="saem"` only (an `ar()` endpoint always
fails `.fsaemSupported`, so `fsaem` degrades to standard SAEM here). The
"censored previous record" second-order caveat noted in the issue (`e_prev`
is only approximate for a *run* of consecutive BQL records) is left as-is,
deferred to #916 as the issue specifies.

## Review

Two rounds of an independent Antigravity/Gemini review:
- Round 1 confirmed the `src/saem.cpp` fix has no correctness/thread-safety
  issues (SAEM's chain/mixture loops are sequential; `arDYFhyp` fully
  populates the scratch vectors before the `doCensNormal1` loop reads them),
  but flagged the accompanying test as non-discriminating -- its assertions
  (`is.finite(objf)`, `0<=cor<1`) were also satisfied by the pre-fix (buggy)
  code, because that dataset let SAEM drive `ar1.cor` toward 0, which makes
  the whitening step (and therefore the bug) a no-op regardless.
- The test was rewritten as a deterministic regression pin: every population
  parameter is `fix()`ed (`saemControl(nBurn=50, nEm=0)`, no outer
  optimization), asserting an exact `objf` value. Verified by hand that
  reverting the `src/saem.cpp` fix changes this value from `-7.2012761860`
  to `4.5103307107` -- a change in which distribution is scored, not a small
  perturbation.
- Round 2 confirmed the fix and the rewritten pin are correct and
  deterministic, and additionally found: (a) the "censored previous record"
  point above (already an explicitly-scoped-out issue caveat, not new), and
  (b) that the new test only exercises 2 of the 6 patched call sites -- the
  ones reachable from a plain (non-mixture) SAEM fit. The other 4 require an
  `ar()` + finite-mixture (`nMix>1`) model, a combination not covered
  anywhere else in the test suite either and outside this issue's stated
  scope ("Plain `est="saem"` only"). The fix itself is a mechanically
  identical one-line substitution at all six sites, so this is noted as a
  known gap rather than expanded into new mixture-model test infrastructure.

## Test plan

- [x] `devtools::load_all()` compiles cleanly
- [x] `tests/testthat/test-focei-cens.R` -- 40/40 assertions pass, including
      the new `ar() + M3 censoring scores the AR(1) conditional distribution
      (#918)` test
- [x] `tests/testthat/test-ar-est.R` (existing AR regression suite) -- no
      regressions, both tests pass