### PR TITLE
fix(saem): apply the declared boxCox/yeoJohnson lambda transform (#914)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -112,6 +112,19 @@
   halving then doubling compounded into a 4x inflated covariance. Point
   estimates, the objective value, and the log-likelihood were unaffected.
 
+- `est="saem"` on a `boxCox()`/`yeoJohnson()` model (estimated or `fixed()`)
+  fit at the identity transform instead of the declared one (#914). Two
+  compounding defects: the kernel's working `lambda` was never refreshed from
+  the M-step's `lres`, so every `_powerD()` call used the transform's initial
+  value (1) all fit long, and `transMat` reported that same wrong value
+  instead of the fitted/fixed lambda; and the pure additive-plus-lambda and
+  proportional/power-plus-lambda residual models never zeroed the error
+  component they do not use (`bres`/`ares`), leaving it at its nonzero
+  default and corrupting the residual SD `g = ares + bres*|f|`. Together
+  these biased theta, BSV, and the residual SD (the BSV would collapse and
+  the residual SD would inflate to absorb the untransformed data), matching
+  neither the declared model nor FOCEi's fit of the same data.
+
 ## New features
 
 - `est="saem"` gained controls for the cost of the `nonMuTheta="regress"`

--- a/NEWS.md
+++ b/NEWS.md
@@ -123,7 +123,10 @@
   default and corrupting the residual SD `g = ares + bres*|f|`. Together
   these biased theta, BSV, and the residual SD (the BSV would collapse and
   the residual SD would inflate to absorb the untransformed data), matching
-  neither the declared model nor FOCEi's fit of the same data.
+  neither the declared model nor FOCEi's fit of the same data. The unzeroed
+  component defect also affected the plain (non-`boxCox`/`yeoJohnson`) pure
+  power error model `pow()` with no `add()`/`prop()` term, which shares the
+  same fix.
 
 ## New features
 

--- a/R/saem_fit.R
+++ b/R/saem_fit.R
@@ -760,8 +760,15 @@
   cfg$lambda <- rep(1.0, cfg$nendpnt)
   cfg$low <- rep(0.0, cfg$nendpnt)
   cfg$hi <- rep(1.0, cfg$nendpnt)
-  cfg$ares[cfg$res.mod == 2] <- 0
-  cfg$bres[cfg$res.mod == 1] <- 0
+  # res.mod codes without an additive/proportional component leave that
+  # component's cfg value at its nonzero default (10/1) forever: the M-step
+  # switch for that res.mod never assigns it (src/saem.cpp), so an unzeroed
+  # bres/ares corrupts g = ares + bres*|ft| with a spurious component (#914).
+  cfg$ares[cfg$res.mod == 2] <- 0  # prop
+  cfg$ares[cfg$res.mod == 7] <- 0  # prop + lambda
+  cfg$ares[cfg$res.mod == 8] <- 0  # pow + lambda
+  cfg$bres[cfg$res.mod == 1] <- 0  # add
+  cfg$bres[cfg$res.mod == 6] <- 0  # add + lambda
   cfg$res_offset <- cumsum(c(0L, nres))
   nMix <- max(1L, length(mixProb))
   cfg$nMix <- nMix

--- a/R/saem_fit.R
+++ b/R/saem_fit.R
@@ -765,6 +765,7 @@
   # switch for that res.mod never assigns it (src/saem.cpp), so an unzeroed
   # bres/ares corrupts g = ares + bres*|ft| with a spurious component (#914).
   cfg$ares[cfg$res.mod == 2] <- 0  # prop
+  cfg$ares[cfg$res.mod == 3] <- 0  # pow
   cfg$ares[cfg$res.mod == 7] <- 0  # prop + lambda
   cfg$ares[cfg$res.mod == 8] <- 0  # pow + lambda
   cfg$bres[cfg$res.mod == 1] <- 0  # add

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -1427,7 +1427,10 @@ public:
     lres = as<vec>(x["lres"]);
     yj = as<uvec>(x["yj"]);
     propT=as<uvec>(x["propT"]);
-    lambda = as<vec>(x["lambda"]);
+    // lambda mirrors lres (the M-step's working boxCox/yeoJohnson estimate);
+    // seed it from lres, not x["lambda"] (which the R side always ships as 1),
+    // and keep it synced wherever lres is updated below (#914).
+    lambda = lres;
     low = as<vec>(x["low"]);
     hi = as<vec>(x["hi"]);
 
@@ -3054,6 +3057,7 @@ public:
               ares(b) = ares(b) + pas(kiter)*(pxmin[0]*pxmin[0] - ares(b));    //force are & bres to be positive
               lres(b) = lres(b) + pas(kiter)*(toLambda(pxmin[1]) - lres(b));   //force are & bres to be positive
             }
+            lambda(b) = lres(b);
           }
           break;
         case rmPropLam:
