### PR TITLE
fix: MSAEM mixObsLoss()/mixNaiveClassify() propT()/powT() basis swap (#982)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -151,6 +151,19 @@
 
 ## Bug fixes
 
+- `est="saem"` with `saemControl(nMix > 1)` (mixture SAEM) inverted the
+  `propT()`/`powT()` (transformed-basis) vs. plain `prop()`/`pow()`
+  (raw-basis) proportional/power error term in the two MSAEM-only E-step
+  helpers, `mixObsLoss()` (softmax mixture-component responsibility weights)
+  and `mixNaiveClassify()` (chain-init classification) (#982). Every other
+  E-step call site picks the boxCox/yeoJohnson-transformed prediction when
+  `propT()`/`powT()` is used and the raw prediction otherwise; these two
+  passed the pair in the opposite order, so a `propT()`/`powT()` model was
+  scored against the raw prediction and a plain `prop()`/`pow()` model
+  against the transformed one, biasing mixture-component assignment for any
+  `nMix > 1` fit with a transformed residual model. `nMix == 1` fits are
+  unaffected.
+
 - Every NLM-family method (`nlm`, `bobyqa`, `newuoa`, `uobyqa`, `n1qn1`,
   `lbfgsb3c`, `optim`, `nlminb`) silently mis-scored any M2/M3/M4-censored
   normal endpoint, whether or not `ar()` was present (#976). NLM forces every

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -4200,7 +4200,7 @@ private:
               int cur = ix_endpnt(i);
               _scratch_limitT(i) = _powerD(limitk(i), lambda(cur), yj(cur), low(cur), hi(cur));
               _scratch_ft(i) = _powerD(fsk(i), lambda(cur), yj(cur), low(cur), hi(cur));
-              _scratch_ftT(i) = handleF(propT(cur), fsk(i), _scratch_ft(i), false, true);
+              _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fsk(i), false, true);
             }
             saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, veccres, vecaddProp);
             _scratch_g.elem(find(_scratch_g == 0.0)).fill(1);
@@ -4311,7 +4311,7 @@ private:
             int cur = ix_endpnt(i);
             _scratch_limitT(i) = _powerD(limitk(i), lambda(cur), yj(cur), low(cur), hi(cur));
             _scratch_ft(i) = _powerD(fk(i), lambda(cur), yj(cur), low(cur), hi(cur));
-            _scratch_ftT(i) = handleF(propT(cur), fk(i), _scratch_ft(i), false, true);
+            _scratch_ftT(i) = handleF(propT(cur), _scratch_ft(i), fk(i), false, true);
           }
           saemFormG(_scratch_g, vecares, vecbres, _scratch_ftT, veccres, vecaddProp);
           _scratch_g.elem(find(_scratch_g == 0.0)).fill(1.0);

--- a/tests/testthat/test-saem-mix.R
+++ b/tests/testthat/test-saem-mix.R
@@ -615,6 +615,84 @@ nmTest({
     expect_true(clMuLinear[1] < 2)
     expect_true(clMuLinear[2] > 4)
   })
