### PR TITLE
saem: apply the pow() exponent in the E-step, not just the M-step (#972)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,17 @@
 
 ## Bug fixes
 
+- `est="saem"` with a `pow()` residual error model (`rmPow`/`rmAddPow`/
+  `rmPowLam`/`rmAddPowLam`) never applied the estimated power exponent in the
+  E-step's MCMC-acceptance likelihood -- it always scored proposals as if the
+  exponent were 1, no matter what the M-step estimated (#972). The M-step's
+  own objective did use the exponent, so the two steps disagreed about what
+  model they were fitting: the power estimate collapsed toward 0 while the
+  proportional-SD estimate inflated to compensate. The per-observation
+  combined-error-SD builder now applies the current power exponent (refreshed
+  from the M-step every iteration, not just read once at setup), matching the
+  M-step's `combined1`/`combined2` formulas.
+
 - `est="saem"` scored a censored (M2/M3/M4) observation with the wrong sign,
   the wrong scale, and the untransformed DV, so a censored row's contribution
   to the chain's acceptance could drive the fit away from, rather than

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -768,8 +768,8 @@ saem_fit <- function(xSEXP) {
     .Call(`_nlmixr2est_saem_fit`, xSEXP)
 }
 
-saemFormGTest <- function(inA, inB, inFt, inAddProp) {
-    .Call(`_nlmixr2est_saemFormGTest`, inA, inB, inFt, inAddProp)
+saemFormGTest <- function(inA, inB, inFt, inC, inAddProp) {
+    .Call(`_nlmixr2est_saemFormGTest`, inA, inB, inFt, inC, inAddProp)
 }
 
 nlmixr2Parameters <- function(theta, eta) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1851,16 +1851,17 @@ BEGIN_RCPP
 END_RCPP
 }
 // saemFormGTest
-SEXP saemFormGTest(SEXP inA, SEXP inB, SEXP inFt, SEXP inAddProp);
-RcppExport SEXP _nlmixr2est_saemFormGTest(SEXP inASEXP, SEXP inBSEXP, SEXP inFtSEXP, SEXP inAddPropSEXP) {
+SEXP saemFormGTest(SEXP inA, SEXP inB, SEXP inFt, SEXP inC, SEXP inAddProp);
+RcppExport SEXP _nlmixr2est_saemFormGTest(SEXP inASEXP, SEXP inBSEXP, SEXP inFtSEXP, SEXP inCSEXP, SEXP inAddPropSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type inA(inASEXP);
     Rcpp::traits::input_parameter< SEXP >::type inB(inBSEXP);
     Rcpp::traits::input_parameter< SEXP >::type inFt(inFtSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type inC(inCSEXP);
     Rcpp::traits::input_parameter< SEXP >::type inAddProp(inAddPropSEXP);
-    rcpp_result_gen = Rcpp::wrap(saemFormGTest(inA, inB, inFt, inAddProp));
+    rcpp_result_gen = Rcpp::wrap(saemFormGTest(inA, inB, inFt, inC, inAddProp));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/init.c
+++ b/src/init.c
@@ -130,7 +130,7 @@ SEXP _nlmixr2est_nlmixr2Unscaled_(SEXP, SEXP);
 
 SEXP _nlmixr2est_saem_fit(SEXP);
 SEXP _nlmixr2est_saem_do_pred(SEXP, SEXP, SEXP);
-SEXP _nlmixr2est_saemFormGTest(SEXP, SEXP, SEXP, SEXP);
+SEXP _nlmixr2est_saemFormGTest(SEXP, SEXP, SEXP, SEXP, SEXP);
 
 SEXP _nlmixr2est_augPredTrans(SEXP, SEXP, SEXP, SEXP, SEXP,
                               SEXP);
@@ -349,7 +349,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_setSilentErr", (DL_FUNC) &_nlmixr2est_setSilentErr, 1},
   {"_nlmixr2est_saem_fit", (DL_FUNC) &_nlmixr2est_saem_fit, 1},
   {"_nlmixr2est_saem_do_pred", (DL_FUNC) &_nlmixr2est_saem_do_pred, 3},
-  {"_nlmixr2est_saemFormGTest", (DL_FUNC) &_nlmixr2est_saemFormGTest, 4},
+  {"_nlmixr2est_saemFormGTest", (DL_FUNC) &_nlmixr2est_saemFormGTest, 5},
   {"_nlmixr2est_powerD", (DL_FUNC) &_nlmixr2est_powerD, 5},
   {"_nlmixr2est_powerDLambda", (DL_FUNC) &_nlmixr2est_powerDLambda, 5},
   {"_nlmixr2est_powerDLambda2", (DL_FUNC) &_nlmixr2est_powerDLambda2, 5},

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -123,10 +123,15 @@ static inline void saemFormG(vec &g, const vec &a, const vec &b, const vec &ft, 
   const arma::uword n = ft.n_elem;
   for (arma::uword i = 0; i < n; ++i) {
     double fa = std::fabs(ft[i]);
+    // c[i]==1 is every non-pow() endpoint (the overwhelming common case) --
+    // skip pow() there so g is bit-identical to the pre-#972 formula instead
+    // of merely numerically equal (SAEM's MCMC acceptance is sensitive
+    // enough to a ULP-level g difference that it is not a no-op in practice).
+    double fac = (c[i] == 1.0) ? fa : std::pow(fa, c[i]);
     if (addPropVec[i] == 1) {
-      g[i] = a[i] + b[i]*std::pow(fa, c[i]);
+      g[i] = a[i] + b[i]*fac;
     } else {
-      g[i] = std::sqrt(a[i]*a[i] + b[i]*b[i]*std::pow(fa, 2.0*c[i]));
+      g[i] = std::sqrt(a[i]*a[i] + b[i]*b[i]*fac*fac);
     }
   }
 }

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -111,18 +111,22 @@ static inline double handleF(int powt, double &ft, double &f, bool trunc, bool a
 
 // Per-observation combined-error SD for the E-step/simulation, matching the
 // per-endpoint combined1/combined2 branch the M-step objective functions use
-// (obj()/objH()/objI(): combined1 g = a + b*|f|, combined2 g = sqrt(a^2+b^2*f^2)).
+// (objC()/objD(): combined1 g = a + b*|f|^c, combined2 g = sqrt(a^2+b^2*f^(2c))).
+// c (cres) defaults to 1 for every non-pow() residual model (rmAdd/rmProp/
+// rmAddProp and their lambda siblings), so this reduces to the pre-#972
+// formula there; only rmPow/rmAddPow/rmPowLam/rmAddPowLam actually estimate
+// c != 1 (#972).
 // Fills g in place (a scalar loop, no temporaries) so it can run inside the
 // pre-allocated per-chain E-step scratch buffers (_scratch_g) without
 // defeating their point.
-static inline void saemFormG(vec &g, const vec &a, const vec &b, const vec &ft, const uvec &addPropVec) {
+static inline void saemFormG(vec &g, const vec &a, const vec &b, const vec &ft, const vec &c, const uvec &addPropVec) {
   const arma::uword n = ft.n_elem;
   for (arma::uword i = 0; i < n; ++i) {
     double fa = std::fabs(ft[i]);
     if (addPropVec[i] == 1) {
-      g[i] = a[i] + b[i]*fa;
+      g[i] = a[i] + b[i]*std::pow(fa, c[i]);
     } else {
-      g[i] = std::sqrt(a[i]*a[i] + b[i]*b[i]*fa*fa);
+      g[i] = std::sqrt(a[i]*a[i] + b[i]*b[i]*std::pow(fa, 2.0*c[i]));
     }
   }
 }
@@ -2066,7 +2070,7 @@ public:
                 _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
                 _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fk(i), false, true);
               }
-              saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
+              saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, veccres, vecaddProp);
               _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
               _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -2273,7 +2277,7 @@ public:
                 _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
                 _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fk(i), false, true);
               }
-              saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
+              saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, veccres, vecaddProp);
               _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
               _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -2556,7 +2560,7 @@ public:
               _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
               _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fk(i), false, true);
             }
