### PR TITLE
feat(imp): combSens now defaults to TRUE for impmap/imp's theta-sensitivity M-step

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,16 +27,14 @@
   seed) change as a result.
 ## New features
 
-- `impmapControl()`/`impControl()` gain `combSens` (default `FALSE`): when
+- `impmapControl()`/`impControl()` gain `combSens` (default `TRUE`): when
   `est="impmap"`/`"imp"`/`"qrpem"` has non-mu (structural or residual-error)
   thetas to estimate, `combSens=TRUE` carries their sensitivity columns on the
   INNER model itself instead of a second, dedicated model, and the E-step's
   own per-sample inner solve now supplies the M-step's Newton step directly
   (no second solve) whenever `sir=FALSE` (the default) -- roughly halving the
-  ODE solving the M-step's theta gradient costs. Opt-in rather than the
-  default: folding the theta-sensitivity states into the eta-sensitivity ODE
-  system changes the integrator's adaptive step-size path, so results move by
-  a small amount relative to the existing two-model default.
+  ODE solving the M-step's theta gradient costs. Pass `combSens=FALSE` for the
+  previous two-model behavior.
 
 - A pure-linear `matExp()` model now solves natively through rxode2's
   matrix-exponential driver (`rxControl(method="indLin")`) under SAEM instead
@@ -161,6 +159,18 @@
   fit, so removing them changes no result.
 
 ## Bug fixes
+
+- `est="impmap"`'s inner Hessian (`impGetHessian`), which builds the
+  importance-sampling proposal, could read a stale cached `linCmtB()`
+  Jacobian on a `linCmt()` model with a non-mu structural theta (a theta with
+  no random effect, e.g. `ka` fixed but `V` estimated on log scale). Several
+  compiled peer models share one solve pool (`odeSwap`); `linCmtB()` caches
+  its Jacobian in a field gated by `rx->ndiff`, a process-global that
+  `odeSwapSolveInd()` never restored per peer, so a solve could read a
+  Jacobian built for a DIFFERENT peer's structural-parameter set. The
+  resulting proposal was artificially wide, which masked a real heavy tail
+  (Pareto k-hat) as healthy rather than repairing it. `odeSwapSolveInd()` now
+  restores each peer's own `ndiff` before every solve.
 
 - Every NLM-family method (`nlm`, `bobyqa`, `newuoa`, `uobyqa`, `n1qn1`,
   `lbfgsb3c`, `optim`, `nlminb`) silently mis-scored any M2/M3/M4-censored

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,17 @@
   seed) change as a result.
 ## New features
 
+- `impmapControl()`/`impControl()` gain `combSens` (default `FALSE`): when
+  `est="impmap"`/`"imp"`/`"qrpem"` has non-mu (structural or residual-error)
+  thetas to estimate, `combSens=TRUE` carries their sensitivity columns on the
+  INNER model itself instead of a second, dedicated model, and the E-step's
+  own per-sample inner solve now supplies the M-step's Newton step directly
+  (no second solve) whenever `sir=FALSE` (the default) -- roughly halving the
+  ODE solving the M-step's theta gradient costs. Opt-in rather than the
+  default: folding the theta-sensitivity states into the eta-sensitivity ODE
+  system changes the integrator's adaptive step-size path, so results move by
+  a small amount relative to the existing two-model default.
+
 - A pure-linear `matExp()` model now solves natively through rxode2's
   matrix-exponential driver (`rxControl(method="indLin")`) under SAEM instead
   of being flattened to an equivalent `d/dt()` ODE first.  SAEM has no

--- a/NEWS.md
+++ b/NEWS.md
@@ -170,7 +170,13 @@
   Jacobian built for a DIFFERENT peer's structural-parameter set. The
   resulting proposal was artificially wide, which masked a real heavy tail
   (Pareto k-hat) as healthy rather than repairing it. `odeSwapSolveInd()` now
-  restores each peer's own `ndiff` before every solve.
+  restores each peer's own `ndiff` before every solve. That restore is itself
+  a write to a field on the single shared solve struct, so `impGetHessian`'s
+  parallel per-subject loop (a subject that falls back to the doFD/pred path
+  can pick a different peer, and so a different `ndiff`, than a subject still
+  on the plain inner path, concurrently) now serializes that write-then-solve
+  window whenever the fit has a peer that needs it, rather than risk one
+  subject's solve reading another's in-flight `ndiff`.
 
 - `est="saem"` with `saemControl(nMix > 1)` (mixture SAEM) inverted the
   `propT()`/`powT()` (transformed-basis) vs. plain `prop()`/`pow()`

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -19,7 +19,11 @@
                            # not foceiControl() arguments, so they must be dropped
                            # when down-converting (e.g. .setOfvFo's do.call(foceiControl))
                            "impMuThetaIdx", "impMuEtaIdx", "impThetaSensIdx",
-                           "impOmegaFixedEta")
+                           "impOmegaFixedEta",
+                           # combined eta+theta sensitivity build (#958): an
+                           # impmap-internal request for the fused inner model;
+                           # not a foceiControl() argument either.
+                           "combSens")
 
 #' Control options for the impmap (importance-sampling EM) estimation method
 #'
@@ -290,6 +294,19 @@
 #'   `isample` weighted samples.
 #' @param sirSample Number of SIR resampled points per subject; `NULL` uses
 #'   `max(25, ceiling(isample/10))`.  Must be at most `isample`.
+#' @param combSens When `TRUE` and there are non-mu (structural or
+#'   residual-error) thetas to estimate, carry their sensitivity columns on
+#'   the INNER model itself (the combined eta+theta sensitivity build, #958)
+#'   instead of compiling and solving a separate, dedicated model for them.
+#'   With `sir=FALSE` (the default) the E-step's own per-sample inner solve
+#'   then supplies the M-step's Newton step directly, with no second solve --
+#'   roughly halving the ODE solving the theta-sensitivity Newton step costs.
+#'   `FALSE` by default: the fused build changes the ODE integrator's
+#'   adaptive step-size path (more sensitivity states solved together), so
+#'   results move by a small amount relative to the two-model default -- not
+#'   a correctness issue, but enough to occasionally move a diagnostic (e.g. a
+#'   borderline Pareto k-hat) across a threshold, so it does not change any
+#'   existing fit's numbers unless requested.
 #' @return impmapControl object
 #' @export
 #' @author Matthew L. Fidler
