### PR TITLE
nlm-family: fix M2/M3/M4 censoring (rx_r_ hardcoded to 0) (#976)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,18 @@
 
 ## Bug fixes
 
+- Every NLM-family method (`nlm`, `bobyqa`, `newuoa`, `uobyqa`, `n1qn1`,
+  `lbfgsb3c`, `optim`, `nlminb`) silently mis-scored any M2/M3/M4-censored
+  normal endpoint, whether or not `ar()` was present (#976). NLM forces every
+  normal endpoint through a log-likelihood (`dnorm`) path so a single scalar
+  objective can be emitted; that path always set `rx_r_ ~ 0` (a full
+  log-density has no separate variance to report), but the censoring
+  correction reads `rx_r_` as a real variance, so a hardcoded zero corrupted
+  the correction for every censored observation. `rx_rll_` (the standard
+  deviation actually used to build the log-density) is emitted immediately
+  beforehand in the same branch, so it is now squared back into `rx_r_`
+  instead of being discarded.
+
 - `est="saem"` scored a censored (M2/M3/M4) observation with the wrong sign,
   the wrong scale, and the untransformed DV, so a censored row's contribution
   to the chain's acceptance could drive the fit away from, rather than

--- a/R/nlm.R
+++ b/R/nlm.R
@@ -404,6 +404,47 @@ getValidNlmixrCtl.nlm <- function(control) {
   })
 }
 
