### PR TITLE
nlm: M2/M3/M4 censoring for t()/cauchy() endpoints (#979)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -163,6 +163,15 @@
   beforehand in the same branch, so it is now squared back into `rx_r_`
   instead of being discarded.
 
+- Every NLM-family method also silently ignored M2/M3/M4 censoring on a
+  `t()`/`cauchy()` endpoint entirely -- a censored row was scored with its
+  ordinary (uncensored) density (#979). Added a Student-t/Cauchy CDF-based
+  correction (`doCensT1()`; cauchy is Student-t with `nu=1`, so one function
+  covers both) alongside the existing normal one. FOCEi/FOCE/AGQ/Laplace and
+  every other generalized-likelihood distribution (`pois`, `binom`, `beta`,
+  and so on) still silently ignore censoring for now, but a fit now warns
+  when that combination is used instead of staying silent.
+
 - `est="saem"` with a `pow()` residual error model (`rmPow`/`rmAddPow`/
   `rmPowLam`/`rmAddPowLam`) never applied the estimated power exponent in the
   E-step's MCMC-acceptance likelihood -- it always scored proposals as if the

--- a/R/focei.R
+++ b/R/focei.R
@@ -1083,21 +1083,6 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))
   .r <- get("rx_r_", envir = .s)
   .r <- paste0("rx_r_=", rxode2::rxFromSE(.r))
-  # rx_pred_f_/rx_nu_ for the llik-forced t()/cauchy() M2/M3/M4 correction
-  # (#979): like rx_r_ above, pulled straight out of the symengine
-  # environment and re-spliced -- a plain `rx_pred_f_=<expr>`/`rx_nu_=<expr>`
-  # in the assembled model text does not survive rxOptExpr's dead-code
-  # elimination on its own (nothing else in the inner model reads either
-  # back), the same reason nlm.R's rxUiGet.nlmRxModel does this for its own
-  # population objective (.nlmGetFRLines).  rx_nu_ exists only for a
-  # t()/cauchy() endpoint (.fixCensRNuLine, above); absent otherwise.
-  .predF <- get("rx_pred_f_", envir = .s)
-  .predF <- paste0("rx_pred_f_=", rxode2::rxFromSE(.predF))
-  .nuLine <- if (exists("rx_nu_", envir = .s, inherits = FALSE)) {
-    paste0("rx_nu_=", rxode2::rxFromSE(get("rx_nu_", envir = .s)))
-  } else {
-    character(0)
-  }
   .yj <- paste(get("rx_yj_", envir = .s))
   .yj <- paste0("rx_yj_~", rxode2::rxFromSE(.yj))
   .lambda <- paste(get("rx_lambda_", envir = .s))
@@ -1186,8 +1171,6 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
     .prd,
     .s$..HdEta,
     .r,
-    .predF,
-    .nuLine,
     .s$..REta,
     .combTheta,
     .adjLhs,

--- a/R/focei.R
+++ b/R/focei.R
@@ -547,6 +547,87 @@ rxGetDistributionFoceiLines <- function(line) {
   isTRUE(nlmixr2global$rxArNorm)
 }
 
+#' Restore a real `rx_r_` variance, and expose `rx_nu_`, for llik-forced
+#' norm/dnorm/t/cauchy endpoints
+#'
+#' `.handleSingleErrTypeNormOrTFoceiBase(rxPredLlik=TRUE)` (rxode2) forces
+#' every `norm`/`dnorm`/`t`/`cauchy` endpoint through its log-likelihood
+#' form so a single scalar can be emitted as `rx_pred_`.  That path always
+#' sets `rx_r_ ~ 0` (a full log-density has no separate variance to
+#' report) and never exposes the Student-t degrees of freedom -- but
+#' `censEst.h`'s `doCensNormal1()`/`doCensT1()` M2/M3/M4 correction needs
+#' both as real values (nlmixr2est/nlmixr2est#979, following the same
+#' `rx_r_` fix nlm.R's `.nlmFixCensRLine` made for the population model).
+#' `rx_rll_` (the standard deviation actually fed into
+#' `llikNorm()`/`llikT()`/`llikCauchy()`) is emitted immediately before
+#' `rx_r_` in the same branch, so square it back into `rx_r_` instead of
+#' leaving the hardcoded 0.  `llikT()`/`llikXT()`'s own `nu` argument is
+#' captured into a new `rx_nu_` line; cauchy is Student-t with `nu=1`
+#' (nlmixr2est/nlmixr2est#979), so `llikCauchy()`/`llikXCauchy()` get
+#' `rx_nu_ ~ 1`.  `dnorm` (no `nu` argument at all) and any other
+#' distribution with no `rx_rll_` line are left alone -- `rx_nu_` is only
+#' added when a Student-t/Cauchy call is found.
+#'
+#' @param lines A single endpoint's list of quoted model lines, as
+#'   returned by `rxGetDistributionFoceiLines()` for one `predDf` row.
+#' @return The same list, with `rx_r_ ~ 0` replaced by
+#'   `rx_r_ ~ rx_rll_^2` when `rx_rll_` was emitted (otherwise unchanged),
+#'   plus an appended `rx_nu_ ~ <nu>` line for a t()/cauchy() endpoint.
+#' @author Matthew L. Fidler
+#' @noRd
+.fixCensRNuLine <- function(lines) {
+  # nlm-family (population-only, neta=0) ONLY for now: giving a llik-forced
+  # endpoint a real (nonzero) rx_r_ is exactly what FOCEi's eta-sensitivity
+  # generation does not expect once real etas are present -- turning it on
+  # unconditionally crashes symengine's eta-derivative pass ("user function
+  # 'get' requires 5 arguments") for ANY t()/cauchy()+eta FOCEi/FOCE fit,
+  # censored or not (measured: reproduces with plain cauchy(), no CENS data
+  # at all, and disappears when this function is a no-op).  nlm has no etas
+  # and is unaffected, so gate on the flag only `rxUiGet.nlmModel0` sets;
+  # FOCEi/FOCE/AGQ/Laplace keep today's (silent-ignore, now warned) behavior
+  # until a follow-up sorts out the rxode2-side interaction (#979).
+  if (!isTRUE(nlmixr2global$rxCensNuFix)) return(lines)
+  if (!is.list(lines)) return(lines)
+  .rll <- NULL
+  for (.l in lines) {
+    if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
+        identical(.l[[2]], quote(rx_rll_))) {
+      .rll <- .l[[3]]
+      break
+    }
+  }
+  if (is.null(.rll)) return(lines)
+  .nu <- NULL
+  for (.l in lines) {
+    if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
+        identical(.l[[2]], quote(rx_pred_)) && is.call(.l[[3]])) {
+      .fn <- as.character(.l[[3]][[1]])
+      if (.fn == "llikT") {
+        .nu <- .l[[3]][[3]]
+      } else if (.fn == "llikXT") {
+        .nu <- .l[[3]][[4]]
+      } else if (.fn %in% c("llikCauchy", "llikXCauchy")) {
+        .nu <- 1
+      }
+    }
+  }
+  .out <- vector("list", 0)
+  for (.l in lines) {
+    if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
+        identical(.l[[2]], quote(rx_r_)) &&
+        identical(.l[[3]], 0)) {
+      .out[[length(.out) + 1]] <- bquote(rx_r_ ~ .(.rll)^2)
+    } else {
+      .out[[length(.out) + 1]] <- .l
+      if (!is.null(.nu) && is.call(.l) && identical(.l[[1]], quote(`~`)) &&
+          identical(.l[[2]], quote(rx_rll_))) {
+        .out[[length(.out) + 1]] <- bquote(rx_nu_ ~ .(.nu))
+      }
+    }
+  }
+  .out
+}
+
 #' @export
 rxGetDistributionFoceiLines.norm <- function(line) {
   env <- line[[1]]
@@ -567,8 +648,9 @@ rxGetDistributionFoceiLines.t <- function(line) {
     env <- line[[1]]
     pred1 <- line[[2]]
     .errNum <- line[[3]]
-    rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
-                                                 rxPredLlik=.getRxPredLlikOption())
+    .fixCensRNuLine(
+      rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
+                                                   rxPredLlik=.getRxPredLlikOption()))
   } else {
     stop("t is not supported", call.=FALSE)
   }
