### PR TITLE
focei: keep op_focei.omega refreshed every outer iteration

### DIFF
--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4371,6 +4371,13 @@ void innerOpt() {
     foceiOmegaEnvSyncFromTail(); // fast omega path leaves the env theta stale
     op_focei.omegaInv=getOmegaInv();
     op_focei.logDetOmegaInv5 = getOmegaDet();
+    // The non-inverted Omega was previously only kept current for est="fo"
+    // (foceiOmegaFromTheta's own om==1 branch) -- any OTHER inner-loop reader
+    // of op_focei.omega saw whatever theta last set it at, stale across outer
+    // iterations. Refresh it here unconditionally, on the same cadence as
+    // omegaInv, so a future consumer (e.g. a per-eta scale derived from
+    // Omega) can't silently read a stale value.
+    op_focei.omega = getOmegaMat();
   }
   // Pre-draw per-subject ETA samples serially before the parallel for-loop so
   // workers only do memory access (no R API calls), making mceta safe under cores > 1.


### PR DESCRIPTION
## Summary

`op_focei.omega` (the non-inverted Omega covariance matrix) was only kept
current for `est="fo"` -- `foceiOmegaFromTheta()`'s own `om==1` branch is the
only place that refreshes it. `op_focei.omegaInv` (its inverse) IS refreshed
every outer iteration in `innerOpt()`, right before the per-subject parallel
loop runs, but the non-inverted matrix was not given the same treatment.

Today this is harmless: the only other reader of `op_focei.omega`
(`likInner0`'s `mat Ci = a * op_focei.omega * trans(a) + Vid;`) is itself
inside the `fo==1` branch, so it always sees a fresh value. But that's an
implicit coupling between two separate code paths -- nothing stops a future
consumer of `op_focei.omega` outside `est="fo"` from silently reading a
stale value left over from an earlier theta.

Found this while extending FOCEi's inner optimizer with a per-eta scale
derived from `sqrt(diag(Omega))` (extracted out of #987, where the fix was
originally an `innerOpt`-gated special case -- generalizing it here instead
so any future reader is safe by construction, not by coincidence).

## Change

In `innerOpt()`, refresh `op_focei.omega` via `getOmegaMat()` at the same
point (and same cadence) `op_focei.omegaInv` already is. Uses the same
`rxSymInvCholEnvCalculate(_rxInv, "omega", ...)` engine `omegaInv`/
`cholOmegaInv` already go through, rather than inverting `omegaInv` back
(more numerically consistent, and matches the existing `fo==1` branch's own
`op_focei.omega = getOmegaMat();`).

## Test plan

- [x] `devtools::load_all()` -- clean rebuild, no new warnings
- [x] `test-focei-wang2007-basic.R` (pinned correctness regression, 198
      assertions): passes identically before and after -- confirms no
      behavior change for any existing estimation path