+#' Restore a real `rx_r_` variance for nlm's llik-forced normal endpoints
+#'
+#' `est="nlm"` forces every `norm` endpoint through the log-likelihood
+#' (`dnorm`) path so a single scalar objective can be emitted
+#' (`rxUiGet.nlmModel0`).  That path always sets `rx_r_ ~ 0` (a full
+#' log-density has no separate variance to report), but `src/nlm.cpp`'s
+#' M2/M3/M4 censoring correction (`doCensNormal1()`) reads `rx_r_` as a real
+#' variance -- a hardcoded 0 corrupts every censored normal endpoint,
+#' independent of `ar()` (#976).  `rx_rll_` (the standard deviation actually
+#' fed into `llikNorm()`/`llikT()`/`llikCauchy()`) is emitted immediately
+#' before `rx_r_` in the same branch, so square it back into `rx_r_` instead
+#' of leaving the hardcoded 0.
+#'
+#' @param lines A single endpoint's list of quoted model lines, as returned
+#'   by `rxGetDistributionFoceiLines()` for one `predDf` row.
+#' @return The same list, with `rx_r_ ~ 0` replaced by `rx_r_ ~ rx_rll_^2`
+#'   when `rx_rll_` was emitted; otherwise unchanged.
+#' @author Matthew L. Fidler
+#' @noRd
+.nlmFixCensRLine <- function(lines) {
+  if (!is.list(lines)) return(lines)
+  .rll <- NULL
+  for (.l in lines) {
+    if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
+        identical(.l[[2]], quote(rx_rll_))) {
+      .rll <- .l[[3]]
+      break
+    }
+  }
+  if (is.null(.rll)) return(lines)
+  lapply(lines, function(.l) {
+    if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
+        identical(.l[[2]], quote(rx_r_)) &&
+        identical(.l[[3]], 0)) {
+      bquote(rx_r_ ~ .(.rll)^2)
+    } else {
+      .l
+    }
+  })
+}
+
 #'@export
 rxUiGet.nlmModel0 <- function(x, ...) {
   .ui <- rxode2::rxUiDecompress(x[[1]])
@@ -415,7 +456,8 @@ rxUiGet.nlmModel0 <- function(x, ...) {
   assign(".predDfFocei", .predDf, envir=.ui)
   #assign("predDf", .predDf, envir=.ui)
   on.exit(assign("predDf", .save, envir=.ui))
-  .ret <- rxode2::rxCombineErrorLines(.ui, errLines=rxGetDistributionFoceiLines(.ui),
+  .errLines <- lapply(rxGetDistributionFoceiLines(.ui), .nlmFixCensRLine)
+  .ret <- rxode2::rxCombineErrorLines(.ui, errLines=.errLines,
                               prefixLines=.uiGetThetaDropFixed(.ui),
                               paramsLine=NA, #.uiGetThetaEtaParams(.f),
                               modelVars=TRUE,

--- a/tests/testthat/test-nlm-cens.R
+++ b/tests/testthat/test-nlm-cens.R
@@ -206,4 +206,33 @@ nmTest({
     })
   }
 
+  test_that("nlm-family M3-censored parameter estimates match focei (#976)", {
+    # #976: nlm-family forces every normal endpoint through the log-likelihood
+    # path, which always emitted `rx_r_ ~ 0`; the M2/M3/M4 censoring
+    # correction (doCensNormal1()) then divided by a zero variance, silently
+    # corrupting every censored fit (no ar() needed).  The checks above only
+    # ever assert that a fit "runs" and reports the right censoring text, so
+    # a corrupted objective/parameter set passed them undetected.  Derivative-
+    # free (bobyqa/newuoa/uobyqa) and FD-gradient (nlminb) nlm-family members
+    # should now recover parameters close to focei's on the same censored
+    # data.  The analytic-gradient members (nlm/n1qn1/lbfgsb3c/optim) have a
+    # separate, pre-existing convergence stall on this bounded-tcl model that
+    # reproduces even without censoring -- out of scope here, so they are not
+    # checked for parameter accuracy.
+    f.focei <- .nlmixr(one.cmt, .datM3, est = "focei", control = foceiControl(print = 0))
+    for (meth in c("bobyqa", "newuoa", "uobyqa", "nlminb")) {
+      fit <- .nlmixr(one.cmt, .datM3, est = meth, control = nlmControl(print = 0))
+      expect_equal(as.numeric(fit$theta[["tka"]]), as.numeric(f.focei$theta[["tka"]]),
+                   tolerance = 0.1, info = meth)
+      expect_equal(as.numeric(fit$theta[["tcl"]]), as.numeric(f.focei$theta[["tcl"]]),
+                   tolerance = 0.1, info = meth)
+      expect_equal(as.numeric(fit$theta[["tv"]]), as.numeric(f.focei$theta[["tv"]]),
+                   tolerance = 0.1, info = meth)
+      # add.sd is the parameter the r=0 bug corrupted most (it inflated it
+      # ~9x in the reproduction that motivated #976); give it a bit more room
+      expect_equal(as.numeric(fit$theta[["add.sd"]]), as.numeric(f.focei$theta[["add.sd"]]),
+                   tolerance = 0.2, info = meth)
+    }
+  })
+
 })


### PR DESCRIPTION
## Summary

`est="nlm"` (and every nlm-family sub-method: `bobyqa`, `newuoa`, `uobyqa`,
`n1qn1`, `lbfgsb3c`, `optim`, `nlminb`) forces every `norm` endpoint through
a log-likelihood (`dnorm`) path so a single scalar objective can be emitted
(`rxUiGet.nlmModel0`). That path always emitted `rx_r_ ~ 0` (a full
log-density has no separate variance to report), but `src/nlm.cpp`'s
M2/M3/M4 censoring correction (`doCensNormal1()`) reads `rx_r_` as a real
variance -- the hardcoded 0 silently corrupted every censored normal
endpoint, independent of `ar()` (bobyqa/nlminb landed at the wrong
objective *scale* entirely on a censored reproduction, ~7200 vs FOCEI's
~190 on identical data).

- `rx_rll_` (the sd actually fed into `llikNorm()`/`llikT()`/`llikCauchy()`)
  is emitted right before `rx_r_ ~ 0` in the same branch, so a new
  `.nlmFixCensRLine()` helper in `R/nlm.R` squares it back into `rx_r_`
  instead of discarding it. Applied to every endpoint's lines before
  `rxCombineErrorLines` -- the single shared source both the
  objective-only and gradient/sensitivity nlm-family models are derived
  from, so one fix point reaches every nlm-family method. No rxode2 or C++
  changes needed.
- Added a regression test that pins parameter-closeness-to-focei for the
  derivative-free/FD-gradient members (`bobyqa`/`newuoa`/`uobyqa`/`nlminb`)
  under M3 censoring -- the existing tests only ever checked that a fit
  "runs" and reports the right censoring text, never that the estimates
  were anywhere close to correct.

Not in scope for this PR (documented, tracked separately):
- The analytic-gradient members (`nlm` itself, `n1qn1`, `lbfgsb3c`,
  `optim`) have a separate, pre-existing convergence stall on the
  bounded-tcl reproduction model, present identically with or without
  censoring and unchanged by this diff.
- `t()`/`cauchy()` endpoints never get M2/M3/M4 censoring correction
  anywhere in the codebase (nlm.cpp's and inner.cpp's C++ guards only
  handle normal/dnorm) -- pre-existing, confirmed bit-for-bit unchanged by
  this diff, found via an independent Antigravity review and filed as #979.

Closes #976.

## Test plan

- [x] `tests/testthat/test-nlm-cens.R` (116 assertions, 0 failures) --
      includes the new parameter-accuracy regression test
- [x] Reproduced the issue's exact scenario pre-fix (objf ~7200/7422 for
      bobyqa/nlminb vs FOCEI's ~190) and confirmed post-fix all land within
      ~3 decimal places of FOCEI on tka/tcl/tv/add.sd
- [x] Confirmed the no-censoring case is bit-for-bit unaffected
- [x] Independent Antigravity (Gemini 3.1 Pro) review, two rounds: first
      confirmed the fix's matching/reconstruction/multi-endpoint-scoping
      logic is correct and surfaced the pre-existing t()/cauchy() gap
      (filed as #979); second round, given that context, found nothing
      further