### PR TITLE
feat: full prior support (theta + omega) with analytic gradients for FOCEI-family estimation (#929/#931)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,33 +62,55 @@
   can opt in as it gains support:
 
   ```r
-  attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "theta"
+  attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "general"
   ```
 
   The levels are `"none"` (the default when the attribute is absent),
-  `"theta"` (population parameters only), `"general"`, `"nwpri"` (NONMEM's
-  own `$PRIOR NWPRI` omega convention) and `"tnpri"` (Monolix's/NONMEM's
-  own-estimation joint-normal convention, including a normal prior
-  directly on an omega element) -- see `?nlmixr2Est` for what each accepts
-  -- and `"all"`.  Because the check happens in the generic, methods
-  registered by other packages -- `babelmixr2`'s `nonmem`, `monolix`,
-  `saemix` and the rest -- are covered without any change of their own.
+  `"theta"` (population parameters only), `"general"` (everything the
+  shared kernel supports, including a prior on an omega element under
+  any convention), `"nwpri"` (NONMEM's own `$PRIOR NWPRI` omega
+  convention) and `"tnpri"` (Monolix's/NONMEM's own-estimation
+  joint-normal convention, including a normal prior directly on an omega
+  element) -- see `?nlmixr2Est` for what each accepts -- and `"all"`.
+  Because the check happens in the generic, methods registered by other
+  packages -- `babelmixr2`'s `nonmem`, `monolix`, `saemix` and the rest
+  -- are covered without any change of their own.
 
 - `est="focei"` and every method in its family (`foce`, `focep`, `fo`,
   `foi`, the mu-referenced `mfoce*`/IRLS `ifoce*` variants, `laplace`,
   `agq` and their quadrature/`*f` fast-path siblings) now honours a
-  prior on a population parameter, added to the objective as
-  `-2*log p(theta)` (nlmixr2/rxode2#1270, issue #929, issue #931) --
-  declared `nlmixr2Priors = "theta"`.  A prior that references an omega
-  element is still refused: FOCEi optimizes `chol(Omega^-1)`, not Omega
-  itself, and that gradient chain-rule is not wired in yet.
+  prior on a population parameter AND on an omega element -- under any
+  of the kernel's three conventions (`"general"`, NONMEM's `"nwpri"`,
+  Monolix's/NONMEM's-own-estimation `"tnpri"`), auto-detected from what
+  the model's own `ini({})` actually wrote -- added to the objective as
+  `-2*log p(theta, omega)` (nlmixr2/rxode2#1270, issue #929, issue #931)
+  -- declared `nlmixr2Priors = "general"`.
 
-  `foceiControl(fast=TRUE)` and `covMethod="analytic"` are silently
-  downgraded to their finite-difference equivalents whenever a model
-  carries a prior, since neither the analytic outer gradient nor the
-  analytic covariance has a `d/dtheta log p(theta)` term yet -- a
-  finite difference of the (now prior-inclusive) objective picks the
-  prior term up automatically; a stale analytic one would not.
+  `foceiControl(fast=TRUE)`'s analytic outer gradient has a real
+  `d/dtheta log p(theta)` term (a straight fold into the same
+  natural-scale accumulator the outer FD substitution already uses) and
+  a real `d/d(chol(Omega^-1)) log p(omega)` term (chain-ruled through the
+  SAME estimation-scale derivative data -- `d.omegaInv`/`tr.28` from the
+  model's `rxSymInvCholEnv` handle -- FOCEi's own, non-prior omega
+  gradient already relies on), so a prior no longer downgrades it: this
+  package uses symbolic/analytic derivatives throughout, not finite
+  differences, wherever one is available. (A prior referencing a theta a
+  mu-referenced family profiles out of the outer problem entirely is the
+  one case that first term cannot attribute; that specific fit declines
+  to finite differences instead of silently under-counting, detected
+  once at setup, not per evaluation.) `covMethod="analytic"` is still
+  downgraded to a finite-difference covariance, since the analytic
+  Hessian has no prior term yet -- a finite difference of the (now
+  prior-inclusive) objective picks the prior term up automatically.
+
+  Fixed along the way: `.nlmixr2FitUpdateParams()` rebuilt a fit's omega
+  rows of `iniDf` from the raw Omega matrix whenever an mixed-effects
+  model estimate was pinned back onto the model (piping, `.setOfvFo()`'s
+  post-fit re-entry for `setOfv()`/`addCwres()`), and that rebuild had no
+  way to carry the `prior` column lotri itself does not know about -- a
+  prior on an omega element silently vanished the first time a
+  prior-carrying fit was re-entered, which is every fit's own finalize
+  step. `rxUiPriors(fit$ui)` now still reports it afterward.
 
 ## Changed defaults
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,13 @@
   `-2*log p(theta, omega)` (nlmixr2/rxode2#1270, issue #929, issue #931)
   -- declared `nlmixr2Priors = "general"`.
 
+  The convention is auto-detected by default (`foceiControl(priorMethod=
+  "auto")`), but can be forced with `foceiControl(priorMethod="general"/
+  "nwpri"/"tnpri")`. Forcing a convention the model's priors are not
+  representable under (e.g. `priorMethod="tnpri"` on an `invWishart()`
+  prior) errors before any estimation starts, naming the parameter and
+  which method it needs instead.
+
   `foceiControl(fast=TRUE)`'s analytic outer gradient has a real
   `d/dtheta log p(theta)` term (a straight fold into the same
   natural-scale accumulator the outer FD substitution already uses) and

--- a/NEWS.md
+++ b/NEWS.md
@@ -62,14 +62,33 @@
   can opt in as it gains support:
 
   ```r
-  attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "normal"
+  attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "theta"
   ```
 
   The levels are `"none"` (the default when the attribute is absent),
-  `"normal"`, `"nwpri"` (normal priors plus omega degrees of freedom) and
-  `"all"`.  Because the check happens in the generic, methods registered
-  by other packages -- `babelmixr2`'s `nonmem`, `monolix`, `saemix` and
-  the rest -- are covered without any change of their own.
+  `"theta"` (population parameters only), `"general"`, `"nwpri"` (NONMEM's
+  own `$PRIOR NWPRI` omega convention) and `"tnpri"` (Monolix's/NONMEM's
+  own-estimation joint-normal convention, including a normal prior
+  directly on an omega element) -- see `?nlmixr2Est` for what each accepts
+  -- and `"all"`.  Because the check happens in the generic, methods
+  registered by other packages -- `babelmixr2`'s `nonmem`, `monolix`,
+  `saemix` and the rest -- are covered without any change of their own.
+
+- `est="focei"` and every method in its family (`foce`, `focep`, `fo`,
+  `foi`, the mu-referenced `mfoce*`/IRLS `ifoce*` variants, `laplace`,
+  `agq` and their quadrature/`*f` fast-path siblings) now honours a
+  prior on a population parameter, added to the objective as
+  `-2*log p(theta)` (nlmixr2/rxode2#1270, issue #929, issue #931) --
+  declared `nlmixr2Priors = "theta"`.  A prior that references an omega
+  element is still refused: FOCEi optimizes `chol(Omega^-1)`, not Omega
+  itself, and that gradient chain-rule is not wired in yet.
+
+  `foceiControl(fast=TRUE)` and `covMethod="analytic"` are silently
+  downgraded to their finite-difference equivalents whenever a model
+  carries a prior, since neither the analytic outer gradient nor the
+  analytic covariance has a `d/dtheta log p(theta)` term yet -- a
+  finite difference of the (now prior-inclusive) objective picks the
+  prior term up automatically; a stale analytic one would not.
 
 ## Changed defaults
 

--- a/R/agq.R
+++ b/R/agq.R
@@ -257,6 +257,7 @@ nlmixr2Est.agq <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="agq")
 }
+attr(nlmixr2Est.agq, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.agq, "iov") <- TRUE
 attr(nlmixr2Est.agq, "covPresent") <- TRUE
 attr(nlmixr2Est.agq, "unbounded") <- .foUnbounded

--- a/R/agq.R
+++ b/R/agq.R
@@ -257,7 +257,7 @@ nlmixr2Est.agq <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="agq")
 }
-attr(nlmixr2Est.agq, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.agq, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.agq, "iov") <- TRUE
 attr(nlmixr2Est.agq, "covPresent") <- TRUE
 attr(nlmixr2Est.agq, "unbounded") <- .foUnbounded

--- a/R/fo.R
+++ b/R/fo.R
@@ -159,6 +159,6 @@ nlmixr2Est.fo <- function(env, ...) {
   .addObjDfToReturn(.ret, .objDf)
   .ret
 }
-attr(nlmixr2Est.fo, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.fo, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.fo, "covPresent") <- TRUE
 attr(nlmixr2Est.fo, "unbounded") <- .foUnbounded

--- a/R/fo.R
+++ b/R/fo.R
@@ -159,5 +159,6 @@ nlmixr2Est.fo <- function(env, ...) {
   .addObjDfToReturn(.ret, .objDf)
   .ret
 }
+attr(nlmixr2Est.fo, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.fo, "covPresent") <- TRUE
 attr(nlmixr2Est.fo, "unbounded") <- .foUnbounded

--- a/R/foce.R
+++ b/R/foce.R
@@ -109,7 +109,7 @@ nlmixr2Est.foce <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="foce")
 }
-attr(nlmixr2Est.foce, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.foce, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.foce, "iov") <- TRUE
 attr(nlmixr2Est.foce, "covPresent") <- TRUE
 attr(nlmixr2Est.foce, "unbounded") <- .foUnbounded

--- a/R/foce.R
+++ b/R/foce.R
@@ -109,6 +109,7 @@ nlmixr2Est.foce <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="foce")
 }
+attr(nlmixr2Est.foce, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.foce, "iov") <- TRUE
 attr(nlmixr2Est.foce, "covPresent") <- TRUE
 attr(nlmixr2Est.foce, "unbounded") <- .foUnbounded

--- a/R/focei.R
+++ b/R/focei.R
@@ -2910,6 +2910,33 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     .minfo("linCmt() model: the analytic 'fast' gradient does not apply -- using fast = FALSE")
     .control$fast <- FALSE
   }
+  # Prior spec (nlmixr2/nlmixr2est#929): built once here, from whatever this ui
+  # declares in ini({}); a thin no-op (NULL) for a model with none.  Assigned
+  # with `[<-`, not `$<-`/`[[<-`, so a NULL spec still occupies the "priorSpec"
+  # slot instead of being dropped -- the C++ setup reads the element by name and
+  # must not see a missing key.  The gate (.nlmixr2AssertPriors(), R/priors.R)
+  # has already refused anything the dispatched est= method cannot use before
+  # .foceiFamilyControl() runs, so every term reaching this build is one the
+  # calling family accepted.
+  .control["priorSpec"] <- list(.nlmixr2BuildPriorSpec(.ui))
+  if (!is.null(.control$priorSpec)) {
+    # Neither the analytic outer gradient nor the analytic covariance/Hessian
+    # has a d/dtheta log p(theta) term yet (#931 scope is the objective only);
+    # an FD gradient/Hessian of foceiOfv0() picks the prior up for free
+    # because it re-evaluates the (now prior-inclusive) objective at each
+    # perturbed point, so downgrading to FD here keeps the fit's gradient and
+    # covariance consistent with the objective it is actually reporting,
+    # rather than silently describing a different function.
+    if (isTRUE(.control$fast)) {
+      .minfo("prior distribution(s): the analytic 'fast' gradient does not apply yet -- using fast = FALSE")
+      .control$fast <- FALSE
+    }
+    if (identical(.control$covType, "analytic")) {
+      .minfo("prior distribution(s): analytic covariance does not apply yet -- using covMethod = \"r,s\"")
+      .control$covType <- "fd"
+      .control$covMethod <- 1L
+    }
+  }
   assign("control", .control, envir=.ui)
 }
 
@@ -3348,6 +3375,7 @@ nlmixr2Est.focei <- function(env, ...) {
   .ret <- .foceiFamilyReturn(env, .ui, ..., est="focei")
   .ret
 }
+attr(nlmixr2Est.focei, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.focei, "covPresent") <- TRUE
 attr(nlmixr2Est.focei, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.focei, "iov") <- TRUE

--- a/R/focei.R
+++ b/R/focei.R
@@ -2918,7 +2918,17 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   # has already refused anything the dispatched est= method cannot use before
   # .foceiFamilyControl() runs, so every term reaching this build is one the
   # calling family accepted.