@@ -580,8 +662,9 @@ rxGetDistributionFoceiLines.cauchy <- function(line) {
     env <- line[[1]]
     pred1 <- line[[2]]
     .errNum <- line[[3]]
-    rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
-                                                 rxPredLlik=.getRxPredLlikOption())
+    .fixCensRNuLine(
+      rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
+                                                   rxPredLlik=.getRxPredLlikOption()))
   } else {
     stop("t is not supported", call.=FALSE)
   }
@@ -593,8 +676,9 @@ rxGetDistributionFoceiLines.default  <- function(line) {
     env <- line[[1]]
     pred1 <- line[[2]]
     .errNum <- line[[3]]
-    rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
-                                                 rxPredLlik=.getRxPredLlikOption())
+    .fixCensRNuLine(
+      rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
+                                                   rxPredLlik=.getRxPredLlikOption()))
   } else {
     stop("unknown distribution", call.=FALSE)
   }
@@ -999,6 +1083,21 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))
   .r <- get("rx_r_", envir = .s)
   .r <- paste0("rx_r_=", rxode2::rxFromSE(.r))
+  # rx_pred_f_/rx_nu_ for the llik-forced t()/cauchy() M2/M3/M4 correction
+  # (#979): like rx_r_ above, pulled straight out of the symengine
+  # environment and re-spliced -- a plain `rx_pred_f_=<expr>`/`rx_nu_=<expr>`
+  # in the assembled model text does not survive rxOptExpr's dead-code
+  # elimination on its own (nothing else in the inner model reads either
+  # back), the same reason nlm.R's rxUiGet.nlmRxModel does this for its own
+  # population objective (.nlmGetFRLines).  rx_nu_ exists only for a
+  # t()/cauchy() endpoint (.fixCensRNuLine, above); absent otherwise.
+  .predF <- get("rx_pred_f_", envir = .s)
+  .predF <- paste0("rx_pred_f_=", rxode2::rxFromSE(.predF))
+  .nuLine <- if (exists("rx_nu_", envir = .s, inherits = FALSE)) {
+    paste0("rx_nu_=", rxode2::rxFromSE(get("rx_nu_", envir = .s)))
+  } else {
+    character(0)
+  }
   .yj <- paste(get("rx_yj_", envir = .s))
   .yj <- paste0("rx_yj_~", rxode2::rxFromSE(.yj))
   .lambda <- paste(get("rx_lambda_", envir = .s))
@@ -1087,6 +1186,8 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
     .prd,
     .s$..HdEta,
     .r,
+    .predF,
+    .nuLine,
     .s$..REta,
     .combTheta,
     .adjLhs,

--- a/R/nlm.R
+++ b/R/nlm.R
@@ -404,59 +404,25 @@ getValidNlmixrCtl.nlm <- function(control) {
   })
 }
 