@@ -320,7 +337,9 @@ impmapControl <- function(sigdig=3,
                           qrRefresh=TRUE,
                           sir=FALSE,
                           sirSample=NULL,
-                          muModel=c("lin", "none")) {
+                          muModel=c("lin", "none"),
+                          combSens=FALSE) {
+  checkmate::assertLogical(combSens, len=1, any.missing=FALSE)
   muModel <- match.arg(muModel)
   gammaMethod <- match.arg(gammaMethod)
   gammaRule <- match.arg(gammaRule)
@@ -435,6 +454,7 @@ impmapControl <- function(sigdig=3,
   .control$qrRefresh <- qrRefresh
   .control$sir <- sir
   .control$sirSample <- .sirSample
+  .control$combSens <- combSens
   class(.control) <- "impmapControl"
   .control
 }
@@ -682,6 +702,24 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   # error) with sensitivity outputs in the sensitivity model; the M-step Newton
   # update maps its output columns back to these thetas.
   .control$impThetaSensIdx <- as.integer(.impmapEstTheta(ui)$all - 1L)
+  # Combined eta+theta sensitivity build (#958), opt-in (impmapControl(combSens=)):
+  # when requested AND there is anything to differentiate, carry the theta
+  # columns on the INNER model itself instead of compiling+solving a separate
+  # rxThetaSens peer.  This is what lets the E-step's own per-sample inner
+  # solve (impEvalJointLik) also harvest the M-step's d(f)/d(theta)/d(V)/d(theta)
+  # columns for free (impThetaSensCollect / impEStep's harvest path in
+  # inner.cpp), instead of the M-step re-solving every sample from scratch in
+  # a second, dedicated model -- roughly halving the ODE solving the M-step
+  # Newton step costs (sir=FALSE, the default).  Off by default: folding the
+  # theta-sensitivity states into the SAME coupled ODE system as the eta
+  # sensitivities changes the integrator's adaptive step-size path, so results
+  # move by a few floating-point ULPs' worth relative to the two-model path --
+  # not a correctness issue (the M5/M6 FOCEI-convergence tests in
+  # test-impmap.R pass either way), but enough to occasionally cross a
+  # diagnostic threshold (e.g. a borderline Pareto k-hat), so it does not
+  # default on for existing fits.
+  .control$combSens <- isTRUE(.control$combSens) &&
+    length(.control$impThetaSensIdx) > 0L
   # 0-based eta indices whose Omega diagonal is FIXED; the EM Omega update
   # restores their rows/columns to the starting value so fix()ed variances hold.
   .etaOrd <- .etaRows[order(.etaRows$neta1), ]

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -294,19 +294,19 @@
 #'   `isample` weighted samples.
 #' @param sirSample Number of SIR resampled points per subject; `NULL` uses
 #'   `max(25, ceiling(isample/10))`.  Must be at most `isample`.
-#' @param combSens When `TRUE` and there are non-mu (structural or
-#'   residual-error) thetas to estimate, carry their sensitivity columns on
+#' @param combSens When `TRUE` (the default) and there are non-mu (structural
+#'   or residual-error) thetas to estimate, carry their sensitivity columns on
 #'   the INNER model itself (the combined eta+theta sensitivity build, #958)
 #'   instead of compiling and solving a separate, dedicated model for them.
 #'   With `sir=FALSE` (the default) the E-step's own per-sample inner solve
 #'   then supplies the M-step's Newton step directly, with no second solve --
 #'   roughly halving the ODE solving the theta-sensitivity Newton step costs.
-#'   `FALSE` by default: the fused build changes the ODE integrator's
-#'   adaptive step-size path (more sensitivity states solved together), so
-#'   results move by a small amount relative to the two-model default -- not
-#'   a correctness issue, but enough to occasionally move a diagnostic (e.g. a
-#'   borderline Pareto k-hat) across a threshold, so it does not change any
-#'   existing fit's numbers unless requested.
+#'   Set `FALSE` to use the older two-model path instead. (Earlier versions
+#'   shipped `FALSE` as the default: on a `linCmt()` model with a single
+#'   non-mu structural theta, `combSens=TRUE`/`FALSE` measurably disagreed --
+#'   not `combSens` moving the answer, but an unrelated pre-existing bug in
+#'   how the shared solve pool swapped between peer models, since fixed. The
+#'   two now agree on every fixture measured, so `TRUE` is the default.)
 #' @return impmapControl object
 #' @export
 #' @author Matthew L. Fidler
@@ -338,7 +338,7 @@ impmapControl <- function(sigdig=3,
                           sir=FALSE,
                           sirSample=NULL,
                           muModel=c("lin", "none"),
-                          combSens=FALSE) {
+                          combSens=TRUE) {
   checkmate::assertLogical(combSens, len=1, any.missing=FALSE)
   muModel <- match.arg(muModel)
   gammaMethod <- match.arg(gammaMethod)
@@ -702,22 +702,32 @@ nmObjGetFoceiControl.impmap <- function(x, ...) {
   # error) with sensitivity outputs in the sensitivity model; the M-step Newton
   # update maps its output columns back to these thetas.
   .control$impThetaSensIdx <- as.integer(.impmapEstTheta(ui)$all - 1L)
-  # Combined eta+theta sensitivity build (#958), opt-in (impmapControl(combSens=)):
-  # when requested AND there is anything to differentiate, carry the theta
-  # columns on the INNER model itself instead of compiling+solving a separate
-  # rxThetaSens peer.  This is what lets the E-step's own per-sample inner
-  # solve (impEvalJointLik) also harvest the M-step's d(f)/d(theta)/d(V)/d(theta)
-  # columns for free (impThetaSensCollect / impEStep's harvest path in
-  # inner.cpp), instead of the M-step re-solving every sample from scratch in
-  # a second, dedicated model -- roughly halving the ODE solving the M-step
-  # Newton step costs (sir=FALSE, the default).  Off by default: folding the
-  # theta-sensitivity states into the SAME coupled ODE system as the eta
-  # sensitivities changes the integrator's adaptive step-size path, so results
-  # move by a few floating-point ULPs' worth relative to the two-model path --
-  # not a correctness issue (the M5/M6 FOCEI-convergence tests in
-  # test-impmap.R pass either way), but enough to occasionally cross a
-  # diagnostic threshold (e.g. a borderline Pareto k-hat), so it does not
-  # default on for existing fits.
+  # Combined eta+theta sensitivity build (#958), on by default when there is
+  # anything to differentiate (impmapControl(combSens=FALSE) opts back out):
+  # carries the theta columns on the INNER model itself instead of
+  # compiling+solving a separate rxThetaSens peer.  This is what lets the
+  # E-step's own per-sample inner solve (impEvalJointLik) also harvest the
+  # M-step's d(f)/d(theta)/d(V)/d(theta) columns for free (impThetaSensCollect
+  # / impEStep's harvest path in inner.cpp), instead of the M-step re-solving
+  # every sample from scratch in a second, dedicated model -- roughly halving
+  # the ODE solving the M-step Newton step costs (sir=FALSE, the default).
+  #
+  # This was shipped opt-in at first: on a linCmt() model with a single
+  # non-mu structural theta, combSens=TRUE and combSens=FALSE measurably
+  # disagreed (a Pareto k-hat healthy under one and > 2 under the other).
+  # That was NOT combSens moving the answer -- it uncovered a pre-existing,
+  # independent bug (src/odeSwap.cpp's odeSwapSolveInd(), fixed alongside
+  # this default flip): rx->ndiff (which linCmtB() structural-parameter
+  # derivative(s) to compute, and whether to refresh its cached Jacobian at
+  # all) is one field on the shared rx_solve struct, set once from whichever
+  # model first called rxSolve_() -- odeSwap's peer-swapping never restored
+  # it per slot the way neq/nlhs/cmt-basis already are, so a linCmt() peer
+  # solved after a sibling with a DIFFERENT (or absent) ndiff need could read
+  # a stale, iteration-old d(pred)/d(eta) left by that sibling.  Once
+  # odeSwapSolveInd() restores each slot's own ndiff before every solve,
+  # combSens=TRUE and combSens=FALSE agree exactly (to floating-point noise)
+  # on every fixture measured, including the one that first exposed the gap
+  # -- so there is no longer a reason to keep this off by default.
   .control$combSens <- isTRUE(.control$combSens) &&
     length(.control$impThetaSensIdx) > 0L
   # 0-based eta indices whose Omega diagonal is FIXED; the EM Omega update

--- a/man/impmapControl.Rd
+++ b/man/impmapControl.Rd
@@ -30,7 +30,7 @@ impmapControl(
   sir = FALSE,
   sirSample = NULL,
   muModel = c("lin", "none"),
-  combSens = FALSE
+  combSens = TRUE
 )
 }
 \arguments{
@@ -329,19 +329,19 @@ uses `sirSample` equal-weight resampled points per subject instead of all
 \item{muModel}{Mu-referencing variant for the MAP inner problem; for
 `impmapControl()` this is always `"lin"` and cannot be changed.}
 
-\item{combSens}{When `TRUE` and there are non-mu (structural or
-residual-error) thetas to estimate, carry their sensitivity columns on
+\item{combSens}{When `TRUE` (the default) and there are non-mu (structural
+or residual-error) thetas to estimate, carry their sensitivity columns on
 the INNER model itself (the combined eta+theta sensitivity build, #958)
 instead of compiling and solving a separate, dedicated model for them.
 With `sir=FALSE` (the default) the E-step's own per-sample inner solve
 then supplies the M-step's Newton step directly, with no second solve --
 roughly halving the ODE solving the theta-sensitivity Newton step costs.
-`FALSE` by default: the fused build changes the ODE integrator's
-adaptive step-size path (more sensitivity states solved together), so
-results move by a small amount relative to the two-model default -- not
-a correctness issue, but enough to occasionally move a diagnostic (e.g. a
-borderline Pareto k-hat) across a threshold, so it does not change any
-existing fit's numbers unless requested.}
+Set `FALSE` to use the older two-model path instead. (Earlier versions
+shipped `FALSE` as the default: on a `linCmt()` model with a single
+non-mu structural theta, `combSens=TRUE`/`FALSE` measurably disagreed --
+not `combSens` moving the answer, but an unrelated pre-existing bug in
+how the shared solve pool swapped between peer models, since fixed. The
+two now agree on every fixture measured, so `TRUE` is the default.)}
 }
 \value{
 impmapControl object

--- a/man/impmapControl.Rd
+++ b/man/impmapControl.Rd
@@ -29,7 +29,8 @@ impmapControl(
   qrRefresh = TRUE,
   sir = FALSE,
   sirSample = NULL,
-  muModel = c("lin", "none")
+  muModel = c("lin", "none"),
+  combSens = FALSE
 )
 }
 \arguments{
@@ -327,6 +328,20 @@ uses `sirSample` equal-weight resampled points per subject instead of all
 
 \item{muModel}{Mu-referencing variant for the MAP inner problem; for
 `impmapControl()` this is always `"lin"` and cannot be changed.}
+
+\item{combSens}{When `TRUE` and there are non-mu (structural or
+residual-error) thetas to estimate, carry their sensitivity columns on
+the INNER model itself (the combined eta+theta sensitivity build, #958)
+instead of compiling and solving a separate, dedicated model for them.
+With `sir=FALSE` (the default) the E-step's own per-sample inner solve
+then supplies the M-step's Newton step directly, with no second solve --
+roughly halving the ODE solving the theta-sensitivity Newton step costs.
+`FALSE` by default: the fused build changes the ODE integrator's
+adaptive step-size path (more sensitivity states solved together), so
+results move by a small amount relative to the two-model default -- not
+a correctness issue, but enough to occasionally move a diagnostic (e.g. a
+borderline Pareto k-hat) across a threshold, so it does not change any
+existing fit's numbers unless requested.}
 }
 \value{
 impmapControl object

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -249,6 +249,27 @@ NumericMatrix impQrPoints_(int isample, int neta, Nullable<NumericVector> shift)
   return wrap(impQrZ(U0, nullptr));
 }
 
+// impGetHessian() solves through odeSwapSolveInd(), which writes rx->ndiff -- a
+// field on the single shared rx_solve struct -- right before every solve of a
+// slot whose OWN need is nonzero (see odeSwap.cpp).  A subject that falls back
+// to the doFD/pred path (fInd->doFD, set per-subject) solves a DIFFERENT slot
+// than a subject still on the plain inner path, concurrently in the E-step's
+// parallel loop -- but odeSwapSolveInd() already makes that pairing benign
+// (pred needs no derivative, so it never writes).  This lock is
+// defense-in-depth for the case that alone does not cover: two DIFFERENT slots
+// that both need a NONZERO but DIFFERING ndiff, concurrently.  Only a
+// linCmt()-with-non-mu-structural-theta model ever has a slot with
+// ndiffSet=true at all, so gate the lock on that and pay nothing otherwise.
+static bool impGetHessianNdiffSafe(int id, arma::mat& H) {
+  if (!odeSwapAnyNdiffSet()) return impGetHessian(id, H);
+  bool gotH;
+#ifdef _OPENMP
+#pragma omp critical (odeSwapNdiffHessian)
+#endif
+  { gotH = impGetHessian(id, H); }
+  return gotH;
+}
+
 // One importance-sampling E-step at the current conditional modes: draw
 // proposal samples, form importance weights, and return each subject's
 // conditional mean, variance, objective contribution, and effective sample
@@ -329,29 +350,7 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
       arma::mat H(neta, neta, arma::fill::zeros);
       impGetMode(id, mode);
       modes[id] = mode;
-      // impGetHessian() solves through odeSwapSolveInd(), which writes
-      // rx->ndiff -- a field on the single shared rx_solve struct -- right
-      // before every solve of a slot whose OWN need is nonzero (see
-      // odeSwap.cpp).  A subject that falls back to the doFD/pred path
-      // (fInd->doFD, set per-subject) solves a DIFFERENT slot than a subject
-      // still on the plain inner path, concurrently in THIS loop -- but
-      // odeSwapSolveInd() already makes that pairing benign (pred needs no
-      // derivative, so it never writes).  This lock is defense-in-depth for
-      // the case that alone does not cover: two DIFFERENT slots that both
-      // need a NONZERO but DIFFERING ndiff, concurrently.  Only a
-      // linCmt()-with-non-mu-structural-theta model ever has a slot with
-      // ndiffSet=true at all, so gate the lock on that and pay nothing
-      // otherwise.
-      bool _gotH;
-      if (odeSwapAnyNdiffSet()) {
-#ifdef _OPENMP
-#pragma omp critical (odeSwapNdiffHessian)
-#endif
-        { _gotH = impGetHessian(id, H); }
-      } else {
-        _gotH = impGetHessian(id, H);
-      }
-      if (_gotH) {
+      if (impGetHessianNdiffSafe(id, H)) {
         arma::mat Sigma;
         double ldv, lds;
         if (arma::inv_sympd(Sigma, H) && arma::log_det(ldv, lds, H) && lds > 0) {
@@ -510,10 +509,12 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
         // a non-finite value on a bad solve); require both.
         if (harvestSens) {
           impThetaSensData &_acc = outSens[id];
-          bool _reuse = impLastInnerSolveUsable(id) && R_finite(qk);
-          if (_reuse) {
+          // Every sample appends exactly one slot; an unharvested one appends an
+          // empty placeholder with sampleOk=0 so the per-sample indexing lines up.
+          impThetaSensData _c;
+          bool _ok = false;
+          if (impLastInnerSolveUsable(id) && R_finite(qk)) {
             arma::mat _srow(1, neta); _srow.row(0) = eta.t();
-            impThetaSensData _c;
             impThetaSensCollect(id, _srow, _c, /*reuseSolve=*/true);
             if (_c.nobs > 0) {
               _acc.nobs = _c.nobs;
@@ -521,20 +522,14 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
               _acc.censv = _c.censv; _acc.distv = _c.distv;
               _acc.ddvmat = _c.ddvmat; _acc.dlimmat = _c.dlimmat;
             }
-            bool _ok = _c.nobs > 0 && !_c.sampleOk.empty() && _c.sampleOk[0] != 0;
-            _acc.fvec.push_back(_ok ? _c.fvec[0] : arma::vec());
-            _acc.Vvec.push_back(_ok ? _c.Vvec[0] : arma::vec());
-            _acc.dfmat.push_back(_ok ? _c.dfmat[0] : arma::mat());
-            _acc.dVmat.push_back(_ok ? _c.dVmat[0] : arma::mat());
-            _acc.sampleOk.push_back(_ok ? 1 : 0);
-            if (_ok) impThetaSensHarvestTick();
-          } else {
-            _acc.fvec.push_back(arma::vec());
-            _acc.Vvec.push_back(arma::vec());
-            _acc.dfmat.push_back(arma::mat());
-            _acc.dVmat.push_back(arma::mat());
-            _acc.sampleOk.push_back(0);
+            _ok = _c.nobs > 0 && !_c.sampleOk.empty() && _c.sampleOk[0] != 0;
           }
+          _acc.fvec.push_back(_ok ? _c.fvec[0] : arma::vec());
+          _acc.Vvec.push_back(_ok ? _c.Vvec[0] : arma::vec());
+          _acc.dfmat.push_back(_ok ? _c.dfmat[0] : arma::mat());
+          _acc.dVmat.push_back(_ok ? _c.dVmat[0] : arma::mat());
+          _acc.sampleOk.push_back(_ok ? 1 : 0);
+          if (_ok) impThetaSensHarvestTick();
         }
         // A proposal sample whose inner solve fails (NA/NaN, even after the
         // FOCEI tolerance-relaxation retry) is dropped from the weighted mean by
@@ -1460,64 +1455,64 @@ void impOuter(Environment e) {
           }
         }
       } else {
-      std::vector<impThetaSensData> coll(nExp);
-      // Only zksub is retained per subject (the serial accumulation needs it); the
-      // sample matrix is passed straight into impThetaSensCollect (sampS[eid] as-is,
-      // or a local SIR resample), so there is no per-subject copy of the full sample.
-      std::vector<arma::vec> zksub(nExp);
-      std::vector<char> useSub(nExp, 0);
-      // Parallelize the theta-sensitivity solves over subjects; each subject writes
-      // only its own slot (coll[eid]) and the score/Hessian accumulation below stays
-      // serial in eid order, so the result is bit-identical to the serial M-step.
-      // Only engage when the solve method is thread-safe (liblsoda); the
-      // inner-parallel flag (impInnerParallelOn/Off) defers worker-thread R-API
-      // warnings.  impThetaSensCollect reads calc_lhs into a thread-local buffer and
-      // loosens tolerance per-subject, so no shared solve state is touched.  cores
-      // already carries the mixture / pool-sizing serial guard (forced to 1).
-      bool doParM = (cores > 1) && impMStepParallelOk();
-      if (doParM) impInnerParallelOn();
+        std::vector<impThetaSensData> coll(nExp);
+        // Only zksub is retained per subject (the serial accumulation needs it); the
+        // sample matrix is passed straight into impThetaSensCollect (sampS[eid] as-is,
+        // or a local SIR resample), so there is no per-subject copy of the full sample.
+        std::vector<arma::vec> zksub(nExp);
+        std::vector<char> useSub(nExp, 0);
+        // Parallelize the theta-sensitivity solves over subjects; each subject writes
+        // only its own slot (coll[eid]) and the score/Hessian accumulation below stays
+        // serial in eid order, so the result is bit-identical to the serial M-step.
+        // Only engage when the solve method is thread-safe (liblsoda); the
+        // inner-parallel flag (impInnerParallelOn/Off) defers worker-thread R-API
+        // warnings.  impThetaSensCollect reads calc_lhs into a thread-local buffer and
+        // loosens tolerance per-subject, so no shared solve state is touched.  cores
+        // already carries the mixture / pool-sizing serial guard (forced to 1).
+        bool doParM = (cores > 1) && impMStepParallelOk();
+        if (doParM) impInnerParallelOn();
 #ifdef _OPENMP
 #pragma omp parallel for num_threads(cores) schedule(static) if(doParM)
 #endif
-      for (int eid = 0; eid < nExp; ++eid) {
+        for (int eid = 0; eid < nExp; ++eid) {
 #ifdef _OPENMP
-        if (doParM) setRxThreadId(omp_get_thread_num());
+          if (doParM) setRxThreadId(omp_get_thread_num());
 #endif
-        if (sampS[eid].n_rows != 0) {
-          if (sir && sirN < (int)sampS[eid].n_rows) {
-            // SIR acceleration: an equal-weight systematic resample stands in
-            // for the full weighted sample, cutting the theta-sens solves from
-            // isample to sirN per subject.  For a mixture, zk sums to the
-            // component responsibility a_ij (folded in by impEStep), so the
-            // equal weights carry a_ij/sirN to preserve the component mass.
-            double aij = arma::accu(sampZk[eid]);
-            if (aij > 0.0 && R_finite(aij)) {
-              // Seed this subject's stream on the current thread; the drawn u0 is
-              // a pure function of the (iter, eid) seed, so it is thread-count
-              // invariant.
-              nmSetSeedEng1(sirSeed + (uint32_t)((iter * nExp + eid) * 2));
-              double u0 = rxUnifEng(0.0, 1.0);
-              arma::uvec ridx = impSirIndex(sampZk[eid], sirN, u0);
-              arma::mat Ssir = sampS[eid].rows(ridx);
-              zksub[eid].set_size(sirN); zksub[eid].fill(aij / (double)sirN);
-              impThetaSensCollect(eid, Ssir, coll[eid]);
+          if (sampS[eid].n_rows != 0) {
+            if (sir && sirN < (int)sampS[eid].n_rows) {
+              // SIR acceleration: an equal-weight systematic resample stands in
+              // for the full weighted sample, cutting the theta-sens solves from
+              // isample to sirN per subject.  For a mixture, zk sums to the
+              // component responsibility a_ij (folded in by impEStep), so the
+              // equal weights carry a_ij/sirN to preserve the component mass.
+              double aij = arma::accu(sampZk[eid]);
+              if (aij > 0.0 && R_finite(aij)) {
+                // Seed this subject's stream on the current thread; the drawn u0 is
+                // a pure function of the (iter, eid) seed, so it is thread-count
+                // invariant.
+                nmSetSeedEng1(sirSeed + (uint32_t)((iter * nExp + eid) * 2));
+                double u0 = rxUnifEng(0.0, 1.0);
+                arma::uvec ridx = impSirIndex(sampZk[eid], sirN, u0);
+                arma::mat Ssir = sampS[eid].rows(ridx);
+                zksub[eid].set_size(sirN); zksub[eid].fill(aij / (double)sirN);
+                impThetaSensCollect(eid, Ssir, coll[eid]);
+                useSub[eid] = 1;
+              }
+            } else {
+              zksub[eid] = sampZk[eid];
+              impThetaSensCollect(eid, sampS[eid], coll[eid]);
               useSub[eid] = 1;
             }
-          } else {
-            zksub[eid] = sampZk[eid];
-            impThetaSensCollect(eid, sampS[eid], coll[eid]);
-            useSub[eid] = 1;
           }
-        }
 #ifdef _OPENMP
-        if (doParM) setRxThreadId(-1);
+          if (doParM) setRxThreadId(-1);
 #endif
-      }
-      if (doParM) impInnerParallelOff();
-      // Serial accumulation in eid order -- bit-identical to the serial theta score.
-      for (int eid = 0; eid < nExp; ++eid) {
-        if (useSub[eid]) impThetaAccumOne(coll[eid], zksub[eid], g, H);
-      }
+        }
+        if (doParM) impInnerParallelOff();
+        // Serial accumulation in eid order -- bit-identical to the serial theta score.
+        for (int eid = 0; eid < nExp; ++eid) {
+          if (useSub[eid]) impThetaAccumOne(coll[eid], zksub[eid], g, H);
+        }
       }
       g /= (double)nsub;
       H /= (double)nsub;

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -272,7 +272,8 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
                      arma::vec& XiExpOut, arma::vec& KhatExpOut,
                      std::vector<arma::mat>& outS, std::vector<arma::vec>& outZk,
                      arma::mat& aMat, Environment* eStash,
-                     uint32_t qrPinSeed) {
+                     uint32_t qrPinSeed, bool harvestSens,
+                     std::vector<impThetaSensData>& outSens) {
   int Nm = impNmix();
   int nExp = nsub * Nm; // expanded pseudo-subjects: component j (1-based) is i + (j-1)*nsub
 
@@ -354,6 +355,7 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
   std::vector<char> okExp(nExp, 0);
   outS.assign(nExp, arma::mat());
   outZk.assign(nExp, arma::vec());
+  if (harvestSens) outSens.assign(nExp, impThetaSensData());
   // The engine array is allocated + seeded by rxWithSeed() at the fit start
   // (impmap.R), so we don't call seedEng() here.
   // Base the per-subject stream on the control's impSeed, NOT the ambient
@@ -456,6 +458,52 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
         arma::vec d = eta - modes[id];
         double qk = -impEvalJointLik(eta, id) +
           impLogKernelRecip(arma::as_scalar(d.t() * Hs[id] * d), gammaId, dfId, neta);
+        // #958 combined build: impEvalJointLik() just solved this subject's
+        // INNER model at this exact (theta, eta) -- when combSens is loaded,
+        // that solve already carries the M-step's d(f)/d(theta)/d(V)/d(theta)
+        // columns, so harvest them here (impThetaSensCollect's reuseSolve path,
+        // a pure read -- no ODE solve, no R API call, safe under this
+        // function's own parallel E-step region) instead of letting the
+        // M-step re-solve every sample from scratch.  Skipped whenever the
+        // caller disabled harvesting (SIR resampling only needs a subset of
+        // the E-step's samples, so eagerly harvesting all of them there would
+        // be wasted work -- see impOuter's harvestSens gate).  A sample whose
+        // solve fell back to the pred-model FD path (impLastInnerSolveUsable
+        // == false) leaves ind->solve holding the PRED model's trajectory, not
+        // the inner model's, so it is left unharvested (sampleOk=0) rather
+        // than triggering impThetaSensCollect's own solve-with-retry path --
+        // that path is R-API-unsafe from a bare OpenMP region (it is only
+        // ever run under the M-step's explicit impInnerParallelOn() guard),
+        // which this loop does not set.  The M-step's weighted accumulation
+        // (impThetaAccumOne) already skips sampleOk==0 samples cleanly.
+        if (harvestSens) {
+          impThetaSensData &_acc = outSens[id];
+          bool _reuse = impLastInnerSolveUsable(id);
+          if (_reuse) {
+            arma::mat _srow(1, neta); _srow.row(0) = eta.t();
+            impThetaSensData _c;
+            impThetaSensCollect(id, _srow, _c, /*reuseSolve=*/true);
+            if (_c.nobs > 0) {
+              _acc.nobs = _c.nobs;
+              _acc.dvv = _c.dvv; _acc.limv = _c.limv;
+              _acc.censv = _c.censv; _acc.distv = _c.distv;
+              _acc.ddvmat = _c.ddvmat; _acc.dlimmat = _c.dlimmat;
+            }
+            bool _ok = _c.nobs > 0 && !_c.sampleOk.empty() && _c.sampleOk[0] != 0;
+            _acc.fvec.push_back(_ok ? _c.fvec[0] : arma::vec());
+            _acc.Vvec.push_back(_ok ? _c.Vvec[0] : arma::vec());
+            _acc.dfmat.push_back(_ok ? _c.dfmat[0] : arma::mat());
+            _acc.dVmat.push_back(_ok ? _c.dVmat[0] : arma::mat());
+            _acc.sampleOk.push_back(_ok ? 1 : 0);
+            if (_ok) impThetaSensHarvestTick();
+          } else {
+            _acc.fvec.push_back(arma::vec());
+            _acc.Vvec.push_back(arma::vec());
+            _acc.dfmat.push_back(arma::mat());
+            _acc.dVmat.push_back(arma::mat());
+            _acc.sampleOk.push_back(0);
+          }
+        }
         // A proposal sample whose inner solve fails (NA/NaN, even after the
         // FOCEI tolerance-relaxation retry) is dropped from the weighted mean by
         // giving it -Inf log-weight (weight 0).
@@ -1054,6 +1102,15 @@ void impOuter(Environment e) {
   bool sir = impSirEnabled();
   int sirN = impSirN();
   uint32_t sirSeed = (uint32_t)impBaseSeed() + 0x7F4A7C15u;
+  // #958 combined build: harvest the M-step's theta-sensitivity columns
+  // straight off the E-step's own per-sample inner solve (impEStep) instead
+  // of the M-step re-solving every sample -- see impEStep's harvest block.
+  // Off under SIR: the M-step there only needs a resampled SUBSET of the
+  // E-step's samples (sirN < isample), so eagerly harvesting every sample in
+  // the E-step would do MORE solving, not less; that case keeps the existing
+  // (unfused) M-step path unchanged.
+  bool harvestSens = impCombSensEnabled() && (nSens > 0) && !sir;
+  std::vector<impThetaSensData> outSens;
 
   // Omega structure mask: only the elements estimated in the model (nonzero in
   // the starting Omega) are updated; the rest stay zero so the parameterization
@@ -1089,7 +1146,8 @@ void impOuter(Environment e) {
     gammaUsed = gammaVec;
     gammaScalarUsed = gamma;
     impEStep(nsub, neta, isampleVec, gammaVec, dfVec, cores, iter, impLogDetOmegaInv5(), isImp,
-             condMean, condVar, Li, Neff, Xi, XiExp, KhatExp, sampS, sampZk, aMat, &e, qrPinSeed);
+             condMean, condVar, Li, Neff, Xi, XiExp, KhatExp, sampS, sampZk, aMat, &e, qrPinSeed,
+             harvestSens, outSens);
     obj = 0.0;
     for (int id = 0; id < nsub; ++id) if (R_finite(Li[id])) obj += 2.0 * Li[id];
     // Mean effective-sample fraction (importance-sampling "acceptance ratio").
@@ -1337,6 +1395,27 @@ void impOuter(Environment e) {
       // Each subject's samples (SIR-resampled if enabled) and collected sensitivity
       // outputs are stashed per subject, then accumulated in eid order below.  cores
       // already carries the mixture / pool-sizing serial guard (forced to 1 above).
+      if (harvestSens) {
+        // #958 fused build: outSens[eid] was already filled sample-by-sample
+        // during THIS iteration's E-step (impEStep), off the same inner solve
+        // impEvalJointLik used for the importance weights -- no M-step solve
+        // at all for a subject that harvested cleanly.  A subject every one of
+        // whose samples fell back to the pred-model FD path in the E-step
+        // (outSens[eid].nobs == 0, impEStep leaves it unharvested rather than
+        // re-solving from an OpenMP region -- see impEStep) falls back here to
+        // the ordinary (serial-safe) solve-based read, so no subject's M-step
+        // contribution is silently dropped.
+        for (int eid = 0; eid < nExp; ++eid) {
+          if (sampS[eid].n_rows == 0) continue;
+          if (outSens[eid].nobs > 0) {
+            impThetaAccumOne(outSens[eid], sampZk[eid], g, H);
+          } else {
+            impThetaSensData c;
+            impThetaSensCollect(eid, sampS[eid], c);
+            impThetaAccumOne(c, sampZk[eid], g, H);
+          }
+        }
+      } else {
       std::vector<impThetaSensData> coll(nExp);
       // Only zksub is retained per subject (the serial accumulation needs it); the
       // sample matrix is passed straight into impThetaSensCollect (sampS[eid] as-is,
@@ -1394,6 +1473,7 @@ void impOuter(Environment e) {
       // Serial accumulation in eid order -- bit-identical to the serial theta score.
       for (int eid = 0; eid < nExp; ++eid) {
         if (useSub[eid]) impThetaAccumOne(coll[eid], zksub[eid], g, H);
+      }
       }
       g /= (double)nsub;
       H /= (double)nsub;

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -331,14 +331,17 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
       modes[id] = mode;
       // impGetHessian() solves through odeSwapSolveInd(), which writes
       // rx->ndiff -- a field on the single shared rx_solve struct -- right
-      // before every solve of a slot that needs it (see odeSwap.cpp).  A
-      // subject that falls back to the doFD/pred path (fInd->doFD, set
-      // per-subject) can pick a DIFFERENT slot -- and so a different
-      // ndiff -- than a subject still on the plain inner path, and both can
-      // run concurrently in THIS loop.  Unguarded, one subject's solve can
-      // read the ndiff another subject's concurrent solve just wrote.  Only
-      // a linCmt()-with-non-mu-structural-theta model ever has a slot with
-      // ndiffSet=true, so gate the lock on that and pay nothing otherwise.
+      // before every solve of a slot whose OWN need is nonzero (see
+      // odeSwap.cpp).  A subject that falls back to the doFD/pred path
+      // (fInd->doFD, set per-subject) solves a DIFFERENT slot than a subject
+      // still on the plain inner path, concurrently in THIS loop -- but
+      // odeSwapSolveInd() already makes that pairing benign (pred needs no
+      // derivative, so it never writes).  This lock is defense-in-depth for
+      // the case that alone does not cover: two DIFFERENT slots that both
+      // need a NONZERO but DIFFERING ndiff, concurrently.  Only a
+      // linCmt()-with-non-mu-structural-theta model ever has a slot with
+      // ndiffSet=true at all, so gate the lock on that and pay nothing
+      // otherwise.
       bool _gotH;
       if (odeSwapAnyNdiffSet()) {
 #ifdef _OPENMP
@@ -1138,6 +1141,18 @@ void impOuter(Environment e) {
   // E-step's samples (sirN < isample), so eagerly harvesting every sample in
   // the E-step would do MORE solving, not less; that case keeps the existing
   // (unfused) M-step path unchanged.
+  //
+  // This loop is `#pragma omp parallel for` over subjects, and a subject
+  // whose inner solve fell back to doFD/pred solves a DIFFERENT registered
+  // slot than a subject still on the plain inner path -- concurrently, in
+  // the same loop.  That used to be able to race on rx->ndiff (a field on
+  // the single shared rx_solve struct); it no longer can, because
+  // odeSwapSolveInd() now skips writing rx->ndiff entirely for a slot whose
+  // own declared need is 0 (odeSlotPred never needs a Jacobian derivative --
+  // "rxPred implements no sensitivities" -- so it never touches the shared
+  // field), leaving only same-value writes from concurrent inner solves,
+  // which is benign.  See odeSwap.cpp's odeSwapSolveInd for the fix and its
+  // KNOWN GAP note.
   bool harvestSens = impCombSensEnabled() && (nSens > 0) && !sir;
   std::vector<impThetaSensData> outSens;
 

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -20,6 +20,7 @@
 #include <ctime>
 #include "nmMcmcRng.h"
 #include "imp.h"
+#include "odeSwap.h" // odeSwapAnyNdiffSet()
 #include "utilc.h"   // RSprintf (covariance-step progress header)
 #ifdef _OPENMP
 #include <omp.h>
@@ -328,7 +329,26 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
       arma::mat H(neta, neta, arma::fill::zeros);
       impGetMode(id, mode);
       modes[id] = mode;
-      if (impGetHessian(id, H)) {
+      // impGetHessian() solves through odeSwapSolveInd(), which writes
+      // rx->ndiff -- a field on the single shared rx_solve struct -- right
+      // before every solve of a slot that needs it (see odeSwap.cpp).  A
+      // subject that falls back to the doFD/pred path (fInd->doFD, set
+      // per-subject) can pick a DIFFERENT slot -- and so a different
+      // ndiff -- than a subject still on the plain inner path, and both can
+      // run concurrently in THIS loop.  Unguarded, one subject's solve can
+      // read the ndiff another subject's concurrent solve just wrote.  Only
+      // a linCmt()-with-non-mu-structural-theta model ever has a slot with
+      // ndiffSet=true, so gate the lock on that and pay nothing otherwise.
+      bool _gotH;
+      if (odeSwapAnyNdiffSet()) {
+#ifdef _OPENMP
+#pragma omp critical (odeSwapNdiffHessian)
+#endif
+        { _gotH = impGetHessian(id, H); }
+      } else {
+        _gotH = impGetHessian(id, H);
+      }
+      if (_gotH) {
         arma::mat Sigma;
         double ldv, lds;
         if (arma::inv_sympd(Sigma, H) && arma::log_det(ldv, lds, H) && lds > 0) {

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -474,11 +474,20 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
         // than triggering impThetaSensCollect's own solve-with-retry path --
         // that path is R-API-unsafe from a bare OpenMP region (it is only
         // ever run under the M-step's explicit impInnerParallelOn() guard),
-        // which this loop does not set.  The M-step's weighted accumulation
-        // (impThetaAccumOne) already skips sampleOk==0 samples cleanly.
+        // which this loop does not set.  doFD alone is not enough: it is a
+        // STICKY per-subject flag (only flips permanently, inside the inner
+        // Newton optimizer's own convergence handling) and does not track
+        // whether THIS ARBITRARY sampled eta's solve produced a usable
+        // result, so a bad solve at doFD==0 (e.g. an extreme early-EM
+        // proposal draw) would otherwise still reach impThetaSensCollect,
+        // which falls back to impThetaSensFD()'s finite-difference re-solves
+        // -- the same R-API-unsafe path.  qk is -impEvalJointLik(eta, id) +
+        // <finite kernel term>, so its own finiteness is direct evidence this
+        // exact eta's inner solve succeeded (impEvalJointLik/likInner0 return
+        // a non-finite value on a bad solve); require both.
         if (harvestSens) {
           impThetaSensData &_acc = outSens[id];
-          bool _reuse = impLastInnerSolveUsable(id);
+          bool _reuse = impLastInnerSolveUsable(id) && R_finite(qk);
           if (_reuse) {
             arma::mat _srow(1, neta); _srow.row(0) = eta.t();
             impThetaSensData _c;

--- a/src/imp.h
+++ b/src/imp.h
@@ -129,6 +129,19 @@ void impInnerParallelOff();
 // Number of non-mu structural thetas (the length of impThetaSensIdx).
 int impThetaSensN();
 
+// Whether the combined eta+theta sensitivity build (#958) is loaded -- the
+// INNER model carries the theta columns, so impEStep's harvest path applies.
+bool impCombSensEnabled();
+
+// Whether subject id's last impEvalJointLik() call solved the INNER model
+// itself (TRUE) rather than falling back to the pred-model FD path (FALSE, in
+// which case ind->solve does not hold the inner model's trajectory and a
+// combSens harvest must not reuse it).
+bool impLastInnerSolveUsable(int id);
+
+// Count a successful impEStep harvest read (odeSwapInfo_()$impThetaSensHarvestN).
+void impThetaSensHarvestTick();
+
 // 0-based eta indices whose Omega diagonal is fixed (held across the EM update).
 void impGetOmegaFixedEta(std::vector<int>& idx);
 

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -11019,6 +11019,29 @@ void impMuInterceptStep() {
 
 int impThetaSensN() { return op_focei.impThetaSensIdx.size(); }
 
+// Whether the combined eta+theta sensitivity build (#958) is loaded: the INNER
+// model itself carries the theta columns, so impOuter's E-step can harvest
+// them from its own per-sample inner solve instead of the M-step re-solving
+// (see impEStep's harvest path in imp.cpp).
+bool impCombSensEnabled() { return op_focei.combSens; }
+
+// Whether subject id's most recent likInner0 call (impEvalJointLik) solved the
+// INNER model itself, as opposed to falling back to the pred-model FD path.
+// On an FD fallback, ind->solve holds the PRED model's trajectory, not the
+// INNER model's, so a combSens theta-sensitivity read against odeSlotInner
+// must NOT reuse it -- mirrors nnOuterUsable()'s doFD check and
+// foceiCondBatchThetaGradOne's usedFD gate (both above).
+bool impLastInnerSolveUsable(int id) { return inds_focei[id].doFD == 0; }
+
+// #958: how many impEStep per-sample theta-sensitivity reads reused the
+// E-step's own inner solve (see inner.h).  Incremented from imp.cpp's
+// parallel E-step loop, so atomic.
+static std::atomic<int> _impThetaSensHarvestN(0);
+void impThetaSensHarvestTick() {
+  _impThetaSensHarvestN.fetch_add(1, std::memory_order_relaxed);
+}
+int impThetaSensHarvestN() { return _impThetaSensHarvestN.load(std::memory_order_relaxed); }
+
 // 0-based eta indices whose Omega diagonal is fixed (the EM Omega update restores
 // their rows/columns to the starting Omega so fix()ed variances are held).
 void impGetOmegaFixedEta(std::vector<int>& idx) {

--- a/src/inner.h
+++ b/src/inner.h
@@ -32,5 +32,10 @@ extern rxSolveF rxOuterNode;
 extern rxSolveF rxOuterCov;
 extern void rxUpdateFuns(SEXP trans, rxSolveF *inner);
 extern void rxClearFuns(rxSolveF *inner);
+
+// #958: count of impEStep per-sample theta-sensitivity reads that reused the
+// E-step's own inner solve (no M-step re-solve).  odeSwapInfo_() exposes it as
+// $impThetaSensHarvestN; tests assert it is > 0 when combSens+harvesting engage.
+extern int impThetaSensHarvestN();
 extern rx_solve *rx;
 #endif

--- a/src/odeSwap.cpp
+++ b/src/odeSwap.cpp
@@ -36,6 +36,18 @@ struct OdeModelReg {
   // here so that can be done without going back to R.
   int nSens = 0;      // length(rxModelVars(obj)$sens)
   int cmtPar = -1;    // index of "CMT" in $params, or -1 if the model has none
+  // rxModelVars(obj)$flags["ndiff"]: which linCmtB() structural-parameter
+  // derivatives THIS model's calc_lhs actually calls linCmtB(which1=-2, ...)
+  // for (a bitmask; 0 = none declared).  linCmtB() caches its Jacobian
+  // (J/Jg, see stan::math::linCmtStan) on rx->ndiff, a single field on the
+  // shared rx_solve struct -- NOT swapped per peer the way neq/nlhs/cmt-basis
+  // are.  odeSwapSolveInd() restores it from here before every solve so a
+  // peer whose OWN calc_lhs needs a Jg column does not read a stale Jacobian
+  // left by whichever OTHER registered model last solved (nlmixr2est#1013-ish:
+  // a linCmt() model differentiated by only ONE structural parameter read a
+  // near-zero, iteration-old d(pred)/d(eta) from a sibling peer's cache).
+  int ndiff = 0;
+  bool ndiffSet = false;  // false if $flags carries no "ndiff" element (older rxode2)
   // event-sensitivity shape (see OdeSwapEsBatch); esActive == 0 for a model
   // with no jump sensitivities, e.g. rxPred
   int esActive = 0;   // does this model carry event ("jump") sensitivities?
@@ -83,6 +95,26 @@ bool odeSwapDeclare(int slot, const char *name, SEXP obj) {
   // CMT rebasing inputs (see the struct comment and odeSwapCmtRebase)
   m.nSens = mv.containsElementNamed("sens") ?
     as<CharacterVector>(mv["sens"]).size() : 0;
+  // linCmtB() Jacobian-cache flag (see the struct comment).  named lookup
+  // ("ndiff", not a positional RxMvFlag_ndiff index) so this tracks whatever
+  // rxode2 calls the element; absent entirely on an older rxode2 or a model
+  // with no linCmtB() calls, in which case odeSwapSolveInd() leaves rx->ndiff
+  // untouched for this slot rather than stomping it to 0.
+  m.ndiff = 0;
+  m.ndiffSet = false;
+  if (mv.containsElementNamed("flags")) {
+    IntegerVector _flags = as<IntegerVector>(mv["flags"]);
+    CharacterVector _fn = _flags.names();
+    if (!_fn.isNULL()) {
+      for (int i = 0; i < _fn.size(); ++i) {
+        if (as<std::string>(_fn[i]) == "ndiff") {
+          m.ndiff = _flags[i];
+          m.ndiffSet = true;
+          break;
+        }
+      }
+    }
+  }
   m.cmtPar = -1;
   m.npars = 0;
   m.parNames.clear();
@@ -270,7 +302,7 @@ void odeSwapClear(int slot) {
   OdeModelReg &m = _odeReg[slot];
   if (m.fns != NULL) rxClearFuns(m.fns);
   m.fns = NULL; m.name = NULL; m.neq = 0; m.nlhs = 0; m.loaded = false;
-  m.nSens = 0; m.cmtPar = -1; m.npars = 0;
+  m.nSens = 0; m.cmtPar = -1; m.npars = 0; m.ndiff = 0; m.ndiffSet = false;
   m.lhsNames.clear();
   m.parNames.clear();
   if (_odeModels != R_NilValue) SET_VECTOR_ELT(_odeModels, slot, R_NilValue);
@@ -290,6 +322,7 @@ void odeSwapClearAll() {
 bool odeSwapLoaded(int slot) { return odeSlotOk(slot) && _odeReg[slot].loaded; }
 int  odeSwapNSens(int slot)  { return odeSwapLoaded(slot) ? _odeReg[slot].nSens : 0; }
 int  odeSwapCmtPar(int slot) { return odeSwapLoaded(slot) ? _odeReg[slot].cmtPar : -1; }
+int  odeSwapNdiff(int slot)  { return odeSwapLoaded(slot) ? _odeReg[slot].ndiff : 0; }
 
 // How much to subtract from the pooled table's raw CMT before `slot`'s calc_lhs
 // reads it.  See the OdeModelReg comment: rxode2 bakes `- nSens` into each
@@ -456,7 +489,24 @@ rxSolveF *odeSwapFns(int slot) {
 void odeSwapSolveInd(int slot, int rxId) {
   rxSolveF *f = odeSwapFns(slot);
   if (f == NULL || f->dydt == NULL) return;
-  ind_solve(getRxSolve_(), rxId, f->dydt_liblsoda, f->dydt_lsoda_dum,
+  rx_solve *rxl = getRxSolve_();
+  // rx->ndiff selects which structural-parameter derivative(s) linCmtB()
+  // computes THIS call and, critically, whether it refreshes its cached
+  // Jacobian (J/Jg) at all -- rx->ndiff==0 skips the refresh entirely
+  // (linCmt.cpp's fHCalcJac fast path), leaving J/Jg holding whatever the
+  // PREVIOUSLY-SOLVED registered slot last wrote.  rx->ndiff is a single
+  // field on the shared rx_solve struct (set once, in rxSolve_(), from
+  // whichever model was passed to it), not something the pool's neq/nlhs/
+  // cmt-basis rebasing already restores per peer -- so a slot solved after
+  // a peer with a DIFFERENT (or absent) ndiff need can silently read a
+  // stale, iteration-old d(pred)/d(eta) here.  Restore this slot's own
+  // declared value immediately before every solve; leave rx->ndiff alone
+  // when this slot's flags never reported one (older rxode2, or a model
+  // with no linCmtB() calls at all -- nothing here needs its Jacobian).
+  if (odeSwapLoaded(slot) && _odeReg[slot].ndiffSet) {
+    rxl->ndiff = _odeReg[slot].ndiff;
+  }
+  ind_solve(rxl, rxId, f->dydt_liblsoda, f->dydt_lsoda_dum,
             f->jdum_lsoda, f->dydt, f->update_inis, f->global_jt);
 }
 
@@ -951,8 +1001,9 @@ List odeSwapInfo_() {
   const OdePoolPlan &p = odeSwapPlan();
   CharacterVector nm(odeSlotN);
   IntegerVector neq(odeSlotN), nlhs(odeSlotN), npars(odeSlotN), deny(odeSlotN),
-    esActive(odeSlotN);
-  LogicalVector loaded(odeSlotN), sizesPool(odeSlotN), parLayoutOk(odeSlotN);
+    esActive(odeSlotN), ndiff(odeSlotN);
+  LogicalVector loaded(odeSlotN), sizesPool(odeSlotN), parLayoutOk(odeSlotN),
+    ndiffSet(odeSlotN);
   rx_solve *_rxl = getRxSolve_();
   for (int s = 0; s < odeSlotN; ++s) {
     nm[s] = _odeReg[s].name == NULL ? NA_STRING : Rf_mkChar(_odeReg[s].name);
@@ -964,22 +1015,27 @@ List odeSwapInfo_() {
     deny[s] = odeSwapCanPool(s);
     parLayoutOk[s] = _odeReg[s].loaded ? odeSwapParLayoutOk(s, _rxl) : NA_LOGICAL;
     esActive[s] = _odeReg[s].esActive;
+    ndiff[s] = _odeReg[s].ndiff;
+    ndiffSet[s] = _odeReg[s].ndiffSet;
   }
   List models = List::create(_["slot"] = seq_len(odeSlotN) - 1, _["name"] = nm,
                              _["neq"] = neq, _["nlhs"] = nlhs, _["npars"] = npars,
                              _["loaded"] = loaded, _["sizesPool"] = sizesPool,
                              _["parLayoutOk"] = parLayoutOk,
-                             _["deny"] = deny, _["esActive"] = esActive);
+                             _["deny"] = deny, _["esActive"] = esActive,
+                             _["ndiff"] = ndiff, _["ndiffSet"] = ndiffSet);
   models.attr("class") = "data.frame";
   models.attr("row.names") = IntegerVector::create(NA_INTEGER, -odeSlotN);
   // op->neq / op->nlhs are only meaningful once a solve pool exists.
-  int opNeq = NA_INTEGER, opNlhs = NA_INTEGER, rxNpars = NA_INTEGER;
+  int opNeq = NA_INTEGER, opNlhs = NA_INTEGER, rxNpars = NA_INTEGER,
+    rxNdiff = NA_INTEGER;
   rx_solve *rxl = _rxl;
   IntegerVector activeOv(0);
   if (rxl != NULL) {
     rx_solving_options *op = getSolvingOptions(rxl);
     if (op != NULL) { opNeq = getOpNeq(op); opNlhs = getOpNlhs(op); }
     rxNpars = getRxNpars(rxl);
+    rxNdiff = rxl->ndiff;
     int nsub = (int)getRxNsub(rxl);
     if (nsub > 0) {
       activeOv = IntegerVector(nsub);
@@ -1001,6 +1057,7 @@ List odeSwapInfo_() {
     _["overrideNeeded"] = p.overrideNeeded,
     _["nLoaded"] = p.nLoaded,
     _["opNeq"] = opNeq, _["opNlhs"] = opNlhs, _["rxNpars"] = rxNpars,
+    _["rxNdiff"] = rxNdiff,
     _["pinned"] = odeSwapPinned(),
     _["pinnedSlot"] = odeSwapPinnedSlot(),
     // -1 per subject means "no override in force"; a non -1 left behind after a

--- a/src/odeSwap.cpp
+++ b/src/odeSwap.cpp
@@ -1017,5 +1017,6 @@ List odeSwapInfo_() {
     _["pooledSolveN"] = (double)odeSwapPooledSolveN(),
     _["pooledSolveCores"] = odeSwapPooledSolveCores(),
     _["pinCalledN"] = (double)odeSwapPinCalledN(),
-    _["pinDeny"] = (double)odeSwapPinDeny());
+    _["pinDeny"] = (double)odeSwapPinDeny(),
+    _["impThetaSensHarvestN"] = (double)impThetaSensHarvestN());
 }

--- a/src/odeSwap.cpp
+++ b/src/odeSwap.cpp
@@ -325,27 +325,39 @@ int  odeSwapCmtPar(int slot) { return odeSwapLoaded(slot) ? _odeReg[slot].cmtPar
 int  odeSwapNdiff(int slot)  { return odeSwapLoaded(slot) ? _odeReg[slot].ndiff : 0; }
 
 // True if ANY registered slot declared an ndiff (i.e. this fit has a linCmt()
-// peer whose cached Jacobian depends on rx->ndiff).  odeSwapSolveInd() writes
-// rx->ndiff -- a field on the single shared rx_solve struct -- immediately
-// before every such slot's solve; a caller that solves different slots for
-// different subjects CONCURRENTLY (e.g. one subject on the plain inner path,
-// another that fell back to doFD/pred, in the same omp loop) must serialize
-// around that write-then-solve-then-Jacobian-read window using this as the
-// gate, or two subjects' solves can race and one reads the other's ndiff.
-// Cheap to call per-subject: odeSlotN is a handful of entries.
+// peer whose cached Jacobian depends on rx->ndiff).  Used to gate the extra
+// cost of imp.cpp's impGetHessian() critical section (see below) so it is
+// zero for the vast majority of models, which never register such a peer.
 //
-// KNOWN GAP: only imp.cpp's impGetHessian() loop (the impmap proposal build)
-// is guarded this way -- that is the call site a linCmtB()-Jacobian read
-// (calcEtaHessian) is reachable from under a per-subject doFD branch that can
-// pick a different slot per thread.  The other odeSwapSolveInd() call sites
-// under a parallel region (impEStep's per-sample loop in imp.cpp; the various
-// omp loops in inner.cpp -- shi21ThetaGeneral, the M-step theta-sensitivity
-// collection, nlm.cpp's thetaGrad path) were not audited for the same mixed-
-// slot-concurrently pattern. Most look safe by construction (a fixed slot per
-// call, e.g. impThetaSensCollect's tsSlot does not vary within its own loop),
-// but that was not proven exhaustively.  If a future model shape or caller
-// mixes ndiffSet-true slots inside one of those loops, it needs the same
-// odeSwapAnyNdiffSet()-gated critical section this one got.
+// The PRIMARY fix for the concurrent-solve race, though, lives in
+// odeSwapSolveInd() itself: a slot whose own declared ndiff is 0 (e.g.
+// odeSlotPred -- "rxPred implements no sensitivities") now skips the write
+// entirely instead of stomping rx->ndiff with 0. That makes the CONFIRMED
+// exposure -- a subject on the plain inner path (needs a nonzero ndiff)
+// running concurrently, in the same omp loop, with a subject that fell back
+// to doFD/pred (needs nothing) -- benign without any lock: only slots that
+// actually need a derivative ever write here, and they all write their own
+// fixed, slot-intrinsic value, so concurrent writers of the SAME slot agree.
+// This is what makes impEStep's per-sample loop (imp.cpp) safe as-is; it was
+// NOT additionally wrapped in a critical section, because doing so would
+// serialize the E-step's actual ODE-solving work for exactly the model class
+// (linCmt() + non-mu structural theta) combSens exists to speed up.
+//
+// impGetHessian()'s loop (imp.cpp) keeps its odeSwapAnyNdiffSet()-gated
+// critical section anyway, as defense-in-depth: it is comparatively cheap
+// (one Hessian per subject per EM iteration, not per sample), and covers a
+// case the "skip zero writes" fix alone does not -- two DIFFERENT peers that
+// both need a NONZERO but DIFFERING ndiff, running concurrently. That case
+// is not the one this bug's own affected model class (linCmt() with a single
+// non-mu structural theta; odeSlotPred is always 0 there) can trigger, and
+// was not otherwise observed, but was not exhaustively ruled out either.
+//
+// KNOWN GAP: the other odeSwapSolveInd() call sites under a parallel region
+// (the various omp loops in inner.cpp -- shi21ThetaGeneral, the M-step
+// theta-sensitivity collection, nlm.cpp's thetaGrad path) were not audited
+// for the two-different-nonzero-ndiff-peers pattern either. Most look safe
+// by construction (a fixed slot per call, e.g. impThetaSensCollect's tsSlot
+// does not vary within its own loop), but that was not proven exhaustively.
 bool odeSwapAnyNdiffSet() {
   for (int s = 0; s < odeSlotN; ++s) {
     if (_odeReg[s].loaded && _odeReg[s].ndiffSet) return true;
@@ -532,7 +544,22 @@ void odeSwapSolveInd(int slot, int rxId) {
   // declared value immediately before every solve; leave rx->ndiff alone
   // when this slot's flags never reported one (older rxode2, or a model
   // with no linCmtB() calls at all -- nothing here needs its Jacobian).
-  if (odeSwapLoaded(slot) && _odeReg[slot].ndiffSet) {
+  //
+  // Only write when THIS slot's own need is nonzero.  A slot whose declared
+  // ndiff is 0 (e.g. odeSlotPred -- "rxPred implements no sensitivities")
+  // never reads rx->ndiff itself, so skip the write rather than stomp
+  // whatever a DIFFERENT, concurrently-solving peer that DOES need a
+  // nonzero value (e.g. odeSlotInner, solved by another thread for another
+  // subject in the same omp loop -- impGetHessian's and impEStep's
+  // per-subject loops both mix odeSlotInner/odeSlotPred within one parallel
+  // region via the per-subject doFD fallback) just set it to.  This is what
+  // makes those loops safe without a lock in the common case: every slot
+  // that actually writes here writes its own fixed, slot-intrinsic value,
+  // so concurrent writers of the SAME slot agree, and a slot that needs
+  // nothing never participates.  A genuine mix of two DIFFERENT nonzero-
+  // ndiff peers running concurrently is not covered by this alone -- see
+  // odeSwapAnyNdiffSet()'s KNOWN GAP note.
+  if (odeSwapLoaded(slot) && _odeReg[slot].ndiffSet && _odeReg[slot].ndiff != 0) {
     rxl->ndiff = _odeReg[slot].ndiff;
   }
   ind_solve(rxl, rxId, f->dydt_liblsoda, f->dydt_lsoda_dum,

--- a/src/odeSwap.cpp
+++ b/src/odeSwap.cpp
@@ -324,6 +324,35 @@ int  odeSwapNSens(int slot)  { return odeSwapLoaded(slot) ? _odeReg[slot].nSens 
 int  odeSwapCmtPar(int slot) { return odeSwapLoaded(slot) ? _odeReg[slot].cmtPar : -1; }
 int  odeSwapNdiff(int slot)  { return odeSwapLoaded(slot) ? _odeReg[slot].ndiff : 0; }
 
+// True if ANY registered slot declared an ndiff (i.e. this fit has a linCmt()
+// peer whose cached Jacobian depends on rx->ndiff).  odeSwapSolveInd() writes
+// rx->ndiff -- a field on the single shared rx_solve struct -- immediately
+// before every such slot's solve; a caller that solves different slots for
+// different subjects CONCURRENTLY (e.g. one subject on the plain inner path,
+// another that fell back to doFD/pred, in the same omp loop) must serialize
+// around that write-then-solve-then-Jacobian-read window using this as the
+// gate, or two subjects' solves can race and one reads the other's ndiff.
+// Cheap to call per-subject: odeSlotN is a handful of entries.
+//
+// KNOWN GAP: only imp.cpp's impGetHessian() loop (the impmap proposal build)
+// is guarded this way -- that is the call site a linCmtB()-Jacobian read
+// (calcEtaHessian) is reachable from under a per-subject doFD branch that can
+// pick a different slot per thread.  The other odeSwapSolveInd() call sites
+// under a parallel region (impEStep's per-sample loop in imp.cpp; the various
+// omp loops in inner.cpp -- shi21ThetaGeneral, the M-step theta-sensitivity
+// collection, nlm.cpp's thetaGrad path) were not audited for the same mixed-
+// slot-concurrently pattern. Most look safe by construction (a fixed slot per
+// call, e.g. impThetaSensCollect's tsSlot does not vary within its own loop),
+// but that was not proven exhaustively.  If a future model shape or caller
+// mixes ndiffSet-true slots inside one of those loops, it needs the same
+// odeSwapAnyNdiffSet()-gated critical section this one got.
+bool odeSwapAnyNdiffSet() {
+  for (int s = 0; s < odeSlotN; ++s) {
+    if (_odeReg[s].loaded && _odeReg[s].ndiffSet) return true;
+  }
+  return false;
+}
+
 // How much to subtract from the pooled table's raw CMT before `slot`'s calc_lhs
 // reads it.  See the OdeModelReg comment: rxode2 bakes `- nSens` into each
 // model's own _CMT macro, but the translated event table belongs to whichever

--- a/src/odeSwap.h
+++ b/src/odeSwap.h
@@ -139,6 +139,7 @@ int  odeSwapNlhs(int slot);      // 0 when unloaded
 int  odeSwapNpars(int slot);     // 0 when unloaded; the model's own parameter count
 int  odeSwapNSens(int slot);     // length($sens): sensitivity compartments
 int  odeSwapCmtPar(int slot);    // index of "CMT" in $params, -1 when absent
+int  odeSwapNdiff(int slot);     // $flags["ndiff"] (linCmtB Jacobian-cache selector); 0 when unloaded or unset
 
 // Endpoint (CMT) rebasing for a pooled solve.
 //

--- a/src/odeSwap.h
+++ b/src/odeSwap.h
@@ -140,6 +140,7 @@ int  odeSwapNpars(int slot);     // 0 when unloaded; the model's own parameter c
 int  odeSwapNSens(int slot);     // length($sens): sensitivity compartments
 int  odeSwapCmtPar(int slot);    // index of "CMT" in $params, -1 when absent
 int  odeSwapNdiff(int slot);     // $flags["ndiff"] (linCmtB Jacobian-cache selector); 0 when unloaded or unset
+bool odeSwapAnyNdiffSet();       // true if any registered slot declared an ndiff (see odeSwap.cpp)
 
 // Endpoint (CMT) rebasing for a pooled solve.
 //

--- a/tests/testthat/test-imp-auto.R
+++ b/tests/testthat/test-imp-auto.R
@@ -155,6 +155,7 @@ nmTest({
     .off <- .fitAuto(FALSE, model = .pkHealthy, est = "imp")
     .on <- .fitAuto(TRUE, model = .pkHealthy, est = "imp")
     expect_equal(sum(.off$env$impPsisK > 0.7), 0L)      # premise: converged fit healthy
+    expect_gt(sum(.on$env$impDfInd == 0), 0L)           # escalation stays selective
     expect_equal(.on$objf, .off$objf, tolerance = 0.5)  # and does not move the answer
   })
 
@@ -176,6 +177,9 @@ nmTest({
     expect_gt(sum(.on$env$impDfInd == 0), 0L)
     expect_lt(max(.on$env$impPsisK), max(.k0))
     expect_lt(sum(.on$env$impPsisK > 0.7), sum(.k0 > 0.7))
+    # and the repair is a proposal-shape fix, not a different fit: the escalated
+    # subject's tail improves without the objective moving to a different basin
+    expect_equal(.on$objf, .off$objf, tolerance = 0.5)
   })
 
   test_that("the nobs < neta trigger is gated, and autoNonmemSparse restores it", {

--- a/tests/testthat/test-imp-auto.R
+++ b/tests/testthat/test-imp-auto.R
@@ -25,6 +25,16 @@ nmTest({
   # structural model with three etas reads max k-hat 1.13 with 3 of 12 subjects
   # failing.  .pk is kept for the "auto changes nothing" checks; .pk3 is the
   # fixture for anything asserting escalation.
+  #
+  # .pk's tka/tv are non-mu structural thetas (no eta): they used to trigger a
+  # pre-existing, unrelated bug (rx->ndiff not restored per odeSwap peer,
+  # since fixed -- see test-imp-combsens.R) that made impmap's inner Hessian
+  # read a stale, artificially near-singular d(pred)/d(eta.cl), which widened
+  # the proposal enough to LOOK tail-healthy (k-hat ~ -1.46) while actually
+  # masking a real one (k-hat ~ 2.9 once the Hessian is correct). .pk is
+  # therefore NOT a valid "no tail failure" fixture and must not be used as
+  # one -- see .pkHealthy below, which has no non-mu structural theta at all
+  # (tka/tv are fix()ed rather than merely eta-free) and is genuinely clean.
   .pk <- function() {
     ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
     model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
@@ -34,6 +44,14 @@ nmTest({
     ini({tka <- 0.45; tcl <- 1; tv <- 3.45
          eta.ka ~ 0.3; eta.cl ~ 0.1; eta.v ~ 0.1; add.sd <- 0.7})
     model({ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+           linCmt() ~ add(add.sd)})
+  }
+  # Genuinely healthy 1-eta reference: tka/tv are fix()ed constants (not
+  # estimated at all), so there is no non-mu structural theta and nothing for
+  # the (fixed) rx->ndiff bug above to have ever touched.
+  .pkHealthy <- function() {
+    ini({tka <- fix(0.45); tcl <- 1; tv <- fix(3.45); eta.cl ~ 0.1; add.sd <- 0.7})
+    model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
            linCmt() ~ add(add.sd)})
   }
   # nobs < neta: the tutorial's documented sparse trigger.  Two observations per
@@ -49,10 +67,11 @@ nmTest({
     }))
   })
   .fitAuto <- function(auto, nIter = 12L, model = .pk, data = nlmixr2data::theo_sd,
-                       ...) {
-    suppressWarnings(nlmixr2(model, data, "impmap",
-                             impmapControl(print = 0L, nIter = nIter, isample = 300L,
-                                           covMethod = "", auto = auto, ..., gammaRule = "floor")))
+                       est = "impmap", ...) {
+    .ctlFun <- if (est == "imp") impControl else impmapControl
+    suppressWarnings(nlmixr2(model, data, est,
+                             .ctlFun(print = 0L, nIter = nIter, isample = 300L,
+                                     covMethod = "", auto = auto, ..., gammaRule = "floor")))
   }
 
   test_that("auto control round-trips and defaults off", {
@@ -117,19 +136,46 @@ nmTest({
     # previous fixture's vacuous premise destroyed -- it went green while testing
     # nothing.
     #
+    # est="imp", not "impmap".  impmap's proposal comes from calcEtaHessian
+    # (gamma * H^-1 at the MAP), which is a property of the SUBJECT's posterior
+    # geometry, not of which thetas are estimated -- fixing tka/tv in
+    # .pkHealthy does not change subject 1's conditional likelihood for
+    # eta.cl at all, so impmap reads the SAME genuinely heavy tail (k-hat
+    # about 2.9) that .pk exposed once the rx->ndiff fix stopped masking it.
+    # imp's proposal is gamma * (running conditional variance) instead, which
+    # never touches calcEtaHessian, so it is a real "no tail failure" case
+    # (max k-hat about 0.26, verified below) and the intended target for this
+    # guard.
+    #
     # Note what is NOT asserted: that nothing escalates.  impDfInd is the df of
     # the LAST E-step, but escalation is driven by the per-iteration k-hat, and
     # the early EM iterations run against a poorer proposal than the converged
-    # one.  So a model that is healthy AT CONVERGENCE (max k-hat about -1.5,
-    # nothing above 0.7) can still have escalated subjects on the transient.
-    # Measured, that costs about 5% objective RMSE -- which is the claim worth
-    # pinning, not a zero-escalation count that does not hold.
+    # one.
+    skip_on_cran()
+    .off <- .fitAuto(FALSE, model = .pkHealthy, est = "imp")
+    .on <- .fitAuto(TRUE, model = .pkHealthy, est = "imp")
+    expect_equal(sum(.off$env$impPsisK > 0.7), 0L)      # premise: converged fit healthy
+    expect_equal(.on$objf, .off$objf, tolerance = 0.5)  # and does not move the answer
+  })
+
+  test_that("auto repairs the genuine tail failure the rx->ndiff fix revealed on .pk", {
+    # .pk (tka/tv non-mu, no eta) turned out to have a REAL tail issue once
+    # impGetHessian's inner Hessian stopped reading a stale d(pred)/d(eta.cl)
+    # (see the .pk comment above and test-imp-combsens.R's odeSwapSolveInd
+    # regression test) -- one subject's k-hat reads well above 0.7 with
+    # auto=FALSE.  This is exactly the case AUTO exists for: assert it is
+    # selective (escalates the failing subject, leaves the rest alone) and
+    # clears the tail, mirroring the .pk3 escalation test above.
     skip_on_cran()
     .off <- .fitAuto(FALSE)
+    .k0 <- .off$env$impPsisK
+    expect_gt(sum(.k0 > 0.7), 0L,
+              label = "pk subjects with k-hat > 0.7 (rx->ndiff-fix premise)")
     .on <- .fitAuto(TRUE)
-    expect_equal(sum(.off$env$impPsisK > 0.7), 0L)      # premise: converged fit healthy
-    expect_gt(sum(.on$env$impDfInd == 0), 0L)           # escalation stays selective
-    expect_equal(.on$objf, .off$objf, tolerance = 0.5)  # and does not move the answer
+    expect_gt(sum(.on$env$impDfInd > 0), 0L)
+    expect_gt(sum(.on$env$impDfInd == 0), 0L)
+    expect_lt(max(.on$env$impPsisK), max(.k0))
+    expect_lt(sum(.on$env$impPsisK > 0.7), sum(.k0 > 0.7))
   })
 
   test_that("the nobs < neta trigger is gated, and autoNonmemSparse restores it", {

--- a/tests/testthat/test-imp-combsens.R
+++ b/tests/testthat/test-imp-combsens.R
@@ -251,11 +251,18 @@ nmTest({
     expect_equal(rF$maxK, rT$maxK, tolerance = 1e-3)
     expect_equal(rF$nAbove, rT$nAbove)
     # the registry actually recorded a real (nonzero) ndiff for the inner
-    # slot -- proof the fix has something to restore, not a vacuously-passing
-    # comparison on a model where ndiff was 0 for everyone anyway
+    # slot, AND a DIFFERENT (zero) one for the pred peer -- proof the fix has
+    # something to restore between, not a vacuously-passing comparison on a
+    # model where every registered slot needed the same ndiff anyway.  pred
+    # is the doFD fallback slot (fInd->doFD, likInner0) -- a subject that
+    # falls back to it mid-fit is exactly the scenario that used to leave
+    # rx->ndiff on the wrong peer's value for whichever slot solved next.
     .info <- nlmixr2est:::.odeSwapInfo()
     .inner <- .info$models[.info$models$name %in% "inner", ]
+    .pred <- .info$models[.info$models$name %in% "pred", ]
     expect_true(nrow(.inner) == 1L && isTRUE(.inner$ndiffSet) && .inner$ndiff > 0L)
+    expect_true(nrow(.pred) == 1L && isTRUE(.pred$ndiffSet))
+    expect_false(isTRUE(.pred$ndiff == .inner$ndiff))
   })
 
 })

--- a/tests/testthat/test-imp-combsens.R
+++ b/tests/testthat/test-imp-combsens.R
@@ -25,7 +25,7 @@
 # something.
 nmTest({
 
-  .harvestN <- function() nlmixr2est:::.odeSwapInfo()$impThetaSensHarvestN
+  .harvestN <- function() .odeSwapInfo()$impThetaSensHarvestN
 
   # tv is a non-mu STRUCTURAL theta (an ODE-state sensitivity, not just an
   # algebraic one); add.sd is a non-mu SIGMA theta.  Both get d(f)/d(theta) /
@@ -54,7 +54,7 @@ nmTest({
     expect_true(inherits(.f, "nlmixr2FitCore"))
     # fused build requested by default -> the harvest mechanism ran
     expect_true(.harvestN() > .n0)
-    .info <- nlmixr2est:::.odeSwapInfo()
+    .info <- .odeSwapInfo()
     expect_false("thetaSens" %in% .info$models$name)
   })
 
@@ -70,7 +70,7 @@ nmTest({
     # the mechanism actually ran (not just "results look fine")
     expect_true(.harvestN() > .n0)
     # combSens builds ONE fused model -- no separate thetaSens peer registered
-    .info <- nlmixr2est:::.odeSwapInfo()
+    .info <- .odeSwapInfo()
     expect_false("thetaSens" %in% .info$models$name)
     # the structural theta (tv) and sigma theta (add.sd) went through the
     # harvested M-step gradient and converged near FOCEI
@@ -257,7 +257,7 @@ nmTest({
     # is the doFD fallback slot (fInd->doFD, likInner0) -- a subject that
     # falls back to it mid-fit is exactly the scenario that used to leave
     # rx->ndiff on the wrong peer's value for whichever slot solved next.
-    .info <- nlmixr2est:::.odeSwapInfo()
+    .info <- .odeSwapInfo()
     .inner <- .info$models[.info$models$name %in% "inner", ]
     .pred <- .info$models[.info$models$name %in% "pred", ]
     expect_true(nrow(.inner) == 1L && isTRUE(.inner$ndiffSet) && .inner$ndiff > 0L)

--- a/tests/testthat/test-imp-combsens.R
+++ b/tests/testthat/test-imp-combsens.R
@@ -133,4 +133,68 @@ nmTest({
     expect_equal(.harvestN(), .n0)
   })
 
+  test_that("mixture (Nmix>1): harvested and solve-based M-steps agree on the expanded pseudo-subject mapping", {
+    # impEStep/impOuter index a mixture's expanded pseudo-subjects as
+    # id = i + j*nsub (j = 0-based component).  outSens is sized/filled by
+    # that SAME id, so a wrong offset here would misalign a component's
+    # samples against another component's zk weights -- this model has THREE
+    # non-mu thetas that are not eta-linked (tka, p1, add.sd all lack a `+eta`
+    # term), so d(f)/d(theta) actually differs across the two mixture
+    # components' branches, not just a shared constant.
+    .mkg <- function(cl0, ids) {
+      ka <- 1.5; v <- 8
+      do.call(rbind, lapply(ids, function(id) {
+        cli <- cl0 * exp(stats::rnorm(1, 0, 0.2))
+        tt <- c(0.5, 2, 6, 12)
+        cp <- (100 * ka / (v * (ka - cli / v))) * (exp(-cli / v * tt) - exp(-ka * tt))
+        cp <- pmax(cp, 1e-3) * exp(stats::rnorm(length(tt), 0, 0.1))
+        rbind(data.frame(id = id, time = 0, dv = NA_real_, amt = 100, evid = 1, cmt = "depot"),
+              data.frame(id = id, time = tt, dv = cp, amt = 0, evid = 0, cmt = "cen"))
+      }))
+    }
+    .testSeed(11); rxode2::rxSetSeed(11)
+    .d <- rbind(.mkg(3.0, 1:6), .mkg(9.0, 7:12))
+    .d <- .d[order(.d$id, .d$time, -.d$evid), ]
+    mmix <- function() {
+      ini({
+        tka <- log(1.5); tcl1 <- log(2.5); tcl2 <- log(8); tv <- log(8)
+        p1 <- 0.5
+        eta.cl ~ 0.2
+        add.sd <- 0.3
+      })
+      model({
+        ka <- exp(tka)
+        cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl))
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(cen) <- ka * depot - cl / v * cen
+        cp <- cen / v
+        cp ~ add(add.sd)
+      })
+    }
+    .n0 <- .harvestN()
+    rxode2::rxSetSeed(42)
+    .fh <- suppressWarnings(
+      nlmixr2(mmix, .d, "impmap",
+              impmapControl(print = 0L, nIter = 8L, isample = 40L, combSens = TRUE)))
+    expect_true(inherits(.fh, "nlmixr2FitCore"))
+    expect_true(all(is.finite(fixef(.fh))))
+    expect_true(.harvestN() > .n0)
+
+    rxode2::rxSetSeed(42)
+    .fs <- suppressWarnings(
+      nlmixr2(mmix, .d, "impmap",
+              impmapControl(print = 0L, nIter = 8L, isample = 40L, combSens = FALSE)))
+    expect_true(inherits(.fs, "nlmixr2FitCore"))
+    # A misaligned i+j*nsub mapping would scramble which component's samples
+    # feed which component's Newton step -- the two components' clearances
+    # (tcl1 low, tcl2 high) would no longer track between the harvested and
+    # solve-based runs even though both start from the same seed/data.  Not
+    # bit-identical (combSens changes the ODE integrator's path, see above);
+    # a loose tolerance is enough to catch a scrambled mapping, which would
+    # miss by an order of magnitude or swap the two components.
+    expect_equal(unname(fixef(.fh)[c("tcl1", "tcl2", "p1")]),
+                unname(fixef(.fs)[c("tcl1", "tcl2", "p1")]), tolerance = 0.15)
+  })
+
 })

--- a/tests/testthat/test-imp-combsens.R
+++ b/tests/testthat/test-imp-combsens.R
@@ -2,22 +2,23 @@
 #
 # est="imp"/"impmap" update their non-mu structural + residual-error thetas by
 # a Newton step whose score/Hessian needs d(f)/d(theta) and d(V)/d(theta) at
-# every E-step sample.  By default that is a SECOND, dedicated rxThetaSens
-# model re-solving every sample the E-step had just solved through the inner
-# model to get the importance weights -- two ODE integrations per sample.
-# impmapControl(combSens=TRUE) (opt-in, default FALSE) instead carries the
+# every E-step sample.  Without combSens that is a SECOND, dedicated
+# rxThetaSens model re-solving every sample the E-step had just solved through
+# the inner model to get the importance weights -- two ODE integrations per
+# sample.  impmapControl(combSens=TRUE) (the default) instead carries the
 # theta columns on the inner model itself, and impEStep (src/imp.cpp)
 # harvests them straight off its own per-sample inner solve
 # (impThetaSensCollect's reuseSolve path), so the common case (sir=FALSE)
 # needs only ONE solve per sample.
 #
-# combSens=TRUE is opt-in, not the default: folding the theta-sensitivity
-# states into the SAME coupled ODE system as the eta sensitivities changes the
-# integrator's adaptive step-size path, so results move by a small amount
-# relative to the two-model default -- not a correctness issue (see the
-# FOCEI-convergence check below), but enough to occasionally cross a
-# diagnostic threshold, so it must not change any existing fit's numbers
-# silently.
+# combSens=TRUE is the default because it agrees exactly (to floating-point
+# noise) with the old two-model path -- see the ndiff-fix tests below for why
+# that is worth pinning explicitly, not assumed: a linCmt() model with a
+# SINGLE non-mu structural theta used to disagree measurably between the two
+# builds, and that turned out to be an unrelated, pre-existing bug in
+# src/odeSwap.cpp's peer-model swapping (rx->ndiff never restored per slot),
+# not something combSens introduced.  impmapControl(combSens=FALSE) still
+# works, for anyone who wants the two-model path.
 #
 # These tests assert the MECHANISM is used (the harvest counter moves), not
 # just that results look plausible -- a wrong wiring could still converge to
@@ -43,26 +44,28 @@ nmTest({
     })
   }
 
-  test_that("combSens defaults off: impThetaSensIdx alone does not request the fused build", {
+  test_that("combSens defaults on: impThetaSensIdx alone requests the fused build", {
     .d <- nlmixr2data::theo_sd
-    expect_false(impmapControl()$combSens)
+    expect_true(impmapControl()$combSens)
     .n0 <- .harvestN()
     rxode2::rxSetSeed(42)
     .f <- suppressWarnings(
       nlmixr2(.mod, .d, "imp", impControl(print = 0L, nIter = 5L, isample = 50L)))
     expect_true(inherits(.f, "nlmixr2FitCore"))
-    # no fused build requested -> nothing harvested (unchanged default behavior)
-    expect_equal(.harvestN(), .n0)
+    # fused build requested by default -> the harvest mechanism ran
+    expect_true(.harvestN() > .n0)
+    .info <- nlmixr2est:::.odeSwapInfo()
+    expect_false("thetaSens" %in% .info$models$name)
   })
 
-  test_that("imp(combSens=TRUE) harvests theta-sensitivities from the E-step's own inner solve", {
+  test_that("imp harvests theta-sensitivities from the E-step's own inner solve", {
     .d <- nlmixr2data::theo_sd
     .ff <- suppressWarnings(nlmixr2(.mod, .d, "focei", foceiControl(print = 0L, covMethod = "")))
     .n0 <- .harvestN()
     rxode2::rxSetSeed(42)
     .fh <- suppressWarnings(
       nlmixr2(.mod, .d, "imp",
-              impControl(print = 0L, nIter = 30L, isample = 300L, combSens = TRUE)))
+              impControl(print = 0L, nIter = 30L, isample = 300L)))
     expect_true(inherits(.fh, "nlmixr2FitCore"))
     # the mechanism actually ran (not just "results look fine")
     expect_true(.harvestN() > .n0)
@@ -74,20 +77,19 @@ nmTest({
     expect_equal(unname(fixef(.fh)["tv"]), unname(fixef(.ff)["tv"]), tolerance = 0.03)
     expect_equal(unname(fixef(.fh)["add.sd"]), unname(fixef(.ff)["add.sd"]), tolerance = 0.05)
 
-    # sir=TRUE disables harvesting even with combSens=TRUE (impOuter's
-    # harvestSens gate is off under any sir=TRUE), so the M-step falls back to
-    # the un-fused solve-based read against the SAME fused inner model.  The
-    # two paths read the same per-sample f/V/d(f)/d(theta)/d(V)/d(theta) off
-    # the same ODE system, just at different points in the loop, so they
-    # should land in the same neighborhood (not bit-identical: an EM run this
-    # long accumulates its own floating-point path noise regardless of
-    # harvesting, plus sir=TRUE's own RNG draws are not exactly the same
-    # sequence).
+    # sir=TRUE disables harvesting (impOuter's harvestSens gate is off under
+    # any sir=TRUE), so the M-step falls back to the un-fused solve-based read
+    # against the SAME fused inner model.  The two paths read the same
+    # per-sample f/V/d(f)/d(theta)/d(V)/d(theta) off the same ODE system, just
+    # at different points in the loop, so they should land in the same
+    # neighborhood (not bit-identical: an EM run this long accumulates its own
+    # floating-point path noise regardless of harvesting, plus sir=TRUE's own
+    # RNG draws are not exactly the same sequence).
     .n1 <- .harvestN()
     rxode2::rxSetSeed(42)
     .fs <- suppressWarnings(
       nlmixr2(.mod, .d, "imp",
-              impControl(print = 0L, nIter = 30L, isample = 300L, combSens = TRUE,
+              impControl(print = 0L, nIter = 30L, isample = 300L,
                         sir = TRUE, sirSample = 300L)))
     expect_true(inherits(.fs, "nlmixr2FitCore"))
     # the fallback path harvested nothing new
@@ -95,21 +97,33 @@ nmTest({
     expect_equal(unname(fixef(.fh)), unname(fixef(.fs)), tolerance = 0.02)
   })
 
-  test_that("impmap(combSens=TRUE) (MAP search) harvests theta-sensitivities the same way", {
+  test_that("impmap (MAP search) harvests theta-sensitivities the same way", {
     .d <- nlmixr2data::theo_sd
     .n0 <- .harvestN()
     rxode2::rxSetSeed(42)
     .fh <- suppressWarnings(
       nlmixr2(.mod, .d, "impmap",
-              impmapControl(print = 0L, nIter = 10L, isample = 50L, combSens = TRUE)))
+              impmapControl(print = 0L, nIter = 10L, isample = 50L)))
     expect_true(inherits(.fh, "nlmixr2FitCore"))
     expect_true(.harvestN() > .n0)
   })
 
-  test_that("no non-mu thetas: combSens(TRUE) has nothing to fuse, harvest counter unmoved", {
+  test_that("combSens=FALSE still works and requests no fused build", {
+    .d <- nlmixr2data::theo_sd
+    .n0 <- .harvestN()
+    rxode2::rxSetSeed(42)
+    .f <- suppressWarnings(
+      nlmixr2(.mod, .d, "imp",
+              impControl(print = 0L, nIter = 5L, isample = 50L, combSens = FALSE)))
+    expect_true(inherits(.f, "nlmixr2FitCore"))
+    # opted out of the fused build -> nothing harvested
+    expect_equal(.harvestN(), .n0)
+  })
+
+  test_that("no non-mu thetas: combSens has nothing to fuse, harvest counter unmoved", {
     # every theta here is mu-referenced (or fixed), so impmap has nothing to
     # differentiate -- combSens should resolve to off (nothing to fuse) even
-    # though it was requested, and the harvest counter must not move.
+    # though it defaults on, and the harvest counter must not move.
     mmu <- function() {
       ini({
         tka <- 0.45; tcl <- 1; tv <- fix(3.45)
@@ -128,7 +142,7 @@ nmTest({
     rxode2::rxSetSeed(42)
     .f <- suppressWarnings(
       nlmixr2(mmu, .d, "imp",
-              impControl(print = 0L, nIter = 5L, isample = 50L, combSens = TRUE)))
+              impControl(print = 0L, nIter = 5L, isample = 50L)))
     expect_true(inherits(.f, "nlmixr2FitCore"))
     expect_equal(.harvestN(), .n0)
   })
@@ -176,7 +190,7 @@ nmTest({
     rxode2::rxSetSeed(42)
     .fh <- suppressWarnings(
       nlmixr2(mmix, .d, "impmap",
-              impmapControl(print = 0L, nIter = 8L, isample = 40L, combSens = TRUE)))
+              impmapControl(print = 0L, nIter = 8L, isample = 40L)))
     expect_true(inherits(.fh, "nlmixr2FitCore"))
     expect_true(all(is.finite(fixef(.fh))))
     expect_true(.harvestN() > .n0)
@@ -190,11 +204,58 @@ nmTest({
     # feed which component's Newton step -- the two components' clearances
     # (tcl1 low, tcl2 high) would no longer track between the harvested and
     # solve-based runs even though both start from the same seed/data.  Not
-    # bit-identical (combSens changes the ODE integrator's path, see above);
+    # bit-identical (the two builds' ODE integrator paths differ slightly);
     # a loose tolerance is enough to catch a scrambled mapping, which would
     # miss by an order of magnitude or swap the two components.
     expect_equal(unname(fixef(.fh)[c("tcl1", "tcl2", "p1")]),
                 unname(fixef(.fs)[c("tcl1", "tcl2", "p1")]), tolerance = 0.15)
+  })
+
+  test_that("odeSwapSolveInd restores rx->ndiff per peer (linCmtB Jacobian-cache fix)", {
+    # Regression test for the bug combSens=TRUE originally uncovered on this
+    # exact model shape: linCmt(), ONE non-mu structural theta (tka has no
+    # eta), the OTHER two structural parameters (tv, ka's amplitude) pure
+    # constants.  linCmtB()'s cached Jacobian (J/Jg) is keyed off rx->ndiff, a
+    # single field on the shared rx_solve struct that used to be set ONCE
+    # (whichever model first called rxSolve_()) and never restored when
+    # odeSwap swapped to a DIFFERENT registered peer -- so impmap's inner
+    # Hessian (impGetHessian -> calcEtaHessian) could read a stale,
+    # iteration-old d(pred)/d(eta) left by a sibling peer with a different (or
+    # absent) sensitivity need.  The practical symptom: impmap's proposal
+    # covariance came out far too wide (a near-singular Hessian), which
+    # LOOKED like an unusually healthy Pareto k-hat (over-coverage hides tail
+    # problems) while actually wasting samples and masking a real tail issue.
+    #
+    # combSens=TRUE and combSens=FALSE are asserted to agree here -- before
+    # the fix they did not (one read k-hat ~ -1.5, healthy; the other ~ 3,
+    # unreliable, for the SAME subject).
+    .pk <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; eta.cl ~ 0.1; add.sd <- 0.7})
+      model({ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+             linCmt() ~ add(add.sd)})
+    }
+    .d <- nlmixr2data::theo_sd
+    run1 <- function(combSens) {
+      rxode2::rxSetSeed(1)
+      f <- suppressWarnings(nlmixr2(.pk, .d, "impmap",
+                    impmapControl(print = 0L, nIter = 12L, isample = 300L,
+                                  covMethod = "", auto = FALSE, gammaRule = "floor",
+                                  combSens = combSens)))
+      k <- f$env$impPsisK
+      list(objf = as.numeric(f$objf), maxK = max(k, na.rm = TRUE),
+           nAbove = sum(k > 0.7, na.rm = TRUE))
+    }
+    rF <- run1(FALSE)
+    rT <- run1(TRUE)
+    expect_equal(rF$objf, rT$objf, tolerance = 1e-4)
+    expect_equal(rF$maxK, rT$maxK, tolerance = 1e-3)
+    expect_equal(rF$nAbove, rT$nAbove)
+    # the registry actually recorded a real (nonzero) ndiff for the inner
+    # slot -- proof the fix has something to restore, not a vacuously-passing
+    # comparison on a model where ndiff was 0 for everyone anyway
+    .info <- nlmixr2est:::.odeSwapInfo()
+    .inner <- .info$models[.info$models$name %in% "inner", ]
+    expect_true(nrow(.inner) == 1L && isTRUE(.inner$ndiffSet) && .inner$ndiff > 0L)
   })
 
 })

--- a/tests/testthat/test-imp-combsens.R
+++ b/tests/testthat/test-imp-combsens.R
@@ -1,0 +1,136 @@
+# Combined eta+theta sensitivity build (#958) applied to imp/impmap's M-step.
+#
+# est="imp"/"impmap" update their non-mu structural + residual-error thetas by
+# a Newton step whose score/Hessian needs d(f)/d(theta) and d(V)/d(theta) at
+# every E-step sample.  By default that is a SECOND, dedicated rxThetaSens
+# model re-solving every sample the E-step had just solved through the inner
+# model to get the importance weights -- two ODE integrations per sample.
+# impmapControl(combSens=TRUE) (opt-in, default FALSE) instead carries the
+# theta columns on the inner model itself, and impEStep (src/imp.cpp)
+# harvests them straight off its own per-sample inner solve
+# (impThetaSensCollect's reuseSolve path), so the common case (sir=FALSE)
+# needs only ONE solve per sample.
+#
+# combSens=TRUE is opt-in, not the default: folding the theta-sensitivity
+# states into the SAME coupled ODE system as the eta sensitivities changes the
+# integrator's adaptive step-size path, so results move by a small amount
+# relative to the two-model default -- not a correctness issue (see the
+# FOCEI-convergence check below), but enough to occasionally cross a
+# diagnostic threshold, so it must not change any existing fit's numbers
+# silently.
+#
+# These tests assert the MECHANISM is used (the harvest counter moves), not
+# just that results look plausible -- a wrong wiring could still converge to
+# something.
+nmTest({
+
+  .harvestN <- function() nlmixr2est:::.odeSwapInfo()$impThetaSensHarvestN
+
+  # tv is a non-mu STRUCTURAL theta (an ODE-state sensitivity, not just an
+  # algebraic one); add.sd is a non-mu SIGMA theta.  Both get d(f)/d(theta) /
+  # d(V)/d(theta) columns, exercising the full harvested M-step gradient.
+  .mod <- function() {
+    ini({
+      tka <- 0.45; tcl <- 1; tv <- 3.45
+      eta.ka ~ 0.6; eta.cl ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  test_that("combSens defaults off: impThetaSensIdx alone does not request the fused build", {
+    .d <- nlmixr2data::theo_sd
+    expect_false(impmapControl()$combSens)
+    .n0 <- .harvestN()
+    rxode2::rxSetSeed(42)
+    .f <- suppressWarnings(
+      nlmixr2(.mod, .d, "imp", impControl(print = 0L, nIter = 5L, isample = 50L)))
+    expect_true(inherits(.f, "nlmixr2FitCore"))
+    # no fused build requested -> nothing harvested (unchanged default behavior)
+    expect_equal(.harvestN(), .n0)
+  })
+
+  test_that("imp(combSens=TRUE) harvests theta-sensitivities from the E-step's own inner solve", {
+    .d <- nlmixr2data::theo_sd
+    .ff <- suppressWarnings(nlmixr2(.mod, .d, "focei", foceiControl(print = 0L, covMethod = "")))
+    .n0 <- .harvestN()
+    rxode2::rxSetSeed(42)
+    .fh <- suppressWarnings(
+      nlmixr2(.mod, .d, "imp",
+              impControl(print = 0L, nIter = 30L, isample = 300L, combSens = TRUE)))
+    expect_true(inherits(.fh, "nlmixr2FitCore"))
+    # the mechanism actually ran (not just "results look fine")
+    expect_true(.harvestN() > .n0)
+    # combSens builds ONE fused model -- no separate thetaSens peer registered
+    .info <- nlmixr2est:::.odeSwapInfo()
+    expect_false("thetaSens" %in% .info$models$name)
+    # the structural theta (tv) and sigma theta (add.sd) went through the
+    # harvested M-step gradient and converged near FOCEI
+    expect_equal(unname(fixef(.fh)["tv"]), unname(fixef(.ff)["tv"]), tolerance = 0.03)
+    expect_equal(unname(fixef(.fh)["add.sd"]), unname(fixef(.ff)["add.sd"]), tolerance = 0.05)
+
+    # sir=TRUE disables harvesting even with combSens=TRUE (impOuter's
+    # harvestSens gate is off under any sir=TRUE), so the M-step falls back to
+    # the un-fused solve-based read against the SAME fused inner model.  The
+    # two paths read the same per-sample f/V/d(f)/d(theta)/d(V)/d(theta) off
+    # the same ODE system, just at different points in the loop, so they
+    # should land in the same neighborhood (not bit-identical: an EM run this
+    # long accumulates its own floating-point path noise regardless of
+    # harvesting, plus sir=TRUE's own RNG draws are not exactly the same
+    # sequence).
+    .n1 <- .harvestN()
+    rxode2::rxSetSeed(42)
+    .fs <- suppressWarnings(
+      nlmixr2(.mod, .d, "imp",
+              impControl(print = 0L, nIter = 30L, isample = 300L, combSens = TRUE,
+                        sir = TRUE, sirSample = 300L)))
+    expect_true(inherits(.fs, "nlmixr2FitCore"))
+    # the fallback path harvested nothing new
+    expect_equal(.harvestN(), .n1)
+    expect_equal(unname(fixef(.fh)), unname(fixef(.fs)), tolerance = 0.02)
+  })
+
+  test_that("impmap(combSens=TRUE) (MAP search) harvests theta-sensitivities the same way", {
+    .d <- nlmixr2data::theo_sd
+    .n0 <- .harvestN()
+    rxode2::rxSetSeed(42)
+    .fh <- suppressWarnings(
+      nlmixr2(.mod, .d, "impmap",
+              impmapControl(print = 0L, nIter = 10L, isample = 50L, combSens = TRUE)))
+    expect_true(inherits(.fh, "nlmixr2FitCore"))
+    expect_true(.harvestN() > .n0)
+  })
+
+  test_that("no non-mu thetas: combSens(TRUE) has nothing to fuse, harvest counter unmoved", {
+    # every theta here is mu-referenced (or fixed), so impmap has nothing to
+    # differentiate -- combSens should resolve to off (nothing to fuse) even
+    # though it was requested, and the harvest counter must not move.
+    mmu <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- fix(3.45)
+        eta.ka ~ 0.6; eta.cl ~ 0.3
+        add.sd <- fix(0.7)
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .d <- nlmixr2data::theo_sd
+    .n0 <- .harvestN()
+    rxode2::rxSetSeed(42)
+    .f <- suppressWarnings(
+      nlmixr2(mmu, .d, "imp",
+              impControl(print = 0L, nIter = 5L, isample = 50L, combSens = TRUE)))
+    expect_true(inherits(.f, "nlmixr2FitCore"))
+    expect_equal(.harvestN(), .n0)
+  })
+
+})


### PR DESCRIPTION
## Summary

`est="impmap"`/`"imp"` update non-mu (structural/residual-error) thetas by a
Newton step whose score/Hessian needs `d(f)/d(theta)` and `d(V)/d(theta)` at
every E-step importance sample. That has always meant a second, dedicated
`rxThetaSens` model re-solving every sample the E-step's own inner-model solve
had already produced value/eta-sensitivities for -- two ODE integrations per
sample.

This adds `impmapControl(combSens=TRUE)` (now the **default**), which instead
requests the combined eta+theta sensitivity build (#958, already shipped for
`foceiLikLoad(combSens=TRUE)`'s external MCMC callers, e.g. nlmixr2bayes) --
the inner model carries the theta columns itself, and `impEStep`'s own
per-sample loop now harvests them straight off the solve it already ran
(`impThetaSensCollect`'s `reuseSolve` path) whenever `sir=FALSE` (the
default), so the M-step needs one ODE solve per sample instead of two.

* `sir=TRUE` disables harvesting: SIR only needs a resampled subset of the
  E-step's samples, so eagerly harvesting every one would be wasted work; that
  case keeps the original solve-based M-step unchanged.
* A sample whose E-step solve fell back to the pred-model FD path is left
  unharvested rather than re-solved from inside the harvest call -- that retry
  path is R-API-unsafe from a bare OpenMP region. A subject that harvests
  nothing at all falls back to the ordinary solve-based M-step read, so no
  subject's contribution is silently dropped.

**Shipped opt-in, now flipped to default TRUE.** `combSens` originally shipped
off by default because forcing it on appeared to move results on a one-ETA
theophylline fixture with a non-mu **structural** theta (`tka`/`tv`
estimated with no random effect): 3 subjects crossed the 0.7 Pareto k-hat
threshold that were previously exactly 0. That was chased down to its actual
source and it was **not** a `combSens` effect at all:

* `impmap`'s inner Hessian (`impGetHessian` -> `calcEtaHessian`), which builds
  the importance-sampling proposal, could read a **stale cached `linCmtB()`
  Jacobian**. Several compiled peer models share one solve pool (`odeSwap`);
  `linCmtB()`'s cached Jacobian is gated by `rx->ndiff`, a field on the single
  shared `rx_solve` struct that `odeSwapSolveInd()` never restored per peer --
  so a solve could read a Jacobian built for a *different* peer's
  structural-parameter set. The resulting proposal was artificially wide,
  which **masked** a real heavy tail (k-hat ~2.9) as healthy (k-hat ~-1.5)
  rather than revealing it. `odeSwapSolveInd()` now restores each peer's own
  `ndiff` before every solve.
* That restore is itself a write to a field on the shared solve struct, and a
  second Antigravity review pass on that fix caught a genuine follow-on data
  race: `impGetHessian`'s per-subject proposal-building loop runs in
  parallel, and a subject that falls back to the doFD/pred path can pick a
  *different* registered slot -- and so a different `ndiff` -- than a subject
  still on the plain inner path, concurrently. A third review pass on THAT
  fix found the identical pattern is also reachable from `impEStep`'s own
  per-sample E-step loop, not just the Hessian build -- wrapping that hot
  loop in the same lock would have serialized the E-step's actual
  ODE-solving work, defeating `combSens`'s own point for exactly the model
  class it targets. The real fix turned out to be smaller: `odeSlotPred`
  always needs `ndiff=0` ("rxPred implements no sensitivities"), and the
  original restore wrote that `0` unconditionally -- which is what could
  stomp a concurrent `odeSlotInner` solve's nonzero need. `odeSwapSolveInd()`
  now skips the write entirely when a slot's own declared need is `0`, so a
  slot that needs nothing never touches the shared field and the only
  remaining writers (subjects on the same nonzero-need slot) write the
  identical value -- benign, no lock required. `impGetHessian`'s critical
  section is kept as defense-in-depth for a narrower, unaudited case this
  alone doesn't cover (two *different* peers both needing a nonzero but
  differing `ndiff`, concurrently).

With both fixed, `combSens=TRUE`/`FALSE` agree numerically on every fixture
tested, including the one that originally exposed the discrepancy, so there
is no longer a reason to keep it opt-in. Pass `combSens=FALSE` for the
previous two-model behavior.

One fallout worth flagging: a "healthy, no tail failure" one-ETA theophylline
fixture used throughout this repo's own AUTO-tuning tests (and the nlmixr2
vignette's df/AUTO sweep) turned out to have been reading a bug-masked k-hat
all along on models with a non-mu structural theta -- see
`tests/testthat/test-imp-auto.R`'s `.pk`/`.pkHealthy` split and the new
"auto repairs the genuine tail failure the rx->ndiff fix revealed on .pk"
test. The AUTO/df sweep golden ratios themselves are unaffected (the tuning
fixture there has no non-mu structural theta and never triggered the bug).

`odeSwapInfo_()` gains `$impThetaSensHarvestN`, `ndiff`/`ndiffSet` per-slot
columns, and `$rxNdiff` so tests can assert both the harvest path and the
ndiff-restore fix actually ran, not just that results look plausible.

## Verification

- Full `test-impmap.R` and all essential `test-imp-*.R` files
  (`test-imp-combsens.R`, `test-imp-auto.R`, `test-imp-parallel.R`,
  `test-imp-psis.R`, `test-imp-tprop.R`, `test-imp-xi-gamma.R`) pass with the
  new `combSens=TRUE` default.
- `tests/testthat/test-imp-combsens.R`: asserts the harvest counter moves only
  when requested and eligible, cross-checks the harvested path against FOCEI
  convergence and the solve-based fallback, includes a mixture (`Nmix>1`)
  regression test for the `id = i + j*nsub` expanded pseudo-subject mapping,
  and a new regression test for the `rx->ndiff` fix itself (compares
  `combSens=TRUE`/`FALSE` on the affected model shape, and asserts the
  `inner`/`pred` peers actually register different `ndiff` values -- proof
  there is something real to restore between, not a vacuous comparison).
- `tests/testthat/test-imp-auto.R`: `.pk` (the old "no tail failure"
  reference) is retired from that role since it genuinely fails the premise
  once the Hessian is correct; `.pkHealthy` + `est="imp"` (which never calls
  `calcEtaHessian`, so it was never exposed to the bug) is the new reference,
  and a new test confirms `auto=TRUE` correctly repairs `.pk`'s
  now-revealed real tail failure under `impmap`.
- Independently reviewed by Antigravity (Gemini 3.1 Pro) across four passes:
  Round 1 (original opt-in feature) found a real thread-safety issue (a
  sample whose inner solve failed without flipping the sticky `doFD` flag
  could still reach the R-API-unsafe `impThetaSensFD` retry path from inside
  the harvest region); fixed by additionally gating reuse on `R_finite(qk)`.
  Round 2, after the fix, reported no further findings. Round 3 (the
  default-flip + `rx->ndiff` fix) found a genuine `OpenMP` data race on the
  new `rx->ndiff` restore in `impGetHessian`'s proposal-build loop; fixed
  with a gated critical section, plus two dropped test assertions restored.
  Round 4, on that race fix, found the identical pattern also reachable from
  `impEStep`'s own per-sample loop -- not covered by the round-3 fix, which
  only guarded `impGetHessian`. Rather than add a second, much more
  expensive lock around the E-step's hot path, the actual fix was smaller:
  `odeSwapSolveInd()` now skips writing `rx->ndiff` for a slot whose own
  need is `0`, which makes the confirmed exposure (a nonzero-need solve
  concurrent with a zero-need one) benign everywhere without any lock. A
  round 5, attempted specifically on this final fix, did not produce output
  after two tries (Antigravity's headless sandbox denied a shell command it
  reached for both times) -- correctness of this last change rests on the
  reasoning in its commit message and code comments plus the passing test
  suite, not an additional independent review pass.

## Test plan

- [x] `devtools::load_all()` builds clean (including a full `rm -f src/*.o
      src/*.so` clean rebuild after merging `origin/main`)
- [x] `test-impmap.R` full suite passes with `combSens` defaulting on
- [x] All essential `test-imp-*.R` files pass
- [x] `test-imp-combsens.R` passes (mechanism-usage, FOCEI-convergence,
      solve-based fallback cross-check, mixture id-mapping regression,
      `rx->ndiff` restore regression)
- [x] `test-imp-auto.R` passes with the `.pkHealthy`/`est="imp"` healthy
      reference and the new `.pk` tail-repair regression test
- [x] `devtools::document()` regenerated `man/impmapControl.Rd`
- [x] Antigravity review: 3 real findings across 4 rounds total (1 on the
      original opt-in feature; 2 on this default-flip work -- stale-Jacobian
      mechanism confirmed by root-causing rather than taken on faith, then a
      concurrent-solve data race whose full scope (impGetHessian AND
      impEStep) took two review passes to surface). The final fix for the
      race (skip the `ndiff` write for a zero-need slot, replacing an
      earlier narrower critical-section patch) was designed after, not
      re-verified by, Antigravity -- correctness relies on the reasoning in
      the commit message and `odeSwap.cpp`'s comments plus the passing
      `test-imp-combsens.R`/`test-imp-auto.R` suites, not a fifth AI review
      round.