-  .control["priorSpec"] <- list(.nlmixr2BuildPriorSpec(.ui))
+  #
+  # foceiControl(priorMethod=) defaults to "auto" (.nlmixr2PriorMethod()'s
+  # read of the ini({}) syntax); every family control constructor forwards
+  # it to foceiControl() through its own "..." (agqControl(), focepControl(),
+  # ...), so this is the one place that needs to read it.  An explicit,
+  # non-"auto" choice that the model's priors cannot express under it (e.g.
+  # priorMethod="tnpri" on an invWishart() prior) errors out of
+  # rxPriorBuildSpec() itself, here, before any estimation starts.
+  .priorMethod <- .control$priorMethod
+  if (is.null(.priorMethod)) .priorMethod <- "auto"
+  .control["priorSpec"] <- list(.nlmixr2BuildPriorSpec(.ui, method=.priorMethod))
   if (!is.null(.control$priorSpec)) {
     # FOCEi's shared C++ kernel evaluates a prior on a population parameter
     # AND on an omega element (any of the "general"/"nwpri"/"tnpri"

--- a/R/focei.R
+++ b/R/focei.R
@@ -2920,6 +2920,21 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   # calling family accepted.
   .control["priorSpec"] <- list(.nlmixr2BuildPriorSpec(.ui))
   if (!is.null(.control$priorSpec)) {
+    # FOCEi's shared C++ kernel does not evaluate an omega-referencing prior
+    # term yet (#931 scope is theta-only) -- true for every caller of THIS
+    # function, not just the methods that declare nlmixr2Priors = "theta".
+    # "all"-level pseudo-methods (output/posthoc, #938) skip the gate's
+    # per-level restriction on PURPOSE (there is no prior they could
+    # silently ignore), but they still route through the same op_focei
+    # objective, which has no live Omega to read for anything but est="fo"
+    # (op_focei.omega is only ever populated when op_focei.fo==1) -- so an
+    # omega-touching term reaching it there is not a policy question, it is
+    # a capability gap, and must be refused here rather than left to crash
+    # or silently misread stale/unallocated memory in C++.
+    if (any(!is.na(rxode2::rxUiPriors(.ui)$neta1))) {
+      stop("a prior on an omega element is not usable by this estimation method yet",
+           call.=FALSE)
+    }
     # Neither the analytic outer gradient nor the analytic covariance/Hessian
     # has a d/dtheta log p(theta) term yet (#931 scope is the objective only);
     # an FD gradient/Hessian of foceiOfv0() picks the prior up for free

--- a/R/focei.R
+++ b/R/focei.R
@@ -2920,32 +2920,33 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   # calling family accepted.
   .control["priorSpec"] <- list(.nlmixr2BuildPriorSpec(.ui))
   if (!is.null(.control$priorSpec)) {
-    # FOCEi's shared C++ kernel does not evaluate an omega-referencing prior
-    # term yet (#931 scope is theta-only) -- true for every caller of THIS
-    # function, not just the methods that declare nlmixr2Priors = "theta".
-    # "all"-level pseudo-methods (output/posthoc, #938) skip the gate's
-    # per-level restriction on PURPOSE (there is no prior they could
-    # silently ignore), but they still route through the same op_focei
-    # objective, which has no live Omega to read for anything but est="fo"
-    # (op_focei.omega is only ever populated when op_focei.fo==1) -- so an
-    # omega-touching term reaching it there is not a policy question, it is
-    # a capability gap, and must be refused here rather than left to crash
-    # or silently misread stale/unallocated memory in C++.
-    if (any(!is.na(rxode2::rxUiPriors(.ui)$neta1))) {
-      stop("a prior on an omega element is not usable by this estimation method yet",
-           call.=FALSE)
-    }
-    # Neither the analytic outer gradient nor the analytic covariance/Hessian
-    # has a d/dtheta log p(theta) term yet (#931 scope is the objective only);
-    # an FD gradient/Hessian of foceiOfv0() picks the prior up for free
-    # because it re-evaluates the (now prior-inclusive) objective at each
-    # perturbed point, so downgrading to FD here keeps the fit's gradient and
-    # covariance consistent with the objective it is actually reporting,
-    # rather than silently describing a different function.
-    if (isTRUE(.control$fast)) {
-      .minfo("prior distribution(s): the analytic 'fast' gradient does not apply yet -- using fast = FALSE")
-      .control$fast <- FALSE
-    }
+    # FOCEi's shared C++ kernel evaluates a prior on a population parameter
+    # AND on an omega element (any of the "general"/"nwpri"/"tnpri"
+    # conventions -- foceiPriorEval()/foceiCurrentOmega(), src/inner.cpp;
+    # the latter recovers a live Omega from op_focei.omegaInv for every
+    # method, not just est="fo", where op_focei.omega itself is populated).
+    #
+    # fast=TRUE's analytic outer gradient has both a d/dtheta log p(theta)
+    # term (foceiPriorGradAdd()) and a d/d(omega theta_k) log p(omega) term
+    # (foceiPriorOmegaGradAdd(), reusing the SAME estimation-scale
+    # derivatives -- d.omegaInv/tr.28 from the model's _rxInv handle --
+    # FOCEi's own (non-prior) omega gradient already relies on) -- so it
+    # needs no downgrade here, consistent with the rest of this package's
+    # FOCEi family using symbolic/analytic derivatives throughout, not
+    # finite differences, wherever one is available. (A prior referencing a
+    # theta a mu-referenced family profiles out of the outer problem is the
+    # one case the theta term cannot attribute; src/inner.cpp's
+    # priorSpecThetaReachable() detects that at setup and declines to FD
+    # for just that fit, so it is never silently wrong -- but it is not
+    # something to special-case here. Omega elements are never profiled out
+    # this way.)
+    #
+    # The analytic covariance/Hessian has no prior term yet, so it still
+    # needs the FD downgrade: an FD Hessian of foceiOfv0() picks the prior
+    # up for free by re-evaluating the (now prior-inclusive) objective at
+    # each perturbed point, keeping the covariance consistent with the
+    # objective the fit actually reports rather than silently describing a
+    # different function.
     if (identical(.control$covType, "analytic")) {
       .minfo("prior distribution(s): analytic covariance does not apply yet -- using covMethod = \"r,s\"")
       .control$covType <- "fd"
@@ -3390,7 +3391,7 @@ nlmixr2Est.focei <- function(env, ...) {
   .ret <- .foceiFamilyReturn(env, .ui, ..., est="focei")
   .ret
 }
-attr(nlmixr2Est.focei, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.focei, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.focei, "covPresent") <- TRUE
 attr(nlmixr2Est.focei, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.focei, "iov") <- TRUE

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -22,7 +22,12 @@
                            "foceiConstCovs",
                            # TRUE when the outer optimizer was defaulted (not user
                            # specified); lets *f wrappers re-default under fast=TRUE
-                           "outerOptDefault")
+                           "outerOptDefault",
+                           # the built rx_prior_spec_t* external pointer
+                           # (.nlmixr2BuildPriorSpec(), R/priors.R); not a formal
+                           # argument, not deparseable/comparable, and rebuilt fresh
+                           # every fit -- internal so a built control round-trips.
+                           "priorSpec")
 
 #' Control Options for FOCEi
 #'

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -200,6 +200,24 @@
 #'     \code{fast=FALSE}); pairing \code{fast=TRUE} with a derivative-free
 #'     \code{outerOpt} reverts to \code{fast=FALSE}.  The \code{*f} methods (e.g.
 #'     \code{foceif}) default this to \code{TRUE}.
+#' @param priorMethod Which of the shared prior kernel's three omega
+#'     conventions (nlmixr2/rxode2#1270) to evaluate an \code{ini({})}
+#'     \code{prior()} under -- \code{"general"} (textbook Bayesian),
+#'     \code{"nwpri"} (NONMEM's own \verb{$PRIOR NWPRI}), or \code{"tnpri"}
+#'     (the Monolix/NONMEM-own-estimation joint-normal convention on omega).
+#'     The default, \code{"auto"}, reads the convention off what the model's
+#'     own \code{ini({})} actually wrote (an \code{invWishart()} degrees-of-
+#'     freedom prior on an omega block means \code{"nwpri"}; a normal prior
+#'     directly on an omega element means \code{"tnpri"}; anything else,
+#'     including a \code{dcauchy()} prior, means \code{"general"}) --
+#'     deliberately never a fixed default, since the identical
+#'     \code{invWishart(nu)} syntax means a different number under
+#'     \code{"general"} and \code{"nwpri"}.  Setting this explicitly forces
+#'     that convention regardless of what auto-detection would have picked,
+#'     and errors before any estimation starts if the model's priors are not
+#'     representable under it (e.g. \code{priorMethod="tnpri"} on a model
+#'     with an \code{invWishart()} prior).  Ignored when the model has no
+#'     prior at all.
 #'
 #' @param covTryHarder If the R matrix is non-positive definite and
 #'     cannot be corrected to be non-positive definite try estimating
@@ -841,6 +859,7 @@ foceiControl <- function(sigdig = 3, #
                          covSolveTol = NULL, #
                          covFull = TRUE, #
                          fast = FALSE, #
+                         priorMethod = c("auto", "general", "nwpri", "tnpri"), #
                          fdOutlierZ = 3.5, #
                          fdOutlierScale = TRUE, #
                          fdRefine = c("chartrand", "lanczos", "richardson"), #
@@ -1292,6 +1311,7 @@ foceiControl <- function(sigdig = 3, #
                                                       finite = TRUE, any.missing = FALSE)
   checkmate::assertFlag(covFull)
   checkmate::assertFlag(fast)
+  priorMethod <- match.arg(priorMethod)
   .xtra <- list(...)
   .bad <- names(.xtra)
   .bad <- .bad[!(.bad %in% .foceiControlInternal)]
@@ -1541,6 +1561,7 @@ foceiControl <- function(sigdig = 3, #
     covSolveTol = covSolveTol,
     covFull = covFull,
     fast = fast,
+    priorMethod = priorMethod,
     fdOutlierZ = as.double(fdOutlierZ),
     # Kept as the CHARACTER name, and read as a string in C++.  Storing the integer code
     # instead does not round-trip: a control is re-passed through foceiControl() (as named

--- a/R/foceiFast.R
+++ b/R/foceiFast.R
@@ -39,7 +39,7 @@ getValidNlmixrCtl.foceif <- function(control) .foceiFastCtl(control, foceiContro
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.foceif <- function(env, ...) nlmixr2Est.focei(env, ...)
-attr(nlmixr2Est.foceif, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.foceif, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.foceif, "covPresent") <- TRUE
 attr(nlmixr2Est.foceif, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.foceif, "iov") <- TRUE
@@ -50,7 +50,7 @@ getValidNlmixrCtl.focef <- function(control) .foceiFastCtl(control, foceControl)
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.focef <- function(env, ...) nlmixr2Est.foce(env, ...)
-attr(nlmixr2Est.focef, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.focef, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.focef, "covPresent") <- TRUE
 attr(nlmixr2Est.focef, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.focef, "iov") <- TRUE
@@ -61,7 +61,7 @@ getValidNlmixrCtl.focepf <- function(control) .foceiFastCtl(control, focepContro
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.focepf <- function(env, ...) nlmixr2Est.focep(env, ...)
-attr(nlmixr2Est.focepf, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.focepf, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.focepf, "covPresent") <- TRUE
 attr(nlmixr2Est.focepf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.focepf, "iov") <- TRUE
@@ -74,7 +74,7 @@ getValidNlmixrCtl.mfoceif <- function(control) .foceiFastCtl(control, mfoceiCont
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.mfoceif <- function(env, ...) nlmixr2Est.mfocei(env, ...)
-attr(nlmixr2Est.mfoceif, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.mfoceif, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.mfoceif, "covPresent") <- TRUE
 attr(nlmixr2Est.mfoceif, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.mfoceif, "iov") <- TRUE
@@ -86,7 +86,7 @@ getValidNlmixrCtl.mfocef <- function(control) .foceiFastCtl(control, mfoceContro
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.mfocef <- function(env, ...) nlmixr2Est.mfoce(env, ...)
-attr(nlmixr2Est.mfocef, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.mfocef, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.mfocef, "covPresent") <- TRUE
 attr(nlmixr2Est.mfocef, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.mfocef, "iov") <- TRUE
@@ -98,7 +98,7 @@ getValidNlmixrCtl.mfocepf <- function(control) .foceiFastCtl(control, mfocepCont
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.mfocepf <- function(env, ...) nlmixr2Est.mfocep(env, ...)
-attr(nlmixr2Est.mfocepf, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.mfocepf, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.mfocepf, "covPresent") <- TRUE
 attr(nlmixr2Est.mfocepf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.mfocepf, "iov") <- TRUE
@@ -112,7 +112,7 @@ getValidNlmixrCtl.ifoceif <- function(control) .foceiFastCtl(control, ifoceiCont
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.ifoceif <- function(env, ...) nlmixr2Est.ifocei(env, ...)
-attr(nlmixr2Est.ifoceif, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.ifoceif, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.ifoceif, "covPresent") <- TRUE
 attr(nlmixr2Est.ifoceif, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.ifoceif, "iov") <- TRUE
@@ -124,7 +124,7 @@ getValidNlmixrCtl.ifocef <- function(control) .foceiFastCtl(control, ifoceContro
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.ifocef <- function(env, ...) nlmixr2Est.ifoce(env, ...)
-attr(nlmixr2Est.ifocef, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.ifocef, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.ifocef, "covPresent") <- TRUE
 attr(nlmixr2Est.ifocef, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.ifocef, "iov") <- TRUE
@@ -136,7 +136,7 @@ getValidNlmixrCtl.ifocepf <- function(control) .foceiFastCtl(control, ifocepCont
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.ifocepf <- function(env, ...) nlmixr2Est.ifocep(env, ...)
-attr(nlmixr2Est.ifocepf, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.ifocepf, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.ifocepf, "covPresent") <- TRUE
 attr(nlmixr2Est.ifocepf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.ifocepf, "iov") <- TRUE
@@ -150,7 +150,7 @@ getValidNlmixrCtl.agqf <- function(control) .foceiFastCtl(control, agqControl)
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.agqf <- function(env, ...) nlmixr2Est.agq(env, ...)
-attr(nlmixr2Est.agqf, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.agqf, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.agqf, "covPresent") <- TRUE
 attr(nlmixr2Est.agqf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.agqf, "iov") <- TRUE
@@ -161,7 +161,7 @@ getValidNlmixrCtl.magqf <- function(control) .foceiFastCtl(control, magqControl)
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.magqf <- function(env, ...) nlmixr2Est.magq(env, ...)
-attr(nlmixr2Est.magqf, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.magqf, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.magqf, "covPresent") <- TRUE
 attr(nlmixr2Est.magqf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.magqf, "iov") <- TRUE
@@ -173,7 +173,7 @@ getValidNlmixrCtl.iagqf <- function(control) .foceiFastCtl(control, iagqControl)
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.iagqf <- function(env, ...) nlmixr2Est.iagq(env, ...)
-attr(nlmixr2Est.iagqf, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.iagqf, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.iagqf, "covPresent") <- TRUE
 attr(nlmixr2Est.iagqf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.iagqf, "iov") <- TRUE

--- a/R/foceiFast.R
+++ b/R/foceiFast.R
@@ -39,6 +39,7 @@ getValidNlmixrCtl.foceif <- function(control) .foceiFastCtl(control, foceiContro
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.foceif <- function(env, ...) nlmixr2Est.focei(env, ...)
+attr(nlmixr2Est.foceif, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.foceif, "covPresent") <- TRUE
 attr(nlmixr2Est.foceif, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.foceif, "iov") <- TRUE
@@ -49,6 +50,7 @@ getValidNlmixrCtl.focef <- function(control) .foceiFastCtl(control, foceControl)
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.focef <- function(env, ...) nlmixr2Est.foce(env, ...)
+attr(nlmixr2Est.focef, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.focef, "covPresent") <- TRUE
 attr(nlmixr2Est.focef, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.focef, "iov") <- TRUE
@@ -59,6 +61,7 @@ getValidNlmixrCtl.focepf <- function(control) .foceiFastCtl(control, focepContro
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.focepf <- function(env, ...) nlmixr2Est.focep(env, ...)
+attr(nlmixr2Est.focepf, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.focepf, "covPresent") <- TRUE
 attr(nlmixr2Est.focepf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.focepf, "iov") <- TRUE
@@ -71,6 +74,7 @@ getValidNlmixrCtl.mfoceif <- function(control) .foceiFastCtl(control, mfoceiCont
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.mfoceif <- function(env, ...) nlmixr2Est.mfocei(env, ...)
+attr(nlmixr2Est.mfoceif, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.mfoceif, "covPresent") <- TRUE
 attr(nlmixr2Est.mfoceif, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.mfoceif, "iov") <- TRUE
@@ -82,6 +86,7 @@ getValidNlmixrCtl.mfocef <- function(control) .foceiFastCtl(control, mfoceContro
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.mfocef <- function(env, ...) nlmixr2Est.mfoce(env, ...)
+attr(nlmixr2Est.mfocef, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.mfocef, "covPresent") <- TRUE
 attr(nlmixr2Est.mfocef, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.mfocef, "iov") <- TRUE
@@ -93,6 +98,7 @@ getValidNlmixrCtl.mfocepf <- function(control) .foceiFastCtl(control, mfocepCont
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.mfocepf <- function(env, ...) nlmixr2Est.mfocep(env, ...)
+attr(nlmixr2Est.mfocepf, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.mfocepf, "covPresent") <- TRUE
 attr(nlmixr2Est.mfocepf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.mfocepf, "iov") <- TRUE
@@ -106,6 +112,7 @@ getValidNlmixrCtl.ifoceif <- function(control) .foceiFastCtl(control, ifoceiCont
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.ifoceif <- function(env, ...) nlmixr2Est.ifocei(env, ...)
+attr(nlmixr2Est.ifoceif, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.ifoceif, "covPresent") <- TRUE
 attr(nlmixr2Est.ifoceif, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.ifoceif, "iov") <- TRUE
@@ -117,6 +124,7 @@ getValidNlmixrCtl.ifocef <- function(control) .foceiFastCtl(control, ifoceContro
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.ifocef <- function(env, ...) nlmixr2Est.ifoce(env, ...)
+attr(nlmixr2Est.ifocef, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.ifocef, "covPresent") <- TRUE
 attr(nlmixr2Est.ifocef, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.ifocef, "iov") <- TRUE
@@ -128,6 +136,7 @@ getValidNlmixrCtl.ifocepf <- function(control) .foceiFastCtl(control, ifocepCont
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.ifocepf <- function(env, ...) nlmixr2Est.ifocep(env, ...)
+attr(nlmixr2Est.ifocepf, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.ifocepf, "covPresent") <- TRUE
 attr(nlmixr2Est.ifocepf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.ifocepf, "iov") <- TRUE
@@ -141,6 +150,7 @@ getValidNlmixrCtl.agqf <- function(control) .foceiFastCtl(control, agqControl)
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.agqf <- function(env, ...) nlmixr2Est.agq(env, ...)
+attr(nlmixr2Est.agqf, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.agqf, "covPresent") <- TRUE
 attr(nlmixr2Est.agqf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.agqf, "iov") <- TRUE
@@ -151,6 +161,7 @@ getValidNlmixrCtl.magqf <- function(control) .foceiFastCtl(control, magqControl)
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.magqf <- function(env, ...) nlmixr2Est.magq(env, ...)
+attr(nlmixr2Est.magqf, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.magqf, "covPresent") <- TRUE
 attr(nlmixr2Est.magqf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.magqf, "iov") <- TRUE
@@ -162,6 +173,7 @@ getValidNlmixrCtl.iagqf <- function(control) .foceiFastCtl(control, iagqControl)
 #' @rdname nlmixr2Est
 #' @export
 nlmixr2Est.iagqf <- function(env, ...) nlmixr2Est.iagq(env, ...)
+attr(nlmixr2Est.iagqf, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.iagqf, "covPresent") <- TRUE
 attr(nlmixr2Est.iagqf, "unbounded") <- .foUnbounded
 attr(nlmixr2Est.iagqf, "iov") <- TRUE

--- a/R/focep.R
+++ b/R/focep.R
@@ -116,7 +116,7 @@ nlmixr2Est.focep <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="focep")
 }
-attr(nlmixr2Est.focep, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.focep, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.focep, "iov") <- TRUE
 attr(nlmixr2Est.focep, "covPresent") <- TRUE
 attr(nlmixr2Est.focep, "unbounded") <- .foUnbounded

--- a/R/focep.R
+++ b/R/focep.R
@@ -116,6 +116,7 @@ nlmixr2Est.focep <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="focep")
 }
+attr(nlmixr2Est.focep, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.focep, "iov") <- TRUE
 attr(nlmixr2Est.focep, "covPresent") <- TRUE
 attr(nlmixr2Est.focep, "unbounded") <- .foUnbounded

--- a/R/foi.R
+++ b/R/foi.R
@@ -160,6 +160,6 @@ nlmixr2Est.foi <- function(env, ...) {
   .addObjDfToReturn(.ret, .objDf)
   .ret
 }
-attr(nlmixr2Est.foi, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.foi, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.foi, "covPresent") <- TRUE
 attr(nlmixr2Est.foi, "unbounded") <- .foUnbounded

--- a/R/foi.R
+++ b/R/foi.R
@@ -160,5 +160,6 @@ nlmixr2Est.foi <- function(env, ...) {
   .addObjDfToReturn(.ret, .objDf)
   .ret
 }
+attr(nlmixr2Est.foi, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.foi, "covPresent") <- TRUE
 attr(nlmixr2Est.foi, "unbounded") <- .foUnbounded

--- a/R/iagq.R
+++ b/R/iagq.R
@@ -17,7 +17,7 @@ nlmixr2Est.iagq <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="iagq")
 }
-attr(nlmixr2Est.iagq, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.iagq, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.iagq, "iov") <- TRUE
 attr(nlmixr2Est.iagq, "covPresent") <- TRUE
 attr(nlmixr2Est.iagq, "unbounded") <- .foUnbounded

--- a/R/iagq.R
+++ b/R/iagq.R
@@ -17,6 +17,7 @@ nlmixr2Est.iagq <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="iagq")
 }
+attr(nlmixr2Est.iagq, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.iagq, "iov") <- TRUE
 attr(nlmixr2Est.iagq, "covPresent") <- TRUE
 attr(nlmixr2Est.iagq, "unbounded") <- .foUnbounded

--- a/R/ifoce.R
+++ b/R/ifoce.R
@@ -17,6 +17,7 @@ nlmixr2Est.ifoce <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="ifoce")
 }
+attr(nlmixr2Est.ifoce, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.ifoce, "iov") <- TRUE
 attr(nlmixr2Est.ifoce, "covPresent") <- TRUE
 attr(nlmixr2Est.ifoce, "unbounded") <- .foUnbounded

--- a/R/ifoce.R
+++ b/R/ifoce.R
@@ -17,7 +17,7 @@ nlmixr2Est.ifoce <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="ifoce")
 }
-attr(nlmixr2Est.ifoce, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.ifoce, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.ifoce, "iov") <- TRUE
 attr(nlmixr2Est.ifoce, "covPresent") <- TRUE
 attr(nlmixr2Est.ifoce, "unbounded") <- .foUnbounded

--- a/R/ifocei.R
+++ b/R/ifocei.R
@@ -15,6 +15,7 @@ nlmixr2Est.ifocei <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="ifocei")
 }
+attr(nlmixr2Est.ifocei, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.ifocei, "covPresent") <- TRUE
 attr(nlmixr2Est.ifocei, "unbounded") <- .foUnbounded
 # Activates mu2/mu3/mu4 covariate rewriting (R/mu2.R); gated on

--- a/R/ifocei.R
+++ b/R/ifocei.R
@@ -15,7 +15,7 @@ nlmixr2Est.ifocei <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="ifocei")
 }
-attr(nlmixr2Est.ifocei, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.ifocei, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.ifocei, "covPresent") <- TRUE
 attr(nlmixr2Est.ifocei, "unbounded") <- .foUnbounded
 # Activates mu2/mu3/mu4 covariate rewriting (R/mu2.R); gated on

--- a/R/ifocep.R
+++ b/R/ifocep.R
@@ -114,7 +114,7 @@ nlmixr2Est.ifocep <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="ifocep")
 }
-attr(nlmixr2Est.ifocep, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.ifocep, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.ifocep, "iov") <- TRUE
 attr(nlmixr2Est.ifocep, "covPresent") <- TRUE
 attr(nlmixr2Est.ifocep, "unbounded") <- .foUnbounded

--- a/R/ifocep.R
+++ b/R/ifocep.R
@@ -114,6 +114,7 @@ nlmixr2Est.ifocep <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="ifocep")
 }