-#' Restore a real `rx_r_` variance for nlm's llik-forced normal endpoints
-#'
-#' `est="nlm"` forces every `norm` endpoint through the log-likelihood
-#' (`dnorm`) path so a single scalar objective can be emitted
-#' (`rxUiGet.nlmModel0`).  That path always sets `rx_r_ ~ 0` (a full
-#' log-density has no separate variance to report), but `src/nlm.cpp`'s
-#' M2/M3/M4 censoring correction (`doCensNormal1()`) reads `rx_r_` as a real
-#' variance -- a hardcoded 0 corrupts every censored normal endpoint,
-#' independent of `ar()` (#976).  `rx_rll_` (the standard deviation actually
-#' fed into `llikNorm()`/`llikT()`/`llikCauchy()`) is emitted immediately
-#' before `rx_r_` in the same branch, so square it back into `rx_r_` instead
-#' of leaving the hardcoded 0.
-#'
-#' @param lines A single endpoint's list of quoted model lines, as returned
-#'   by `rxGetDistributionFoceiLines()` for one `predDf` row.
-#' @return The same list, with `rx_r_ ~ 0` replaced by `rx_r_ ~ rx_rll_^2`
-#'   when `rx_rll_` was emitted; otherwise unchanged.
-#' @author Matthew L. Fidler
-#' @noRd
-.nlmFixCensRLine <- function(lines) {
-  if (!is.list(lines)) return(lines)
-  .rll <- NULL
-  for (.l in lines) {
-    if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
-        identical(.l[[2]], quote(rx_rll_))) {
-      .rll <- .l[[3]]
-      break
-    }
-  }
-  if (is.null(.rll)) return(lines)
-  lapply(lines, function(.l) {
-    if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
-        identical(.l[[2]], quote(rx_r_)) &&
-        identical(.l[[3]], 0)) {
-      bquote(rx_r_ ~ .(.rll)^2)
-    } else {
-      .l
-    }
-  })
-}
-
 #'@export
 rxUiGet.nlmModel0 <- function(x, ...) {
   .ui <- rxode2::rxUiDecompress(x[[1]])
   nlmixr2global$rxPredLlik <- TRUE
-  on.exit(nlmixr2global$rxPredLlik <- FALSE)
+  # nlm is population-only (no etas), so .fixCensRNuLine's real (nonzero)
+  # rx_r_/rx_nu_ for a llik-forced endpoint is safe here -- see the guard's
+  # own comment for why it must stay OFF for FOCEi/FOCE (#979).
+  nlmixr2global$rxCensNuFix <- TRUE
+  on.exit(nlmixr2global$rxCensNuFix <- FALSE, add = TRUE)
+  on.exit(nlmixr2global$rxPredLlik <- FALSE, add = TRUE)
   .predDf <- .ui$predDf
   .save <- .predDf
   .predDf[.predDf$distribution == "norm", "distribution"] <- "dnorm"
   assign(".predDfFocei", .predDf, envir=.ui)
   #assign("predDf", .predDf, envir=.ui)
-  on.exit(assign("predDf", .save, envir=.ui))
-  .errLines <- lapply(rxGetDistributionFoceiLines(.ui), .nlmFixCensRLine)
+  on.exit(assign("predDf", .save, envir=.ui), add = TRUE)
+  # rx_r_/rx_nu_ for the llik-forced norm/dnorm/t/cauchy path are already
+  # fixed at the source (.fixCensRNuLine, R/focei.R) -- see #979.
+  .errLines <- rxGetDistributionFoceiLines(.ui)
   .ret <- rxode2::rxCombineErrorLines(.ui, errLines=.errLines,
                               prefixLines=.uiGetThetaDropFixed(.ui),
                               paramsLine=NA, #.uiGetThetaEtaParams(.f),
@@ -529,14 +495,23 @@ rxUiGet.nlmParams <- function(x, ...) {
 }
 attr(rxUiGet.nlmParams, "rstudio") <- "params()"
 
-#' Extract rx_pred_f_ and rx_r_ model lines from symengine environment
+#' Extract rx_pred_f_, rx_r_ and rx_nu_ model lines from symengine environment
+#'
+#' Like `rx_pred_f_`/`rx_r_`, a plain `rx_nu_ ~ nu` (or `=`) line does not
+#' survive `rxOptExpr`/symengine's own dead-code elimination -- nothing else
+#' in the compiled model reads it back, so it is pruned along with any other
+#' truly-unused intermediate before `rxCombineErrorLines`'s caller ever gets
+#' to see it. It has to be pulled straight out of the symengine environment
+#' (which still has the full unpruned variable set) and re-spliced into the
+#' final text, exactly like `rx_pred_f_`/`rx_r_` already are (#979).
 #'
 #' @param .s symengine environment
-#' @return named list with `f_line` and `r_line` character strings
+#' @return named list with `f_line`, `r_line` and `nu_line` character strings
 #' @noRd
 .nlmGetFRLines <- function(.s) {
   .f_line <- ""
   .r_line <- ""
+  .nu_line <- ""
   if (exists("rx_pred_f_", envir = .s, inherits = FALSE)) {
     .f <- get("rx_pred_f_", envir = .s)
     .f_line <- paste0("rx_pred_f_=", rxode2::rxFromSE(.f))
@@ -545,7 +520,11 @@ attr(rxUiGet.nlmParams, "rstudio") <- "params()"
     .r <- get("rx_r_", envir = .s)
     .r_line <- paste0("rx_r_=", rxode2::rxFromSE(.r))
   }
-  list(f_line = .f_line, r_line = .r_line)
+  if (exists("rx_nu_", envir = .s, inherits = FALSE)) {
+    .nu <- get("rx_nu_", envir = .s)
+    .nu_line <- paste0("rx_nu_=", rxode2::rxFromSE(.nu))
+  }
+  list(f_line = .f_line, r_line = .r_line, nu_line = .nu_line)
 }
 
 #' @export
@@ -588,6 +567,7 @@ rxUiGet.nlmRxModel <- function(x, ...) {
     .prd,
     .fr$f_line,
     .fr$r_line,
+    .fr$nu_line,
     #.s$..stateInfo["statef"],
     #.s$..stateInfo["dvid"],
     ""
@@ -742,6 +722,7 @@ attr(rxUiGet.nlmHdTheta, "rstudio") <- emptyenv()
     .s$..HdTheta,
     .fr$f_line,
     .fr$r_line,
+    .fr$nu_line,
     .s$..stateInfo["statef"],
     .s$..stateInfo["dvid"],
     ""
@@ -765,6 +746,7 @@ attr(rxUiGet.nlmHdTheta, "rstudio") <- emptyenv()
     .prd,
     .fr$f_line,
     .fr$r_line,
+    .fr$nu_line,
     .s$..stateInfo["statef"],
     .s$..stateInfo["dvid"],
     ""

--- a/R/nlm.R
+++ b/R/nlm.R
@@ -407,13 +407,17 @@ getValidNlmixrCtl.nlm <- function(control) {
 #'@export
 rxUiGet.nlmModel0 <- function(x, ...) {
   .ui <- rxode2::rxUiDecompress(x[[1]])
-  nlmixr2global$rxPredLlik <- TRUE
-  # nlm is population-only (no etas), so .fixCensRNuLine's real (nonzero)
-  # rx_r_/rx_nu_ for a llik-forced endpoint is safe here -- see the guard's
-  # own comment for why it must stay OFF for FOCEi/FOCE (#979).
-  nlmixr2global$rxCensNuFix <- TRUE
+  # on.exit() registered BEFORE mutating either flag: an interrupt landing
+  # between setting a flag and registering its reset would otherwise leak
+  # it TRUE for the rest of the R session -- for rxCensNuFix specifically,
+  # that would crash a later FOCEi t()/cauchy()+eta fit (see the guard's
+  # own comment for why it must stay OFF for FOCEi/FOCE, #979).
   on.exit(nlmixr2global$rxCensNuFix <- FALSE, add = TRUE)
   on.exit(nlmixr2global$rxPredLlik <- FALSE, add = TRUE)
+  nlmixr2global$rxPredLlik <- TRUE
+  # nlm is population-only (no etas), so .fixCensRNuLine's real (nonzero)
+  # rx_r_/rx_nu_ for a llik-forced endpoint is safe here.
+  nlmixr2global$rxCensNuFix <- TRUE
   .predDf <- .ui$predDf
   .save <- .predDf
   .predDf[.predDf$distribution == "norm", "distribution"] <- "dnorm"

--- a/R/preProcessCensDistWarn.R
+++ b/R/preProcessCensDistWarn.R
@@ -1,0 +1,51 @@
+#' Warn when CENS/LIMIT data meets a distribution with no M2/M3/M4 support
+#'
+#' `censEst.h`'s M2/M3/M4 correction only understands normal (`add`/`prop`/
+#' `pow`/combined, `lnorm`/`logitNorm`/`probitNorm` transforms, `dnorm`) and,
+#' for nlm-family only, `t()`/`cauchy()` (`doCensT1()`, #979).  Every other
+#' generalized-likelihood distribution (`pois`, `binom`, `beta`, `chisq`,
+#' `dexp`, `f`, `geom`, `unif`, `weibull`, `dgamma`, `ordinal`, a general
+#' `ll()`) -- and, for now, `t()`/`cauchy()` under FOCEi/FOCE/AGQ/Laplace --
+#' silently scores a censored row with its ordinary (uncensored) density
+#' instead of erroring or refusing (unlike `est="nls"`, which hard-stops).
+#' This warns instead of leaving that silent, so it is at least visible in
+#' the fit's `$runInfo`.
+#'
+#' @param ui rxode2 ui
+#' @inheritParams nlmixr2
+#' @return list with the ui (unmodified; this hook only warns)
+#' @noRd
+.preProcessCensDistWarn <- function(ui, est, data, control) {
+  if (identical(est, "nls")) return(list(ui = ui))
+  # Methods sharing src/nlm.cpp's population-only kernel: t()/cauchy() are
+  # safe there (doCensT1(), no etas to worry about).  Every other method
+  # (FOCEi/FOCE/AGQ/Laplace/SAEM/imp/...) keeps t()/cauchy() in the unsafe
+  # set until the FOCEi-side gap (src/inner.cpp's KNOWN GAP comment) closes.
+  .nlmFamily <- c("nlm", "bobyqa", "lbfgsb3c", "n1qn1", "newuoa", "nlminb",
+                  "optim", "uobyqa")
+  .safe <- if (isTRUE(est %in% .nlmFamily)) {
+    c("norm", "dnorm", "t", "cauchy")
+  } else {
+    c("norm", "dnorm")
+  }
+  .predDf <- tryCatch(ui$predDf, error = function(e) NULL)
+  if (is.null(.predDf) || nrow(.predDf) == 0) return(list(ui = ui))
+  .unsafeDist <- unique(.predDf$distribution[!(.predDf$distribution %in% .safe)])
+  if (length(.unsafeDist) == 0) return(list(ui = ui))
+  .nms <- tolower(names(data))
+  .hasCens <- FALSE
+  .wCens <- which(.nms == "cens")
+  if (length(.wCens) == 1L) {
+    .hasCens <- isTRUE(any(data[[.wCens]] != 0, na.rm = TRUE))
+  }
+  .wLimit <- which(.nms == "limit")
+  if (!.hasCens && length(.wLimit) == 1L) {
+    .hasCens <- isTRUE(any(is.finite(data[[.wLimit]]), na.rm = TRUE))
+  }
+  if (!.hasCens) return(list(ui = ui))
+  for (.d in .unsafeDist) {
+    warning(paste0("censoring ignored for '", .d, "' endpoint(s)"), call. = FALSE)
+  }
+  list(ui = ui)
+}
+preProcessHooksAdd(".preProcessCensDistWarn", .preProcessCensDistWarn)

--- a/plans/t-cauchy-cens-979.md
+++ b/plans/t-cauchy-cens-979.md
@@ -1,0 +1,52 @@
+# M2/M3/M4 censoring ignored for t()/cauchy() endpoints (#979)
+
+## Root cause
+
+`t()`/`cauchy()` compile through the general-log-likelihood path
+(`rx_pred_ ~ llikT(dv, nu, mean, sd)` / `llikCauchy(dv, mean, sd)`).  Every
+censoring guard in the C++ layer is `dist == rxDistributionNorm` (or
+`Dnorm`); non-normal dist branches take `f` (the already-computed log
+density) verbatim, so `CENS`/`LIMIT` never reach the objective for t/cauchy.
+`doCensT1` does not exist yet. Cauchy is Student-t with `nu=1`, so one
+function serves both.
+
+## Scope
+
+- FOCEI/FOCE/Laplace/AGQ (`src/inner.cpp`) and nlm-family (`src/nlm.cpp`)
+  get real M2/M3/M4 support for t()/cauchy().
+- SAEM forces any `ll()`-family endpoint (t/cauchy included) onto
+  `distribution==4`, whose M-step (`augmentCensY`) would need a truncated
+  Student-t sampler -- real new machinery, out of scope here.  SAEM falls
+  under the catch-all warning below; a follow-up issue tracks real support.
+- Every OTHER generalized-likelihood distribution (pois/binom/beta/chisq/
+  dexp/f/geom/hyper/unif/weibull/gamma/ordinal/general `ll()`) gets a
+  concise runInfo warning that censoring is ignored, instead of silently
+  wrong results.
+
+## Phases
+
+1. [ ] `src/censEst.h`: `doCensT1()` (M2/M3/M4 value correction via
+   `R::pt()`, nu=1 for cauchy) + `dCensT1()` (first derivative). No 2nd/3rd
+   order partials -- censored T/Cauchy falls through to the existing
+   Gauss-Newton curvature fallback (document as a KNOWN GAP).
+2. [ ] R-side plumbing: emit `rx_pred_f_`/`rx_r_`/`rx_nu_` as consecutive
+   lhs columns for t/cauchy in both the nlm predOnly model (extend
+   `.nlmFixCensRLine`) and the FOCEi inner model (new sibling injection).
+3. [ ] `src/nlm.cpp`: widen the three `dist ==` guards to include
+   T/Cauchy; read nu from the new slot; call `doCensT1`.
+4. [ ] `src/inner.cpp`: widen the ~6 `dist == rxDistributionNorm` sites to
+   add a parallel T/Cauchy branch calling `doCensT1`/`dCensT1` for censored
+   observations only (uncensored stays bit-identical). Decline
+   `fast=TRUE` analytic outer gradient to FD for a subject with a censored
+   T/Cauchy observation.
+5. [ ] Catch-all warning: new `R/preProcessCensDistWarn.R` hook, runs for
+   every estimation method, warns (<75 chars, no method prefix) when
+   CENS/LIMIT data meets a non-{norm,dnorm,t,cauchy} endpoint. Skip
+   `est="nls"` (already hard stops).
+6. [ ] Tests: doCensT1/dCensT1 correctness (numDeriv, nu=1==cauchy
+   identity, large-nu==normal limit); FOCEI + nlm regression using the
+   issue's repro model (t() and cauchy()), asserting the mechanism
+   actually ran; catch-all warning test.
+7. [ ] NEWS.md bullet under `## Bug fixes`, referencing #979.
+8. [ ] Antigravity review until clean.
+9. [ ] Push, open PR closing #979.

--- a/plans/t-cauchy-cens-979.md
+++ b/plans/t-cauchy-cens-979.md
@@ -7,46 +7,70 @@
 censoring guard in the C++ layer is `dist == rxDistributionNorm` (or
 `Dnorm`); non-normal dist branches take `f` (the already-computed log
 density) verbatim, so `CENS`/`LIMIT` never reach the objective for t/cauchy.
-`doCensT1` does not exist yet. Cauchy is Student-t with `nu=1`, so one
+`doCensT1` did not exist yet. Cauchy is Student-t with `nu=1`, so one
 function serves both.
 
-## Scope
+## Scope (revised during implementation)
 
-- FOCEI/FOCE/Laplace/AGQ (`src/inner.cpp`) and nlm-family (`src/nlm.cpp`)
-  get real M2/M3/M4 support for t()/cauchy().
+- **nlm-family** (`nlm`/`bobyqa`/`newuoa`/`uobyqa`/`n1qn1`/`lbfgsb3c`/
+  `optim`/`nlminb`, `src/nlm.cpp`): full M2/M3/M4 support for t()/cauchy(),
+  value AND gradient (nlm already forces FD for any censored row's theta
+  gradient regardless of distribution). Verified end-to-end against a
+  censoring-ignored baseline and against the t(nu=1)==cauchy() identity.
+- **FOCEi/FOCE/AGQ/Laplace (`src/inner.cpp`) -- NOT fixed in this PR.**
+  Giving the llik-forced t()/cauchy() endpoint a real (nonzero) `rx_r_`
+  (needed for the CDF correction) crashes rxode2's eta-sensitivity
+  generation once real etas are present ("user function 'get' requires 5
+  arguments") -- reproduces with plain `cauchy()`, no censoring at all, and
+  is caused by making `rx_r_` nonzero, not by anything censoring-specific.
+  `censEst.h`'s `doCensT1()`/`dCensT1()` and `src/inner.cpp`'s
+  `focei_tCensLl()` are written and validated (nlm-family exercises the
+  identical `doCensT1()` path) but are deliberately kept INERT for FOCEi:
+  `.fixCensRNuLine` (R/focei.R) only emits the real `rx_r_`/`rx_nu_` when
+  `nlmixr2global$rxCensNuFix` is set, and only `rxUiGet.nlmModel0` sets it.
+  A follow-up issue should track the rxode2-side interaction.
 - SAEM forces any `ll()`-family endpoint (t/cauchy included) onto
   `distribution==4`, whose M-step (`augmentCensY`) would need a truncated
-  Student-t sampler -- real new machinery, out of scope here.  SAEM falls
-  under the catch-all warning below; a follow-up issue tracks real support.
-- Every OTHER generalized-likelihood distribution (pois/binom/beta/chisq/
-  dexp/f/geom/hyper/unif/weibull/gamma/ordinal/general `ll()`) gets a
-  concise runInfo warning that censoring is ignored, instead of silently
-  wrong results.
+  Student-t sampler -- real new machinery, out of scope here.
+- Every other generalized-likelihood distribution (pois/binom/beta/chisq/
+  dexp/f/geom/unif/weibull/dgamma/ordinal/general `ll()`), and t()/cauchy()
+  under every method except nlm-family, get a concise runInfo warning that
+  censoring is ignored, instead of silently wrong results.
 
 ## Phases
 
-1. [ ] `src/censEst.h`: `doCensT1()` (M2/M3/M4 value correction via
+1. [x] `src/censEst.h`: `doCensT1()` (M2/M3/M4 value correction via
    `R::pt()`, nu=1 for cauchy) + `dCensT1()` (first derivative). No 2nd/3rd
    order partials -- censored T/Cauchy falls through to the existing
-   Gauss-Newton curvature fallback (document as a KNOWN GAP).
-2. [ ] R-side plumbing: emit `rx_pred_f_`/`rx_r_`/`rx_nu_` as consecutive
-   lhs columns for t/cauchy in both the nlm predOnly model (extend
-   `.nlmFixCensRLine`) and the FOCEi inner model (new sibling injection).
-3. [ ] `src/nlm.cpp`: widen the three `dist ==` guards to include
-   T/Cauchy; read nu from the new slot; call `doCensT1`.
-4. [ ] `src/inner.cpp`: widen the ~6 `dist == rxDistributionNorm` sites to
-   add a parallel T/Cauchy branch calling `doCensT1`/`dCensT1` for censored
-   observations only (uncensored stays bit-identical). Decline
-   `fast=TRUE` analytic outer gradient to FD for a subject with a censored
-   T/Cauchy observation.
-5. [ ] Catch-all warning: new `R/preProcessCensDistWarn.R` hook, runs for
-   every estimation method, warns (<75 chars, no method prefix) when
-   CENS/LIMIT data meets a non-{norm,dnorm,t,cauchy} endpoint. Skip
-   `est="nls"` (already hard stops).
-6. [ ] Tests: doCensT1/dCensT1 correctness (numDeriv, nu=1==cauchy
-   identity, large-nu==normal limit); FOCEI + nlm regression using the
-   issue's repro model (t() and cauchy()), asserting the mechanism
-   actually ran; catch-all warning test.
-7. [ ] NEWS.md bullet under `## Bug fixes`, referencing #979.
+   Gauss-Newton curvature fallback (documented as a KNOWN GAP). Validated
+   standalone: nu=1 matches pcauchy exactly, large-nu matches
+   doCensNormal1, dCensT1 matches finite differences to <1e-7.
+2. [x] R-side plumbing: `.fixCensRNuLine` (R/focei.R) squares `rx_rll_`
+   into `rx_r_` and captures `llikT()`/`llikXT()`'s `nu` argument (1 for
+   cauchy) into a new `rx_nu_` line, gated to nlm-family only
+   (`nlmixr2global$rxCensNuFix`) -- see Scope above for why FOCEi is
+   excluded. `.nlmGetFRLines`/`rxUiGet.nlmRxModel` (R/nlm.R) re-splice
+   `rx_nu_` from the symengine environment the same way they already do
+   for `rx_pred_f_`/`rx_r_` (a lone `rx_nu_ ~ nu` does not survive
+   rxOptExpr's dead-code elimination on its own).
+3. [x] `src/nlm.cpp`: widened the three `dist ==` guards (objective,
+   likelihood-contrib cotangent, gradient) to include T/Cauchy via a new
+   name-looked-up `predNuOffset`/`gradNuOffset`; calls `doCensT1`.
+4. [x] `src/inner.cpp`: added `predFOffset`/`predROffset`/`predNuOffset`
+   and `focei_tCensLl()` (mirrors nlm's value correction) at the three
+   `llikObs[kk] = f` sites -- currently inert for FOCEi (see Scope); ready
+   for the follow-up. Eta-gradient/curvature stay a documented KNOWN GAP
+   even once FOCEi's R-side gap closes (no `d(rx_pred_f_)/d(eta)` column).
+5. [x] Catch-all warning: `R/preProcessCensDistWarn.R` hook, runs for every
+   estimation method, warns (<75 chars, no method prefix) when CENS/LIMIT
+   data meets an endpoint outside {norm, dnorm} (plus {t, cauchy} for
+   nlm-family only). Skips `est="nls"` (already hard stops).
+6. [x] Tests: `test-nlm-cens-t.R` (nlm t()/cauchy() censoring vs a
+   censoring-ignored baseline, censInformation asserts the mechanism ran,
+   t(nu=1)==cauchy() identity, no spurious warning) and
+   `test-cens-dist-warn.R` (pois()+nlm warns, t()+focei warns but
+   t()+nlm does not, message-length check). Both essential-tier (small,
+   fast fits) -- not added to `.slowBatches`.
+7. [x] NEWS.md bullet under `## Bug fixes`, referencing #979.
 8. [ ] Antigravity review until clean.
 9. [ ] Push, open PR closing #979.

--- a/plans/t-cauchy-cens-979.md
+++ b/plans/t-cauchy-cens-979.md
@@ -72,5 +72,14 @@ function serves both.
    t()+nlm does not, message-length check). Both essential-tier (small,
    fast fits) -- not added to `.slowBatches`.
 7. [x] NEWS.md bullet under `## Bug fixes`, referencing #979.
-8. [ ] Antigravity review until clean.
-9. [ ] Push, open PR closing #979.
+8. [x] Antigravity review until clean. Two rounds: the first (full diff)
+   found (1) `.rxFinalizeInner`'s unconditional `rx_pred_f_` splice risked
+   shifting FOCEi's inner-model lhs column layout for EVERY endpoint type,
+   not just t()/cauchy() -- reverted entirely, since `predNuOffset` is
+   always -1 for FOCEi anyway so it was pointless besides; (2) the
+   `rxCensNuFix`/`rxPredLlik` `on.exit()` registration happened after the
+   flag mutation, leaving an interrupt-safety gap -- reordered so
+   `on.exit()` registers first; (3) missing M2/M4 test coverage for
+   `doCensT1` -- added. A second, targeted review of those three fixes
+   found nothing further.
+9. [x] Push, open PR closing #979.

--- a/src/censEst.h
+++ b/src/censEst.h
@@ -233,6 +233,90 @@ rxOptExpr(x)
   return dll;
 }
 
+// M2/M3/M4 censored log-likelihood correction for a location-scale Student-t
+// endpoint (`t(nu)`).  Cauchy is Student-t with nu=1 (armahead.h's
+// rxDistributionT/rxDistributionCauchy both route here; cauchy call sites
+// just pass nu=1.0) -- see #979.  f/r follow doCensNormal1's convention
+// (r is the VARIANCE, sd=sqrt(r) is the scale fed to llikT()/llikCauchy()).
+// `ll` is the full, already-normalized llikT()/llikCauchy() log-density
+// (rxode2ll, Stan-backed autodiff) -- unlike doCensNormal1 there is no
+// adjLik term to remove.
+//
+// @noRd
+static inline double doCensT1(double cens, double limDv, double lim, double ll,
+                              double f, double r, double nu) {
+  double sd = _safe_sqrt(r);
+  if (isM2(cens, lim)) {
+    // M2 adds likelihood even when the observation is defined; see
+    // doCensNormal1 for the derivation this mirrors.
+    updateCensFlag(censFlagM2);
+    double z = ((lim<f)*2.0 - 1.0)*(lim - f)/sd;
+    return ll - finite_log_prob(R::pt(z, nu, 0, 1));
+  } else if (isM3orM4(cens)) {
+    if (hasFiniteLimit(lim)) {
+      // M4 method
+      double logCum1 = R::pt(cens*(limDv-f)/sd, nu, 1, 1);
+      double logCum2 = R::pt(cens*(lim - f)/sd, nu, 1, 1);
+      double logTail = R::pt(cens*(lim - f)/sd, nu, 0, 1);
+      updateCensFlag(censFlagM4);
+      return finite_log_prob(logspace_sub(logCum1, logCum2)) -
+        finite_log_prob(logTail);
+    } else {
+      // M3 method
+      updateCensFlag(censFlagM3);
+      return finite_log_prob(R::pt(cens*(limDv-f)/sd, nu, 1, 1));
+    }
+  }
+  return ll;
+}
+
+// First derivative (w.r.t. eta, via the df/dr chain rule) of doCensT1's
+// correction.  Like dCensNormal1: M2 ADDS to dll (the observation is still
+// scored by its ordinary density); M3/M4 REPLACE dll entirely (the whole
+// contribution comes from the tail probability).  nu has no derivative
+// term here -- it is a fixed/estimated THETA, not eta-dependent; its outer
+// gradient is handled separately (nlm.cpp forces finite differences for
+// ANY censored observation's theta columns, independent of distribution).
+//
+// @noRd
+static inline double dCensT1(double cens, double limDv, double lim,
+                             double dll, double f, double r, double nu,
+                             double df, double dr) {
+  double sd = _safe_sqrt(r);
+  double dsd = dr/_safe_zero(2.0*sd);
+  double sd2 = _safe_zero(sd*sd);
+  auto dz = [&](double x, double sgn) {
+    return sgn*(-df*sd - (x - f)*dsd)/sd2;
+  };
+  if (isM2(cens, lim)) {
+    double sgn = (lim<f)*2.0 - 1.0;
+    double z = sgn*(lim - f)/sd;
+    double dzv = dz(lim, sgn);
+    double upper = R::pt(z, nu, 0, 0);
+    return dll + R::dt(z, nu, 0)*dzv/_safe_zero(upper);
+  } else if (isM3orM4(cens)) {
+    if (hasFiniteLimit(lim)) {
+      double z1 = cens*(limDv - f)/sd;
+      double z2 = cens*(lim - f)/sd;
+      double dz1 = dz(limDv, cens);
+      double dz2 = dz(lim, cens);
+      double t1 = R::pt(z1, nu, 1, 0);
+      double t2 = R::pt(z2, nu, 1, 0);
+      double upper2 = R::pt(z2, nu, 0, 0);
+      double pdf1 = R::dt(z1, nu, 0);
+      double pdf2 = R::dt(z2, nu, 0);
+      return (pdf1*dz1 - pdf2*dz2)/_safe_zero(t1 - t2) +
+        pdf2*dz2/_safe_zero(upper2);
+    } else {
+      double z = cens*(limDv - f)/sd;
+      double dzv = dz(limDv, cens);
+      double tcdf = R::pt(z, nu, 1, 0);
+      return R::dt(z, nu, 0)*dzv/_safe_zero(tcdf);
+    }
+  }
+  return dll;
+}
+
 // Analytic partials of the censored normal objective rho = -logLik-per-obs (kernel
 // orientation, transformed scale) w.r.t. the prediction f and variance r, for M2/M3/M4.
 // out[0..8] = rho_f, rho_r, rho_ff, rho_fr, rho_rr, rho_fff, rho_ffr, rho_frr, rho_rrr

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -306,6 +306,15 @@ struct focei_options {
   // d(r)/d(eta) columns follow rx_pred_ contiguously; located by name at setup.
   int predOffset;
   int predNoLhsOffset; // same, for the predNoLhs model used in the FD fallback
+  // t()/cauchy() M2/M3/M4 censoring (#979): rx_pred_f_/rx_r_/rx_nu_ indices in
+  // the inner lhs for a llik-forced endpoint (rx_pred_ itself holds the full
+  // llikT()/llikCauchy() log-density there, not a mean).  -1 when absent (no
+  // t()/cauchy() endpoint in this model).  Located by name, independently of
+  // predOffset -- unlike rx_pred_f_/rx_r_'s NORMAL-branch columns (comment
+  // above), these are not assumed contiguous with rx_pred_.
+  int predFOffset = -1;
+  int predROffset = -1;
+  int predNuOffset = -1;
   // fast=TRUE log-likelihood/generalized endpoint: a SEPARATE compiled model (rxHess2)
   // carries the exact second-order eta expansion rx__d2pred_i_j__ = d2(logLik)/deta_i deta_j
   // (upper triangle i<=j, j-outer/i-inner order).  This offset is the lhs index of its first
@@ -2310,6 +2319,52 @@ static inline double likInner0Contrib(int id, int k, int dist, int cens,
   return llAdd;
 }
 
+// M2/M3/M4 censored log-likelihood VALUE for a t()/cauchy() observation
+// (#979).  `llVal` is the already-computed llikT()/llikCauchy() log-density
+// (what every `dist != rxDistributionNorm` branch uses verbatim today).
+// Reads RAW (untransformed) dv/limit against RAW rx_pred_f_ -- the same
+// convention nlm.cpp's doCensT1 call uses -- since rx_pred_f_ is
+// `.rxGetPredictionF()` (pre-transform), unlike the tbs()-transformed
+// dv/limit locals likInner0 computes for the NORMAL branch.
+//
+// KNOWN GAP (two layers, #979):
+//  1. This function currently NEVER fires for FOCEi/FOCE/AGQ/Laplace:
+//     predNuOffset stays -1 there (see its setup comment above, in the
+//     alloc block) because the R side only emits rx_nu_/a real rx_r_ for
+//     nlm-family.  nlm-family (src/nlm.cpp) IS fully corrected -- value
+//     AND gradient, since nlm has no etas to worry about.
+//  2. Once FOCEi's R-side gap closes, only the VALUE would be corrected
+//     here.  The eta-gradient (`lp`, via the analytic d(llikT)/d(eta)
+//     sensitivity column already read into `fpm`/`a(k,i)`) and the inner-
+//     Hessian curvature (`cHff`/`cHfr`/`cHrr`, Gauss-Newton fallback) would
+//     still score a censored t()/cauchy() row as if uncensored -- closing
+//     THAT requires a d(rx_pred_f_)/d(eta) sensitivity column rxode2 does
+//     not currently emit.
+// This function is exercised and validated end-to-end today only via
+// nlm-family's identical doCensT1 call; it is deliberately-ready, currently
+// inert infrastructure for FOCEi, not dead code.
+static inline double focei_tCensLl(rx_solving_options_ind *ind, int kk,
+                                   int dist, int cens, double llVal,
+                                   double *lhs) {
+  if ((dist != rxDistributionT && dist != rxDistributionCauchy) ||
+      op_focei.predFOffset < 0 || op_focei.predROffset < 0 ||
+      op_focei.predNuOffset < 0) {
+    return llVal;
+  }
+  double limit = R_NegInf;
+  if (hasRxLimit(rx)) {
+    limit = getIndLimit(ind, kk);
+    if (ISNA(limit)) limit = R_NegInf;
+  }
+  bool isCensObs = (cens != 0) || (R_FINITE(limit) && !ISNA(limit));
+  if (!isCensObs) return llVal;
+  double dv = getIndDv(ind, kk);
+  double f = lhs[op_focei.predFOffset];
+  double r = lhs[op_focei.predROffset];
+  double nu = lhs[op_focei.predNuOffset];
+  return doCensT1((double)cens, dv, limit, llVal, f, r, nu);
+}
+
 double likInner0(double *eta, int id) {
   rx = getRxSolve_();
   rx_solving_options_ind *ind = getSolvingOptionsInd(rx, getRxId(id));
@@ -2722,8 +2777,9 @@ double likInner0(double *eta, int id) {
               fInd->llik += ll;
               fInd->nObs++;
             } else {
-              llikObs[kk] = f;
-              fInd->llik += f;
+              double llT = focei_tCensLl(ind, kk, dist, cens, f, lhs);
+              llikObs[kk] = llT;
+              fInd->llik += llT;
               fInd->nNonNormal++;
               fInd->nObs++;
             }
@@ -2819,8 +2875,9 @@ double likInner0(double *eta, int id) {
                  fInd->llik +=  ll;
                  fInd->nObs++;
                } else {
-                 llikObs[kk] = f;
-                 fInd->llik += f;
+                 double llT = focei_tCensLl(ind, kk, dist, cens, f, lhs);
+                 llikObs[kk] = llT;
+                 fInd->llik += llT;
                  fInd->nNonNormal++;
                  fInd->nObs++;
                }
@@ -2847,8 +2904,9 @@ double likInner0(double *eta, int id) {
                 fInd->llik +=  ll;
                 fInd->nObs++;
               } else {
-                llikObs[kk] = f;
-                fInd->llik += f;
+                double llT = focei_tCensLl(ind, kk, dist, cens, f, lhs);
+                llikObs[kk] = llT;
+                fInd->llik += llT;
                 fInd->nNonNormal++;
                 fInd->nObs++;
               }
@@ -6207,6 +6265,19 @@ static inline void foceiSetupTheta_(List mvi,
     // Locate rx_pred_ in the inner lhs (AR(1) lag defs may precede it).
     int _ipi = odeSwapLhsIndex(odeSlotInner, "rx_pred_");
     op_focei.predOffset = (_ipi < 0) ? 0 : _ipi;
+    op_focei.predFOffset = odeSwapLhsIndex(odeSlotInner, "rx_pred_f_");
+    op_focei.predROffset = odeSwapLhsIndex(odeSlotInner, "rx_r_");
+    // predNuOffset is currently ALWAYS -1 for FOCEi/FOCE/AGQ/Laplace: the R
+    // side (.fixCensRNuLine, R/focei.R) only emits rx_nu_ for nlm-family
+    // (nlmixr2global$rxCensNuFix), because doing so for FOCEi's llik-forced
+    // t()/cauchy() endpoint crashes rxode2's eta-sensitivity generation once
+    // real etas are present ("user function 'get' requires 5 arguments";
+    // reproduces with plain cauchy(), no censoring at all).  focei_tCensLl()
+    // below is written and validated against a real fit already (nlm-family
+    // uses the identical doCensT1 path), so this is deliberately-inert,
+    // ready infrastructure -- KNOWN GAP pending a fix to that rxode2-side
+    // interaction, not a TODO in this file (#979).
+    op_focei.predNuOffset = odeSwapLhsIndex(odeSlotInner, "rx_nu_");
     // The exact-Hessian rx__d2pred_ columns live in the SEPARATE 2nd-order model (rxHess2),
     // located in foceiFitCpp_ after this setup; predHess2Offset is set there, not here.
   } else if (!op_focei.alloc){

--- a/src/nlm.cpp
+++ b/src/nlm.cpp
@@ -77,6 +77,12 @@ struct nlmOptions {
   // stay correct regardless of how many intermediates precede rx_pred_.
   int predOffset=0; // rx_pred_ index in the predOnly model (rxPred)
   int gradOffset=0; // rx_pred_ index in the thetaGrad model (rxInner)
+  // rx_nu_ (Student-t degrees of freedom; cauchy's rx_nu_ is a constant 1) index,
+  // or -1 when the endpoint has none (norm/dnorm, or no llik-forced endpoint at
+  // all).  Looked up by name like predOffset/gradOffset rather than assumed
+  // contiguous with rx_pred_f_/rx_r_ -- see #979.
+  int predNuOffset=-1;
+  int gradNuOffset=-1;
   scaling scale;
   bool loaded=false;
 };
@@ -128,6 +134,7 @@ RObject nlmSetup(Environment e) {
                  odeSwapLhsIndex(odeSlotPred, "rx_r_") >= 0) ? 1 : 0;
   int _ip = odeSwapLhsIndex(odeSlotPred, "rx_pred_");
   nlmOp.predOffset = (_ip < 0) ? 0 : _ip;
+  nlmOp.predNuOffset = odeSwapLhsIndex(odeSlotPred, "rx_nu_");
   resetCensFlag();
 
   nlmOp.solveType = as<int>(control["solveType"]);
@@ -145,11 +152,13 @@ RObject nlmSetup(Environment e) {
     // rx_pred_f_/rx_r_ follow contiguously).
     int _ig = odeSwapLhsIndex(odeSlotInner, "rx_pred_");
     nlmOp.gradOffset = (_ig < 0) ? 0 : _ig;
+    nlmOp.gradNuOffset = odeSwapLhsIndex(odeSlotInner, "rx_nu_");
   } else {
     if (nlmOp.solveType != solveType_nls_pred) {
       nlmOp.solveType = solveType_pred;
     }
     model = pred;
+    nlmOp.gradNuOffset = -1;
   }
 
   List rxControl = as<List>(e["rxControl"]);
@@ -463,7 +472,9 @@ void nlmSolveFid(double *retD, int nobs, arma::vec &theta, int id) {
       if (nlmOp.hasFR && (hasRxCens(rx) || hasRxLimit(rx))) {
         int yj = getIndYj(ind), dist = 0, yj0 = 0;
         _splitYj(&yj, &dist, &yj0);
-        if (dist == rxDistributionDnorm || dist == rxDistributionNorm) {
+        if (dist == rxDistributionDnorm || dist == rxDistributionNorm ||
+            ((dist == rxDistributionT || dist == rxDistributionCauchy) &&
+             nlmOp.predNuOffset >= 0)) {
           int censi = 0;
           if (hasRxCens(rx)) censi = getIndCens(ind, kk);
           double dvi = getIndDv(ind, kk);
@@ -475,7 +486,15 @@ void nlmSolveFid(double *retD, int nobs, arma::vec &theta, int id) {
           if (censi != 0 || (R_FINITE(limiti) && !ISNA(limiti))) {
             double f = lhs[po + 1]; // rx_pred_f_
             double r = lhs[po + 2]; // rx_r_
-            double ll = doCensNormal1((double)censi, dvi, limiti, -val, f, r, 0);
+            double ll;
+            if (dist == rxDistributionT || dist == rxDistributionCauchy) {
+              // cauchy is Student-t with nu=1 (#979); .fixCensRNuLine (R/focei.R)
+              // already emits rx_nu_ ~ 1 for cauchy, so this always reads a real nu.
+              double nu = lhs[nlmOp.predNuOffset];
+              ll = doCensT1((double)censi, dvi, limiti, -val, f, r, nu);
+            } else {
+              ll = doCensNormal1((double)censi, dvi, limiti, -val, f, r, 0);
+            }
             val = -ll;
           }
         }
@@ -561,8 +580,10 @@ arma::mat nlmSolveGradId(arma::vec &theta, int id) {
       rxInner.calc_lhs(id, curT, getOpIndSolve(op, ind, j), lhs);
       // Save outer kk (time index) for censoring data access before inner kk loop shadows it
       int kkOuter = kk;
-      // Determine censoring status for this observation (only for normal distributions)
+      // Determine censoring status for this observation (normal/dnorm and,
+      // via doCensT1(), t()/cauchy() -- see #979)
       bool hasCensObs = false;
+      bool isTDist = false;
       int censi = 0;
       double dvi = 0.0, limiti = R_NegInf;
       if (nlmOp.hasFR && (hasRxCens(rx) || hasRxLimit(rx))) {
@@ -576,6 +597,16 @@ arma::mat nlmSolveGradId(arma::vec &theta, int id) {
             if (ISNA(limiti)) limiti = R_NegInf;
           }
           hasCensObs = (censi != 0) || (R_FINITE(limiti) && !ISNA(limiti));
+        } else if ((dist == rxDistributionT || dist == rxDistributionCauchy) &&
+                   nlmOp.gradNuOffset >= 0) {
+          if (hasRxCens(rx)) censi = getIndCens(ind, kkOuter);
+          dvi = getIndDv(ind, kkOuter);
+          if (hasRxLimit(rx)) {
+            limiti = getIndLimit(ind, kkOuter);
+            if (ISNA(limiti)) limiti = R_NegInf;
+          }
+          hasCensObs = (censi != 0) || (R_FINITE(limiti) && !ISNA(limiti));
+          isTDist = true;
         }
       }
       // rx_pred_ is at lhs[gradOffset]; the ntheta sensitivity columns follow
@@ -593,7 +624,13 @@ arma::mat nlmSolveGradId(arma::vec &theta, int id) {
             double f = lhs[go + nlmOp.ntheta + 1]; // rx_pred_f_
             double r = lhs[go + nlmOp.ntheta + 2]; // rx_r_
             if (!ISNA(f) && !ISNA(r)) {
-              double ll = doCensNormal1((double)censi, dvi, limiti, -val, f, r, 0);
+              double ll;
+              if (isTDist) {
+                double nu = lhs[nlmOp.gradNuOffset];
+                ll = doCensT1((double)censi, dvi, limiti, -val, f, r, nu);
+              } else {
+                ll = doCensNormal1((double)censi, dvi, limiti, -val, f, r, 0);
+              }
               val = -ll;
             }
           }

--- a/tests/testthat/test-cens-dist-warn.R
+++ b/tests/testthat/test-cens-dist-warn.R
@@ -1,0 +1,74 @@
+nmTest({
+  # Tests for the catch-all "censoring ignored" warning (#979): any
+  # distribution the M2/M3/M4 machinery does not understand (everything
+  # except norm/dnorm, and -- nlm-family only -- t()/cauchy()) should warn
+  # instead of silently scoring a censored row as uncensored.
+
+  one.cmt.pois <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      lam <- 1
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      lambda <- exp(lam) * cp
+      cp ~ pois(lambda)
+    })
+  }
+
+  one.cmt.t <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      nu <- fix(5)
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd) + t(nu)
+    })
+  }
+
+  .dat <- nlmixr2data::theo_sd
+  .dat <- .dat[.dat$ID <= 2, ]
+  .dat$CENS <- ifelse(.dat$DV < 3 & .dat$EVID == 0, 1L, 0L)
+  .dat$DV[.dat$CENS == 1] <- 3
+
+  test_that("pois() + CENS warns (censoring ignored) on nlm", {
+    fit <- suppressMessages(suppressWarnings(
+      nlmixr2(one.cmt.pois, .dat, est = "nlm", control = list(print = 0))))
+    expect_true(any(grepl("censoring ignored for 'pois'", fit$runInfo,
+                          fixed = TRUE)))
+  })
+
+  test_that("t() + CENS warns on focei (not yet supported there) but not on nlm", {
+    fitNlm <- suppressMessages(suppressWarnings(
+      nlmixr2(one.cmt.t, .dat, est = "nlm", control = list(print = 0))))
+    expect_false(any(grepl("censoring ignored", fitNlm$runInfo, fixed = TRUE)))
+
+    fitFocei <- suppressMessages(suppressWarnings(
+      nlmixr2(one.cmt.t, .dat, est = "focei", control = list(print = 0))))
+    expect_true(any(grepl("censoring ignored for 't'", fitFocei$runInfo,
+                          fixed = TRUE)))
+  })
+
+  test_that("censoring-ignored warning text stays under 75 characters", {
+    for (.d in c("pois", "binom", "beta", "chisq", "dexp", "f", "geom",
+                 "unif", "weibull", "dgamma", "ordinal", "t", "cauchy")) {
+      expect_lt(nchar(paste0("censoring ignored for '", .d, "' endpoint(s)")), 75)
+    }
+  })
+})

--- a/tests/testthat/test-nlm-cens-t.R
+++ b/tests/testthat/test-nlm-cens-t.R
@@ -74,6 +74,37 @@ nmTest({
   .datNaive <- .datM3
   .datNaive$CENS <- 0L
 
+  # M2 censoring: CENS=0 everywhere, with a finite LIMIT (interval lower
+  # bound) on every observation.
+  .datM2 <- .dat
+  .datM2$CENS <- 0L
+  .datM2$LIMIT <- 0
+
+  # M4 censoring: M3's CENS=1 rows PLUS a LIMIT on every row -- the
+  # uncensored (CENS=0) rows are M2, the censored (CENS=1) rows are M4.
+  .datM4 <- .datM3
+  .datM4$LIMIT <- 0
+
+  test_that("nlm t() endpoint honors M2 censoring (#979)", {
+    fitCens <- suppressMessages(suppressWarnings(
+      .nlmixr(one.cmt.t, .datM2, est = "nlm", list(print = 0))))
+    expect_equal(as.character(fitCens$censInformation), "M2 censoring")
+
+    fitNaive <- suppressMessages(suppressWarnings(
+      .nlmixr(one.cmt.t, .dat, est = "nlm", list(print = 0))))
+    expect_true(abs(fitCens$objf - fitNaive$objf) > 1e-6)
+  })
+
+  test_that("nlm t() endpoint honors M4 censoring (#979)", {
+    fitCens <- suppressMessages(suppressWarnings(
+      .nlmixr(one.cmt.t, .datM4, est = "nlm", list(print = 0))))
+    expect_equal(as.character(fitCens$censInformation), "M2 and M4 censoring")
+
+    fitNaive <- suppressMessages(suppressWarnings(
+      .nlmixr(one.cmt.t, .datNaive, est = "nlm", list(print = 0))))
+    expect_true(abs(fitCens$objf - fitNaive$objf) > 1e-6)
+  })
+
   test_that("nlm t() endpoint honors M3 censoring (#979)", {
     fitCens <- suppressMessages(suppressWarnings(
       .nlmixr(one.cmt.t, .datM3, est = "nlm", list(print = 0))))

--- a/tests/testthat/test-nlm-cens-t.R
+++ b/tests/testthat/test-nlm-cens-t.R
@@ -1,0 +1,121 @@
+nmTest({
+  # Tests for M2/M3/M4 censoring support for t()/cauchy() endpoints on the
+  # NLM estimation engine (#979).  Cauchy is Student-t with nu=1, so
+  # doCensT1() serves both; verify that identity too.
+
+  one.cmt.t <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      nu <- fix(5)
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd) + t(nu)
+    })
+  }
+
+  one.cmt.cauchy <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd) + cauchy()
+    })
+  }
+
+  one.cmt.t1 <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      nu <- fix(1)
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd) + t(nu)
+    })
+  }
+
+  .dat <- nlmixr2data::theo_sd
+  .dat <- .dat[.dat$ID <= 4, ]
+
+  .LLOQ <- 3.0
+  .datM3 <- .dat
+  .datM3$CENS <- ifelse(.datM3$DV < .LLOQ & .datM3$EVID == 0, 1L, 0L)
+  .datM3$DV[.datM3$CENS == 1] <- .LLOQ
+
+  # A "naive" comparison dataset: same DV values, but CENS all zero, so the
+  # censored rows are scored as if they were real, uncensored observations
+  # AT the LLOQ.  If the M2/M3/M4 correction is being applied, the fitted
+  # objective must differ from this baseline.
+  .datNaive <- .datM3
+  .datNaive$CENS <- 0L
+
+  test_that("nlm t() endpoint honors M3 censoring (#979)", {
+    fitCens <- suppressMessages(suppressWarnings(
+      .nlmixr(one.cmt.t, .datM3, est = "nlm", list(print = 0))))
+    expect_equal(as.character(fitCens$censInformation), "M3 censoring")
+
+    fitNaive <- suppressMessages(suppressWarnings(
+      .nlmixr(one.cmt.t, .datNaive, est = "nlm", list(print = 0))))
+    expect_equal(as.character(fitNaive$censInformation), "No censoring")
+
+    # the M2/M3/M4 correction must change the objective relative to the
+    # naive (censoring-ignored) baseline -- this is the exact silent-
+    # corruption issue #979 reported.
+    expect_true(abs(fitCens$objf - fitNaive$objf) > 1e-6)
+  })
+
+  test_that("nlm cauchy() endpoint honors M3 censoring (#979)", {
+    fitCens <- suppressMessages(suppressWarnings(
+      .nlmixr(one.cmt.cauchy, .datM3, est = "nlm", list(print = 0))))
+    expect_equal(as.character(fitCens$censInformation), "M3 censoring")
+
+    fitNaive <- suppressMessages(suppressWarnings(
+      .nlmixr(one.cmt.cauchy, .datNaive, est = "nlm", list(print = 0))))
+    expect_equal(as.character(fitNaive$censInformation), "No censoring")
+
+    expect_true(abs(fitCens$objf - fitNaive$objf) > 1e-6)
+  })
+
+  test_that("t(nu=1) censored objective matches cauchy() censored objective (#979)", {
+    # cauchy() is Student-t with nu=1 -- doCensT1() is a single function
+    # serving both, so the fitted -2LL at the same starting values/data
+    # should agree to solver tolerance.
+    fitT1 <- suppressMessages(suppressWarnings(
+      .nlmixr(one.cmt.t1, .datM3, est = "nlm", list(print = 0))))
+    fitCauchy <- suppressMessages(suppressWarnings(
+      .nlmixr(one.cmt.cauchy, .datM3, est = "nlm", list(print = 0))))
+    expect_equal(fitT1$objf, fitCauchy$objf, tolerance = 1e-3)
+  })
+
+  test_that("nlm t()/cauchy() censoring does not warn (#979 catch-all)", {
+    expect_no_warning(suppressMessages(
+      .nlmixr(one.cmt.t, .datM3, est = "nlm", list(print = 0))))
+    expect_no_warning(suppressMessages(
+      .nlmixr(one.cmt.cauchy, .datM3, est = "nlm", list(print = 0))))
+  })
+})