+
+  test_that("MSAEM mixture separates under propT()+boxCox() (#982)", {
+    # #982: mixObsLoss()/mixNaiveClassify() (the nMix>1-only E-step loss and
+    # chain-init classification helpers) passed the transformed/raw prediction
+    # pair to handleF() in the opposite order from every other call site, so
+    # propT()'s "use the boxCox-transformed prediction" basis silently used
+    # the raw prediction instead (and vice versa for plain prop()). With
+    # lambda=1 (no transform) transformed==raw and the bug is invisible, so
+    # this pins a fixed lambda far from 1 and simulates the noise on the
+    # boxCox-transformed scale (propT() semantics) to make the two bases
+    # diverge. Under the pre-fix argument order this reliably collapses the
+    # mixture to one component (min(mixTab) == 1); the fix restores a real
+    # split matching the true two-population design.
+    rxode2::rxWithSeed(42, {
+    n_subj <- 30
+    sub_pop <- rbinom(n_subj, 1, 0.6) + 1 # 1 or 2
+    cl_sim <- ifelse(sub_pop == 1, 1.2, 6.0)
+    lambda <- 0.3
+
+    sim_data <- do.call(rbind, lapply(1:n_subj, function(i) {
+      subj_cl <- cl_sim[i]
+      times <- c(0.5, 1, 2, 4, 8, 12, 24)
+      ka_val <- 1.5
+      v_val <- 24.0
+      k_val <- subj_cl / v_val
+      cp <- 100 * ka_val / (v_val * (ka_val - k_val)) * (exp(-k_val * times) - exp(-ka_val * times))
+      # boxCox-transformed-scale proportional noise -- this is what propT()
+      # (transformed-basis prop) assumes the observation noise follows.
+      ft <- (cp^lambda - 1) / lambda
+      ftNoisy <- ft * (1 + rnorm(length(times), 0, 0.10))
+      cpNoisy <- (lambda * ftNoisy + 1)^(1 / lambda)
+      cpNoisy[!is.finite(cpNoisy) | cpNoisy < 0] <- 0
+      data.frame(
+        ID = i,
+        TIME = c(0, times),
+        AMT = c(100, rep(0, length(times))),
+        EVID = c(1, rep(0, length(times))),
+        DV = c(0, cpNoisy),
+        CMT = c(1, rep(2, length(times)))
+      )
+    }))
+    })
+
+    one.compartment.mix.propT <- function() {
+      ini({
+        tka <- log(1.5)
+        tcl1 <- log(1.0)
+        tcl2 <- log(5.0)
+        tv <- log(20)
+        p1 <- 0.5
+        eta.cl ~ 0.01
+        eta.v ~ 0.01
+        eta.ka ~ 0.01
+        prop.sd <- 0.10
+        lm <- fixed(0.3)
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl))
+        v <- exp(tv + eta.v)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ propT(prop.sd) + boxCox(lm)
+      })
+    }
+
+    fit <- .nlmixr(one.compartment.mix.propT, sim_data, est = "saem",
+                   saemControl(print = 0, seed = 1234, nBurn = 200, nEm = 300,
+                               calcTables = TRUE, covMethod = 0L))
+
+    mixTab <- table(fit$mixNum$mixnum)
+    expect_true(length(mixTab) > 1)
+    expect_true(min(mixTab) >= 2)
+
+    agree <- mean(fit$mixNum$mixnum[order(fit$mixNum$ID)] == sub_pop)
+    expect_true(agree > 0.6 || (1 - agree) > 0.6) # allow for label swap
+  })
 })
 
 


### PR DESCRIPTION
## Summary
- `mixObsLoss()` and `mixNaiveClassify()` (the two MSAEM/`nMix>1`-only E-step helpers in `src/saem.cpp`) passed the transformed/raw prediction pair to `handleF()` in the opposite order from every other call site, inverting `propT()`/`powT()` (transformed-basis) vs. plain `prop()`/`pow()` (raw-basis) semantics for any mixture fit.
- Swaps the arguments at `src/saem.cpp:4203` and `:4314` to match the `(transformed, raw)` convention used everywhere else (e.g. `:2076`, `:2283`, `:2566`, `:4094`).
- Adds a regression test (`test-saem-mix.R`, "MSAEM mixture separates under propT()+boxCox() (#982)") using a `propT()+boxCox(lambda=0.3)` mixture model; empirically verified to fail pre-fix (mixture collapses to one component) and pass post-fix (real two-population split recovered).

Fixes #982.

## Test plan
- [x] `devtools::load_all()` builds clean
- [x] `testthat::test_file("tests/testthat/test-saem-mix.R")`: 0 failures with the fix
- [x] Manually reverted the two lines, rebuilt, reran the same test file: new test fails as expected (mixture collapses, `min(mixTab) == 1`), confirming it actually exercises the fixed code path
- [x] Independent Antigravity (Gemini) review of the diff: no findings, confirms no other `handleF` call sites have the defect and no memory/concurrency issues introduced