-            saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
+            saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, veccres, vecaddProp);
             _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
             _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
             _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -3587,6 +3591,7 @@ public:
       }
       vecares = ares(ix_endpnt);
       vecbres = bres(ix_endpnt);
+      veccres = cres(ix_endpnt);
       if (DEBUG>0) Rcout << "par update successful\n";
 
       //    Fisher information
@@ -4083,7 +4088,7 @@ private:
                 _scratch_ft(i) = _powerD(fsk(i), lambda(cur), yj(cur), low(cur), hi(cur));
                 _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fsk(i), false, true);
               }
-              saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
+              saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, veccres, vecaddProp);
               _scratch_g.elem(find(_scratch_g == 0.0)).fill(1);
               _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
               _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -4192,7 +4197,7 @@ private:
               _scratch_ft(i) = _powerD(fsk(i), lambda(cur), yj(cur), low(cur), hi(cur));
               _scratch_ftT(i) = handleF(propT(cur), fsk(i), _scratch_ft(i), false, true);
             }
-            saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
+            saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, veccres, vecaddProp);
             _scratch_g.elem(find(_scratch_g == 0.0)).fill(1);
             _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
             _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -4303,7 +4308,7 @@ private:
             _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
             _scratch_ftT(i) = handleF(propT(cur), fk(i), _scratch_ft(i), false, true);
           }