### PR DESCRIPTION
## Summary

- `t()`/`cauchy()` endpoints compile through the general-log-likelihood path, and every M2/M3/M4 censoring guard in the C++ layer only checked `dist == rxDistributionNorm`/`Dnorm` — so a censored `t()`/`cauchy()` observation was silently scored with its ordinary (uncensored) density instead of the correct tail-probability correction.
- Adds `doCensT1()`/`dCensT1()` to `src/censEst.h` — a Student-t/Cauchy CDF-based M2/M3/M4 correction mirroring the existing `doCensNormal1()`/`dCensNormal1()`. Cauchy is Student-t with `nu=1`, so one function serves both (validated: `nu=1` matches `pcauchy()` exactly, large-`nu` matches the normal correction, and the derivative matches finite differences to <1e-7).
- Wires it into **nlm-family** (`nlm`/`bobyqa`/`lbfgsb3c`/`n1qn1`/`newuoa`/`nlminb`/`optim`/`uobyqa`, `src/nlm.cpp`) — full support, value and gradient, verified end-to-end against a censoring-ignored baseline and the `t(nu=1)==cauchy()` identity.
- **FOCEi/FOCE/AGQ/Laplace are intentionally NOT fixed here.** Giving the llik-forced `t()`/`cauchy()` endpoint a real (nonzero) `rx_r_` — needed for the CDF correction — crashes rxode2's eta-sensitivity generation once real etas are present (`"user function 'get' requires 5 arguments"`), reproduced independent of censoring with a plain `cauchy()` model. `src/inner.cpp`'s `focei_tCensLl()`/offset wiring is written and ready but deliberately kept inert (gated by a flag only nlm's model build sets) pending a follow-up on that rxode2-side interaction. Filed as #992.
- Every distribution still missing M2/M3/M4 support (every generalized-likelihood distribution besides norm/dnorm, plus t()/cauchy() outside nlm-family) now gets a concise `$runInfo` warning instead of silently scoring a censored row as uncensored (`R/preProcessCensDistWarn.R`).

Closes #979. Follow-up: #992 (FOCEi eta-sensitivity crash blocking the FOCEi-side fix).

## Test plan

- [x] `src/censEst.h` new functions validated standalone via a scratch Rcpp harness against finite differences, `pcauchy()`, and the large-`nu` normal limit.
- [x] `tests/testthat/test-nlm-cens-t.R`: M2/M3/M4 coverage for `t()` and `cauchy()` on nlm, asserting `censInformation` proves the mechanism ran, the objective differs from a censoring-ignored baseline, the `t(nu=1)==cauchy()` identity, and no spurious warning.
- [x] `tests/testthat/test-cens-dist-warn.R`: catch-all warning fires for `pois()`+nlm and `t()`+focei, but not `t()`+nlm; message length check.
- [x] Existing `test-nlm-cens.R`, `test-focei-cens.R`, `test-cov-analytic.R` rerun clean (no regressions).
- [x] Two rounds of independent (Gemini/antigravity) code review; findings addressed (interrupt-safe `on.exit()` ordering, reverted an unrelated-endpoint risk in FOCEi's inner-model lhs splicing, added missing M2/M4 test coverage).