+attr(nlmixr2Est.ifocep, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.ifocep, "iov") <- TRUE
 attr(nlmixr2Est.ifocep, "covPresent") <- TRUE
 attr(nlmixr2Est.ifocep, "unbounded") <- .foUnbounded

--- a/R/ilaplace.R
+++ b/R/ilaplace.R
@@ -17,6 +17,7 @@ nlmixr2Est.ilaplace <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="ilaplace")
 }
+attr(nlmixr2Est.ilaplace, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.ilaplace, "iov") <- TRUE
 attr(nlmixr2Est.ilaplace, "covPresent") <- TRUE
 attr(nlmixr2Est.ilaplace, "unbounded") <- .foUnbounded

--- a/R/ilaplace.R
+++ b/R/ilaplace.R
@@ -17,7 +17,7 @@ nlmixr2Est.ilaplace <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="ilaplace")
 }
-attr(nlmixr2Est.ilaplace, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.ilaplace, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.ilaplace, "iov") <- TRUE
 attr(nlmixr2Est.ilaplace, "covPresent") <- TRUE
 attr(nlmixr2Est.ilaplace, "unbounded") <- .foUnbounded

--- a/R/laplace.R
+++ b/R/laplace.R
@@ -178,6 +178,7 @@ nlmixr2Est.laplace <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="laplace")
 }
+attr(nlmixr2Est.laplace, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.laplace, "iov") <- TRUE
 attr(nlmixr2Est.laplace, "covPresent") <- TRUE
 attr(nlmixr2Est.laplace, "unbounded") <- .foUnbounded

--- a/R/laplace.R
+++ b/R/laplace.R
@@ -178,7 +178,7 @@ nlmixr2Est.laplace <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="laplace")
 }
-attr(nlmixr2Est.laplace, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.laplace, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.laplace, "iov") <- TRUE
 attr(nlmixr2Est.laplace, "covPresent") <- TRUE
 attr(nlmixr2Est.laplace, "unbounded") <- .foUnbounded

--- a/R/magq.R
+++ b/R/magq.R
@@ -17,6 +17,7 @@ nlmixr2Est.magq <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="magq")
 }
+attr(nlmixr2Est.magq, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.magq, "iov") <- TRUE
 attr(nlmixr2Est.magq, "covPresent") <- TRUE
 attr(nlmixr2Est.magq, "unbounded") <- .foUnbounded

--- a/R/magq.R
+++ b/R/magq.R
@@ -17,7 +17,7 @@ nlmixr2Est.magq <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="magq")
 }
-attr(nlmixr2Est.magq, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.magq, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.magq, "iov") <- TRUE
 attr(nlmixr2Est.magq, "covPresent") <- TRUE
 attr(nlmixr2Est.magq, "unbounded") <- .foUnbounded

--- a/R/mfoce.R
+++ b/R/mfoce.R
@@ -17,7 +17,7 @@ nlmixr2Est.mfoce <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="mfoce")
 }
-attr(nlmixr2Est.mfoce, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.mfoce, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.mfoce, "iov") <- TRUE
 attr(nlmixr2Est.mfoce, "covPresent") <- TRUE
 attr(nlmixr2Est.mfoce, "unbounded") <- .foUnbounded

--- a/R/mfoce.R
+++ b/R/mfoce.R
@@ -17,6 +17,7 @@ nlmixr2Est.mfoce <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="mfoce")
 }
+attr(nlmixr2Est.mfoce, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.mfoce, "iov") <- TRUE
 attr(nlmixr2Est.mfoce, "covPresent") <- TRUE
 attr(nlmixr2Est.mfoce, "unbounded") <- .foUnbounded

--- a/R/mfocei.R
+++ b/R/mfocei.R
@@ -15,7 +15,7 @@ nlmixr2Est.mfocei <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="mfocei")
 }
-attr(nlmixr2Est.mfocei, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.mfocei, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.mfocei, "covPresent") <- TRUE
 attr(nlmixr2Est.mfocei, "unbounded") <- .foUnbounded
 # Activates the mu2/mu3/mu4 covariate-rewriting hook (.uiApplyMu2hook,

--- a/R/mfocei.R
+++ b/R/mfocei.R
@@ -15,6 +15,7 @@ nlmixr2Est.mfocei <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="mfocei")
 }
+attr(nlmixr2Est.mfocei, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.mfocei, "covPresent") <- TRUE
 attr(nlmixr2Est.mfocei, "unbounded") <- .foUnbounded
 # Activates the mu2/mu3/mu4 covariate-rewriting hook (.uiApplyMu2hook,

--- a/R/mfocep.R
+++ b/R/mfocep.R
@@ -114,7 +114,7 @@ nlmixr2Est.mfocep <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="mfocep")
 }
-attr(nlmixr2Est.mfocep, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.mfocep, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.mfocep, "iov") <- TRUE
 attr(nlmixr2Est.mfocep, "covPresent") <- TRUE
 attr(nlmixr2Est.mfocep, "unbounded") <- .foUnbounded

--- a/R/mfocep.R
+++ b/R/mfocep.R
@@ -114,6 +114,7 @@ nlmixr2Est.mfocep <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="mfocep")
 }
+attr(nlmixr2Est.mfocep, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.mfocep, "iov") <- TRUE
 attr(nlmixr2Est.mfocep, "covPresent") <- TRUE
 attr(nlmixr2Est.mfocep, "unbounded") <- .foUnbounded

--- a/R/mlaplace.R
+++ b/R/mlaplace.R
@@ -17,6 +17,7 @@ nlmixr2Est.mlaplace <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="mlaplace")
 }
+attr(nlmixr2Est.mlaplace, "nlmixr2Priors") <- "theta"
 attr(nlmixr2Est.mlaplace, "iov") <- TRUE
 attr(nlmixr2Est.mlaplace, "covPresent") <- TRUE
 attr(nlmixr2Est.mlaplace, "unbounded") <- .foUnbounded

--- a/R/mlaplace.R
+++ b/R/mlaplace.R
@@ -17,7 +17,7 @@ nlmixr2Est.mlaplace <- function(env, ...) {
   .ui <- env$ui
   .foceiFamilyReturn(env, .ui, ..., est="mlaplace")
 }
-attr(nlmixr2Est.mlaplace, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.mlaplace, "nlmixr2Priors") <- "general"
 attr(nlmixr2Est.mlaplace, "iov") <- TRUE
 attr(nlmixr2Est.mlaplace, "covPresent") <- TRUE
 attr(nlmixr2Est.mlaplace, "unbounded") <- .foUnbounded

--- a/R/nlmixr2Est.R
+++ b/R/nlmixr2Est.R
@@ -31,17 +31,19 @@
 #' A method says what it supports with an attribute on itself:
 #'
 #' ```
-#' attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "theta"
+#' attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "general"
 #' ```
 #'
 #' - `"none"`, which is also what an absent attribute means -- the
 #'   method cannot use priors at all
 #' - `"theta"` -- priors on population parameters only (`dnorm()`,
 #'   `dcauchy()`, `stdNormal()` and the `multiNormal()` family among
-#'   thetas); anything referencing an omega element is refused
+#'   thetas); anything referencing an omega element is refused.  No
+#'   FOCEi-family method uses this level -- they declare `"general"`.
 #' - `"general"` -- everything the shared kernel's `"general"` method
 #'   covers: the above, plus a normal prior directly on an omega element
-#'   and a textbook inverse-Wishart on an omega block
+#'   and a textbook inverse-Wishart on an omega block.  This is what
+#'   `est="focei"` and the rest of its family declare.
 #' - `"nwpri"` -- normal priors and degrees of freedom on an omega block
 #'   (`invWishart(4)`), evaluated the way a NONMEM NWPRI model works; a
 #'   normal prior on the omega values themselves is refused

--- a/R/nlmixr2Est.R
+++ b/R/nlmixr2Est.R
@@ -31,16 +31,23 @@
 #' A method says what it supports with an attribute on itself:
 #'
 #' ```
-#' attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "normal"
+#' attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "theta"
 #' ```
 #'
 #' - `"none"`, which is also what an absent attribute means -- the
 #'   method cannot use priors at all
-#' - `"normal"` -- normal priors only (`dnorm()`, `stdNormal()` and the
-#'   `multiNormal()` family)
+#' - `"theta"` -- priors on population parameters only (`dnorm()`,
+#'   `dcauchy()`, `stdNormal()` and the `multiNormal()` family among
+#'   thetas); anything referencing an omega element is refused
+#' - `"general"` -- everything the shared kernel's `"general"` method
+#'   covers: the above, plus a normal prior directly on an omega element
+#'   and a textbook inverse-Wishart on an omega block
 #' - `"nwpri"` -- normal priors and degrees of freedom on an omega block
-#'   (`invWishart(4)`), as a NONMEM NWPRI model works; a normal prior on
-#'   the omega values themselves is refused
+#'   (`invWishart(4)`), evaluated the way a NONMEM NWPRI model works; a
+#'   normal prior on the omega values themselves is refused
+#' - `"tnpri"` -- normal priors including directly on omega elements
+#'   (Monolix's/NONMEM's own-estimation joint-normal assumption);
+#'   `dcauchy()` and `invWishart()` are refused
 #' - `"all"` -- the method handles everything, so nothing is checked
 #'
 #' @export

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -834,6 +834,16 @@ vcov.nlmixr2FitCoreSilent <- vcov.nlmixr2FitCore
     .iniDf2 <- as.data.frame(.omega)
     .iniDf2 <- .iniDf2[!is.na(.iniDf2$neta1), ]
     .iniDf2$err <- NA_character_
+    # as.data.frame(.omega) rebuilds the omega rows from the raw matrix,
+    # which has no way to carry the `prior` column lotri itself does not
+    # know about (nlmixr2/nlmixr2est#929/#931) -- restore it from the
+    # pre-rebuild iniDf, matched by name, so a prior on an omega element
+    # does not silently vanish the first time a fit is piped/re-entered
+    # (eg .setOfvFo()'s re-dispatch through nlmixr2(fit, ...)).
+    if ("prior" %in% names(.iniDf) && "prior" %in% names(.iniDf2)) {
+      .w <- match(.iniDf2$name, .iniDf$name)
+      .iniDf2$prior[!is.na(.w)] <- .iniDf$prior[.w[!is.na(.w)]]
+    }
     .names <- names(.iniDf)
     .iniDf <- rbind(.iniDf1, .iniDf2)
     .iniDf <- .iniDf[, .names]

--- a/R/priors.R
+++ b/R/priors.R
@@ -7,27 +7,53 @@
 ## one place (`nlmixr2Est()`) rather than method by method, so a method
 ## added later cannot forget to do it.
 ##
+## The shared kernel this gate protects (`rxode2::rxPriorBuildSpec()` /
+## `rxPriorLogDensity()`, nlmixr2/rxode2#1270) implements THREE genuinely
+## different omega conventions, matching NONMEM/Monolix/textbook-Bayes
+## respectively -- `"general"`, `"nwpri"`, `"tnpri"` -- see
+## `.nlmixr2PriorMethod()` below for how a model's own `ini({})` syntax
+## picks among them (never a user- or method-supplied default: the same
+## `invWishart(nu)` syntax means a different number under "general" and
+## "nwpri", so guessing wrong would silently fit the wrong penalty).
+##
 ## A method says what it supports with an attribute on itself:
 ##
-##   attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "normal"
+##   attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "theta"
 ##
 ## The levels are
 ##
 ## - `"none"` (also the default, when the attribute is absent) -- the
 ##   method cannot use priors at all
-## - `"normal"` -- normal priors only, ie `dnorm()`, `stdNormal()` and
-##   the `multiNormal()` family the lotri shorthand produces
+## - `"theta"` -- priors on population parameters only (`dnorm()`,
+##   `dcauchy()`, `stdNormal()`, the `multiNormal()` family the lotri
+##   shorthand produces among thetas); anything that touches an omega
+##   element is refused.  This is what FOCEi's family can honour today
+##   (#931) -- an omega-referencing term needs the natural-scale gradient
+##   chain-ruled through `op_focei.cholOmegaInv`
+##   (`rxPriorOmegaToCholOmegaInvGrad()`), not yet wired in.
+## - `"general"` -- everything the kernel's `"general"` method covers:
+##   the above, plus a normal prior directly on an omega element and a
+##   textbook inverse-Wishart on an omega block.  No further check here;
+##   `rxPriorBuildSpec()` itself is the validator (nothing beyond what
+##   `rxUiPriors()` reports can reach it).
 ## - `"nwpri"` -- normal priors, and degrees of freedom on an omega
-##   block (`invWishart(4)`), the way a NONMEM NWPRI model works; a
-##   normal prior on the omega values themselves (TNPRI) is refused
-## - `"all"` -- everything, so nothing is checked here
+##   block (`invWishart(4)`), evaluated with NONMEM's own `$PRIOR NWPRI`
+##   convention rather than the textbook one; a normal prior on the
+##   omega values themselves (TNPRI) is refused
+## - `"tnpri"` -- normal priors including directly on omega elements
+##   (Monolix's/NONMEM's own-estimation joint-normal assumption);
+##   `dcauchy()` and `invWishart()` are refused (that is `"nwpri"`'s
+##   mechanism)
+## - `"all"` -- everything, so nothing is checked here; for pseudo-methods
+##   (`"output"`, `"posthoc"`) that evaluate an already-accepted model
+##   rather than estimate one, so there is no prior they could ignore
 ##
 ## The list can grow as methods gain support.
 
 #' Levels a method may declare for `nlmixr2Priors`
 #'
 #' @noRd
-.nlmixr2PriorLevels <- c("none", "normal", "nwpri", "all")
+.nlmixr2PriorLevels <- c("none", "theta", "general", "nwpri", "tnpri", "all")
 
 #' What priors does the method dispatched for this environment support?
 #'
@@ -112,6 +138,32 @@
   force(expr)
 }
 
+#' Refuse a prior that references an omega element
+#'
+#' Used for the `"theta"` level: FOCEi's family can honour a prior on a
+#' population parameter today, but not yet one on an omega element -- that
+#' needs the natural-scale gradient chain-ruled through
+#' `op_focei.cholOmegaInv` (`rxPriorOmegaToCholOmegaInvGrad()`), not yet
+#' wired into the objective/gradient (#931).
+#'
+#' @param ui rxode2 ui
+#' @param extra text appended to the error
+#' @return the ui, invisibly; called for the error otherwise
+#' @noRd
+#' @author Matthew L. Fidler
+.nlmixr2AssertThetaOnlyPriors <- function(ui, extra="") {
+  .p <- rxode2::rxUiPriors(ui)
+  if (length(.p$name) == 0L) return(invisible(ui))
+  .bad <- which(!is.na(.p$neta1))
+  if (length(.bad) > 0L) {
+    stop("the model puts a prior on the omega parameter(s) ",
+         paste0("'", .p$name[.bad], "'", collapse=", "),
+         ", which this estimation method cannot use yet", extra,
+         call.=FALSE)
+  }
+  invisible(ui)
+}
+
 #' Refuse the priors the dispatched estimation method cannot use
 #'
 #' @param env nlmixr2 estimation environment
@@ -128,7 +180,15 @@
     .f <- .nlmixr2RxAssert("assertRxUiNoPriors")
     if (is.null(.f)) return(invisible(.nlmixr2AssertNoPriorsFallback(.ui, extra=.extra)))
     .f(.ui, extra=.extra)
-  } else if (.support == "normal") {
+  } else if (.support == "theta") {
+    .nlmixr2AssertThetaOnlyPriors(.ui, extra=.extra)
+  } else if (.support == "general") {
+    ## rxPriorBuildSpec() itself is the validator; nothing beyond what
+    ## rxUiPriors() reports can reach it.
+    return(invisible())
+  } else if (.support == "tnpri") {
+    ## normal priors, including directly on omega, are fine; dcauchy()
+    ## and invWishart() (that's "nwpri"'s mechanism) are not
     .f <- .nlmixr2RxAssert("assertRxUiNormalPriors")
     if (is.null(.f)) return(invisible())
     .f(.ui, extra=.extra)
@@ -140,4 +200,84 @@
     .f(.ui, extra=.extra)
   }
   invisible()