-          saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, vecaddProp);
+          saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, veccres, vecaddProp);
           _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);
           _scratch_g.elem(find(_scratch_g < double_xmin)).fill(double_xmin);
           _scratch_g.elem(find(_scratch_g > xmax)).fill(xmax);
@@ -4729,12 +4734,13 @@ SEXP saem_fit(SEXP xSEXP) {
 // (saemFormG(), used at every _scratch_g site) so it can be pinned against
 // the M-step's combined1/combined2 formulas without running a full fit.
 //[[Rcpp::export]]
-SEXP saemFormGTest(SEXP inA, SEXP inB, SEXP inFt, SEXP inAddProp) {
+SEXP saemFormGTest(SEXP inA, SEXP inB, SEXP inFt, SEXP inC, SEXP inAddProp) {
   vec a = as<vec>(inA);
   vec b = as<vec>(inB);
   vec ft = as<vec>(inFt);
+  vec c = as<vec>(inC);
   uvec addPropVec = as<uvec>(inAddProp);
   vec g(a.n_elem);
-  saemFormG(g, a, b, ft, addPropVec);
+  saemFormG(g, a, b, ft, c, addPropVec);
   return wrap(g);
 }

--- a/tests/testthat/test-saem-addprop-estep.R
+++ b/tests/testthat/test-saem-addprop-estep.R
@@ -8,22 +8,44 @@ nmTest({
     a <- c(0.7, 0.7, 0.7)
     b <- c(0.2, 0.2, 0.2)
     f <- c(2, -3, 0)
+    pw <- c(1, 1, 1)
 
-    # combined1: g = a + b*|f|
-    g1 <- as.vector(saemFormGTest(a, b, f, c(1L, 1L, 1L)))
+    # combined1: g = a + b*|f|^c
+    g1 <- as.vector(saemFormGTest(a, b, f, pw, c(1L, 1L, 1L)))
     expect_equal(g1, a + b * abs(f))
 
-    # combined2: g = sqrt(a^2 + b^2*f^2)
-    g2 <- as.vector(saemFormGTest(a, b, f, c(2L, 2L, 2L)))
+    # combined2: g = sqrt(a^2 + b^2*f^(2c))
+    g2 <- as.vector(saemFormGTest(a, b, f, pw, c(2L, 2L, 2L)))
     expect_equal(g2, sqrt(a^2 + b^2 * f^2))
 
     # a multi-endpoint fit mixes both per observation in one call
-    gm <- as.vector(saemFormGTest(a, b, f, c(1L, 2L, 1L)))
+    gm <- as.vector(saemFormGTest(a, b, f, pw, c(1L, 2L, 1L)))
     expect_equal(gm, c(g1[1], g2[2], g1[3]))
 
     # the two formulas must actually disagree when both terms are present,
     # otherwise this test would still pass under the old hardcoded combined1
     expect_false(isTRUE(all.equal(g1, g2)))
+  })
+
+  test_that("saem E-step combined-error SD honors the pow() exponent (#972)", {
+    # #972: veccres was populated once at construction and never applied in
+    # saemFormG()/re-read after the M-step updates cres -- the E-step always
+    # behaved as if the power exponent were 1, no matter what pow() estimated.
+    a <- c(0, 0, 0)
+    b <- c(0.2, 0.2, 0.2)
+    f <- c(2, 3, 4)
+    pw <- c(0.5, 0.5, 0.5)
+
+    # combined1 (pure pow(), a=0): g = b*|f|^c, must differ from the c=1 case
+    gPow <- as.vector(saemFormGTest(a, b, f, pw, c(1L, 1L, 1L)))
+    expect_equal(gPow, b * abs(f)^pw)
+    gLinear <- as.vector(saemFormGTest(a, b, f, c(1, 1, 1), c(1L, 1L, 1L)))
+    expect_false(isTRUE(all.equal(gPow, gLinear)))
+
+    # combined2: g = sqrt(a^2 + b^2*|f|^(2c))
+    a2 <- c(0.5, 0.5, 0.5)
+    gPow2 <- as.vector(saemFormGTest(a2, b, f, pw, c(2L, 2L, 2L)))
+    expect_equal(gPow2, sqrt(a2^2 + b^2 * abs(f)^(2 * pw)))
   })
 
   test_that("saem E-step actually runs with addProp plumbed through (#912)", {

--- a/tests/testthat/test-saem-resid-lambda.R
+++ b/tests/testthat/test-saem-resid-lambda.R
@@ -121,4 +121,13 @@ nmTest({
     expect_lt(fit$parFixedDf["prop.sd", "Estimate"], 0.5)
   })
 
+  # #972 (E-step ignored the pow() exponent when estimated): the "rmPow
+  # recovers truth" test above fixes pw at 1, which happens to match the old
+  # bug's hardcoded assumption, so it can't catch this. An estimated-pw
+  # end-to-end fit does reproduce the pre-fix collapse, but that reproducer is
+  # too numerically marginal for a stable CI assertion (its outcome varies
+  # with OpenMP thread count, unrelated to this fix). See
+  # test-saem-addprop-estep.R's saemFormGTest() tests for the deterministic
+  # regression coverage instead.
+
 })


### PR DESCRIPTION
## Summary

- Fixes #972: `est="saem"`'s E-step (drives eta/theta MCMC acceptance) never applied the `pow()` residual-error exponent (`cres`) -- it built the combined-error SD the same way as a plain `prop()` model, regardless of what the M-step estimated for the power.  `veccres` was also populated once at construction and never refreshed after the M-step updated `cres` each iteration.
- `saemFormG()` (the single helper every `_scratch_g` E-step/simulation call site uses) now takes `cres` and applies `pow(fa, c)` (combined1) / `fac*fac` where `fac=pow(fa,c)` (combined2), matching the M-step's `objC()`/`objD()` formulas; `veccres` is refreshed from `cres(ix_endpnt)` alongside `vecares`/`vecbres` after every M-step.
- `cres` defaults to 1 for every non-`pow()` residual model, so this is a no-op there; only `rmPow`/`rmAddPow`/`rmPowLam`/`rmAddPowLam` with an ESTIMATED power are affected. `c[i]==1.0` is special-cased to skip `pow()` entirely so non-`pow()` endpoints stay bit-identical to the pre-fix formula (SAEM's MCMC acceptance is sensitive enough to a ULP-level `g` difference that this matters in practice -- see review notes below).

## Test plan
- [x] Regenerated `src/RcppExports.cpp`/`R/RcppExports.R` via `Rcpp::compileAttributes(".")` and hand-updated `src/init.c`'s `saemFormGTest` prototype/arg count (4 -> 5) per this repo's manual `.Call` registration convention.
- [x] Extended `saemFormGTest()`'s deterministic unit tests (`test-saem-addprop-estep.R`) with a dedicated `#972` case pinning `g = b*|f|^c` / `g = sqrt(a^2+b^2*|f|^(2c))` against hand-computed values.
- [x] Verified the fix is load-bearing by reverting just the `saemFormG()` math (keeping the plumbing) and confirming the new unit test fails without it, then restoring and confirming it passes.
- [x] Investigated an end-to-end fit using the issue's own reproducer (estimated `pw`); it does reproduce the pre-fix collapse, but turned out to be numerically marginal enough that results vary with OpenMP thread count in effect (a separate, pre-existing, unrelated nondeterminism -- not chased here), so it wasn't kept as a CI assertion. The deterministic C++-level unit test is the regression coverage instead.
- [x] `test-saem-addprop-estep.R` (12 tests) and `test-saem-resid-lambda.R` (11 tests) pass.
- [x] Ran the broader essential (non-slow-batch) SAEM test files; no regressions introduced by this change (one pre-existing failure in `test-saem-cov-sa.R` reproduces identically on unmodified `main`, unrelated to this change).

## Independent review
Ran an Antigravity (Gemini) review over the diff, in two rounds. First round flagged one real, if minuscule, issue in this diff that's now fixed: `std::pow(fa,1.0)`/`std::pow(fa,2.0)` are not guaranteed bit-identical to `fa`/`fa*fa` on every platform, and SAEM's MCMC acceptance can be sensitive enough to a ULP-level `g` difference for that to matter -- addressed by special-casing `cres==1.0` to skip `pow()` entirely. It also surfaced a pre-existing, unrelated latent issue outside this diff's scope (predates this change by 6+ weeks per `git blame`, and this diff does not touch the affected lines): `handleF()`'s `ft`/`f` arguments are swapped in two MSAEM-only helpers, inverting `propT()`/`powT()` semantics for mixture-SAEM fits -- filed separately as #982. Second review round confirmed no further issues in this diff.