@@ -3117,6 +3121,7 @@ public:
               bres(b) = bres(b) + pas(kiter)*(pxmin[0]*pxmin[0] - bres(b));    //force are & bres to be positive
               lres(b) = lres(b) + pas(kiter)*(toLambda(pxmin[1]) - lres(b));            //force are & bres to be positive
             }
+            lambda(b) = lres(b);
           }
           break;
         case rmPowLam:
@@ -3193,6 +3198,7 @@ public:
               cres(b) = cres(b) + pas(kiter)*(toPow(pxmin[1]) - cres(b));    //force are & bres to be positive
               lres(b) = lres(b) + pas(kiter)*(toLambda(pxmin[2]) - lres(b));            //force are & bres to be positive
             }
+            lambda(b) = lres(b);
           }
           break;
         case rmAddPropLam:
@@ -3269,6 +3275,7 @@ public:
               bres(b) = bres(b) + pas(kiter)*(pxmin[1]*pxmin[1] - bres(b));    //force are & bres to be positive
               lres(b) = lres(b) + pas(kiter)*(toLambda(pxmin[2]) - lres(b));            //force are & bres to be positive
             }
+            lambda(b) = lres(b);
           }
           break;
         case rmAddPowLam:
@@ -3358,6 +3365,7 @@ public:
               cres(b) = cres(b) + pas(kiter)*(toPow(pxmin[2]) - cres(b));    //force are & bres to be positive
               lres(b) = lres(b) + pas(kiter)*(toLambda(pxmin[3]) - lres(b));            //force are & bres to be positive
             }
+            lambda(b) = lres(b);
           }
           break;
         }
@@ -3517,6 +3525,7 @@ public:
       Gamma2_phi1Report = _savGamma2_phi1Report; mprior_phi1 = _savMprior_phi1;
       mprior_phi0 = _savMprior_phi0; ares = _savAres; bres = _savBres; cres = _savCres;
       lres = _savLres; vcsig2 = _savVcsig2; phiM = _savPhiM; Ha = _savHa;
+      lambda = lres;
       if (nMix > 1) { mixProb = _savMixProb; mixWeights = _savMixWeights; }
     }
     phiFile.close();

--- a/tests/testthat/test-saem-resid-lambda.R
+++ b/tests/testthat/test-saem-resid-lambda.R
@@ -69,4 +69,56 @@ nmTest({
     expect_lt(fit$parFixedDf["add.sd", "Estimate"], 0.3)
   })
 