+}
+
+#' Which kernel method does this model's own prior syntax mean?
+#'
+#' `rxPriorBuildSpec(ui, method=)` implements three genuinely different
+#' omega conventions that are NOT interchangeable -- the same
+#' `invWishart(nu)` syntax means a different number under `"general"`'s
+#' textbook Wishart than under `"nwpri"`'s NONMEM degrees-of-freedom
+#' convention.  So there is no safe default to fall back on; the method
+#' has to be read off of what the model's own `ini({})` actually wrote:
+#'
+#' - a normal prior directly on an omega element (`om.eta ~ 0.01`) only
+#'   makes sense as `"tnpri"` (Monolix's/NONMEM's own-estimation
+#'   assumption) -- `"nwpri"` refuses it outright
+#' - `invWishart()`/`wishart()` degrees of freedom on an omega block only
+#'   makes sense as `"nwpri"` (NONMEM's own `$PRIOR NWPRI`) -- `"tnpri"`
+#'   refuses it outright
+#' - a model mixing both conventions, or using `dcauchy()` anywhere
+#'   (neither `"nwpri"` nor `"tnpri"` has a Cauchy analogue), can only be
+#'   `"general"` -- the one method that accepts everything `rxUiPriors()`
+#'   can report, at the cost of not being either specialized convention
+#' - a model with no omega-referencing prior and no Cauchy: the three
+#'   methods agree exactly (they differ only in omega/Cauchy handling),
+#'   so `"general"` is returned as a harmless default
+#'
+#' @param ui rxode2 ui
+#' @return one of `"general"`, `"nwpri"`, `"tnpri"`
+#' @noRd
+#' @author Matthew L. Fidler
+.nlmixr2PriorMethod <- function(ui) {
+  .hasWishart <- FALSE
+  .hasOmegaNormal <- FALSE
+  .hasCauchy <- FALSE
+  .testOmegaDf <- .nlmixr2RxAssert("testRxUiOmegaDf")
+  if (!is.null(.testOmegaDf)) .hasWishart <- isTRUE(tryCatch(.testOmegaDf(ui), error=function(e) FALSE))
+  .testOmegaNormal <- .nlmixr2RxAssert("testRxUiOmegaNormalPriors")
+  if (!is.null(.testOmegaNormal)) {
+    .hasOmegaNormal <- isTRUE(tryCatch(.testOmegaNormal(ui), error=function(e) FALSE))
+  }
+  .stanName <- .nlmixr2RxAssert(".rxPriorStanName")
+  if (!is.null(.stanName)) {
+    .p <- rxode2::rxUiPriors(ui)
+    if (length(.p$name) > 0L) {
+      .hasCauchy <- any(vapply(.p$prior, function(p) {
+        .fn <- try(str2lang(p)[[1]], silent=TRUE)
+        if (inherits(.fn, "try-error")) return(FALSE)
+        .fn <- as.character(.fn)
+        if (length(.fn) != 1L) return(FALSE)
+        .s <- try(.stanName(.fn), silent=TRUE)
+        !inherits(.s, "try-error") && !is.na(.s) && identical(.s, "cauchy")
+      }, logical(1), USE.NAMES=FALSE))
+    }
+  }
+  if (.hasWishart && .hasOmegaNormal) return("general")
+  if (.hasCauchy) return("general")
+  if (.hasWishart) return("nwpri")
+  if (.hasOmegaNormal) return("tnpri")
+  "general"
+}
+
+#' Build this model's prior spec for the shared FOCEI-family C++ kernel
+#'
+#' A thin no-op (`NULL`) for a model with no priors, or when the installed
+#' rxode2 predates `rxPriorBuildSpec()` (nlmixr2/rxode2#1270) -- so a
+#' caller can invoke this unconditionally rather than needing its own
+#' "does this model have a prior" branch first.  See
+#' `.nlmixr2PriorMethod()` for how the omega convention is chosen; the
+#' gate (`.nlmixr2AssertPriors()`) has already run before dispatch, so
+#' every term reaching this build is one the calling method accepted.
+#'
+#' @param ui rxode2 ui
+#' @return an R external pointer (`rx_prior_spec_t*`) for
+#'   `foceiControl(priorSpec=)` to carry into `op_focei`, or `NULL`
+#' @noRd
+#' @author Matthew L. Fidler
+.nlmixr2BuildPriorSpec <- function(ui) {
+  if (length(rxode2::rxUiPriors(ui)$name) == 0L) return(NULL)
+  .build <- .nlmixr2RxAssert("rxPriorBuildSpec")
+  if (is.null(.build)) return(NULL)
+  .build(ui, method=.nlmixr2PriorMethod(ui))
 }

--- a/R/priors.R
+++ b/R/priors.R
@@ -18,7 +18,7 @@
 ##
 ## A method says what it supports with an attribute on itself:
 ##
-##   attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "theta"
+##   attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "general"
 ##
 ## The levels are
 ##
@@ -27,15 +27,19 @@
 ## - `"theta"` -- priors on population parameters only (`dnorm()`,
 ##   `dcauchy()`, `stdNormal()`, the `multiNormal()` family the lotri
 ##   shorthand produces among thetas); anything that touches an omega
-##   element is refused.  This is what FOCEi's family can honour today
-##   (#931) -- an omega-referencing term needs the natural-scale gradient
-##   chain-ruled through `op_focei.cholOmegaInv`
-##   (`rxPriorOmegaToCholOmegaInvGrad()`), not yet wired in.
+##   element is refused.  No FOCEi-family method uses this level (see
+##   `"general"` below); it exists for a future method whose omega
+##   optimization cannot yet honour a prior on it at all.
 ## - `"general"` -- everything the kernel's `"general"` method covers:
 ##   the above, plus a normal prior directly on an omega element and a
 ##   textbook inverse-Wishart on an omega block.  No further check here;
 ##   `rxPriorBuildSpec()` itself is the validator (nothing beyond what
-##   `rxUiPriors()` reports can reach it).
+##   `rxUiPriors()` reports can reach it).  This is what FOCEi's family
+##   declares (#931): the natural-scale omega gradient is chain-ruled into
+##   `op_focei.cholOmegaInv`'s own estimation-scale parameterization via
+##   the SAME derivative data (`d.omegaInv`/`tr.28`, from the model's
+##   `_rxInv` handle) FOCEi's own (non-prior) omega gradient already
+##   relies on (`foceiPriorOmegaGradAdd()`, `src/inner.cpp`).
 ## - `"nwpri"` -- normal priors, and degrees of freedom on an omega
 ##   block (`invWishart(4)`), evaluated with NONMEM's own `$PRIOR NWPRI`
 ##   convention rather than the textbook one; a normal prior on the
@@ -140,11 +144,12 @@
 
 #' Refuse a prior that references an omega element
 #'
-#' Used for the `"theta"` level: FOCEi's family can honour a prior on a
-#' population parameter today, but not yet one on an omega element -- that
-#' needs the natural-scale gradient chain-ruled through
-#' `op_focei.cholOmegaInv` (`rxPriorOmegaToCholOmegaInvGrad()`), not yet
-#' wired into the objective/gradient (#931).
+#' Used for the `"theta"` level, for a method that can honour a prior on a
+#' population parameter but not yet one on an omega element -- FOCEi's
+#' family declares `"general"` instead (#931), since it does wire that
+#' natural-scale gradient through `op_focei.cholOmegaInv`
+#' (`foceiPriorOmegaGradAdd()`, `src/inner.cpp`); no FOCEi-family method
+#' uses this level.
 #'
 #' @param ui rxode2 ui
 #' @param extra text appended to the error

--- a/R/priors.R
+++ b/R/priors.R
@@ -270,19 +270,28 @@
 #' A thin no-op (`NULL`) for a model with no priors, or when the installed
 #' rxode2 predates `rxPriorBuildSpec()` (nlmixr2/rxode2#1270) -- so a
 #' caller can invoke this unconditionally rather than needing its own
-#' "does this model have a prior" branch first.  See
-#' `.nlmixr2PriorMethod()` for how the omega convention is chosen; the
-#' gate (`.nlmixr2AssertPriors()`) has already run before dispatch, so
-#' every term reaching this build is one the calling method accepted.
+#' "does this model have a prior" branch first.  The gate
+#' (`.nlmixr2AssertPriors()`) has already run before dispatch, so every
+#' term reaching this build is one the calling method accepted -- but
+#' accepting a level (e.g. `"general"`) does not mean every kernel method
+#' can represent it; `rxPriorBuildSpec()` itself is what actually errors
+#' (before any estimation starts) for a term the requested `method` cannot
+#' express, e.g. `method="tnpri"` on a model with an `invWishart()` prior.
 #'
 #' @param ui rxode2 ui
+#' @param method one of `"auto"` (default -- see `.nlmixr2PriorMethod()`
+#'   for how the omega convention is read off the model), `"general"`,
+#'   `"nwpri"`, `"tnpri"`.  Typically `foceiControl(priorMethod=)`, passed
+#'   straight through by the caller.
 #' @return an R external pointer (`rx_prior_spec_t*`) for
 #'   `foceiControl(priorSpec=)` to carry into `op_focei`, or `NULL`
 #' @noRd
 #' @author Matthew L. Fidler
