### PR TITLE
npag/npb: exclude censored (M3/M4) rows from the residual moment (#978)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -139,10 +139,16 @@
   endpoint, no regressor theta -- that biased moment is installed as the
   final residual-error estimate with no further optimizer correction, so a
   censored row could badly distort it (an extreme recorded LOQ was measured
-  to inflate `est="npag"`'s proportional SD ~200x, and collapse
-  `est="npb"`'s to exactly 0). A censored row's DV is now excluded from the
-  moment entirely, matching how the function already excludes an endpoint
-  with no defined prediction to take a moment of.
+  to inflate `est="npag"`'s proportional SD from 0.03 to 14.7, and
+  `est="npb"`'s from 0.03 to 8.1). A censored row's DV is now excluded from
+  the moment entirely, matching how the function already excludes an
+  endpoint with no defined prediction to take a moment of. Excluding the row
+  still leaves the moment a biased-low estimate of the true residual
+  variance whenever the data really is censored (the variance of a
+  truncated normal is always less than the untruncated one), so an endpoint
+  that had any row excluded this way no longer takes the direct-install
+  fast path either -- it is refined against the already censoring-aware ELS
+  objective instead, the same way a regressor theta already was.
 
 - `foceiControl(fast=TRUE)` could converge to a different fit than `fast=FALSE`
   when a transform-both-sides (`lnorm`/`boxCox`) endpoint's untransformed

--- a/NEWS.md
+++ b/NEWS.md
@@ -132,6 +132,18 @@
   the truncation bounds are a few SDs from the mean, the regime a BQL row's
   bound often sits in.
 
+- `est="npag"`/`est="npb"`'s residual-error moment (`npResidMoments()`) counted
+  a censored (M3/M4) observation's recorded LOQ/limit as if it had been
+  measured, the same bug shape as #916 but in the nonparametric methods
+  (#978). For the common configuration -- one `add()`/`prop()` scale per
+  endpoint, no regressor theta -- that biased moment is installed as the
+  final residual-error estimate with no further optimizer correction, so a
+  censored row could badly distort it (an extreme recorded LOQ was measured
+  to inflate `est="npag"`'s proportional SD ~200x, and collapse
+  `est="npb"`'s to exactly 0). A censored row's DV is now excluded from the
+  moment entirely, matching how the function already excludes an endpoint
+  with no defined prediction to take a moment of.
+
 - `foceiControl(fast=TRUE)` could converge to a different fit than `fast=FALSE`
   when a transform-both-sides (`lnorm`/`boxCox`) endpoint's untransformed
   prediction was non-positive at some observation -- for example a depot model's

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -16400,13 +16400,19 @@ static inline void npAccumMoment(arma::mat &mom, int e, double f, double dv) {
 // the LOQ/limit rather than a real measurement (censEst.h's isM3orM4(cens); M2 is NOT
 // excluded -- isM2 requires cens==0, so its DV is still a defined observation), so it
 // is dropped from the moment entirely (like the whole-endpoint skipMoments guard
-// below) rather than folded in as if observed -- issue #978. Returns an nEnd x 3
-// matrix [sumAdd, sumProp, n].
+// below) rather than folded in as if observed -- issue #978. A moment built only from
+// the UNcensored rows is still a biased (too small) estimate of the true residual
+// variance whenever the model is genuinely censored -- dropping a row does not put its
+// information back, it just stops it from being wrong in the worst way. Column 3
+// counts how many rows were dropped this way per endpoint, so the caller can refuse to
+// treat the moment as final (see npOptimizeResid's allSimpleScale gate) and route
+// through the optimizer's censoring-aware objective instead whenever that count is
+// nonzero. Returns an nEnd x 4 matrix [sumAdd, sumProp, n, nCensDropped].
 arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint, int nEnd) {
   rx = getRxSolve_();
   int nsub = (int)getRxNsub(rx);
   int neta = op_focei.neta;
-  arma::mat mom(std::max(nEnd, 1), 3, arma::fill::zeros);
+  arma::mat mom(std::max(nEnd, 1), 4, arma::fill::zeros);
   std::vector<double> eta(neta);
   int obsIdx = 0;
   for (int i = 0; i < nsub; ++i) {
@@ -16451,7 +16457,7 @@ arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint
       // proportional sum-of-squares as if observed (issue #978).  M2 (cens == 0,
       // finite limit) keeps its real observed dv and is NOT excluded here.
       double cens = hasRxCens(rx) ? getIndCens(ind, kk) : 0.0;
-      if (cens != 0.0) continue;
+      if (cens != 0.0) { mom(e, 3) += 1.0; continue; }
       npAccumMoment(mom, e, f, dv);
     }
   }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -16396,8 +16396,12 @@ static inline void npAccumMoment(arma::mat &mom, int e, double f, double dv) {
 // sum(err^2) and the proportional moment sum((err/f)^2) with the observation count, so
 // the caller can set an additive SD to sqrt(mean(err^2)) and a proportional SD to
 // sqrt(mean((err/f)^2)) -- the saem-style estimate, used to warm start (and, for a
-// single scale per endpoint, to set) the residual optimization.  Returns an
-// nEnd x 3 matrix [sumAdd, sumProp, n].
+// single scale per endpoint, to set) the residual optimization.  An M3/M4 row's DV is
+// the LOQ/limit rather than a real measurement (censEst.h's isM3orM4(cens); M2 is NOT
+// excluded -- isM2 requires cens==0, so its DV is still a defined observation), so it
+// is dropped from the moment entirely (like the whole-endpoint skipMoments guard
+// below) rather than folded in as if observed -- issue #978. Returns an nEnd x 3
+// matrix [sumAdd, sumProp, n].
 arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint, int nEnd) {
   rx = getRxSolve_();
   int nsub = (int)getRxNsub(rx);
@@ -16442,6 +16446,12 @@ arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint
       ko++;
       if (e < 0 || e >= nEnd) continue;
       if (!std::isfinite(cl) || !std::isfinite(f)) continue;
+      // M3/M4 (cens != 0; see isM3orM4() in censEst.h): dv above is the LOQ/limit,
+      // not a real measurement, so it must not be folded into the additive/
+      // proportional sum-of-squares as if observed (issue #978).  M2 (cens == 0,
+      // finite limit) keeps its real observed dv and is NOT excluded here.
+      double cens = hasRxCens(rx) ? getIndCens(ind, kk) : 0.0;
+      if (cens != 0.0) continue;
       npAccumMoment(mom, e, f, dv);
     }
   }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -16389,6 +16389,42 @@ static inline void npAccumMoment(arma::mat &mom, int e, double f, double dv) {
   mom(e, 2) += 1.0;
 }
 
+// Fold one subject's observation rows into mom, on the way accumulating the
+// additive/proportional moment for whichever endpoint each row belongs to.
+// obsIdx indexes obsEndpoint across ALL subjects, so it must advance even on a
+// skipped subject (skipMoments true) or every later subject's rows land in the
+// wrong endpoint. See npResidMoments for what skipMoments/cl/fr/nEnd mean and
+// why an M3/M4 (censored) row is counted into column 3 rather than folded into
+// the additive/proportional sum-of-squares (issue #978).
+static inline void npResidMomentsSubject(rx_solving_options_ind *ind, int n,
+                                          const arma::mat &fr, bool skipMoments,
+                                          double cl, const arma::ivec &obsEndpoint,
+                                          int nEnd, int &obsIdx, arma::mat &mom) {
+  int ko = 0;
+  for (int j = 0; j < n && (skipMoments || ko < (int)fr.n_rows); ++j) {
+    setIndIdx(ind, j);
+    int kk = getIndIx(ind, j);
+    if (getIndEvid(ind, kk) != 0) continue;
+    // No map at all means no per-observation endpoint was supplied; running off the
+    // end of one means the map does not describe this solve.  Either way the row is
+    // dropped (-1) rather than filed under endpoint 0 (issue #856).  It is NOT safe
+    // to read nEnd == 1 as "single endpoint, so 0 is right": nEnd comes from the
+    // ESTIMATED residual parameters, and a multi-endpoint model with one estimated
+    // scale (the rest fixed) also gives 1.
+    int e = (obsIdx < (int)obsEndpoint.n_elem) ? obsEndpoint[obsIdx] : -1;
+    obsIdx++;
+    if (skipMoments) continue;
+    double dv = tbs(getIndDv(ind, kk));
+    double f = fr(ko, 0);
+    ko++;
+    if (e < 0 || e >= nEnd) continue;
+    if (!std::isfinite(cl) || !std::isfinite(f)) continue;
+    double cens = hasRxCens(rx) ? getIndCens(ind, kk) : 0.0;
+    if (cens != 0.0) { mom(e, 3) += 1.0; continue; }
+    npAccumMoment(mom, e, f, dv);
+  }
+}
+
 // Empirical (moment) residual estimate at fixed per-subject etas, per endpoint.
 // obsEndpoint (length = number of observations, in the C++ subject-major getIndIx
 // order) gives each observation's 0-based endpoint; nEnd is the endpoint count.  For
@@ -16430,36 +16466,8 @@ arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint
     rx_solving_options_ind *ind = getSolvingOptionsInd(rx, getRxId(i));
     arma::mat fr;
     if (!skipMoments) fr = grabRFmatFromInner(i, false);
-    int ko = 0;
     int n = getIndNallTimes(ind);
-    for (int j = 0; j < n && (skipMoments || ko < (int)fr.n_rows); ++j) {
-      setIndIdx(ind, j);
-      int kk = getIndIx(ind, j);
-      if (getIndEvid(ind, kk) != 0) continue;
-      // obsIdx indexes obsEndpoint across ALL subjects, so it must advance even on a
-      // skipped subject or every later subject's rows land in the wrong endpoint.
-      // No map at all means no per-observation endpoint was supplied; running off the
-      // end of one means the map does not describe this solve.  Either way the row is
-      // dropped (-1) rather than filed under endpoint 0 (issue #856).  It is NOT safe
-      // to read nEnd == 1 as "single endpoint, so 0 is right": nEnd comes from the
-      // ESTIMATED residual parameters, and a multi-endpoint model with one estimated
-      // scale (the rest fixed) also gives 1.
-      int e = (obsIdx < (int)obsEndpoint.n_elem) ? obsEndpoint[obsIdx] : -1;
-      obsIdx++;
-      if (skipMoments) continue;
-      double dv = tbs(getIndDv(ind, kk));
-      double f = fr(ko, 0);
-      ko++;
-      if (e < 0 || e >= nEnd) continue;
-      if (!std::isfinite(cl) || !std::isfinite(f)) continue;
-      // M3/M4 (cens != 0; see isM3orM4() in censEst.h): dv above is the LOQ/limit,
-      // not a real measurement, so it must not be folded into the additive/
-      // proportional sum-of-squares as if observed (issue #978).  M2 (cens == 0,
-      // finite limit) keeps its real observed dv and is NOT excluded here.
-      double cens = hasRxCens(rx) ? getIndCens(ind, kk) : 0.0;
-      if (cens != 0.0) { mom(e, 3) += 1.0; continue; }
-      npAccumMoment(mom, e, f, dv);
-    }
+    npResidMomentsSubject(ind, n, fr, skipMoments, cl, obsEndpoint, nEnd, obsIdx, mom);
   }
   return mom;
 }

--- a/src/np.h
+++ b/src/np.h
@@ -30,9 +30,10 @@ void npResidFreezeClear();
 
 // Per-endpoint moment residual sums at fixed per-subject etas: for each 0-based
 // endpoint (obsEndpoint gives the endpoint of each observation in subject-major
-// getIndIx order), the additive sum(err^2), the proportional sum((err/f)^2), and the
-// observation count (nEnd x 3).  The saem-style estimate for warm-starting the
-// residual optimization.
+// getIndIx order), the additive sum(err^2), the proportional sum((err/f)^2), the
+// observation count, and the number of censored (M3/M4) rows dropped from the
+// moment (nEnd x 4).  The saem-style estimate for warm-starting the residual
+// optimization.
 arma::mat npResidMoments(const arma::mat& postEta, const arma::ivec& obsEndpoint, int nEnd);
 
 // 0-based endpoint of one observation's cmt within endpointCmt (per-endpoint cmt

--- a/src/npag.cpp
+++ b/src/npag.cpp
@@ -104,7 +104,17 @@ namespace {
 // extended-least-squares objective.  Warm-starts every variance-scale theta from the
 // saem-style per-endpoint moment (additive: sqrt(mean err^2); proportional:
 // sqrt(mean (err/f)^2)); when the optimized set is exactly one such scale per
-// endpoint, the moment IS the ELS optimum, so it is used directly (no bobyqa).
+// endpoint, the moment IS the ELS optimum, so it is used directly (no bobyqa) --
+// EXCEPT when the endpoint actually had a censored (M3/M4) row dropped from its
+// moment (npResidMoments()'s 4th column, issue #978): the variance of a truncated
+// normal is always less than the untruncated one (a standard result -- see e.g. the
+// inverse Mills ratio identity), so a moment built only from the surviving
+// (uncensored) rows is a biased-low estimate of the true residual variance whenever
+// the model is genuinely censored.  That case is now treated the same as a
+// regressor -- disqualified from the fast path and refined against npResidELS,
+// which correctly routes a censored row through doCensNormal1 instead of dropping
+// it.  The (now merely biased, not catastrophic) moment is still used as bobyqa's
+// starting point.
 // optEnd[j]/optProp[j] describe idx[j]: optEnd 0-based endpoint (or -1 if not a
 // variance scale), optProp 1 for proportional else 0.  obsEndpoint gives each
 // observation's endpoint (subject-major getIndIx order) for the moment estimate.
@@ -143,6 +153,9 @@ double npOptimizeResid(const arma::mat& support, const arma::vec& weights,
       if (e < 0 || kind[j] != 1 || endCount[e] > 1) { allSimpleScale = false; continue; }
       double nn = mom(e, 2);
       if (nn <= 0.0) { allSimpleScale = false; continue; }
+      // a censored row was dropped from this endpoint's moment -- it is a biased
+      // warm start now, not the ELS optimum, so route through the optimizer (#978)
+      if (mom(e, 3) > 0.0) allSimpleScale = false;
       double v = std::sqrt(mom(e, (optProp[j] == 1) ? 1 : 0) / nn);
       if (j < (int)lower.size() && std::isfinite(lower[j])) v = std::max(v, lower[j]);
       if (j < (int)upper.size() && std::isfinite(upper[j])) v = std::min(v, upper[j]);

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -112,7 +112,7 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   # in the push/PR subset) and run weekly only.
   c("npag-psi", "npag-cycle", "npag-fit", "npb-fit", "npag-bimodal", "npag-fixed",
     "npag-error-models", "npag-mixture", "npag-general-lik", "npag-muexpand",
-    "npag-golden", "lik-contrib-methods")
+    "npag-golden", "lik-contrib-methods", "npag-npb-cens-978")
 )
 .slowAll <- unlist(.slowBatches)
 

--- a/tests/testthat/test-npag-npb-cens-978.R
+++ b/tests/testthat/test-npag-npb-cens-978.R
@@ -4,7 +4,10 @@
 ## allSimpleScale configuration (one add()/prop() SD per endpoint, no regressor
 ## theta), npOptimizeResid() installs that moment DIRECTLY with no further
 ## optimizer correction, so the biased value was the final residual-error
-## estimate, not just a warm start.
+## estimate, not just a warm start. The model below deliberately uses proper
+## mu-referencing (ke <- exp(tvK + bsvK), not tvK * exp(bsvK)) -- npag treats a
+## non-mu-referenced theta as a regressor, which disqualifies allSimpleScale on
+## its own and would let this test pass even with the bug still present.
 ##
 ## The regression check below is framework-independent: it does not compare
 ## against focei/saem's residual SD (npag/npb's ELS-at-fixed-eta moment is a
@@ -15,17 +18,19 @@
 ## is deliberately absurd (50, far outside the model's range). If those rows
 ## are correctly excluded from the moment, the residual estimate barely moves;
 ## if their absurd recorded DV leaks into the moment (the bug), the residual
-## estimate is grossly distorted. Real fit -> weekly slow batch.
+## estimate is grossly distorted. A parallel check with M2 (not M3/M4) rows
+## confirms those are correctly NOT excluded -- an inverted cens check would
+## fail that one instead. Real fit -> weekly slow batch.
 
 nmTest({
   .cens978Mod <- function() {
     ini({
-      tvK <- 0.5
+      tvK <- log(0.5)
       bsvK ~ 0.04
       prop.sd <- sqrt(0.1)
     })
     model({
-      ke <- tvK * exp(bsvK)
+      ke <- exp(tvK + bsvK)
       v <- 1
       ipre <- 10 * exp(-ke * t)
       ipre ~ prop(prop.sd)
@@ -42,6 +47,15 @@ nmTest({
   .cens978DatCensored <- .cens978DatCensored[order(.cens978DatCensored$ID,
                                                    .cens978DatCensored$Time), ]
 
+  # M2: cens == 0 with a finite `limit` -- a real, defined observation that must
+  # NOT be excluded from the moment (censEst.h's isM2()).  An absurd DV (50)
+  # marked M2 instead of M3/M4 should distort the moment just like an ordinary
+  # uncensored outlier would -- i.e. the OPPOSITE of the M3/M4 check above.
+  .cens978DatM2 <- rbind(.cens978Dat,
+                         data.frame(ID = 1:10, Time = 1.5, DV = 50, cens = 0))
+  .cens978DatM2$limit <- 0
+  .cens978DatM2 <- .cens978DatM2[order(.cens978DatM2$ID, .cens978DatM2$Time), ]
+
   test_that("est='npag' residual moment excludes M3/M4 rows from the moment (#978)", {
     .ctl <- npagControl(points = 128L, cycles = 20L, gammaOptimize = FALSE,
                         calcTables = FALSE, seed = 1L)
@@ -54,10 +68,20 @@ nmTest({
     expect_match(as.character(f.cens$censInformation), "^M3 censoring")
     # An absurd recorded DV (50) leaking into the moment as if observed would
     # blow the proportional SD up by orders of magnitude (measured pre-fix:
-    # 0.027 -> 5.34); properly excluded, it barely moves the estimate.
+    # 0.030 -> 5.34); properly excluded, it barely moves the estimate.
     expect_equal(as.numeric(f.cens$theta[["prop.sd"]]),
                  as.numeric(f.base$theta[["prop.sd"]]),
                  tolerance = 0.05)
+
+    f.m2 <- suppressMessages(suppressWarnings(
+      nlmixr2(.cens978Mod, .cens978DatM2, est = "npag", control = .ctl)
+    ))
+    expect_match(as.character(f.m2$censInformation), "^M2 censoring")
+    # M2 keeps its real (here: absurd) DV, so this should NOT stay close to
+    # baseline -- confirms cens==0 rows are not being wrongly excluded too.
+    expect_false(isTRUE(all.equal(as.numeric(f.m2$theta[["prop.sd"]]),
+                                  as.numeric(f.base$theta[["prop.sd"]]),
+                                  tolerance = 0.05)))
   })
 
   test_that("est='npb' residual moment excludes M3/M4 rows from the moment (#978)", {

--- a/tests/testthat/test-npag-npb-cens-978.R
+++ b/tests/testthat/test-npag-npb-cens-978.R
@@ -1,0 +1,79 @@
+## #978: npag/npb's residual-error moment (npResidMoments(), inner.cpp) folded an
+## M3/M4 censored row's recorded LOQ/limit into the additive/proportional
+## sum-of-squares as if it had been a real measurement.  For the common
+## allSimpleScale configuration (one add()/prop() SD per endpoint, no regressor
+## theta), npOptimizeResid() installs that moment DIRECTLY with no further
+## optimizer correction, so the biased value was the final residual-error
+## estimate, not just a warm start.
+##
+## The regression check below is framework-independent: it does not compare
+## against focei/saem's residual SD (npag/npb's ELS-at-fixed-eta moment is a
+## different object from focei/saem's marginal-likelihood residual by design --
+## see npag.cpp's "final support refinement" comment -- so those are not a valid
+## ground truth here).  Instead it compares a fit WITHOUT any censored rows
+## against the same fit with EXTRA M3-censored rows appended whose recorded DV
+## is deliberately absurd (50, far outside the model's range). If those rows
+## are correctly excluded from the moment, the residual estimate barely moves;
+## if their absurd recorded DV leaks into the moment (the bug), the residual
+## estimate is grossly distorted. Real fit -> weekly slow batch.
+
+nmTest({
+  .cens978Mod <- function() {
+    ini({
+      tvK <- 0.5
+      bsvK ~ 0.04
+      prop.sd <- sqrt(0.1)
+    })
+    model({
+      ke <- tvK * exp(bsvK)
+      v <- 1
+      ipre <- 10 * exp(-ke * t)
+      ipre ~ prop(prop.sd)
+    })
+  }
+
+  .cens978Dat <- nlmixr2data::Wang2007
+  .cens978Dat$DV <- .cens978Dat$Y
+  .cens978Dat <- .cens978Dat[, names(.cens978Dat) != "Y"]
+  .cens978Dat$cens <- 0
+
+  .cens978DatCensored <- rbind(.cens978Dat,
+                               data.frame(ID = 1:10, Time = 1.5, DV = 50, cens = 1))
+  .cens978DatCensored <- .cens978DatCensored[order(.cens978DatCensored$ID,
+                                                   .cens978DatCensored$Time), ]
+
+  test_that("est='npag' residual moment excludes M3/M4 rows from the moment (#978)", {
+    .ctl <- npagControl(points = 128L, cycles = 20L, gammaOptimize = FALSE,
+                        calcTables = FALSE, seed = 1L)
+    f.base <- suppressMessages(suppressWarnings(
+      nlmixr2(.cens978Mod, .cens978Dat, est = "npag", control = .ctl)
+    ))
+    f.cens <- suppressMessages(suppressWarnings(
+      nlmixr2(.cens978Mod, .cens978DatCensored, est = "npag", control = .ctl)
+    ))
+    expect_match(as.character(f.cens$censInformation), "^M3 censoring")
+    # An absurd recorded DV (50) leaking into the moment as if observed would
+    # blow the proportional SD up by orders of magnitude (measured pre-fix:
+    # 0.027 -> 5.34); properly excluded, it barely moves the estimate.
+    expect_equal(as.numeric(f.cens$theta[["prop.sd"]]),
+                 as.numeric(f.base$theta[["prop.sd"]]),
+                 tolerance = 0.05)
+  })
+
+  test_that("est='npb' residual moment excludes M3/M4 rows from the moment (#978)", {
+    .ctl <- npbControl(points = 128L, burnin = 200L, nsamp = 200L,
+                       calcTables = FALSE, seed = 1L)
+    f.base <- suppressMessages(suppressWarnings(
+      nlmixr2(.cens978Mod, .cens978Dat, est = "npb", control = .ctl)
+    ))
+    f.cens <- suppressMessages(suppressWarnings(
+      nlmixr2(.cens978Mod, .cens978DatCensored, est = "npb", control = .ctl)
+    ))
+    expect_match(as.character(f.cens$censInformation), "^M3 censoring")
+    # pre-fix this collapsed the moment to exactly 0 (measured: 0.026 -> 0)
+    expect_equal(as.numeric(f.cens$theta[["prop.sd"]]),
+                 as.numeric(f.base$theta[["prop.sd"]]),
+                 tolerance = 0.05)
+    expect_true(as.numeric(f.cens$theta[["prop.sd"]]) > 0.001)
+  })
+})


### PR DESCRIPTION
## Summary

- `npResidMoments()` (`src/inner.cpp`) counted a censored (M3/M4) observation's recorded LOQ/limit as if it had been measured, folding it into the additive/proportional residual sum-of-squares. For the common `allSimpleScale` configuration (one `add()`/`prop()` SD per endpoint, no regressor), `npOptimizeResid()` (`src/npag.cpp`) installs that moment directly as the final residual-error estimate with no further optimizer correction, so this could badly distort both `est="npag"` and `est="npb"` fits on censored data (measured: an extreme censored DV inflated npag's proportional SD from 0.03 to 14.7, and collapsed npb's to 0).
- A censored row's DV is now excluded from the moment entirely (M2 rows, which carry a real defined observation, are correctly *not* excluded).
- Excluding a row still leaves the moment a biased-low estimator of the true residual variance whenever the data really is censored (a truncated normal's variance is always less than the untruncated one), so an endpoint that had any row excluded this way now also gets disqualified from the `allSimpleScale` fast path -- routed through the existing, already censoring-aware `npResidELS`/`doCensNormal1` objective instead, the same way a regressor theta already was.

Closes #978.

## Test plan

- [x] New regression test `tests/testthat/test-npag-npb-cens-978.R` (added to the weekly slow batch, `tests/testthat.R`): confirms an extreme M3-censored DV barely moves `est="npag"`/`est="npb"`'s residual SD from an uncensored baseline, and that an M2 row (not M3/M4) is correctly *not* excluded.
- [x] Verified the test fails without the fix (npag prop.sd 14.7 vs baseline 0.03; npb collapses to 0) and passes with it.
- [x] Two rounds of independent review via `agy` (Gemini 3.1 Pro) on the diff; round 1 found a real second-order bias (addressed in the second commit) and a test-coverage gap (M2 case added); round 2 found only a stale docstring (fixed).
- [x] `devtools::load_all()` builds clean.