+  # same defect as rmAddLam above, but for the complementary component: a pure
+  # prop+lambda endpoint (rmPropLam) never zeroed `ares`, leaving
+  # g = 10 + bres*|ft| instead of g = bres*|ft|.
+  test_that("SAEM prop + boxCox (rmPropLam) with a fixed lambda recovers truth", {
+    set.seed(915)
+    .dose <- 320; .v <- 70; .times <- c(0.5, 1, 2, 4, 7, 12, 24)
+    .bcF <- function(y, l) (y^l - 1) / l
+    .bcI <- function(x, l) (l * x + 1)^(1 / l)
+    .n <- 20; .lam <- 0.5
+    .eta <- rnorm(.n, 0, sqrt(0.09))
+    .d <- do.call(rbind, lapply(seq_len(.n), function(i) {
+      .f <- .dose / .v * exp(-exp(log(4) + .eta[i]) / .v * .times)
+      .ft <- .bcF(.f, .lam)
+      .yt <- .ft + 0.2 * abs(.ft) * rnorm(length(.times))
+      rbind(data.frame(ID = i, TIME = 0, DV = NA_real_, AMT = .dose, EVID = 1),
+            data.frame(ID = i, TIME = .times, DV = .bcI(.yt, .lam), AMT = 0, EVID = 0))
+    }))
+    f <- function() {
+      ini({ tcl <- log(4); eta.cl ~ 0.09; prop.sd <- 0.2; lambda <- fixed(0.5) })
+      model({ cl <- exp(tcl + eta.cl); v <- 70; linCmt() ~ prop(prop.sd) + boxCox(lambda) })
+    }
+    fit <- .nlmixr(f, .d, est = "saem",
+                   control = saemControl(nBurn = 100, nEm = 100, print = 0L, nmc = 2))
+    expect_equal(unname(fit$saem$transMat[1, 1]), 0.5)
+    expect_lt(abs(fit$theta[["tcl"]] - log(4)), 0.5)
+    expect_lt(fit$parFixedDf["prop.sd", "Estimate"], 0.5)
+  })
+
+  # same defect, no lambda involved at all: a pure pow endpoint (rmPow) never
+  # zeroed `ares` either, so it shares the bug even without a boxCox/yeoJohnson
+  # transform -- included here because it is the same fix (R/saem_fit.R's
+  # ares/bres zeroing table), found while fixing #914.
+  test_that("SAEM pow (rmPow) recovers truth", {
+    set.seed(3)
+    .dose <- 320; .v <- 70; .times <- c(0.5, 1, 2, 4, 7, 12, 24)
+    .n <- 30
+    .eta <- rnorm(.n, 0, sqrt(0.09))
+    .d <- do.call(rbind, lapply(seq_len(.n), function(i) {
+      .f <- .dose / .v * exp(-exp(log(4) + .eta[i]) / .v * .times)
+      rbind(data.frame(ID = i, TIME = 0, DV = NA_real_, AMT = .dose, EVID = 1),
+            data.frame(ID = i, TIME = .times, DV = .f * (1 + rnorm(length(.times), 0, 0.2)),
+                       AMT = 0, EVID = 0))
+    }))
+    f <- function() {
+      ini({ tcl <- log(4); eta.cl ~ 0.09; prop.sd <- 0.2; pw <- fixed(1) })
+      model({ cl <- exp(tcl + eta.cl); v <- 70; linCmt() ~ pow(prop.sd, pw) })
+    }
+    fit <- .nlmixr(f, .d, est = "saem", control = saemControl(print = 0L))
+    expect_lt(abs(fit$theta[["tcl"]] - log(4)), 0.5)
+    expect_lt(fit$parFixedDf["prop.sd", "Estimate"], 0.5)
+  })
+
 })

--- a/tests/testthat/test-saem-resid-lambda.R
+++ b/tests/testthat/test-saem-resid-lambda.R
@@ -37,4 +37,36 @@ nmTest({
     expect_true(all(is.finite(fit$parFixedDf$Estimate)))
   })
 