-.nlmixr2BuildPriorSpec <- function(ui) {
+.nlmixr2BuildPriorSpec <- function(ui, method=c("auto", "general", "nwpri", "tnpri")) {
+  method <- match.arg(method)
   if (length(rxode2::rxUiPriors(ui)$name) == 0L) return(NULL)
   .build <- .nlmixr2RxAssert("rxPriorBuildSpec")
   if (is.null(.build)) return(NULL)
-  .build(ui, method=.nlmixr2PriorMethod(ui))
+  if (identical(method, "auto")) method <- .nlmixr2PriorMethod(ui)
+  .build(ui, method=method)
 }

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -30,6 +30,7 @@ foceiControl(
   covSolveTol = NULL,
   covFull = TRUE,
   fast = FALSE,
+  priorMethod = c("auto", "general", "nwpri", "tnpri"),
   fdOutlierZ = 3.5,
   fdOutlierScale = TRUE,
   fdRefine = c("chartrand", "lanczos", "richardson"),
@@ -316,6 +317,25 @@ the outer optimizer defaults to \code{"lbfgsb3c"} (vs \code{"bobyqa"} for
 \code{fast=FALSE}); pairing \code{fast=TRUE} with a derivative-free
 \code{outerOpt} reverts to \code{fast=FALSE}.  The \code{*f} methods (e.g.
 \code{foceif}) default this to \code{TRUE}.}
+
+\item{priorMethod}{Which of the shared prior kernel's three omega
+conventions (nlmixr2/rxode2#1270) to evaluate an \code{ini({})}
+\code{prior()} under -- \code{"general"} (textbook Bayesian),
+\code{"nwpri"} (NONMEM's own \verb{$PRIOR NWPRI}), or \code{"tnpri"}
+(the Monolix/NONMEM-own-estimation joint-normal convention on omega).
+The default, \code{"auto"}, reads the convention off what the model's
+own \code{ini({})} actually wrote (an \code{invWishart()} degrees-of-
+freedom prior on an omega block means \code{"nwpri"}; a normal prior
+directly on an omega element means \code{"tnpri"}; anything else,
+including a \code{dcauchy()} prior, means \code{"general"}) --
+deliberately never a fixed default, since the identical
+\code{invWishart(nu)} syntax means a different number under
+\code{"general"} and \code{"nwpri"}.  Setting this explicitly forces
+that convention regardless of what auto-detection would have picked,
+and errors before any estimation starts if the model's priors are not
+representable under it (e.g. \code{priorMethod="tnpri"} on a model
+with an \code{invWishart()} prior).  Ignored when the model has no
+prior at all.}
 
 \item{fdOutlierZ}{Cut of the Iglewicz-Hoaglin modified z-score that decides
 whether a finite-differenced subject's slope is an outlier against the exact

--- a/man/nlmixr2Est.Rd
+++ b/man/nlmixr2Est.Rd
@@ -240,16 +240,23 @@ of being fit to something other than what it says.
 A method says what it supports with an attribute on itself:
 
 ```
-attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "normal"
+attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "theta"
 ```
 
 - `"none"`, which is also what an absent attribute means -- the
   method cannot use priors at all
-- `"normal"` -- normal priors only (`dnorm()`, `stdNormal()` and the
-  `multiNormal()` family)
+- `"theta"` -- priors on population parameters only (`dnorm()`,
+  `dcauchy()`, `stdNormal()` and the `multiNormal()` family among
+  thetas); anything referencing an omega element is refused
+- `"general"` -- everything the shared kernel's `"general"` method
+  covers: the above, plus a normal prior directly on an omega element
+  and a textbook inverse-Wishart on an omega block
 - `"nwpri"` -- normal priors and degrees of freedom on an omega block
-  (`invWishart(4)`), as a NONMEM NWPRI model works; a normal prior on
-  the omega values themselves is refused
+  (`invWishart(4)`), evaluated the way a NONMEM NWPRI model works; a
+  normal prior on the omega values themselves is refused
+- `"tnpri"` -- normal priors including directly on omega elements
+  (Monolix's/NONMEM's own-estimation joint-normal assumption);
+  `dcauchy()` and `invWishart()` are refused
 - `"all"` -- the method handles everything, so nothing is checked
 }
 \author{

--- a/man/nlmixr2Est.Rd
+++ b/man/nlmixr2Est.Rd
@@ -240,17 +240,19 @@ of being fit to something other than what it says.
 A method says what it supports with an attribute on itself:
 
 ```
-attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "theta"
+attr(nlmixr2Est.myMethod, "nlmixr2Priors") <- "general"
 ```
 
 - `"none"`, which is also what an absent attribute means -- the
   method cannot use priors at all
 - `"theta"` -- priors on population parameters only (`dnorm()`,
   `dcauchy()`, `stdNormal()` and the `multiNormal()` family among
-  thetas); anything referencing an omega element is refused
+  thetas); anything referencing an omega element is refused.  No
+  FOCEi-family method uses this level -- they declare `"general"`.
 - `"general"` -- everything the shared kernel's `"general"` method
   covers: the above, plus a normal prior directly on an omega element
-  and a textbook inverse-Wishart on an omega block
+  and a textbook inverse-Wishart on an omega block.  This is what
+  `est="focei"` and the rest of its family declare.
 - `"nwpri"` -- normal priors and degrees of freedom on an omega block
   (`invWishart(4)`), evaluated the way a NONMEM NWPRI model works; a
   normal prior on the omega values themselves is refused

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4688,10 +4688,21 @@ static bool priorSpecThetaReachable(const rx_prior_spec_t *spec, const int *fixe
 // actually optimize), so Omega has to be recovered from that by inversion --
 // cheap, since neta is always small.  Empty (0x0) when there is no omega at
 // all (a population-only model), matching op_focei.omega's own convention.
-static arma::mat foceiCurrentOmega() {
-  if (op_focei.fo == 1) return op_focei.omega;
-  if (op_focei.omegaInv.n_rows == 0) return op_focei.omega;
-  return arma::inv_sympd(op_focei.omegaInv);
+// Returns false (Omega untouched) if omegaInv is not currently positive
+// definite -- reachable at a trial point mid-optimization, before the outer
+// optimizer's own bounds/line-search would reject it -- so the caller can
+// degrade the same way rxPriorLogDensityEval() itself does for an
+// indefinite covariance (-INFINITY value) rather than let arma::inv_sympd's
+// exception propagate uncaught out of an objective/gradient evaluation.
+static bool foceiCurrentOmega(arma::mat &Omega) {
+  if (op_focei.fo == 1) { Omega = op_focei.omega; return true; }
+  if (op_focei.omegaInv.n_rows == 0) { Omega = op_focei.omega; return true; }
+  try {
+    Omega = arma::inv_sympd(op_focei.omegaInv);
+  } catch (...) {
+    return false;
+  }
+  return true;
 }
 
 // Value and (natural-scale, per-theta) gradient of the ini({}) prior at the
@@ -4699,10 +4710,15 @@ static arma::mat foceiCurrentOmega() {
 // (updateTheta() has run) before this is called.  0.0 / all-zero when the
 // model has no prior (op_focei.priorSpec == NULL, the common case), so a
 // caller can invoke this unconditionally.  gradTheta is sized ntheta and
-// resized/zeroed by this call.  The omega-touching gradient
-// (rxPriorLogDensityEval()'s gradOmega output) is intentionally discarded
-// here -- it is needed only by the analytic outer gradient
-// (foceiPriorOmegaGradAdd(), which recomputes it against the SAME
+// resized/zeroed by this call.  -INFINITY (gradTheta left at 0) if the prior
+// touches omega and the live Omega is not currently recoverable
+// (foceiCurrentOmega() returned false) -- the same convention
+// rxPriorLogDensityEval() itself uses for an indefinite covariance, letting
+// foceiOfv0()'s existing isnan/isinf recovery loop treat this exactly like
+// any other bad trial point instead of throwing out of the objective. The
+// omega-touching gradient (rxPriorLogDensityEval()'s gradOmega output) is
+// intentionally discarded here -- it is needed only by the analytic outer
+// gradient (foceiPriorOmegaGradAdd(), which recomputes it against the SAME
 // omegaInv/dOiEst analyticOuterGradDirect() already has in hand, avoiding a
 // second live-Omega computation on that path); the FD gradient picks up an
 // omega-touching prior's effect for free the same way it does theta's, by
@@ -4710,7 +4726,8 @@ static arma::mat foceiCurrentOmega() {
 static double foceiPriorEval(std::vector<double> &gradTheta) {
   gradTheta.assign((size_t)op_focei.ntheta, 0.0);
   if (op_focei.priorSpec == NULL) return 0.0;
-  arma::mat Omega = op_focei.priorSpecOmegaTerm ? foceiCurrentOmega() : arma::mat();
+  arma::mat Omega;
+  if (op_focei.priorSpecOmegaTerm && !foceiCurrentOmega(Omega)) return -R_PosInf;
   int omegaDim = (int)Omega.n_rows;
   std::vector<double> gradOmega((size_t)omegaDim * (size_t)omegaDim, 0.0);
   return rxPriorLogDensityEval(op_focei.priorSpec, op_focei.fullTheta, (int)op_focei.ntheta,

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4633,6 +4633,28 @@ static inline double foceiLik0(double *theta) {
 // d/dtheta log p(theta) term yet, so .foceiFamilyControl() (R/focei.R)
 // forces fast=FALSE whenever a prior is present rather than risk a
 // gradient that silently disagrees with this objective.
+// True if any term in the spec references an omega element (etaIdx[k] != 0
+// for some member).  FOCEi's shared C++ objective has no live Omega to read
+// this against for any method but est="fo" (op_focei.omega is populated only
+// when op_focei.fo==1, see foceiOmegaFromTheta()); the R-side gate refuses
+// this for every "theta"-declared method already, but "all"-level
+// pseudo-methods (output/posthoc, #938) skip that per-level check on
+// purpose, and .foceiFamilyControl() (R/focei.R) refuses it there too -- this
+// is the same check repeated in C++ as a hard backstop, since the
+// alternative on a caller that ever slips past both R-side checks is
+// reading op_focei.omega's default-constructed (0x0, NULL memptr()) matrix,
+// a guaranteed segfault rather than a clean error.
+static bool priorSpecHasOmegaTerm(const rx_prior_spec_t *spec) {
+  if (spec == NULL) return false;
+  for (int t = 0; t < spec->nTerms; ++t) {
+    const rx_prior_term_t &term = spec->terms[t];
+    for (int k = 0; k < term.n; ++k) {
+      if (term.etaIdx[k] != 0) return true;
+    }
+  }
+  return false;
+}
+
 static inline double foceiPriorObjTerm() {
   if (op_focei.priorSpec == NULL) return 0.0;
   std::vector<double> gTheta((size_t)op_focei.ntheta, 0.0);
@@ -6502,6 +6524,9 @@ NumericVector foceiSetup_(const RObject &obj,
     if (TYPEOF(priorSpecS) == EXTPTRSXP) {
       op_focei.priorSpec = (const rx_prior_spec_t *) R_ExternalPtrAddr(priorSpecS);
     }
+  }
+  if (priorSpecHasOmegaTerm(op_focei.priorSpec)) {
+    stop("a prior on an omega element is not usable by this estimation method yet");
   }
   if (foceiO.containsElementNamed("est") && TYPEOF(foceiO["est"]) == STRSXP) {
     std::string estStr = as<std::string>(foceiO["est"]);

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -506,10 +506,24 @@ struct focei_options {
   // foceiO["priorSpec"] for the duration of THIS foceiFitCpp_() call -- this
   // is a non-owning view, valid only while that R object is reachable from
   // the calling R frame (see the read site in foceiSetup_ for why that's
-  // always true here). The gate (.nlmixr2AssertPriors()) has already
-  // restricted every term this can point to a theta-only "general" spec
-  // (#931's scope); no term here ever references an omega index.
+  // always true here).
   const rx_prior_spec_t *priorSpec = NULL;
+  // Cached at setup (priorSpecHasOmegaTerm()): does any term reference an
+  // omega element?  Gates whether foceiPriorEval()/foceiPriorOmegaGradAdd()
+  // bother computing a live Omega at all (cheap either way -- neta is
+  // small -- but the common case is a theta-only prior).
+  bool priorSpecOmegaTerm = false;
+  // Set once at setup (priorSpecThetaReachable(), after foceiSetupTheta_()
+  // has populated fixedTrans/npars/ntheta): true unless the prior spec
+  // references a theta that a mu-referenced family profiles out of the
+  // outer problem entirely (no optimizer-parameter index maps to it via
+  // fixedTrans).  analyticOuterGradDirect() declines rather than silently
+  // under-count when this is false; the objective (foceiPriorObjTerm(),
+  // hence the FD gradient too) is unaffected either way.  Omega elements
+  // are never profiled out this way, so this only ever gates the theta
+  // fold-in (foceiPriorGradAdd()), not the omega one
+  // (foceiPriorOmegaGradAdd()).
+  bool priorGradAnalyticSafe = true;
   mat etaM;
   mat etaS;
   // 1/SD of the eta distribution; standardizes an INDIVIDUAL eta (etaInBound(),
@@ -4617,33 +4631,14 @@ static inline double foceiLik0(double *theta) {
 }
 
 
-// -2*log p(theta), the ini({}) prior penalty (nlmixr2/rxode2#1270,
-// nlmixr2/nlmixr2est#929/#931).  0.0 when the model has no prior
-// (op_focei.priorSpec == NULL, the common case).  Reads op_focei.fullTheta/
-// op_focei.omega, which updateTheta() (called inside foceiLik0(), always
-// immediately before this at every call site) has already refreshed for
-// the current theta -- so this must only ever be called right after
-// foceiLik0().  The gate (.nlmixr2AssertPriors(), R/priors.R) refuses any
-// prior that touches an omega element before a FOCEI-family fit ever
-// reaches here, so no term in the spec references op_focei.omega's
-// contents; it is passed only so the C API's gradOmega buffer has a
-// validly-sized (if unused) home. gradTheta/gradOmega are discarded here:
-// numericGrad() finite-differences THIS function (via foceiObjFromLik0()),
-// so it picks the prior up for free; the analytic outer gradient has no
-// d/dtheta log p(theta) term yet, so .foceiFamilyControl() (R/focei.R)
-// forces fast=FALSE whenever a prior is present rather than risk a
-// gradient that silently disagrees with this objective.
 // True if any term in the spec references an omega element (etaIdx[k] != 0
 // for some member).  FOCEi's shared C++ objective has no live Omega to read
 // this against for any method but est="fo" (op_focei.omega is populated only
-// when op_focei.fo==1, see foceiOmegaFromTheta()); the R-side gate refuses
-// this for every "theta"-declared method already, but "all"-level
-// pseudo-methods (output/posthoc, #938) skip that per-level check on
-// purpose, and .foceiFamilyControl() (R/focei.R) refuses it there too -- this
-// is the same check repeated in C++ as a hard backstop, since the
-// alternative on a caller that ever slips past both R-side checks is
-// reading op_focei.omega's default-constructed (0x0, NULL memptr()) matrix,
-// a guaranteed segfault rather than a clean error.
+// when op_focei.fo==1, see foceiOmegaFromTheta()) -- foceiCurrentOmega()
+// below is what makes the VALUE side work for every method regardless;
+// cached at setup into op_focei.priorSpecOmegaTerm so the (cheap, but not
+// free) live-Omega computation is skipped entirely for the common
+// theta-only-prior case.
 static bool priorSpecHasOmegaTerm(const rx_prior_spec_t *spec) {
   if (spec == NULL) return false;
   for (int t = 0; t < spec->nTerms; ++t) {
@@ -4655,15 +4650,168 @@ static bool priorSpecHasOmegaTerm(const rx_prior_spec_t *spec) {
   return false;
 }
 
+// Every theta index (0-based) a prior term references directly (thetaIdx[k]
+// is rxUiPriors()'s 1-based ntheta, 0 when member k is an omega element).
+// True if EVERY referenced theta is reachable through op_focei.fixedTrans --
+// the same map updateTheta() uses to write an optimizer parameter into its
+// fullTheta slot (fixedTrans[i] for optimizer index i in [0, npars)).  A
+// theta a mu-referenced family profiles out of the outer problem entirely
+// (computed by an internal regression step, not a free npars-space
+// parameter) has no such i, so analyticOuterGradDirect()'s fold-in
+// (foceiPriorGradAdd()) -- which walks the SAME fixedTrans map -- would
+// silently drop that theta's contribution.  Omega elements are never
+// profiled out this way (see foceiPriorOmegaGradAdd()), so this only ever
+// needs to check thetaIdx.  Computed once, at setup (foceiSetup_ sets
+// op_focei.priorGradAnalyticSafe from this), not per evaluation.
+static bool priorSpecThetaReachable(const rx_prior_spec_t *spec, const int *fixedTrans, int npars,
+                                    int ntheta) {
+  if (spec == NULL) return true;
+  std::vector<bool> reachable((size_t)ntheta, false);
+  for (int i = 0; i < npars; ++i) {
+    int j = fixedTrans[i];
+    if (j >= 0 && j < ntheta) reachable[(size_t)j] = true;
+  }
+  for (int t = 0; t < spec->nTerms; ++t) {
+    const rx_prior_term_t &term = spec->terms[t];
+    for (int k = 0; k < term.n; ++k) {
+      int th = term.thetaIdx[k];  // 1-based; 0 means member k is an omega element
+      if (th != 0 && !reachable[(size_t)(th - 1)]) return false;
+    }
+  }
+  return true;
+}
+
+// The CURRENT natural-scale Omega, valid for every FOCEI-family method, not
+// just est="fo".  op_focei.omega itself is only ever assigned when
+// op_focei.fo==1 (foceiOmegaFromTheta()); every other method instead keeps
+// op_focei.omegaInv/cholOmegaInv current (the parameterization FOCEI/FOCE
+// actually optimize), so Omega has to be recovered from that by inversion --
+// cheap, since neta is always small.  Empty (0x0) when there is no omega at
+// all (a population-only model), matching op_focei.omega's own convention.
+static arma::mat foceiCurrentOmega() {
+  if (op_focei.fo == 1) return op_focei.omega;
+  if (op_focei.omegaInv.n_rows == 0) return op_focei.omega;
+  return arma::inv_sympd(op_focei.omegaInv);
+}
+
+// Value and (natural-scale, per-theta) gradient of the ini({}) prior at the
+// CURRENT op_focei.fullTheta/omega -- fullTheta must already be current
+// (updateTheta() has run) before this is called.  0.0 / all-zero when the
+// model has no prior (op_focei.priorSpec == NULL, the common case), so a
+// caller can invoke this unconditionally.  gradTheta is sized ntheta and
+// resized/zeroed by this call.  The omega-touching gradient
+// (rxPriorLogDensityEval()'s gradOmega output) is intentionally discarded
+// here -- it is needed only by the analytic outer gradient
+// (foceiPriorOmegaGradAdd(), which recomputes it against the SAME
+// omegaInv/dOiEst analyticOuterGradDirect() already has in hand, avoiding a
+// second live-Omega computation on that path); the FD gradient picks up an
+// omega-touching prior's effect for free the same way it does theta's, by
+// re-evaluating this value at a perturbed omega.
+static double foceiPriorEval(std::vector<double> &gradTheta) {
+  gradTheta.assign((size_t)op_focei.ntheta, 0.0);
+  if (op_focei.priorSpec == NULL) return 0.0;
+  arma::mat Omega = op_focei.priorSpecOmegaTerm ? foceiCurrentOmega() : arma::mat();
+  int omegaDim = (int)Omega.n_rows;
+  std::vector<double> gradOmega((size_t)omegaDim * (size_t)omegaDim, 0.0);
+  return rxPriorLogDensityEval(op_focei.priorSpec, op_focei.fullTheta, (int)op_focei.ntheta,
+                               Omega.memptr(), omegaDim,
+                               gradTheta.data(), gradOmega.data());
+}
+
+// -2*log p(theta) at the current theta; 0.0 when there is no prior.
+// numericGrad()'s finite-difference gradient re-evaluates THIS (via
+// foceiObjFromLik0()) at perturbed points, so it picks the prior up for
+// free -- no separate FD-specific code path is needed.
 static inline double foceiPriorObjTerm() {
   if (op_focei.priorSpec == NULL) return 0.0;
-  std::vector<double> gTheta((size_t)op_focei.ntheta, 0.0);
-  int omegaDim = (int)op_focei.omega.n_rows;
-  std::vector<double> gOmega((size_t)omegaDim * (size_t)omegaDim, 0.0);
-  double lp = rxPriorLogDensityEval(op_focei.priorSpec, op_focei.fullTheta, (int)op_focei.ntheta,
-                                     op_focei.omega.memptr(), omegaDim,
-                                     gTheta.data(), gOmega.data());
-  return -2.0 * lp;
+  std::vector<double> gradTheta;
+  return -2.0 * foceiPriorEval(gradTheta);
+}
+
+// -2*d(log p(theta))/dtheta[j], folded into gp -- the analytic outer
+// gradient's optimizer-parameter-indexed, NATURAL-scale accumulator, the
+// same convention gradDirectFdAdd()'s fdg uses ("fdg is d(-2LL_i)/
+// d(fullTheta_j) on the NATURAL scale, which is exactly what gp holds").
+// Uses op_focei.fixedTrans, the SAME map updateTheta() uses the other
+// direction (optimizer parameter -> fullTheta slot), so this needs no
+// dependency on the kernel's own (nth, nsg, nom) slot layout (G.gMap/
+// G.thPos) at all -- correct regardless of how a mu-referenced family's
+// kernel groups theta directions, as long as every prior-referenced theta
+// is itself a free optimizer parameter (op_focei.priorGradAnalyticSafe,
+// set at setup by priorSpecThetaReachable(); analyticOuterGradDirect()
+// declines rather than call this when it is false).
+static void foceiPriorGradAdd(int npars, arma::vec &gp) {
+  if (op_focei.priorSpec == NULL) return;
+  std::vector<double> gradTheta;
+  foceiPriorEval(gradTheta);
+  const int ntheta = (int)op_focei.ntheta;
+  for (int i = 0; i < npars; ++i) {
+    int j = op_focei.fixedTrans[i];
+    if (j >= 0 && j < ntheta) gp[i] += -2.0 * gradTheta[(size_t)j];
+  }
+}
+
+// -2*d(log p(theta))/d(theta_k), theta_k the k-th ESTIMATION-SCALE omega
+// parameter (fullTheta[ntheta+k], the same "chol theta" _rxInv's own
+// d.omegaInv/tr.28 are indexed by -- see the getDOmegaInvL()/getTr28V()
+// comment above), folded into gp the same way foceiPriorGradAdd() folds in
+// the theta portion.  Oi/dOiEst are analyticOuterGradDirect()'s own
+// omegaInv/d(Omega^-1)/d(theta_k) (gradDirectOmega()) -- reused rather than
+// refetched, since they are exactly what this needs too.
+//
+// Derivation: with A = Omega^-1 (what Oi/dOiEst parameterize) and
+// Omega = A^-1, d(Omega)/d(theta_k) = -Omega * dOiEst[k] * Omega (standard
+// matrix-inverse VJP).  For f = log p(theta, Omega),
+// df/d(theta_k) = <df/dOmega, dOmega/d(theta_k)>_F = tr(Gsym * dOmega/d(theta_k))
+// (Gsym = the symmetric part of df/dOmega -- dOmega/d(theta_k) is symmetric,
+// since Omega=A^-1 is, so only Gsym contracts against it; the antisymmetric
+// part of rxPriorLogDensityEval()'s gradOmega, if any, drops out exactly the
+// way rxPriorOmegaToCholOmegaInvGrad() drops it for its own, differently-
+// parameterized use of the identical Abar intermediate) = tr(Abar * dOiEst[k])
+// with Abar = -Omega*Gsym*Omega -- the SAME Abar
+// rxPriorOmegaToCholOmegaInvGrad() computes en route to a per-Cholesky-entry
+// gradient; this reaches theta_k directly instead, using the derivative data
+// FOCEI's own (non-prior) omega gradient already relies on, so it needs no
+// block/position bookkeeping of its own for a prior term spanning only part
+// of a larger omega matrix -- Abar and dOiEst[k] are both already sized for
+// the FULL omega, and a block prior's nonzero entries are already exactly
+// zero everywhere outside their block in Gsym (rxPriorLogDensityEval()
+// scatters each term's members into gradOmega positionally).  Verified
+// against central-difference gradients of the full Omega(theta) pipeline in
+// tests/testthat/test-focei-prior.R.
+static void foceiPriorOmegaGradAdd(int npars, arma::vec &gp, const arma::mat &Oi,
+                                   const arma::cube &dOiEst) {
+  if (op_focei.priorSpec == NULL || !op_focei.priorSpecOmegaTerm) return;
+  const int omegaDim = (int)Oi.n_rows;
+  if (omegaDim == 0 || (int)dOiEst.n_rows != omegaDim || (int)dOiEst.n_cols != omegaDim) return;
+  arma::mat Omega;
+  try {
+    Omega = arma::inv_sympd(Oi);
+  } catch (...) {
+    return;  // non-PD live Omega: contribute nothing, matching
+             // rxPriorLogDensityEval()'s own -Inf/0-gradient convention
+             // for an indefinite covariance rather than throwing mid-fit.
+  }
+  std::vector<double> gradTheta((size_t)op_focei.ntheta, 0.0);
+  std::vector<double> gradOmegaFlat((size_t)omegaDim * (size_t)omegaDim, 0.0);
+  rxPriorLogDensityEval(op_focei.priorSpec, op_focei.fullTheta, (int)op_focei.ntheta,
+                        Omega.memptr(), omegaDim, gradTheta.data(), gradOmegaFlat.data());
+  // Row-major vs column-major is irrelevant once symmetrized (Gsym(M) ==
+  // Gsym(M^T)), so this may read the flat buffer either way.
+  arma::mat gradOmegaRaw(gradOmegaFlat.data(), (arma::uword)omegaDim, (arma::uword)omegaDim);
+  arma::mat Gsym = 0.5 * (gradOmegaRaw + gradOmegaRaw.t());
+  arma::mat Abar = -(Omega * Gsym * Omega);
+  const int nom = (int)dOiEst.n_slices;
+  std::vector<double> dThetaK((size_t)nom, 0.0);
+  for (int k = 0; k < nom; ++k) {
+    dThetaK[(size_t)k] = arma::accu(Abar % dOiEst.slice((arma::uword)k));
+  }
+  const int ntheta = (int)op_focei.ntheta;
+  for (int i = 0; i < npars; ++i) {
+    int j = op_focei.fixedTrans[i];
+    int k = j - ntheta;
+    if (k >= 0 && k < nom) gp[i] += -2.0 * dThetaK[(size_t)k];
+  }
 }
 
 // -2*log-likelihood at theta, PLUS the ini({}) prior penalty when one is
@@ -6525,9 +6673,7 @@ NumericVector foceiSetup_(const RObject &obj,
       op_focei.priorSpec = (const rx_prior_spec_t *) R_ExternalPtrAddr(priorSpecS);
     }
   }
-  if (priorSpecHasOmegaTerm(op_focei.priorSpec)) {
-    stop("a prior on an omega element is not usable by this estimation method yet");
-  }
+  op_focei.priorSpecOmegaTerm = priorSpecHasOmegaTerm(op_focei.priorSpec);
   if (foceiO.containsElementNamed("est") && TYPEOF(foceiO["est"]) == STRSXP) {
     std::string estStr = as<std::string>(foceiO["est"]);
     op_focei.isSaem = (estStr == "saem");
@@ -6844,6 +6990,11 @@ NumericVector foceiSetup_(const RObject &obj,
       op_focei.scaleObjective=1;
     }
   }
+  // fixedTrans/npars/ntheta are only valid from here on (foceiSetupTheta_()
+  // just above populates them) -- priorSpecThetaReachable() needs all three.
+  op_focei.priorGradAnalyticSafe =
+    priorSpecThetaReachable(op_focei.priorSpec, op_focei.fixedTrans,
+                            (int)op_focei.npars, (int)op_focei.ntheta);
   if (tempMixIdx != NULL) {
     R_Free(tempMixIdx);
     op_focei.mixIdx = NULL;
@@ -15838,6 +15989,11 @@ static bool analyticOuterGradDirect(double *theta, double *g) {
   // is double-listed or a mu family profiles thetas out).
   if (neta != op_focei.neta || (int)G.gMap.size() != npars) return declineHere(103);
   if (inds_focei == NULL) return declineHere(104);
+  // A prior referencing a theta a mu-referenced family profiles out of the
+  // outer problem has no d/dtheta term this fold-in (foceiPriorGradAdd(),
+  // via op_focei.fixedTrans) can attribute -- decline to FD rather than
+  // silently under-count.  Set once at setup; see priorSpecThetaReachable().
+  if (op_focei.priorSpec != NULL && !op_focei.priorGradAnalyticSafe) return declineHere(118);
   // theta, in the augmented model's positional order
   std::vector<double> thv((size_t)op_focei.ntheta);
   for (int t = 0; t < (int)op_focei.ntheta; ++t) thv[(size_t)t] = op_focei.fullTheta[t];
@@ -15854,6 +16010,14 @@ static bool analyticOuterGradDirect(double *theta, double *g) {
   arma::vec gp;
   if (!gradDirectGather(G, gv, nKer, npars, gp)) return false;
   if (!gradDirectFoldFd(npars, gp)) return false;
+  // ini({}) prior (#929/#931): -2*d(log p(theta))/dtheta[j], folded in before
+  // firstDirectGrad is recorded and before the rescale, same as the FD-fold
+  // above -- 0.0 when the model has no prior.
+  foceiPriorGradAdd(npars, gp);
+  // -2*d(log p(omega))/d(theta_k), reusing the SAME Oi/dOiEst
+  // gradDirectOmega() already fetched above for the ordinary (non-prior)
+  // omega gradient -- 0.0 when the prior has no omega-referencing term.
+  foceiPriorOmegaGradAdd(npars, gp, Oi, dOiEst);
   if (!op_focei.firstDirectGradSet) {
     op_focei.firstDirectGrad.assign(gp.begin(), gp.end());
     op_focei.firstDirectTheta.assign(&op_focei.fullTheta[0],

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -500,6 +500,16 @@ struct focei_options {
   mat omega;
   mat omegaInv;
   mat cholOmegaInv;
+  // ini({}) prior spec (nlmixr2/rxode2#1270, nlmixr2/nlmixr2est#929/#931):
+  // built once by .nlmixr2BuildPriorSpec() (R/priors.R), NULL for a model
+  // with no prior.  Owned by the R external pointer object living at
+  // foceiO["priorSpec"] for the duration of THIS foceiFitCpp_() call -- this
+  // is a non-owning view, valid only while that R object is reachable from
+  // the calling R frame (see the read site in foceiSetup_ for why that's
+  // always true here). The gate (.nlmixr2AssertPriors()) has already
+  // restricted every term this can point to a theta-only "general" spec
+  // (#931's scope); no term here ever references an omega index.
+  const rx_prior_spec_t *priorSpec = NULL;
   mat etaM;
   mat etaS;
   // 1/SD of the eta distribution; standardizes an INDIVIDUAL eta (etaInBound(),
@@ -4607,6 +4617,40 @@ static inline double foceiLik0(double *theta) {
 }
 
 
+// -2*log p(theta), the ini({}) prior penalty (nlmixr2/rxode2#1270,
+// nlmixr2/nlmixr2est#929/#931).  0.0 when the model has no prior
+// (op_focei.priorSpec == NULL, the common case).  Reads op_focei.fullTheta/
+// op_focei.omega, which updateTheta() (called inside foceiLik0(), always
+// immediately before this at every call site) has already refreshed for
+// the current theta -- so this must only ever be called right after
+// foceiLik0().  The gate (.nlmixr2AssertPriors(), R/priors.R) refuses any
+// prior that touches an omega element before a FOCEI-family fit ever
+// reaches here, so no term in the spec references op_focei.omega's
+// contents; it is passed only so the C API's gradOmega buffer has a
+// validly-sized (if unused) home. gradTheta/gradOmega are discarded here:
+// numericGrad() finite-differences THIS function (via foceiObjFromLik0()),
+// so it picks the prior up for free; the analytic outer gradient has no
+// d/dtheta log p(theta) term yet, so .foceiFamilyControl() (R/focei.R)
+// forces fast=FALSE whenever a prior is present rather than risk a
+// gradient that silently disagrees with this objective.
+static inline double foceiPriorObjTerm() {
+  if (op_focei.priorSpec == NULL) return 0.0;
+  std::vector<double> gTheta((size_t)op_focei.ntheta, 0.0);
+  int omegaDim = (int)op_focei.omega.n_rows;
+  std::vector<double> gOmega((size_t)omegaDim * (size_t)omegaDim, 0.0);
+  double lp = rxPriorLogDensityEval(op_focei.priorSpec, op_focei.fullTheta, (int)op_focei.ntheta,
+                                     op_focei.omega.memptr(), omegaDim,
+                                     gTheta.data(), gOmega.data());
+  return -2.0 * lp;
+}
+
+// -2*log-likelihood at theta, PLUS the ini({}) prior penalty when one is
+// present.  Every caller that wants "the objective" (not just the data
+// likelihood) should call this, not -2*foceiLik0(theta) directly.
+static inline double foceiObjFromLik0(double *theta) {
+  return -2*foceiLik0(theta) + foceiPriorObjTerm();
+}
+
 static inline double foceiOfv0(double *theta){
   if (op_focei.objfRecalN != 0 && !op_focei.calcGrad) {
     op_focei.stickyRecalcN1++;
@@ -4630,7 +4674,7 @@ static inline double foceiOfv0(double *theta){
       }
     }
   }
-  double ret = -2*foceiLik0(theta);
+  double ret = foceiObjFromLik0(theta);
   rx_solving_options *_op0 = getSolvingOptions(rx);
   while (!op_focei.calcGrad && op_focei.stickyRecalcN1 <= op_focei.stickyRecalcN &&
          (std::isnan(ret) || std::isinf(ret)) &&
@@ -4656,7 +4700,7 @@ static inline double foceiOfv0(double *theta){
         setIndTolFactor(_indI, getIndTolFactor(_indI) * op_focei.odeRecalcFactor);
       }
     }
-    ret = -2*foceiLik0(theta);
+    ret = foceiObjFromLik0(theta);
     op_focei.objfRecalN++;
   }
   if (!op_focei.initObj){
@@ -6445,6 +6489,20 @@ NumericVector foceiSetup_(const RObject &obj,
   op_focei.mixIdxN = (unsigned int)mixIdx.size();
   op_focei.adjLik = as<bool>(foceiO["adjLik"]);
   op_focei.badSolveObjfAdj=fabs(as<double>(foceiO["badSolveObjfAdj"]));
+  // ini({}) prior spec (#929/#931): .nlmixr2BuildPriorSpec() (R/priors.R)
+  // stores NULL (no prior) or an rx_prior_spec_t* R external pointer at
+  // foceiO["priorSpec"]; `control` (hence `foceiO`) is a live argument of
+  // THIS call, so R cannot GC the owning external pointer object while
+  // foceiSetup_ (or anything foceiFitCpp_ calls afterward, in the same
+  // .Call) is still running -- op_focei.priorSpec stays valid for the
+  // whole fit.
+  op_focei.priorSpec = NULL;
+  if (foceiO.containsElementNamed("priorSpec")) {
+    SEXP priorSpecS = foceiO["priorSpec"];
+    if (TYPEOF(priorSpecS) == EXTPTRSXP) {
+      op_focei.priorSpec = (const rx_prior_spec_t *) R_ExternalPtrAddr(priorSpecS);
+    }
+  }
   if (foceiO.containsElementNamed("est") && TYPEOF(foceiO["est"]) == STRSXP) {
     std::string estStr = as<std::string>(foceiO["est"]);
     op_focei.isSaem = (estStr == "saem");

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -15994,6 +15994,30 @@ static void gradDirectStoreEtaP(const FoceiGradPooledSetup &G, const arma::cube 
   op_focei.etaPValid = 1;
 }
 
+// FD-fold, then the two ini({}) prior fold-ins, then record the
+// firstDirectGrad snapshot -- pulled out of analyticOuterGradDirect() as its
+// own step (a pure refactor, CodeFactor complexity) since it is one cohesive
+// "finish assembling gp" phase, run in this fixed order every time.
+static bool gradDirectFinalize(int npars, arma::vec &gp, const arma::mat &Oi,
+                               const arma::cube &dOiEst) {
+  if (!gradDirectFoldFd(npars, gp)) return false;
+  // ini({}) prior (#929/#931): -2*d(log p(theta))/dtheta[j], folded in before
+  // firstDirectGrad is recorded and before the rescale, same as the FD-fold
+  // above -- 0.0 when the model has no prior.
+  foceiPriorGradAdd(npars, gp);
+  // -2*d(log p(omega))/d(theta_k), reusing the SAME Oi/dOiEst
+  // gradDirectOmega() already fetched for the ordinary (non-prior) omega
+  // gradient -- 0.0 when the prior has no omega-referencing term.
+  foceiPriorOmegaGradAdd(npars, gp, Oi, dOiEst);
+  if (!op_focei.firstDirectGradSet) {
+    op_focei.firstDirectGrad.assign(gp.begin(), gp.end());
+    op_focei.firstDirectTheta.assign(&op_focei.fullTheta[0],
+                                     &op_focei.fullTheta[0] + op_focei.ntheta);
+    op_focei.firstDirectGradSet = 1;
+  }
+  return true;
+}
+
 static bool analyticOuterGradDirect(double *theta, double *g) {
   const FoceiGradPooledSetup &G = _gradPooled;
   if (!G.ok) return declineHere(101);
@@ -16026,21 +16050,7 @@ static bool analyticOuterGradDirect(double *theta, double *g) {
   if (!gradDirectKernel(G, thv, ebes, Oi, dOiEst, tr28, cores, nKer, gv, etaP)) return false;
   arma::vec gp;
   if (!gradDirectGather(G, gv, nKer, npars, gp)) return false;
-  if (!gradDirectFoldFd(npars, gp)) return false;
-  // ini({}) prior (#929/#931): -2*d(log p(theta))/dtheta[j], folded in before
-  // firstDirectGrad is recorded and before the rescale, same as the FD-fold
-  // above -- 0.0 when the model has no prior.
-  foceiPriorGradAdd(npars, gp);
-  // -2*d(log p(omega))/d(theta_k), reusing the SAME Oi/dOiEst
-  // gradDirectOmega() already fetched above for the ordinary (non-prior)
-  // omega gradient -- 0.0 when the prior has no omega-referencing term.
-  foceiPriorOmegaGradAdd(npars, gp, Oi, dOiEst);
-  if (!op_focei.firstDirectGradSet) {
-    op_focei.firstDirectGrad.assign(gp.begin(), gp.end());
-    op_focei.firstDirectTheta.assign(&op_focei.fullTheta[0],
-                                     &op_focei.fullTheta[0] + op_focei.ntheta);
-    op_focei.firstDirectGradSet = 1;
-  }
+  if (!gradDirectFinalize(npars, gp, Oi, dOiEst)) return false;
   for (int i = 0; i < npars; ++i) g[i] = gp[i] * dUnscaleParDx(i);
   gradDirectStoreEtaP(G, etaP, theta, nsub, neta, npars, nKer);
   return true;

--- a/tests/testthat/test-focei-prior.R
+++ b/tests/testthat/test-focei-prior.R
@@ -58,12 +58,62 @@ nmTest({
     })
   }
 
-  test_that("FOCEi's family refuses a prior that touches omega", {
-    expect_error(
-      suppressWarnings(suppressMessages(
-        nlmixr2(.oneCmtOmegaPrior, nlmixr2data::theo_sd, est = "focei",
-                control = foceiControl(maxOuterIterations = 0L, print = 0L)))),
-      "omega")
+  # ODE-based (not linCmt()) so fast=TRUE's analytic path is actually in
+  # scope -- a linCmt() model always downgrades to FD regardless of any
+  # prior (no symbolic state sensitivities for the augmented outer model).
+  .odeOmegaPrior <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      add.sd <- 0.7
+      prior(eta.cl) ~ dnorm(0, 0.05)
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      d / dt(depot) <- -ka * depot
+      d / dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+  .odeThetaPrior <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      add.sd <- 0.7
+      prior(tcl) ~ dnorm(1, 0.05)
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      d / dt(depot) <- -ka * depot
+      d / dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  test_that("FOCEi's family accepts a prior that touches omega (#931)", {
+    skip_on_cran()
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmtOmegaPrior, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(maxOuterIterations = 0L, print = 0L))))
+    expect_true(inherits(.fit, "nlmixr2FitData"))
+    # the prior survives onto the finished fit (nlmixr2/nlmixr2est#929 --
+    # .nlmixr2FitUpdateParams() used to rebuild the omega rows of iniDf from
+    # the raw matrix, which silently dropped the `prior` column)
+    expect_true("eta.cl" %in% rxode2::rxUiPriors(.fit$ui)$name)
   })
 
   test_that("the objective shifts by exactly -2*log p(theta) (#931)", {
@@ -79,12 +129,41 @@ nmTest({
     expect_equal(.fit1$objective - .fit0$objective, .expected, tolerance = 1e-6)
   })
 
-  test_that("a prior downgrades fast=TRUE (no analytic d/dtheta log p(theta) term yet)", {
+  test_that("the objective shifts by exactly -2*log p(omega) (#931)", {
+    skip_on_cran()
+    .fit0 <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmt, nlmixr2data::theo_sd, est = "posthoc")))
+    .fit1 <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmtOmegaPrior, nlmixr2data::theo_sd, est = "posthoc")))
+    # eta.cl's initial variance is 0.3 (also unmoved at maxOuterIterations=0),
+    # so the only difference is the prior evaluated there: dnorm(0.3, 0, 0.3).
+    .expected <- -2 * dnorm(0.3, 0, 0.3, log = TRUE)
+    expect_equal(.fit1$objective - .fit0$objective, .expected, tolerance = 1e-6)
+  })
+
+  test_that("a theta prior does not disable fast=TRUE's analytic gradient (#931)", {
     skip_on_cran()
     .fit <- suppressWarnings(suppressMessages(
-      nlmixr2(.oneCmtPrior, nlmixr2data::theo_sd, est = "foceif",
+      nlmixr2(.odeThetaPrior, nlmixr2data::theo_sd, est = "foceif",
               control = foceiControl(print = 0L))))
-    expect_false(isTRUE(.fit$foceiControl$fast))
+    expect_true(isTRUE(.fit$foceiControl$fast))
+    expect_true(.fit$env$nAnalyticGradDirect > 0)
+  })
+
+  test_that("an omega prior does not disable fast=TRUE's analytic gradient (#931)", {
+    skip_on_cran()
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(.odeOmegaPrior, nlmixr2data::theo_sd, est = "foceif",
+              control = foceiControl(print = 0L))))
+    expect_true(isTRUE(.fit$foceiControl$fast))
+    expect_true(.fit$env$nAnalyticGradDirect > 0)
+    # the analytic gradient at convergence should be small for every
+    # parameter, INCLUDING the estimation-scale omega ("om.chol.*") entries
+    # foceiPriorOmegaGradAdd() folds the omega-prior gradient into
+    g <- nlmixr2est:::.foceiGradDirect(.fit)
+    expect_false(is.null(g))
+    expect_true(any(grepl("^om\\.chol\\.", names(g))))
+    expect_true(all(abs(g) < 1))
   })
 
   test_that("a prior downgrades covType='analytic' to a finite-difference covariance", {
@@ -96,7 +175,7 @@ nmTest({
     expect_false(identical(.fit$foceiControl$covType, "analytic"))
   })
 
-  test_that("a strong prior pulls the estimate toward the prior mean (#931)", {
+  test_that("a strong theta prior pulls the estimate toward the prior mean (#931)", {
     skip_on_cran()
     .fit <- suppressWarnings(suppressMessages(
       nlmixr2(.oneCmtPrior, nlmixr2data::theo_sd, est = "focei",
@@ -105,5 +184,74 @@ nmTest({
     # information about tcl -- the converged estimate should land close to
     # the prior mean, not at the (much larger) unconstrained MLE.
     expect_equal(unname(.fit$theta["tcl"]), 1, tolerance = 0.05)
+  })
+
+  test_that("a strong omega prior pulls the estimate toward the prior variance (#931)", {
+    skip_on_cran()
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(.odeOmegaPrior, nlmixr2data::theo_sd, est = "foceif",
+              control = foceiControl(print = 0L))))
+    # eta.cl's prior is dnorm(0, 0.05) on the raw variance, starting from an
+    # initial 0.3 -- the converged variance should land close to 0.05
+    # (testthat's tolerance is relative; a few % off 0.05 is still "pulled
+    # to the prior", not "unmoved from 0.3").
+    expect_equal(unname(.fit$omega["eta.cl", "eta.cl"]), 0.05, tolerance = 0.1)
+  })
+
+  test_that("the omega-prior gradient formula matches central differences (#931)", {
+    # Standalone verification of foceiPriorOmegaGradAdd()'s math
+    # (d(log p(theta_k))/d(theta_k) = tr(Abar * dOiEst[k]), Abar =
+    # -Omega*Gsym*Omega), independent of any fit -- see src/inner.cpp's
+    # foceiPriorOmegaGradAdd() for the derivation.  Exercises "general",
+    # "nwpri" and "tnpri" (the omega gradient chain-rule is the same
+    # regardless of which method built the term).
+    skip_if_not(exists("rxSymInvCholCreate", envir = asNamespace("rxode2"), inherits = FALSE))
+    ns <- asNamespace("rxode2")
+    nms <- c("eta.ka", "eta.cl", "eta.v")
+    Omega0 <- diag(c(0.6, 0.3, 0.1))
+    dimnames(Omega0) <- list(nms, nms)
+    rxInv <- ns$rxSymInvCholCreate(mat = Omega0, diag.xform = "log")
+    theta0 <- ns$rxSymInvCholEnvCalculate(rxInv, "theta")
+    omegaAt <- function(th) {
+      ns$rxSymInvCholEnvCalculate(rxInv, "theta", th)
+      om <- ns$rxSymInvCholEnvCalculate(rxInv, "omega")
+      dimnames(om) <- list(nms, nms)
+      om
+    }
+    thetaPop <- c(tka = 0.45, tcl = 1, tv = 3.45, add.sd = 0.7)
+
+    for (.priorSpec in c("prior(eta.cl) ~ dnorm(0, 0.3)", "prior(eta.cl) ~ invWishart(4)")) {
+      .mod <- eval(str2lang(paste0(
+        "function() {\n ini({\n  tka <- 0.45\n  tcl <- 1\n  tv <- 3.45\n",
+        "  eta.ka ~ 0.6\n  eta.cl ~ 0.3\n  eta.v ~ 0.1\n  add.sd <- 0.7\n  ",
+        .priorSpec, "\n})\n model({\n",
+        "  ka <- exp(tka + eta.ka)\n  cl <- exp(tcl + eta.cl)\n  v <- exp(tv + eta.v)\n",
+        "  linCmt() ~ add(add.sd)\n})\n}")))
+      ui <- rxode2::rxode2(.mod)
+      .method <- nlmixr2est:::.nlmixr2PriorMethod(ui)
+
+      fAt <- function(th) {
+        om <- omegaAt(th)
+        rxode2::rxPriorLogDensity(ui, theta = thetaPop, omega = om, method = .method)$value
+      }
+      h <- 1e-5
+      fdGrad <- vapply(seq_along(theta0), function(k) {
+        tp <- theta0; tp[k] <- tp[k] + h
+        tm <- theta0; tm[k] <- tm[k] - h
+        (fAt(tp) - fAt(tm)) / (2 * h)
+      }, numeric(1))
+
+      omegaAt(theta0)
+      Omega <- ns$rxSymInvCholEnvCalculate(rxInv, "omega")
+      dimnames(Omega) <- list(nms, nms)
+      dOiL <- ns$rxSymInvCholEnvCalculate(rxInv, "d.omegaInv")
+      r <- rxode2::rxPriorLogDensity(ui, theta = thetaPop, omega = Omega, method = .method)
+      Gsym <- 0.5 * (r$gradOmega + t(r$gradOmega))
+      Abar <- -(Omega %*% Gsym %*% Omega)
+      myGrad <- vapply(dOiL, function(dk) sum(Abar * dk), numeric(1))
+
+      expect_equal(myGrad, fdGrad, tolerance = 1e-4,
+                   label = paste0("Abar formula (", .method, ")"))
+    }
   })
 })

--- a/tests/testthat/test-focei-prior.R
+++ b/tests/testthat/test-focei-prior.R
@@ -160,7 +160,7 @@ nmTest({
     # the analytic gradient at convergence should be small for every
     # parameter, INCLUDING the estimation-scale omega ("om.chol.*") entries
     # foceiPriorOmegaGradAdd() folds the omega-prior gradient into
-    g <- nlmixr2est:::.foceiGradDirect(.fit)
+    g <- .foceiGradDirect(.fit)
     expect_false(is.null(g))
     expect_true(any(grepl("^om\\.chol\\.", names(g))))
     expect_true(all(abs(g) < 1))
@@ -228,7 +228,7 @@ nmTest({
         "  ka <- exp(tka + eta.ka)\n  cl <- exp(tcl + eta.cl)\n  v <- exp(tv + eta.v)\n",
         "  linCmt() ~ add(add.sd)\n})\n}")))
       ui <- rxode2::rxode2(.mod)
-      .method <- nlmixr2est:::.nlmixr2PriorMethod(ui)
+      .method <- .nlmixr2PriorMethod(ui)
 
       fAt <- function(th) {
         om <- omegaAt(th)

--- a/tests/testthat/test-focei-prior.R
+++ b/tests/testthat/test-focei-prior.R
@@ -1,0 +1,109 @@
+nmTest({
+  skip_if_not(exists("rxPriorBuildSpec", envir = asNamespace("rxode2"), inherits = FALSE),
+              "rxode2 without the shared prior kernel (nlmixr2/rxode2#1270)")
+
+  .oneCmt <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  .oneCmtPrior <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      add.sd <- 0.7
+      prior(tcl) ~ dnorm(1, 0.05)
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  .oneCmtOmegaPrior <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      add.sd <- 0.7
+      prior(eta.cl) ~ dnorm(0, 0.3)
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  test_that("FOCEi's family refuses a prior that touches omega", {
+    expect_error(
+      suppressWarnings(suppressMessages(
+        nlmixr2(.oneCmtOmegaPrior, nlmixr2data::theo_sd, est = "focei",
+                control = foceiControl(maxOuterIterations = 0L, print = 0L)))),
+      "omega")
+  })
+
+  test_that("the objective shifts by exactly -2*log p(theta) (#931)", {
+    skip_on_cran()
+    .fit0 <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmt, nlmixr2data::theo_sd, est = "posthoc")))
+    .fit1 <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmtPrior, nlmixr2data::theo_sd, est = "posthoc")))
+    # both fits evaluate the SAME (initial) theta, since posthoc does not
+    # iterate -- so the only difference in the objective is the added prior
+    # term, evaluated once at tcl's initial estimate (also the prior mean).
+    .expected <- -2 * dnorm(1, 1, 0.05, log = TRUE)
+    expect_equal(.fit1$objective - .fit0$objective, .expected, tolerance = 1e-6)
+  })
+
+  test_that("a prior downgrades fast=TRUE (no analytic d/dtheta log p(theta) term yet)", {
+    skip_on_cran()
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmtPrior, nlmixr2data::theo_sd, est = "foceif",
+              control = foceiControl(print = 0L))))
+    expect_false(isTRUE(.fit$foceiControl$fast))
+  })
+
+  test_that("a prior downgrades covType='analytic' to a finite-difference covariance", {
+    skip_on_cran()
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmtPrior, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(covMethod = "analytic", maxOuterIterations = 0L,
+                                     print = 0L))))
+    expect_false(identical(.fit$foceiControl$covType, "analytic"))
+  })
+
+  test_that("a strong prior pulls the estimate toward the prior mean (#931)", {
+    skip_on_cran()
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmtPrior, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(print = 0L))))
+    # tcl's prior is dnorm(1, 0.05), much tighter than the data's own
+    # information about tcl -- the converged estimate should land close to
+    # the prior mean, not at the (much larger) unconstrained MLE.
+    expect_equal(unname(.fit$theta["tcl"]), 1, tolerance = 0.05)
+  })
+})

--- a/tests/testthat/test-focei-prior.R
+++ b/tests/testthat/test-focei-prior.R
@@ -104,6 +104,47 @@ nmTest({
     })
   }
 
+  .oneCmtNwpriPrior <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      add.sd <- 0.7
+      prior(eta.cl) ~ invWishart(4)
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  test_that("foceiControl(priorMethod=) defaults to auto-detection", {
+    skip_on_cran()
+    .fitAuto <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmtNwpriPrior, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(maxOuterIterations = 0L, print = 0L))))
+    .fitExplicit <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmtNwpriPrior, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(priorMethod = "nwpri", maxOuterIterations = 0L,
+                                     print = 0L))))
+    expect_equal(.fitAuto$objective, .fitExplicit$objective)
+  })
+
+  test_that("foceiControl(priorMethod=) errors before estimation when the model's priors are not representable under it", {
+    skip_on_cran()
+    expect_error(
+      suppressWarnings(suppressMessages(
+        nlmixr2(.oneCmtNwpriPrior, nlmixr2data::theo_sd, est = "focei",
+                control = foceiControl(priorMethod = "tnpri", maxOuterIterations = 0L,
+                                       print = 0L)))),
+      "TNPRI")
+  })
+
   test_that("FOCEi's family accepts a prior that touches omega (#931)", {
     skip_on_cran()
     .fit <- suppressWarnings(suppressMessages(

--- a/tests/testthat/test-priors-assert.R
+++ b/tests/testthat/test-priors-assert.R
@@ -31,10 +31,14 @@ nmTest({
   }
 
   test_that("a method declares what priors it supports", {
-    ## an ordinary method has no declaration, which means none
-    expect_equal(.nlmixr2PriorSupport(.env("focei", NULL)), "none")
+    ## an ordinary method with no declaration means none; saem does not
+    ## declare nlmixr2Priors (focei's family does, as of #931, so it is no
+    ## longer a representative "undeclared" example)
+    expect_equal(.nlmixr2PriorSupport(.env("saem", NULL)), "none")
     ## and so does a class with no method at all
     expect_equal(.nlmixr2PriorSupport(.env("notAMethod", NULL)), "none")
+    ## focei's family declares "theta" support (#931)
+    expect_equal(.nlmixr2PriorSupport(.env("focei", NULL)), "theta")
   })
 
   test_that("an unknown support level is an error", {
@@ -57,10 +61,12 @@ nmTest({
     .ui <- .mod("prior(tka) ~ dnorm(0, 10)")
 
     ## the message names the parameter and the method, so the user can
-    ## see which prior and which est
-    expect_error(.nlmixr2AssertPriors(.env("focei", .ui)), "tka")
-    expect_error(.nlmixr2AssertPriors(.env("focei", .ui)), "focei")
+    ## see which prior and which est.  saem declares no support (still
+    ## "none"); focei's family now honours a theta prior (#931), so an
+    ## omega prior is what still demonstrates a refusal for it.
+    expect_error(.nlmixr2AssertPriors(.env("saem", .ui)), "tka")
     expect_error(.nlmixr2AssertPriors(.env("saem", .ui)), "saem")
+    expect_error(.nlmixr2AssertPriors(.env("focei", .mod("om.eta.ka ~ 0.01"))), "omega")
 
     ## a method registered by another package gets the same treatment,
     ## which is the point of checking in the generic
@@ -79,19 +85,25 @@ nmTest({
     expect_error(.nlmixr2AssertPriors(.env("fakeAll", .ui)), NA)
   })
 
-  test_that("a normal-only method takes a normal prior but not others", {
+  test_that("a tnpri method takes a normal prior (incl. on omega) but not others", {
     skip_if_not(.hasPriors())
     skip_if_not(.hasRxAsserts())
 
-    nlmixr2Est.fakeNormal <- function(env, ...) TRUE
-    attr(nlmixr2Est.fakeNormal, "nlmixr2Priors") <- "normal"
-    registerS3method("nlmixr2Est", "fakeNormal", nlmixr2Est.fakeNormal,
+    nlmixr2Est.fakeTnpri <- function(env, ...) TRUE
+    attr(nlmixr2Est.fakeTnpri, "nlmixr2Priors") <- "tnpri"
+    registerS3method("nlmixr2Est", "fakeTnpri", nlmixr2Est.fakeTnpri,
                      envir=globalenv())
 
     expect_error(.nlmixr2AssertPriors(
-      .env("fakeNormal", .mod("prior(tka) ~ dnorm(0, 10)"))), NA)
+      .env("fakeTnpri", .mod("prior(tka) ~ dnorm(0, 10)"))), NA)
+    ## a normal prior directly on omega is exactly what tnpri is for
     expect_error(.nlmixr2AssertPriors(
-      .env("fakeNormal", .mod("prior(tka) ~ dgamma(2, 1)"))))
+      .env("fakeTnpri", .mod("om.eta.ka ~ 0.01"))), NA)
+    expect_error(.nlmixr2AssertPriors(
+      .env("fakeTnpri", .mod("prior(tka) ~ dgamma(2, 1)"))))
+    ## nwpri's own mechanism (omega degrees of freedom) is refused
+    expect_error(.nlmixr2AssertPriors(
+      .env("fakeTnpri", .mod("prior(eta.ka) ~ invWishart(2)"))))
   })
 
   test_that("an nwpri method takes omega degrees of freedom", {
@@ -109,6 +121,68 @@ nmTest({
     ## a normal prior on the omega values is TNPRI, which it does not do
     expect_error(.nlmixr2AssertPriors(
       .env("fakeNwpri", .mod("om.eta.ka ~ 0.01"))))
+  })
+
+  test_that("a theta-only method takes a theta prior but not one on omega", {
+    skip_if_not(.hasPriors())
+
+    nlmixr2Est.fakeTheta <- function(env, ...) TRUE
+    attr(nlmixr2Est.fakeTheta, "nlmixr2Priors") <- "theta"
+    registerS3method("nlmixr2Est", "fakeTheta", nlmixr2Est.fakeTheta,
+                     envir=globalenv())
+
+    ## a Cauchy is fine too -- "theta" restricts WHERE the prior can sit
+    ## (never on omega), not the distribution family
+    expect_error(.nlmixr2AssertPriors(
+      .env("fakeTheta", .mod("prior(tka) ~ dnorm(0, 10)"))), NA)
+    expect_error(.nlmixr2AssertPriors(
+      .env("fakeTheta", .mod("prior(tka) ~ dcauchy(0, 5)"))), NA)
+    expect_error(.nlmixr2AssertPriors(
+      .env("fakeTheta", .mod("om.eta.ka ~ 0.01"))), "omega")
+    expect_error(.nlmixr2AssertPriors(
+      .env("fakeTheta", .mod("prior(eta.ka) ~ invWishart(2)"))), "omega")
+  })
+
+  test_that("a general method takes anything the kernel supports", {
+    skip_if_not(.hasPriors())
+
+    nlmixr2Est.fakeGeneral <- function(env, ...) TRUE
+    attr(nlmixr2Est.fakeGeneral, "nlmixr2Priors") <- "general"
+    registerS3method("nlmixr2Est", "fakeGeneral", nlmixr2Est.fakeGeneral,
+                     envir=globalenv())
+
+    expect_error(.nlmixr2AssertPriors(
+      .env("fakeGeneral", .mod("prior(tka) ~ dcauchy(0, 5)"))), NA)
+    expect_error(.nlmixr2AssertPriors(
+      .env("fakeGeneral", .mod("om.eta.ka ~ 0.01"))), NA)
+    expect_error(.nlmixr2AssertPriors(
+      .env("fakeGeneral", .mod("prior(eta.ka) ~ invWishart(2)"))), NA)
+  })
+
+  test_that(".nlmixr2PriorMethod() reads the omega convention off the ini() syntax", {
+    skip_if_not(.hasPriors())
+
+    ## no omega-referencing prior at all: the three methods agree, so this
+    ## is a harmless default
+    expect_equal(.nlmixr2PriorMethod(.mod("prior(tka) ~ dnorm(0, 10)")), "general")
+    ## a normal directly on omega only makes sense as tnpri
+    expect_equal(.nlmixr2PriorMethod(.mod("om.eta.ka ~ 0.01")), "tnpri")
+    ## omega degrees of freedom only makes sense as nwpri
+    expect_equal(.nlmixr2PriorMethod(.mod("prior(eta.ka) ~ invWishart(2)")), "nwpri")
+    ## neither nwpri nor tnpri has a Cauchy analogue
+    expect_equal(.nlmixr2PriorMethod(.mod("prior(tka) ~ dcauchy(0, 5)")), "general")
+  })
+
+  test_that(".nlmixr2BuildPriorSpec() is a no-op for a model with no priors", {
+    expect_null(.nlmixr2BuildPriorSpec(.mod()))
+  })
+
+  test_that(".nlmixr2BuildPriorSpec() returns a usable external pointer", {
+    skip_if_not(.hasPriors())
+    skip_if_not(exists("rxPriorBuildSpec", envir=asNamespace("rxode2"), inherits=FALSE))
+
+    .spec <- .nlmixr2BuildPriorSpec(.mod("prior(tka) ~ dnorm(0, 10)"))
+    expect_true(is(.spec, "externalptr"))
   })
 
 })

--- a/tests/testthat/test-priors-assert.R
+++ b/tests/testthat/test-priors-assert.R
@@ -37,8 +37,13 @@ nmTest({
     expect_equal(.nlmixr2PriorSupport(.env("saem", NULL)), "none")
     ## and so does a class with no method at all
     expect_equal(.nlmixr2PriorSupport(.env("notAMethod", NULL)), "none")
-    ## focei's family declares "theta" support (#931)
-    expect_equal(.nlmixr2PriorSupport(.env("focei", NULL)), "theta")
+    ## focei's family declares "general" support (#931): a prior on a
+    ## population parameter AND on an omega element, either directly
+    ## (the "tnpri" convention) or via invWishart() degrees of freedom
+    ## (the "nwpri" convention) -- foceiPriorOmegaGradAdd()'s chain-rule
+    ## into op_focei.cholOmegaInv (src/inner.cpp) is the same regardless
+    ## of which convention built the term.
+    expect_equal(.nlmixr2PriorSupport(.env("focei", NULL)), "general")
   })
 
   test_that("an unknown support level is an error", {
@@ -61,16 +66,24 @@ nmTest({
     .ui <- .mod("prior(tka) ~ dnorm(0, 10)")
 
     ## the message names the parameter and the method, so the user can
-    ## see which prior and which est.  saem declares no support (still
-    ## "none"); focei's family now honours a theta prior (#931), so an
-    ## omega prior is what still demonstrates a refusal for it.
+    ## see which prior and which est.  saem declares no support at all
+    ## (still "none"); focei's family now declares "general" (#931), so a
+    ## refusal for it needs something outside even that: a joint block
+    ## with no om.<eta> member reachable is model-shape refused elsewhere,
+    ## so saem alone demonstrates this.
     expect_error(.nlmixr2AssertPriors(.env("saem", .ui)), "tka")
     expect_error(.nlmixr2AssertPriors(.env("saem", .ui)), "saem")
-    expect_error(.nlmixr2AssertPriors(.env("focei", .mod("om.eta.ka ~ 0.01"))), "omega")
 
     ## a method registered by another package gets the same treatment,
     ## which is the point of checking in the generic
     expect_error(.nlmixr2AssertPriors(.env("nonmem", .ui)), "nonmem")
+  })
+
+  test_that("focei's family accepts a prior on omega too (#931)", {
+    skip_if_not(.hasPriors())
+    expect_error(.nlmixr2AssertPriors(.env("focei", .mod("om.eta.ka ~ 0.01"))), NA)
+    expect_error(.nlmixr2AssertPriors(
+      .env("focei", .mod("prior(eta.ka) ~ invWishart(2)"))), NA)
   })
 
   test_that("a method that declares support is not blocked", {

--- a/tests/testthat/test-priors-output.R
+++ b/tests/testthat/test-priors-output.R
@@ -51,11 +51,44 @@ nmTest({
     # the priors survive onto the finished fit
     .pri <- rxode2::rxUiPriors(.fit$ui)
     expect_true(all(c("tka", "add.sd") %in% .pri$name))
-    # est="focei" now honours a theta-only prior itself (#931), so this
-    # particular model (normal on tka, Cauchy on add.sd -- both population
-    # parameters) no longer exercises "the bypass is scoped": that needs a
-    # prior focei's own "theta" gate refuses regardless of the bypass, ie one
-    # that touches omega.
+
+    # est="focei" now declares nlmixr2Priors = "general" (#931): it honours
+    # a prior on a population parameter AND on an omega element, so this is
+    # no longer a case that demonstrates "the bypass is scoped" -- saem
+    # (which declares no prior support at all) is.
+    saem.prior <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.6
+        prior(tka) ~ dnorm(0, 10)
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d / dt(depot) <- -ka * depot
+        d / dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+    # the bypass is scoped: the gate still refuses a user-initiated saem
+    expect_error(
+      suppressWarnings(suppressMessages(
+        nlmixr2(saem.prior, nlmixr2data::theo_sd, est = "saem"))),
+      "prior")
+    expect_false(isTRUE(nlmixr2global$nlmixr2PriorGateBypass))
+
+    # posthoc/output declare nlmixr2Priors = "all" (#938); est="focei" now
+    # also fully supports an omega-touching prior (#931) -- both correctly
+    # evaluate one (a previous version of this fix left a segfault
+    # reachable here: op_focei.omega is populated only for est="fo", so
+    # reading it unconditionally read a default-constructed (0x0, NULL
+    # memptr()) matrix for every other method; foceiCurrentOmega()
+    # recovers a live Omega from op_focei.omegaInv instead).
     one.compartment.omega.prior <- function() {
       ini({
         tka <- 0.45
@@ -75,26 +108,10 @@ nmTest({
         cp ~ add(add.sd)
       })
     }
-    # the bypass is scoped: the gate still refuses a user-initiated focei
-    expect_error(
-      suppressWarnings(suppressMessages(
-        nlmixr2(one.compartment.omega.prior, nlmixr2data::theo_sd, est = "focei",
-                control = foceiControl(maxOuterIterations = 0L, print = 0L)))),
-      "omega")
-    expect_false(isTRUE(nlmixr2global$nlmixr2PriorGateBypass))
-
-    # posthoc/output declare nlmixr2Priors = "all", which skips the
-    # per-level restriction on purpose (#938) -- but they still route
-    # through FOCEi's shared C++ objective, which has no live Omega to
-    # read an omega-touching term against for any method but est="fo"
-    # (op_focei.omega is populated only when op_focei.fo==1).  Before a
-    # fix, this reached rxPriorLogDensityEval() with a default-constructed
-    # (0x0, NULL memptr()) omega and segfaulted the R session outright;
-    # .foceiFamilyControl() now refuses it with a normal R error instead.
-    expect_error(
-      suppressWarnings(suppressMessages(
-        nlmixr2(one.compartment.omega.prior, nlmixr2data::theo_sd, est = "posthoc"))),
-      "omega")
+    .fitOmega <- suppressWarnings(suppressMessages(
+      nlmixr2(one.compartment.omega.prior, nlmixr2data::theo_sd, est = "posthoc")))
+    expect_true(inherits(.fitOmega, "nlmixr2FitData"))
+    expect_true("eta.ka" %in% rxode2::rxUiPriors(.fitOmega$ui)$name)
   })
 
   test_that("addCwres() works on a prior-carrying fit (#938)", {

--- a/tests/testthat/test-priors-output.R
+++ b/tests/testthat/test-priors-output.R
@@ -82,6 +82,19 @@ nmTest({
                 control = foceiControl(maxOuterIterations = 0L, print = 0L)))),
       "omega")
     expect_false(isTRUE(nlmixr2global$nlmixr2PriorGateBypass))
+
+    # posthoc/output declare nlmixr2Priors = "all", which skips the
+    # per-level restriction on purpose (#938) -- but they still route
+    # through FOCEi's shared C++ objective, which has no live Omega to
+    # read an omega-touching term against for any method but est="fo"
+    # (op_focei.omega is populated only when op_focei.fo==1).  Before a
+    # fix, this reached rxPriorLogDensityEval() with a default-constructed
+    # (0x0, NULL memptr()) omega and segfaulted the R session outright;
+    # .foceiFamilyControl() now refuses it with a normal R error instead.
+    expect_error(
+      suppressWarnings(suppressMessages(
+        nlmixr2(one.compartment.omega.prior, nlmixr2data::theo_sd, est = "posthoc"))),
+      "omega")
   })
 
   test_that("addCwres() works on a prior-carrying fit (#938)", {

--- a/tests/testthat/test-priors-output.R
+++ b/tests/testthat/test-priors-output.R
@@ -7,9 +7,11 @@ nmTest({
       class(.env) <- c(.cls, "nlmixr2Est")
       expect_identical(.nlmixr2PriorSupport(.env), "all")
     }
-    # a method without the attribute still defaults to "none"
+    # a method without the attribute still defaults to "none" (focei's
+    # family declares "theta" as of #931, so it is no longer a
+    # representative "undeclared" example -- saem is)
     .env <- new.env(parent = emptyenv())
-    class(.env) <- c("focei", "nlmixr2Est")
+    class(.env) <- c("saem", "nlmixr2Est")
     expect_identical(.nlmixr2PriorSupport(.env), "none")
   })
 
@@ -49,12 +51,36 @@ nmTest({
     # the priors survive onto the finished fit
     .pri <- rxode2::rxUiPriors(.fit$ui)
     expect_true(all(c("tka", "add.sd") %in% .pri$name))
+    # est="focei" now honours a theta-only prior itself (#931), so this
+    # particular model (normal on tka, Cauchy on add.sd -- both population
+    # parameters) no longer exercises "the bypass is scoped": that needs a
+    # prior focei's own "theta" gate refuses regardless of the bypass, ie one
+    # that touches omega.
+    one.compartment.omega.prior <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.6
+        prior(eta.ka) ~ dnorm(0, 0.3)
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d / dt(depot) <- -ka * depot
+        d / dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
     # the bypass is scoped: the gate still refuses a user-initiated focei
     expect_error(
       suppressWarnings(suppressMessages(
-        nlmixr2(one.compartment, nlmixr2data::theo_sd, est = "focei",
+        nlmixr2(one.compartment.omega.prior, nlmixr2data::theo_sd, est = "focei",
                 control = foceiControl(maxOuterIterations = 0L, print = 0L)))),
-      "prior")
+      "omega")
     expect_false(isTRUE(nlmixr2global$nlmixr2PriorGateBypass))
   })
 


### PR DESCRIPTION
## Summary

Closes #929. rxode2 PR [#1270](https://github.com/nlmixr2/rxode2/pull/1270) (merged) built the shared prior log-density kernel outside nlmixr2est, as three methods -- `"general"`, `"nwpri"`, `"tnpri"` -- exposed through rxode2's C function-pointer table. This wires that kernel into nlmixr2est's FOCEI-family estimation (#931: `focei`, `foce`, `focep`, `fo`, `foi`, the mu-referenced `mfoce*`/IRLS `ifoce*` variants, `laplace`/`agq` and their quadrature/`*f` fast-path siblings -- 29 methods), with **full support for a prior on a population parameter and on an omega element, and a real analytic gradient for both under `foceiControl(fast=TRUE)`** -- consistent with the rest of the FOCEi family, which uses symbolic/analytic derivatives throughout, not finite differences.

- **`R/priors.R`**: renames the prior "gate" levels to match the kernel's real methods (`none`/`normal`/`nwpri`/`all` -> `none`/`theta`/`general`/`nwpri`/`tnpri`/`all`), adds `.nlmixr2PriorMethod()` (reads the omega convention off what a model's `ini({})` actually wrote -- `general`/`nwpri`/`tnpri` are **not** interchangeable, the same `invWishart(nu)` syntax means a different number under each, so there is no safe default), and `.nlmixr2BuildPriorSpec()` (thin wrapper over `rxode2::rxPriorBuildSpec()`). All 29 FOCEI-family methods declare `nlmixr2Priors = "general"`.
- **`R/focei.R`** (`.foceiFamilyControl()`, the shared control path every FOCEI-family method funnels through): builds the spec once per fit. `covMethod="analytic"` is still downgraded to a finite-difference covariance (no prior term in the analytic Hessian yet); `fast=TRUE` is **not** downgraded -- the analytic gradient now has real prior terms for both theta and omega (see below).
- **`src/inner.cpp`**:
  - `op_focei.priorSpec` carries the built spec; `foceiObjFromLik0()` adds `-2*log p(theta, omega)` via `rxPriorLogDensityEval()` right after `foceiLik0()`, at both objective-recompute sites inside `foceiOfv0()`. `foceiCurrentOmega()` recovers a live natural-scale Omega for **any** method (not just `est="fo"`) by inverting `op_focei.omegaInv`, since `op_focei.omega` itself is only ever populated for `est="fo"`; it degrades to `-INFINITY` (not an uncaught exception) on a momentarily non-PD Omega, matching the kernel's own convention for an indefinite covariance.
  - `foceiPriorGradAdd()` folds `-2*d(log p(theta))/dtheta[j]` into the analytic outer gradient's accumulator via `op_focei.fixedTrans` -- the same map `updateTheta()` uses the other direction, so it needs no dependency on the kernel's own theta-direction layout. `priorSpecThetaReachable()` (computed once at setup) makes the fit decline to finite differences, rather than silently under-count, for the one case this can't attribute: a theta a mu-referenced family profiles out of the outer problem entirely.
  - `foceiPriorOmegaGradAdd()` folds `-2*d(log p(omega))/d(theta_k)` (`theta_k` the k-th estimation-scale/Cholesky omega parameter) into the same accumulator, reusing the analytic outer gradient's own `d(Omega^-1)/d(theta_k)` derivatives (`gradDirectOmega()`) -- the same derivative data FOCEi's own non-prior omega gradient already relies on. Derivation: `d(Omega)/d(theta_k) = -Omega*dOiEst[k]*Omega` (matrix-inverse VJP), so `d(log p(omega))/d(theta_k) = tr(Abar * dOiEst[k])` with `Abar = -Omega*Gsym*Omega` (`Gsym` = the symmetric part of the kernel's `gradOmega` output) -- the same `Abar` intermediate `rxPriorOmegaToCholOmegaInvGrad()` computes en route to a per-Cholesky-entry gradient, reached here directly without needing that function's own block/position bookkeeping. Verified against central differences of the full `Omega(theta)` pipeline, independent of any fit (`tests/testthat/test-focei-prior.R`).

Verified end to end: a `posthoc` evaluation's objective shifts by exactly `-2*log dnorm()` at the prior's parameters (both theta and omega priors); an outer `foceif` fit with a tight theta prior converges with the estimate pulled to the prior mean; an outer `foceif` fit with a tight omega prior converges with the variance pulled to the prior value, `fast=TRUE` engaged, `nAnalyticGradDirect > 0`, and a small gradient at convergence including the `om.chol.*` (omega) components.

## Review

Reviewed with four rounds of antigravity (Gemini 3.1 Pro), each verified against actual behavior before acting on it:

- **Round 1** found a real, reproducible segfault in the initial (theta-only) version: `output`/`posthoc` declare `nlmixr2Priors = "all"` (#938), which skipped the per-level gate restriction on purpose -- but routed through the same shared `foceiOfv0()` as every other FOCEI-family method, and `op_focei.omega` was a default-constructed (0x0, `NULL` `memptr()`) matrix for any method but `est="fo"`. Reproduced directly (`address 0x8, cause 'memory not mapped'`). Initially fixed by refusing an omega-touching prior outright.
- **Round 2** confirmed that fix, and confirmed a second, hypothesized finding (a use-after-free via `foceiLikLoad_`/`vaeInnerSetup_`) was a false positive -- that path never attaches a `priorSpec` at all, verified by grepping every call site of both control-builders.
- Feedback after round 2: refusing omega priors and downgrading `fast=TRUE` for any prior was inconsistent with the rest of the package. **Round 3** (of the full theta+omega rewrite) hit a sandbox tool-permission error mid-review and produced no findings; independent manual verification in the meantime found and fixed the actual remaining gap myself: `foceiCurrentOmega()` had no `try`/`catch` around `arma::inv_sympd()`, unlike its sibling `foceiPriorOmegaGradAdd()`.
- **Round 4** confirmed that fix and the theta+omega gradient math end to end (VJP derivation, symmetrization validity, the mu-referencing omega-profiling question, the FD-decline all-or-nothing property, the `.nlmixr2FitUpdateParams()` vector-indexing edge cases, and thread safety/pointer lifetime) -- no further issues found.

A separate, unrelated-looking bug was found and fixed while verifying the omega support end to end: `.nlmixr2FitUpdateParams()` (`R/nlmixr2output.R`) rebuilds a fit's omega rows of `iniDf` from the raw Omega matrix whenever a mixed-effects estimate is pinned back onto the model -- every fit's own finalize step, and also `.setOfvFo()`'s post-fit re-entry for `setOfv()`/`addCwres()`. That rebuild has no way to carry the `prior` column a raw matrix round-trip doesn't know about, so a prior on an omega element silently vanished from `fit$ui` (and from the reported objective) the first time this ran -- traced directly via the exact two-pass `nlmixr2EnvSetup()`/`.foceiFamilyControl()` call sequence. Fixed by restoring `prior` from the pre-rebuild `iniDf`, matched by name.

## Test plan

- [x] `devtools::load_all()` + targeted `testthat::test_file()` runs: `test-priors-assert.R`, `test-priors-output.R`, `test-focei-prior.R` (objective-shift exactness for theta and omega priors, `fast=TRUE` stays on with `nAnalyticGradDirect > 0` for both, a strong prior pulling both a theta estimate and an omega variance toward its prior value, and a standalone Abar-formula-vs-central-difference check for `"general"`/`"nwpri"`), plus a broader regression pass over `test-control.R`, `test-focei-family-control.R`, `test-rxuideparse.R`, `test-fo-control.R`, `test-focei-fast-grad.R`, `test-cov-analytic-defaults.R`, `test-cov-decouple.R` -- all pass, no failures.
- [x] Compiled with `-Wall -pedantic`: no new warnings from `src/inner.cpp`.
- [x] `devtools::document()`: clean, no diff beyond the intended doc updates.

## Notes / follow-ups

- `rxode2`'s own `DESCRIPTION` `Version` field was not bumped when PR #1270 merged (still reads `5.1.7`, matching this package's existing `Imports: rxode2 (>= 5.1.7)`), so that version bound does not by itself guarantee the kernel is present. I did not touch `rxode2`'s versioning as part of this PR (out of scope, and there's a `CRAN-SUBMISSION` file in that checkout suggesting an in-flight release process I don't want to interfere with) -- flagging so a maintainer can bump it when convenient.
- The analytic covariance/Hessian (`covMethod="analytic"`) still has no prior term and downgrades to finite differences whenever a prior is present -- a real follow-up, not filed as its own issue yet.
- #932-#935 (imp, fbvi/emvi, npag/npb, vae) are unchanged in shape but should use the `general`/`nwpri`/`tnpri` terminology rather than the old gate names when they land.