+  # #914: a fixed boxCox lambda never reached the transform (saem.cpp's `lambda`
+  # member was never synced from `lres`, so every kernel _powerD() call ran at
+  # lambda=1) and the pure add+lambda residual model (rmAddLam) never zeroed
+  # bres, leaving g = ares + 1*|ft| instead of g = ares.  Both defects are silent
+  # -- the fit still converges, just to badly biased estimates -- so recovery
+  # against simulated truth is asserted here rather than just finiteness.
+  test_that("SAEM add + boxCox (rmAddLam) with a fixed lambda recovers truth", {
+    set.seed(914)
+    .dose <- 320; .v <- 70; .times <- c(0.5, 1, 2, 4, 7, 12, 24)
+    .bcF <- function(y, l) (y^l - 1) / l
+    .bcI <- function(x, l) (l * x + 1)^(1 / l)
+    .n <- 20; .lam <- 0.5
+    .eta <- rnorm(.n, 0, sqrt(0.09))
+    .d <- do.call(rbind, lapply(seq_len(.n), function(i) {
+      .f <- .dose / .v * exp(-exp(log(4) + .eta[i]) / .v * .times)
+      rbind(data.frame(ID = i, TIME = 0, DV = NA_real_, AMT = .dose, EVID = 1),
+            data.frame(ID = i, TIME = .times,
+                       DV = .bcI(.bcF(.f, .lam) + rnorm(length(.times), 0, 0.15), .lam),
+                       AMT = 0, EVID = 0))
+    }))
+    f <- function() {
+      ini({ tcl <- log(4); eta.cl ~ 0.09; add.sd <- 0.15; lambda <- fixed(0.5) })
+      model({ cl <- exp(tcl + eta.cl); v <- 70; linCmt() ~ add(add.sd) + boxCox(lambda) })
+    }
+    fit <- .nlmixr(f, .d, est = "saem",
+                   control = saemControl(nBurn = 100, nEm = 100, print = 0L, nmc = 2))
+    # the fixed lambda must reach transMat, not stay at the identity default
+    expect_equal(unname(fit$saem$transMat[1, 1]), 0.5)
+    expect_lt(abs(fit$theta[["tcl"]] - log(4)), 0.3)
+    expect_lt(fit$parFixedDf["add.sd", "Estimate"], 0.3)
+  })
+
 })


### PR DESCRIPTION
## Summary

Fixes #914: `est="saem"` on a model with a `boxCox()`/`yeoJohnson()` transform
(estimated or `fixed()`) fit at the identity transform instead of the
declared one. Two compounding defects, both silent (the fit still converges,
just to badly biased estimates):

1. **`src/saem.cpp`**: the kernel's working `lambda` member was seeded once
   from `x["lambda"]` (which the R side always ships as a constant `1.0`) and
   never refreshed from `lres`, the vector the M-step actually updates. Every
   `_powerD()` transform call ran at the identity the whole fit, and
   `transMat` reported that same wrong value instead of the fitted/fixed
   lambda. Fixed by seeding `lambda = lres` at construction and syncing
   `lambda(b) = lres(b)` after each M-step update (including the
   SA-covariance-phase restore path).

2. **`R/saem_fit.R`**: the `ares`/`bres` zeroing table (for residual models
   that don't use one of the two components) only covered the two original
   `rmAdd`/`rmProp` cases, missing the newer `rmAddLam`/`rmPropLam`/
   `rmPowLam` box-cox/yeoJohnson variants -- and, found by an independent
   review pass while validating this fix, the plain `rmPow` (pure power, no
   lambda at all) case too. The unused component stayed at its nonzero
   scaffold default (`ares=10`/`bres=1`) forever, corrupting the shared
   E-step residual-SD formula `g = ares + bres*|f|`. `rmPow`'s severity was
   confirmed independently -- a plain `pow()` fit with the unzeroed `ares`
   diverged to `prop.sd ~ 1e27`.

Verified against the issue's own reproducer (1cmt IV, `linCmt()`, one eta,
`v` constant, `boxCox(lambda <- fixed(0.5))`): saem now matches FOCEi
(tcl ~1.32, add.sd ~0.14, both fits agree) where it previously diverged
badly (tcl 1.90, add.sd 0.54).

## Known follow-up (not in scope here)

An **estimated** (not `fixed()`) lambda still converges poorly for SAEM --
this looks like a separate, pre-existing issue, plausibly a missing
transform-both-sides Jacobian term. Not investigated further here.

While validating the `rmPow` fix, review also surfaced that SAEM's E-step
never applies the `pow()` exponent at all when it is *estimated* (only the
M-step does) -- filed separately as #972, out of scope for this PR.

## Test plan

- [x] New regression tests in `tests/testthat/test-saem-resid-lambda.R`
      assert parameter recovery against simulated truth (the prior tests
      only checked `is.finite()`, which the bug still satisfied) for
      `rmAddLam`, `rmPropLam`, and `rmPow` -- each verified to fail if its
      corresponding fix line is reverted.
- [x] All 11 essential (non-slow-batched) SAEM test files pass locally.
- [x] Reviewed with an independent Antigravity (Gemini) pass; findings
      (missing `rmPow` zeroing, missing test coverage) addressed in a
      follow-up commit and re-reviewed clean.