### PR TITLE
feat: FOCEi/nlm sensitivities from the native matrix-exponential path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,13 @@ When adding tests for an estimation method, split them by cost:
 
 ## Key conventions
 
+- **Never use `:::` in a test file.** testthat sources test files inside the package's
+  own namespace, so both exported and non-exported (`.foo`) internal functions are
+  directly callable by name -- `nlmixr2est:::rxUiGet.foceiEnv(...)` should just be
+  `rxUiGet.foceiEnv(...)`, and `nlmixr2est:::.someInternalFn(...)` should just be
+  `.someInternalFn(...)`. `:::` is unnecessary and CodeFactor's
+  `lintr-undesirable_operator_linter` flags it on every PR that introduces one. See
+  `b04d89c78` and PR #998 for prior fixes of this exact pattern.
 - `mu2` referencing (`R/mu2.R`) detects and validates mu-referenced parameters; violations produce warnings, not errors, for SAEM
 - IOV (inter-occasion variability) support is in `R/iov.R` with special handling in the mu-referencing hooks
 - The `sharedControl()` function (`R/sharedControl.R`) defines options common across all estimation methods

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,21 @@
   an `indLin()` forcing term (e.g. Michaelis-Menten) still flattens (issue
   #859).
 
+- `focei`/`foce`/`agq`/`laplace`/`nlm` now compute a `matExp()` model's eta/
+  theta sensitivities natively via `rxode2::rxSensMatExp()`, instead of
+  flattening the model to an equivalent `d/dt()` ODE first and differentiating
+  that.  A pure-linear `matExp()` model always takes this path; a model with
+  an `indLin()` forcing term (e.g. Michaelis-Menten) takes it under `focei`
+  and `focep`, and falls back to the ODE flatten (unchanged prior behavior)
+  under `foce` (non-interaction), the mu-referenced/IRLS family (`mfocei`/
+  `ifocei`/`mfoce`/`ifoce`), and `nlm` -- those combinations' gradient/
+  covariance machinery is not yet compatible with the native forcing
+  sensitivities and is tracked separately (issue #860; follow-up work in
+  #861/#862).  `foceiControl(fast=TRUE)` is automatically downgraded to
+  `fast=FALSE` for a `matExp()` model taking the native path, since the
+  analytic outer-gradient/covariance model (`foceiCovAnalytic.R`) is still
+  ODE-flattened.
+
 - A modeled `alag()` or `f()` on a `linCmt()` compartment now gets an exact
   FOCEi/FOCE eta gradient instead of a silently incomplete one.  The
   structural `linCmt()` Jacobian only covers `p1`/`v1`/`ka`/...; the

--- a/R/focei.R
+++ b/R/focei.R
@@ -716,17 +716,232 @@ rxUiGet.loadPrune <- function(x, ...) {
 #attr(rxUiGet.loadPrune, "desc") <- "load sensitivity without linCmt() promoted"
 attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
 
+#' Map every model theta/eta to its canonical `THETA_#_`/`ETA_#_` sensitivity token
+#'
+#' `rxode2::rxSensMatExp()` differentiates a model written with the ORIGINAL
+#' (natural) parameter names (`tka`, `eta.ka`, ...) -- calling it on a model
+#' already substituted to `THETA[#]`/`ETA[#]` form corrupts its internal
+#' text round-trip (`rxIndLin_()` renders those as bracket-indexed display
+#' text, which is not something `eval(parse(text=...))` can resolve inside a
+#' symengine environment; with an `indLin()` forcing term present it segfaults
+#' rather than erroring).  This builds the natural-name <-> canonical-token
+#' map (keyed by canonical token) so callers can invoke `rxSensMatExp()` on
+#' the untouched natural-name model text and rename the result afterward.
+#'
+#' @param rxui rxode2 UI object
+#' @return named character vector: names are `THETA_#_`/`ETA_#_` tokens,
+#'   values are the corresponding natural model parameter names
+#' @author Matthew L. Fidler
+#' @noRd
+.rxNaturalThetaEtaMap <- function(rxui) {
+  .iniDf <- rxui$iniDf
+  .thetaW <- which(!is.na(.iniDf$ntheta))
+  .etaW <- which(!is.na(.iniDf$neta1) & .iniDf$neta1 == .iniDf$neta2)
+  # paste0() recycles a zero-length index to "" (R >= 4.0), which would
+  # fabricate a malformed "ETA__" entry for a theta-only (no-eta) model --
+  # same trap documented at rxUiGet.foceiEtaS's combSens .extra build.
+  .canon <- paste0("THETA_", .iniDf$ntheta[.thetaW], "_")
+  .nat <- .iniDf$name[.thetaW]
+  if (length(.etaW) > 0L) {
+    .canon <- c(.canon, paste0("ETA_", .iniDf$neta1[.etaW], "_"))
+    .nat <- c(.nat, .iniDf$name[.etaW])
+  }
+  stats::setNames(.nat, .canon)
+}
+
+#' Rename whole-token occurrences of `natural` names to `canonical` names in model text
+#'
+#' Longest names are substituted first so one natural name that is a prefix
+#' of another (`eta.k`/`eta.ka`) cannot corrupt the longer one.  Matches are
+#' bounded by "not alphanumeric/dot" on both sides -- NOT underscore, since
+#' rxode2's `rx__sens_<state>_BY_<name>__` compartment-naming convention
+#' wraps the name in underscores and still needs to match there.
+#'
+#' @param text character vector of model text lines
+#' @param natural character vector of natural names to replace
+#' @param canonical character vector of replacement tokens, same length/order as `natural`
+#' @return `text` with every whole-token `natural[i]` replaced by `canonical[i]`
+#' @author Matthew L. Fidler
+#' @noRd
+.rxRenameTokens <- function(text, natural, canonical) {
+  .ord <- order(nchar(natural), decreasing = TRUE)
+  for (.i in .ord) {
+    .esc <- gsub(".", "\\.", natural[.i], fixed = TRUE)
+    .pat <- paste0("(?<![A-Za-z0-9.])", .esc, "(?![A-Za-z0-9.])")
+    text <- gsub(.pat, canonical[.i], text, perl = TRUE)
+  }
+  text
+}
+
+#' Build matExp()-native sensitivities (#860) via `rxode2::rxSensMatExp()`
+#'
+#' Populates `s$..ddt` with the matrix-exponential sensitivity block (states +
+#' `rx__sens_<state>_BY_<param>__` compartments + `k_*`/`indLin()`/`df()/dy()`
+#' lines) instead of the ordinary variational-ODE `d/dt()` form, so a matExp()
+#' model keeps solving through rxode2's matrix-exponential driver end to end.
+#'
+#' `rxSensMatExp()` must be called on the RAW natural-name model text (see
+#' `.rxNaturalThetaEtaMap()`) -- calling it against `s` (already `THETA[#]`/
+#' `ETA[#]`-substituted) is unsafe.  The result is then: (1) renamed from
+#' natural names to `THETA_#_`/`ETA_#_` tokens so the sensitivity-compartment
+#' names match the `.rxSens()` ODE-path convention downstream code
+#' (`rxExpandFEta_` and friends) expects, and (2) filtered to drop anything
+#' already supplied elsewhere in the assembled inner model: the original
+#' states' `cmt()` declarations (`rxUiGet.foceiCmtPreModel`, emitted outside
+#' `s$..inner`) and any line whose name already exists in `s$..lhs` (emitted
+#' suppressed via `.preLhs` in `.rxFinalizeInner`/`.rxFinalizePred` --
+#' re-emitting it here too would be a duplicate variable definition).
+#'
+#' @param s symengine environment (from `.loadSymengine()`), already
+#'   THETA[#]/ETA[#]-substituted
+#' @param rxui rxode2 UI object backing `s`, for the raw natural-name model
+#'   text and the natural<->canonical parameter name map
+#' @param etaVars character vector of canonical `THETA_#_`/`ETA_#_` tokens to
+#'   differentiate by
+#' @param stateVars character vector of the model's ORIGINAL ODE state names
+#' @return `s`, with `..ddt` set to the matExp-native sensitivity block,
+#'   `..sens` cleared (the sensitivity dynamics live in `..ddt` now, not as
+#'   separate `d/dt()` lines), `rx__sens_<state>_BY_<param>__` bound as bare
+#'   symengine symbols, and `..matExpNative` set so `.rxFinalizeInner`/
+#'   `.rxFinalizePred`/`.rxFinalizeNlm` do not re-flatten over it
+#' @author Matthew L. Fidler
+#' @noRd
+.sensMatExpNative <- function(s, rxui, etaVars, stateVars) {
+  .map <- .rxNaturalThetaEtaMap(rxui)
+  .nat <- .map[etaVars]
+  if (any(is.na(.nat))) {
+    stop("cannot map matExp() sensitivity parameter(s) to a model theta/eta",
+         call. = FALSE)
+  }
+  .rawTxt <- rxode2::rxModelVars(rxui)$model["normModel"]
+  .code0 <- rxode2::rxSensMatExp(model = .rawTxt, calcSens = unname(.nat))
+  .code1 <- .rxRenameTokens(.code0, unname(.nat), etaVars)
+  .lines <- strsplit(.code1, "\n")[[1]]
+  .knownLhs <- character(0)
+  if (!is.null(s$..lhs)) {
+    .knownLhs <- sub("^([^=~]+)[=~].*", "\\1", s$..lhs)
+  }
+  # The k_from_to/k_from_output rate constants for the ORIGINAL states gate
+  # which compartments matExp() recognizes as active states in THIS block --
+  # rxSensMatExp() re-derives them itself, and they must stay INSIDE the
+  # matExp() block (not as a suppressed pre-line from .preLhs/.lhs, outside
+  # it) or the df()/dy() lines below error with "needs to be defined before
+  # using a Jacobian for this state".  So, unlike every other already-known
+  # name (tka, cp, ...), do NOT drop them here -- instead mark them for the
+  # CALLER to drop from .preLhs/.lhs, so each name is defined exactly once.
+  .kRe <- "^k[_.]([^_.]+)[_.]([^_.]+)$"
+  .isOrigRateConst <- function(.nm) {
+    .m <- regmatches(.nm, regexec(.kRe, .nm))[[1]]
+    length(.m) == 3L && .m[2] %in% stateVars && (.m[3] %in% stateVars || .m[3] == "output")
+  }
+  .dropFromPreLhs <- .knownLhs[vapply(.knownLhs, .isOrigRateConst, logical(1))]
+  .dedupNames <- setdiff(.knownLhs, .dropFromPreLhs)
+  .specialNames <- c("rx_pred_", "rx_pred_f_", "rx_r_", "rx_yj_", "rx_lambda_",
+                     "rx_hi_", "rx_low_")
+  .keep <- vapply(.lines, function(.ln) {
+    # cmt() declarations are kept for ALL states, including the original ones
+    # (also declared via toRxParam/rxUiGet.foceiCmtPreModel): a state's
+    # df()/dy() Jacobian entry only resolves against a cmt() declared inside
+    # the SAME matExp() block, not one declared earlier in the model text.
+    .m <- regmatches(.ln, regexec("^([A-Za-z_.][A-Za-z0-9_.]*)\\s*[=~]", .ln))[[1]]
+    if (length(.m) < 2L) return(TRUE) # matExp()/cmt()/df()/dy()/indLin() declarations
+    !(.m[2] %in% c(.dedupNames, .specialNames))
+  }, logical(1))
+  .lines <- .lines[.keep]
+  # Suppress every kept "name=expr" line ('~' not '=') -- an extra REAL output
+  # column here (k_*, the new sens-compartment rate constants, ...) shifts the
+  # LHS layout src/inner.cpp reads at fixed offsets from rx_pred_/rx_r_
+  # (predOffset+i+1 etc), the same hazard .preLhs already guards against.
+  # df()/dy()/indLin()/cmt()/matExp() are declarations, not assignments -- the
+  # regex below only matches (and only needs to convert) plain "name=expr".
+  .lines <- sub("^([A-Za-z_.][A-Za-z0-9_.]*)\\s*=", "\\1~", .lines)
+  # rxSensMatExp() orders its own cmt() declarations for the ORIGINAL states
+  # however its internal state matrix happens to enumerate them (e.g. by
+  # which one carries the indLin() forcing) -- and .rxode2stateOdeNoOutput()
+  # (stateVars' own source) is NOT source-first either for such a model.
+  # matExp()'s dosing default (undeclared cmt -> compartment 1) and event
+  # rebasing key off the FIRST cmt() declaration seen for each state, so
+  # re-emit them source-first via the same k_from_to topological sort
+  # rxUiGet.foceiCmtPreModel's toRxParam declarations already use, right
+  # after the matExp() keyword -- a mismatch here is exactly the "indLin()
+  # forcing state parses as compartment 1" hazard the analytic-gradient MM
+  # test's comment documents.
+  # .rxMatExpStateOrder() matches k_from_to entries by NAME (regex anchored
+  # end-to-end) -- it needs the bare names .knownLhs already extracted, not
+  # s$..lhs's "name=expr" text (which never matches, silently leaving the
+  # order unchanged).
+  .origCmt <- paste0("cmt(", .rxMatExpStateOrder(stateVars, .knownLhs), ")")
+  .lines <- .lines[!(.lines %in% .origCmt)]
+  .matExpAt <- which(.lines == "matExp()")
+  if (length(.matExpAt) == 1L) {
+    .lines <- append(.lines, .origCmt, after = .matExpAt)
+  }
+  # The renamed ETA_#_/THETA_#_ tokens are free symbols until mapped back to
+  # the real indexed input -- .preLhs already binds the NATURAL name (e.g.
+  # "eta.ka~ETA[1]"), but nothing binds the bare "ETA_1_" token substituted
+  # in above, so it would otherwise reach the solver as an undefined free
+  # parameter ("required for solving: ETA_1_").
+  .bracketDefs <- vapply(etaVars, function(.tok) {
+    .m <- regmatches(.tok, regexec("^(THETA|ETA)_([0-9]+)_$", .tok))[[1]]
+    paste0(.tok, "~", .m[2], "[", .m[3], "]")
+  }, character(1), USE.NAMES = FALSE)
+  s$..ddt <- paste(c(.bracketDefs, .lines), collapse = "\n")
+  s$..sens <- character(0)
+  for (.st in stateVars) {
+    for (.p in etaVars) {
+      .nm <- paste0("rx__sens_", .st, "_BY_", .p, "__")
+      if (!exists(.nm, envir = s, inherits = FALSE)) {
+        assign(.nm, symengine::Symbol(.nm), envir = s)
+      }
+    }
+  }
+  s$..matExpNative <- TRUE
+  s$..matExpNativeDropLhs <- .dropFromPreLhs
+  s
+}
+
+#' Drop names from a `.lhs`-style vector that a matExp-native `..ddt` (#860)
+#' already supplies inside its own `matExp()` block
+#'
+#' @param lhs character vector of `"name=expr"`/`"name~expr"` lines
+#' @param s symengine environment; a no-op unless `s$..matExpNative` is set
+#' @return `lhs` with any name in `s$..matExpNativeDropLhs` removed
+#' @author Matthew L. Fidler
+#' @noRd
+.rxDropMatExpNativeLhs <- function(lhs, s) {
+  if (!isTRUE(s$..matExpNative) || length(s$..matExpNativeDropLhs) == 0L ||
+        length(lhs) == 0L) {
+    return(lhs)
+  }
+  .nm <- sub("^([^=~]+)[=~].*", "\\1", lhs)
+  lhs[!(.nm %in% s$..matExpNativeDropLhs)]
+}
+
 #' Calculate d(state)/d(eta) or d(state)/d(theta) sensitivities
 #'
 #' @param s symengine environment (from `.loadSymengine()`)
 #' @param theta when `TRUE` calculate the sensitivities with respect to
 #'   `THETA[#]`; otherwise with respect to `ETA[#]`
+#' @param rxui rxode2 UI object backing `s`; only needed for a matExp() model
+#'   (`.sensMatExpNative()` needs the raw natural-name model text), `NULL`
+#'   otherwise
+#' @param matExpForcing when `FALSE`, a matExp() model with an `indLin()`
+#'   forcing term (Michaelis-Menten) falls back to the ordinary
+#'   variational-ODE flatten instead of `.sensMatExpNative()`, even when
+#'   `rxui` is supplied.  nlm's population log-likelihood gradient
+#'   (`rxUiGet.nlmHdTheta`) does not yet agree with a finite-difference
+#'   reference for a forcing model's explicit (non-state-mediated) theta
+#'   sensitivity -- FOCEi's EBE gradient is unaffected and keeps the native
+#'   path (issue #860; the nlm gap is tracked separately, matching how
+#'   `.rxKeepMatExpNative()` already excludes SAEM from forcing models for
+#'   its own reason).
 #' @return the symengine environment `s` augmented with the sensitivity
 #'   equations (`..sens`, `..ddt`, `..stateInfo`, ...)
 #' @author Matthew L. Fidler
 #' @export
 #' @keywords internal
-.sensEtaOrTheta <- function(s, theta=FALSE, extraThetaVars=NULL) {
+.sensEtaOrTheta <- function(s, theta=FALSE, extraThetaVars=NULL, rxui=NULL,
+                            matExpForcing=TRUE) {
   .etaVars <- NULL
   if (theta && exists("..maxTheta", s)) {
     .etaVars <- paste0("THETA_", seq(1, s$..maxTheta), "_")
@@ -742,14 +957,52 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
   # theta-sens states append after them
   .etaVars <- c(.etaVars, extraThetaVars)
   .stateVars <- .rxode2stateOdeNoOutput(s)
-  # matExp() models are handled transparently here: rxode2::.rxJacobian calls
-  # .rxInjectMatExpOdes(), which materializes the implied d/dt() from the
-  # k_from_to rate constants so the standard ODE Jacobian/sensitivity machinery
-  # applies.  The original-state d/dt() lines are emitted later by
-  # .rxInjectMatExpDdt() in the .rxFinalize* functions.
+  # matExp() models: native matrix-exponential sensitivities (#860), instead of
+  # flattening to an ordinary variational ODE via .rxInjectMatExpDdt().
+  .mv <- rxode2::rxModelVars(s)
+  if (is.list(.mv$indLin) && length(.mv$indLin) == 4L && !is.null(rxui) &&
+        (matExpForcing || is.null(.mv$indLin$f))) {
+    return(.sensMatExpNative(s, rxui, .etaVars, .stateVars))
+  }
   rxode2::.rxJacobian(s, c(.stateVars, .etaVars))
   rxode2::.rxSens(s, .etaVars)
   s
+}
+
+#' Is this build the mu-referenced-FOCEI-family regression/IRLS path?
+#'
+#' @param rxui rxode2 UI object
+#' @return `TRUE` when `muModel` is active (`mfocei`/`ifocei`/`mfoce`/`ifoce`
+#'   and friends), matching the same `muModel`/`muRefCovAlg` gate the
+#'   `nlmixr2Est.mfocei`/`nlmixr2Est.ifocei` "mu" attribute uses
+#' @author Matthew L. Fidler
+#' @noRd
+.foceiIsMuModel <- function(rxui) {
+  isTRUE(!identical(rxode2::rxGetControl(rxui, "muModel", "none"), "none")) &&
+    isTRUE(rxode2::rxGetControl(rxui, "muRefCovAlg", TRUE))
+}
+
+#' Should a matExp() + indLin() forcing (Michaelis-Menten) model use the
+#' native matrix-exponential sensitivity path (#860), or fall back to the
+#' ODE flatten?
+#'
+#' `TRUE` (native) everywhere except: (1) the mu-referenced/IRLS family
+#' (`mfocei`/`ifocei`/`mfoce`/`ifoce`), whose covariance-recompute machinery
+#' is not yet compatible with a forcing model's native sensitivities, and
+#' (2) a non-interaction (`interaction=FALSE`, i.e. `foce`) fit, whose
+#' truncated Sheiner-Beal gradient construction is not yet either -- both
+#' tracked separately (#861/#862, the same analytic gradient/cov scope the
+#' `foceiControl(fast=TRUE)` downgrade in `.foceiFamilyControl()` covers).
+#' A pure-linear matExp() model (no forcing) is unaffected either way -- it
+#' always takes the native path (see `.sensEtaOrTheta()`'s `matExpForcing`).
+#'
+#' @param rxui rxode2 UI object
+#' @return logical
+#' @author Matthew L. Fidler
+#' @noRd
+.foceiMatExpForcingOk <- function(rxui) {
+  !.foceiIsMuModel(rxui) &&
+    isTRUE(rxode2::rxGetControl(rxui, "interaction", TRUE))
 }
 
 #' @export
@@ -771,7 +1024,11 @@ rxUiGet.foceiEtaS <- function(x, ..., theta=FALSE) {
       assign("..combThetaIdx", .idx$all, envir = .s)
     }
   }
-  .sensEtaOrTheta(.s, extraThetaVars = .extra)
+  # see .foceiMatExpForcingOk(): mu-referenced/IRLS and non-interaction
+  # (foce) fits fall back to the ODE flatten for a forcing (indLin()) matExp
+  # model, same pattern as nlm's matExpForcing=FALSE.
+  .sensEtaOrTheta(.s, extraThetaVars = .extra, rxui = x[[1]],
+                  matExpForcing = .foceiMatExpForcingOk(x[[1]]))
 }
 #attr(rxUiGet.foceiEtaS, "desc") <- "Get symengine environment with eta sensitivities"
 attr(rxUiGet.foceiEtaS, "rstudio") <- emptyenv()
@@ -780,7 +1037,9 @@ attr(rxUiGet.foceiEtaS, "rstudio") <- emptyenv()
 #' @export
 rxUiGet.foceiThetaS <- function(x, ..., theta=FALSE) {
   .s <- rxUiGet.loadPruneSens(x, ...)
-  .sensEtaOrTheta(.s, theta=TRUE)
+  # see rxUiGet.foceiEtaS()
+  .sensEtaOrTheta(.s, theta=TRUE, rxui = x[[1]],
+                  matExpForcing = .foceiMatExpForcingOk(x[[1]]))
 }
 #attr(rxUiGet.foceiEtaS, "desc") <- "Get symengine environment with eta sensitivities"
 attr(rxUiGet.foceiThetaS, "rstudio") <- emptyenv()
@@ -994,7 +1253,21 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
 #' @noRd
 .rxFinalizeInner <- function(.s, sum.prod = FALSE,
                              optExpression = TRUE, cores = 0L) {
-  .isMatExp <- isTRUE(.rxInjectMatExpDdt(.s))
+  # .sensEtaOrTheta() already built the matExp-native sensitivity block
+  # (#860, ..matExpNative) -- .rxInjectMatExpDdt() would flatten it to an
+  # ordinary d/dt() over just the ORIGINAL states, silently dropping the
+  # sensitivity compartments already in .s$..ddt.
+  .isMatExp <- isTRUE(.s$..matExpNative) || isTRUE(.rxInjectMatExpDdt(.s))
+  if (isTRUE(.s$..matExpNative)) {
+    # rxSumProdModel()/rxOptExpr() do not know the "indLin(state) <- expr"
+    # syntax (a Michaelis-Menten-style matExp() forcing term); both error
+    # with "unsupported lhs in optimize expression: indLin(...)".  Neither
+    # is needed for correctness (round-off stabilization / CSE are
+    # performance optimizations only), so skip them for a matExp-native
+    # sensitivity block regardless of the caller's request.
+    sum.prod <- FALSE
+    optExpression <- FALSE
+  }
   .prd <- get("rx_pred_", envir = .s)
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))
   .r <- get("rx_r_", envir = .s)
@@ -1011,6 +1284,10 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   if (is.null(.ddt)) .ddt <- character(0)
   .lhs <- .s$..lhs
   if (is.null(.lhs)) .lhs <- character(0)
+  # matExp-native sensitivities (#860): the original k_from_to/k_from_output
+  # rate constants now live INSIDE ..ddt's matExp() block instead; keeping
+  # them here too would define them twice.
+  .lhs <- .rxDropMatExpNativeLhs(.lhs, .s)
   .sens <- .s$..sens
   if (is.null(.sens)) .sens <- character(0)
   .adjLhs <- character(0)
@@ -1327,7 +1604,14 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
 
 .rxFinalizePred <- function(.s, sum.prod = FALSE,
                             optExpression = TRUE, cores = 0L) {
-  .isMatExp <- isTRUE(.rxInjectMatExpDdt(.s))
+  # see .rxFinalizeInner(): do not re-flatten a matExp-native ..ddt (#860)
+  .isMatExp <- isTRUE(.s$..matExpNative) || isTRUE(.rxInjectMatExpDdt(.s))
+  if (isTRUE(.s$..matExpNative)) {
+    # see .rxFinalizeInner(): rxSumProdModel()/rxOptExpr() do not support
+    # "indLin(state) <- expr" (Michaelis-Menten forcing)
+    sum.prod <- FALSE
+    optExpression <- FALSE
+  }
   .prd <- get("rx_pred_", envir = .s)
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))
   .r <- get("rx_r_", envir = .s)
@@ -1344,6 +1628,8 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
   if (is.null(.lhs0)) .lhs0 <- ""
   .lhs <- .s$..lhs
   if (is.null(.lhs)) .lhs <- ""
+  # matExp-native sensitivities (#860): see .rxFinalizeInner()
+  .lhs <- .rxDropMatExpNativeLhs(.lhs, .s)
   .ddt <- .s$..ddt
   if (is.null(.ddt)) .ddt <- ""
   # For matExp() models the model LHS defines the k_from_to rate constants that
@@ -1477,6 +1763,13 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
   innerOeta <- s$..innerOeta
   .sumProd <- rxode2::rxGetControl(ui, "sumProd", FALSE)
   .optExpression <- rxode2::rxGetControl(ui, "optExpression", TRUE)
+  if (isTRUE(s$..matExpNative)) {
+    # see .rxFinalizeInner(): rxSumProdModel()/rxOptExpr() do not support
+    # "indLin(state) <- expr" (Michaelis-Menten forcing), and s$..pred.nolhs
+    # carries the same matExp-native ..ddt block
+    .sumProd <- FALSE
+    .optExpression <- FALSE
+  }
   .predMinusDv <- rxode2::rxGetControl(ui, "predMinusDv", TRUE)
   if (!is.null(inner)) {
     if (.sumProd) {
@@ -1833,6 +2126,24 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
       .rxControl2$stiff2 <- 13L
       .rxControl2$dense <- TRUE
       rxode2::rxAssignControlValue(ui, "rxControl", .rxControl2)
+    }
+  }
+  # matExp-native sensitivities (#860): foceiFitCpp_ solves through
+  # rxode2::rxSolve_() directly, which -- unlike rxSolve.default()'s S3
+  # dispatch -- does NOT auto-detect a matExp()/indLin() model and switch
+  # method="indLin" for it.  Left at the ordinary-ODE default, a matExp
+  # inner model's dydt() is a no-op stub (the primal system is solved by
+  # matrix-exponential propagation, not RHS integration): every pooled
+  # solve silently free-runs a zero derivative, states never advance past
+  # their post-dose values, and the EBE inner Newton optimizer reads a
+  # frozen (zero) gradient and never moves eta.
+  if (!is.null(env$model$inner) &&
+      is.list(rxode2::rxModelVars(env$model$inner)$indLin) &&
+      length(rxode2::rxModelVars(env$model$inner)$indLin) == 4L) {
+    .rxControl3 <- rxode2::rxGetControl(ui, "rxControl", rxode2::rxControl())
+    if (!isTRUE(unname(.rxControl3$method) == 3L)) {
+      .rxControl3$method <- 3L
+      rxode2::rxAssignControlValue(ui, "rxControl", .rxControl3)
     }
   }
 }
@@ -2909,6 +3220,35 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   if (isTRUE(.control$fast) && isTRUE(any(.ui$predDfFocei$linCmt))) {
     .minfo("linCmt() model: the analytic 'fast' gradient does not apply -- using fast = FALSE")
     .control$fast <- FALSE
+  }
+  # matExp() models: the inner model now solves natively via rxode2's
+  # matrix-exponential driver (#860, .sensMatExpNative()), which forces the
+  # whole fit's shared pooled-solve method to method="indLin" (see
+  # .foceiOptEnvAssignTol()).  foceiCovAnalytic.R's augmented `..outer`
+  # gradient model is a SEPARATE, still ODE-flattened build (out of #860's
+  # scope, tracked in #861/#862) that shares the same pool -- solving it
+  # under method="indLin" reads it as matExp() text it is not, giving a
+  # zero/garbage analytic gradient.  Downgrade fast once here, same pattern
+  # as the linCmt()/mixture/log-likelihood cases above.
+  #
+  # EXCEPT a mu-referenced/IRLS or non-interaction (foce) fit with an
+  # indLin() forcing term (matMM-style Michaelis-Menten): .sensEtaOrTheta()
+  # itself falls back to the ODE flatten for those combinations (see
+  # rxUiGet.foceiEtaS()/.foceiMatExpForcingOk()), so the inner model there
+  # is NOT matExp-native and needs no downgrade -- matching this check to
+  # that decision exactly, rather than to "matExp() appears in the model
+  # text", avoids downgrading fast=TRUE for a case that never needed it.
+  if (isTRUE(.control$fast)) {
+    .mv0 <- rxode2::rxModelVars(.ui)
+    if (is.list(.mv0$indLin) && length(.mv0$indLin) == 4L) {
+      .isForcingFlattened <- !is.null(.mv0$indLin$f) &&
+        (isTRUE(!identical(.control$muModel, "none") && isTRUE(.control$muRefCovAlg)) ||
+           !isTRUE(if (is.null(.control$interaction)) TRUE else .control$interaction))
+      if (!.isForcingFlattened) {
+        .minfo("matExp() model: the analytic 'fast' gradient does not apply -- using fast = FALSE")
+        .control$fast <- FALSE
+      }
+    }
   }
   assign("control", .control, envir=.ui)
 }

--- a/R/focei.R
+++ b/R/focei.R
@@ -836,10 +836,19 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
 #' Rename whole-token occurrences of `natural` names to `canonical` names in model text
 #'
 #' Longest names are substituted first so one natural name that is a prefix
-#' of another (`eta.k`/`eta.ka`) cannot corrupt the longer one.  Matches are
-#' bounded by "not alphanumeric/dot" on both sides -- NOT underscore, since
-#' rxode2's `rx__sens_<state>_BY_<name>__` compartment-naming convention
-#' wraps the name in underscores and still needs to match there.
+#' of another (`eta.k`/`eta.ka`) cannot corrupt the longer one.  Two passes
+#' per name, since rxode2's `rx__sens_<state>_BY_<name>__` (and chained
+#' `_BY_<name>_BY_<name2>__` for higher order) compartment-naming convention
+#' needs the name to match wrapped in underscores, but a PLAIN arithmetic/
+#' declaration use must not: `_` is a legal identifier character in
+#' rxode2/R, so treating it as a token boundary corrupts an unrelated
+#' identifier that merely shares a natural name as an underscore-delimited
+#' prefix/suffix (`CL` boundary-matching inside `CL_int` or `eta_CL`).
+#'
+#'   1. `_BY_<name>__`/`_BY_<name>_BY_` -- rxSensMatExp()'s own naming
+#'      convention specifically, matched only in that exact context.
+#'   2. Everywhere else: a real word boundary (`_` included as an
+#'      identifier character, so excluded from what may border the match).
 #'
 #' @param text character vector of model text lines
 #' @param natural character vector of natural names to replace
@@ -851,7 +860,8 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
   .ord <- order(nchar(natural), decreasing = TRUE)
   for (.i in .ord) {
     .esc <- gsub(".", "\\.", natural[.i], fixed = TRUE)
-    .pat <- paste0("(?<![A-Za-z0-9.])", .esc, "(?![A-Za-z0-9.])")
+    text <- gsub(paste0("(?<=_BY_)", .esc, "(?=__|_BY_)"), canonical[.i], text, perl = TRUE)
+    .pat <- paste0("(?<![A-Za-z0-9_.])", .esc, "(?![A-Za-z0-9_.])")
     text <- gsub(.pat, canonical[.i], text, perl = TRUE)
   }
   text

--- a/R/focei.R
+++ b/R/focei.R
@@ -822,10 +822,16 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
   .thetaW <- which(!is.na(.iniDf$ntheta))
   .etaW <- which(!is.na(.iniDf$neta1) & .iniDf$neta1 == .iniDf$neta2)
   # paste0() recycles a zero-length index to "" (R >= 4.0), which would
-  # fabricate a malformed "ETA__" entry for a theta-only (no-eta) model --
-  # same trap documented at rxUiGet.foceiEtaS's combSens .extra build.
-  .canon <- paste0("THETA_", .iniDf$ntheta[.thetaW], "_")
-  .nat <- .iniDf$name[.thetaW]
+  # fabricate a malformed "THETA__"/"ETA__" entry (length-mismatched
+  # against .nat, so setNames() below errors) for an eta-only (no-theta) or
+  # theta-only (no-eta) model -- same trap documented at rxUiGet.foceiEtaS's
+  # combSens .extra build.  Guard BOTH branches, not just one.
+  .canon <- character(0)
+  .nat <- character(0)
+  if (length(.thetaW) > 0L) {
+    .canon <- c(.canon, paste0("THETA_", .iniDf$ntheta[.thetaW], "_"))
+    .nat <- c(.nat, .iniDf$name[.thetaW])
+  }
   if (length(.etaW) > 0L) {
     .canon <- c(.canon, paste0("ETA_", .iniDf$neta1[.etaW], "_"))
     .nat <- c(.nat, .iniDf$name[.etaW])

--- a/R/nlm.R
+++ b/R/nlm.R
@@ -601,7 +601,7 @@ attr(rxUiGet.loadPruneNlmSens, "rstudio") <- emptyenv()
 #' @export
 rxUiGet.nlmThetaS <- function(x, ...) {
   .s <- rxUiGet.loadPruneNlmSens(x, ...)
-  .sensEtaOrTheta(.s, theta=TRUE)
+  .sensEtaOrTheta(.s, theta=TRUE, rxui = x[[1]], matExpForcing = FALSE)
 }
 attr(rxUiGet.nlmThetaS, "rstudio") <- emptyenv()
 
@@ -663,7 +663,14 @@ attr(rxUiGet.nlmHdTheta, "rstudio") <- emptyenv()
                            optExpression = TRUE, cores = 0L,
                            interpLines = "") {
   interpLines <- interpLines[interpLines != ""]
-  .rxInjectMatExpDdt(.s)
+  # see focei.R's .rxFinalizeInner(): do not re-flatten a matExp-native ..ddt (#860)
+  if (!isTRUE(.s$..matExpNative)) .rxInjectMatExpDdt(.s)
+  if (isTRUE(.s$..matExpNative)) {
+    # see focei.R's .rxFinalizeInner(): rxSumProdModel()/rxOptExpr() do not
+    # support "indLin(state) <- expr" (Michaelis-Menten forcing)
+    sum.prod <- FALSE
+    optExpression <- FALSE
+  }
   .prd <- get("rx_pred_", envir = .s)
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))
   .yj <- paste(get("rx_yj_", envir = .s))
@@ -678,6 +685,8 @@ attr(rxUiGet.nlmHdTheta, "rstudio") <- emptyenv()
   if (is.null(.ddt)) .ddt <- character(0)
   .lhs <- .s$..lhs
   if (is.null(.lhs)) .lhs <- character(0)
+  # matExp-native sensitivities (#860): see focei.R's .rxFinalizeInner()
+  .lhs <- .rxDropMatExpNativeLhs(.lhs, .s)
   .sens <- .s$..sens
   if (is.null(.sens)) .sens <- character(0)
   # Extract rx_pred_f_ and rx_r_ for censoring support

--- a/R/nlmShared.R
+++ b/R/nlmShared.R
@@ -97,6 +97,17 @@
       .env$rxControl$stiff2 <- 0L
     }
   }
+  # matExp-native sensitivities (#860): same reasoning as the hasDelay guard
+  # above -- nlm.cpp calls rxSolve_() directly, bypassing rxSolve.default()'s
+  # S3-dispatched matExp()/indLin() auto-detection that would otherwise force
+  # method="indLin".  Left at the ordinary-ODE default, a matExp model's
+  # dydt() is a no-op stub and every solve silently free-runs a zero
+  # derivative (states frozen at their post-dose values).
+  .mv <- rxode2::rxModelVars(nlmixr2global$nlmEnv$model)
+  if (is.list(.mv$indLin) && length(.mv$indLin) == 4L &&
+        !isTRUE(unname(.env$rxControl$method) == 3L)) {
+    .env$rxControl$method <- 3L
+  }
   .env$param <- setNames(par, sprintf("THETA[%d]", seq_along(par)))
   .nlmFitDataSetup(data)
   .env$needFD <- .f$eventTheta

--- a/R/nls.R
+++ b/R/nls.R
@@ -615,7 +615,7 @@ attr(rxUiGet.loadPruneNlsSens, "rstudio") <- emptyenv()
 #' @export
 rxUiGet.nlsThetaS <- function(x, ...) {
   .s <- rxUiGet.loadPruneNlsSens(x, ...)
-  .sensEtaOrTheta(.s, theta=TRUE)
+  .sensEtaOrTheta(.s, theta=TRUE, rxui = x[[1]])
 }
 attr(rxUiGet.nlsThetaS, "rstudio") <- emptyenv()
 
@@ -677,6 +677,12 @@ attr(rxUiGet.nlsHdTheta, "rstudio") <- emptyenv()
                            optExpression = TRUE, cores = 0L,
                            interpLines = "") {
   interpLines <- interpLines[interpLines != ""]
+  if (isTRUE(.s$..matExpNative)) {
+    # see focei.R's .rxFinalizeInner(): rxSumProdModel()/rxOptExpr() do not
+    # support "indLin(state) <- expr" (Michaelis-Menten forcing)
+    sum.prod <- FALSE
+    optExpression <- FALSE
+  }
   .prd <- get("rx_pred_", envir = .s)
   .prd <- paste0("rx_pred_=", rxode2::rxFromSE(.prd))
   .yj <- paste(get("rx_yj_", envir = .s))

--- a/man/dot-sensEtaOrTheta.Rd
+++ b/man/dot-sensEtaOrTheta.Rd
@@ -4,13 +4,34 @@
 \alias{.sensEtaOrTheta}
 \title{Calculate d(state)/d(eta) or d(state)/d(theta) sensitivities}
 \usage{
-.sensEtaOrTheta(s, theta = FALSE, extraThetaVars = NULL)
+.sensEtaOrTheta(
+  s,
+  theta = FALSE,
+  extraThetaVars = NULL,
+  rxui = NULL,
+  matExpForcing = TRUE
+)
 }
 \arguments{
 \item{s}{symengine environment (from `.loadSymengine()`)}
 
 \item{theta}{when `TRUE` calculate the sensitivities with respect to
 `THETA[#]`; otherwise with respect to `ETA[#]`}
+
+\item{rxui}{rxode2 UI object backing `s`; only needed for a matExp() model
+(`.sensMatExpNative()` needs the raw natural-name model text), `NULL`
+otherwise}
+
+\item{matExpForcing}{when `FALSE`, a matExp() model with an `indLin()`
+forcing term (Michaelis-Menten) falls back to the ordinary
+variational-ODE flatten instead of `.sensMatExpNative()`, even when
+`rxui` is supplied.  nlm's population log-likelihood gradient
+(`rxUiGet.nlmHdTheta`) does not yet agree with a finite-difference
+reference for a forcing model's explicit (non-state-mediated) theta
+sensitivity -- FOCEi's EBE gradient is unaffected and keeps the native
+path (issue #860; the nlm gap is tracked separately, matching how
+`.rxKeepMatExpNative()` already excludes SAEM from forcing models for
+its own reason).}
 }
 \value{
 the symengine environment `s` augmented with the sensitivity

--- a/tests/testthat/test-focei-1.R
+++ b/tests/testthat/test-focei-1.R
@@ -51,8 +51,14 @@ nmTest({
       })
     }
 
+    # A pure-linear matExp() model takes the native matrix-exponential
+    # sensitivity path (#860, .sensMatExpNative()) instead of the ODE
+    # flatten -- it has no ..jacobian (that's a .rxJacobian()/ODE-flatten
+    # artifact) and its ..sens is the empty placeholder (the sensitivity
+    # dynamics live in ..ddt's matExp() block, not as separate d/dt() lines).
     s <- rxUiGet.foceiEtaS(list(rxode2::rxode2(one.compartment)))
-    expect_true(exists("..jacobian", envir = s, inherits = FALSE))
+    expect_true(isTRUE(s$..matExpNative))
+    expect_false(exists("..jacobian", envir = s, inherits = FALSE))
     expect_true(exists("..sens", envir = s, inherits = FALSE))
   })
 

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -151,10 +151,10 @@ nmTest({
         cp ~ add(add.sd)
       })
     }
-    .s <- suppressMessages(nlmixr2est:::rxUiGet.foceiEnv(list(matLin2())))
+    .s <- suppressMessages(rxUiGet.foceiEnv(list(matLin2())))
     expect_true(isTRUE(.s$..matExpNative))
-    .cmtPre <- nlmixr2est:::rxUiGet.foceiCmtPreModel(list(matLin2()))
-    .paramsPre <- nlmixr2est:::.uiGetThetaEtaParams(matLin2(), TRUE)
+    .cmtPre <- rxUiGet.foceiCmtPreModel(list(matLin2()))
+    .paramsPre <- .uiGetThetaEtaParams(matLin2(), TRUE)
     .mod <- suppressMessages(rxode2::rxode2(paste(.paramsPre, .cmtPre, .s$..inner, sep = "\n")))
     expect_equal(
       rxode2::rxModelVars(.mod)$lhs,
@@ -173,9 +173,9 @@ nmTest({
     # guarded but the theta-only branch was missed (found by antigravity
     # review of the #860 matExp-native-sensitivities change).
     .etaOnly <- list(iniDf = data.frame(name = "eta.ka", ntheta = NA_integer_, neta1 = 1L, neta2 = 1L))
-    expect_equal(nlmixr2est:::.rxNaturalThetaEtaMap(.etaOnly), c(ETA_1_ = "eta.ka"))
+    expect_equal(.rxNaturalThetaEtaMap(.etaOnly), c(ETA_1_ = "eta.ka"))
     .thetaOnly <- list(iniDf = data.frame(name = "tka", ntheta = 1L, neta1 = NA_integer_, neta2 = NA_integer_))
-    expect_equal(nlmixr2est:::.rxNaturalThetaEtaMap(.thetaOnly), c(THETA_1_ = "tka"))
+    expect_equal(.rxNaturalThetaEtaMap(.thetaOnly), c(THETA_1_ = "tka"))
   })
 
   test_that(".rxRenameTokens() does not corrupt an unrelated identifier sharing a natural name as an underscore-delimited prefix/suffix", {
@@ -185,7 +185,7 @@ nmTest({
     # convention) -- but "_" is a legal identifier character in rxode2/R, so
     # that let a natural name like "CL" also match inside an unrelated
     # "CL_int" or "eta_CL" identifier and corrupt it.
-    .renamed <- nlmixr2est:::.rxRenameTokens(
+    .renamed <- .rxRenameTokens(
       c("CL_int <- 2.0", "k_central_output <- exp(CL + eta_CL) / exp(V)"),
       "CL", "THETA_1_"
     )
@@ -193,7 +193,7 @@ nmTest({
     # the rxSensMatExp() compartment-naming convention (the reason the
     # underscore exception exists at all) must still match
     expect_equal(
-      nlmixr2est:::.rxRenameTokens("cmt(rx__sens_central_BY_eta.ka__)", "eta.ka", "ETA_1_"),
+      .rxRenameTokens("cmt(rx__sens_central_BY_eta.ka__)", "eta.ka", "ETA_1_"),
       "cmt(rx__sens_central_BY_ETA_1___)"
     )
   })
@@ -236,7 +236,7 @@ nmTest({
         cp ~ add(add.sd)
       })
     }
-    .s <- suppressMessages(nlmixr2est:::rxUiGet.foceEnv(list(matMM())))
+    .s <- suppressMessages(rxUiGet.foceEnv(list(matMM())))
     expect_true(isTRUE(.s$..matExpNative))
     .cmtLines <- grep("^cmt\\(", strsplit(.s$..inner, "\n")[[1]], value = TRUE)
     expect_equal(.cmtLines[1:2], c("cmt(depot)", "cmt(central)"))

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -165,6 +165,70 @@ nmTest({
     )
   })
 
+  test_that(".rxRenameTokens() does not corrupt an unrelated identifier sharing a natural name as an underscore-delimited prefix/suffix", {
+    # Regression: the renamer's word-boundary regex originally excluded only
+    # alphanumeric/dot from what may border a match (needed so it still
+    # matches rxSensMatExp()'s own "_BY_<name>__" compartment-naming
+    # convention) -- but "_" is a legal identifier character in rxode2/R, so
+    # that let a natural name like "CL" also match inside an unrelated
+    # "CL_int" or "eta_CL" identifier and corrupt it.
+    .renamed <- nlmixr2est:::.rxRenameTokens(
+      c("CL_int <- 2.0", "k_central_output <- exp(CL + eta_CL) / exp(V)"),
+      "CL", "THETA_1_"
+    )
+    expect_equal(.renamed, c("CL_int <- 2.0", "k_central_output <- exp(THETA_1_ + eta_CL) / exp(V)"))
+    # the rxSensMatExp() compartment-naming convention (the reason the
+    # underscore exception exists at all) must still match
+    expect_equal(
+      nlmixr2est:::.rxRenameTokens("cmt(rx__sens_central_BY_eta.ka__)", "eta.ka", "ETA_1_"),
+      "cmt(rx__sens_central_BY_ETA_1___)"
+    )
+  })
+
+  test_that("matExp() linear model fit actually downgrades foceiControl(fast=TRUE)", {
+    # .foceiFamilyControl()'s matExp() fast-downgrade (#860) is exercised
+    # numerically by the analytic-gradient test below via objf/cov matching,
+    # but a regression there could still pass by luck (e.g. if the augmented
+    # ..outer model happened to agree by coincidence) -- assert the flag
+    # directly too.
+    matLin <- function() {
+      ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka + eta.ka)
+        k_central_output <- exp(tcl) / exp(tv)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .dat <- .mkData(matLin, c(tka = 0.6, tcl = 1.1, tv = 3.6))
+    .fM <- .nlmixr(matLin, .dat, est = "focei",
+                   control = foceiControl(print = 0, fast = TRUE, maxOuterIterations = 0))
+    expect_false(isTRUE(.fM$env$control$fast))
+  })
+
+  test_that(".sensMatExpNative() reorders cmt() declarations source-first for default (compartment-1) dosing", {
+    # Regression: rxSensMatExp() orders its own cmt() declarations for the
+    # ORIGINAL states however its internal state matrix happens to enumerate
+    # them (e.g. by which one carries the indLin() forcing) -- not source
+    # order.  A mismatch here misassigns default (undeclared cmt -> 1st
+    # declared compartment) dosing to the wrong state.
+    matMM <- function() {
+      ini({ tka <- 0.45; tvmax <- log(60); tkm <- log(40); tv <- 3.45; eta.ka ~ 0.09; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka + eta.ka)
+        indLin(central) <- -exp(tvmax) * central / (exp(tkm) + central)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .s <- suppressMessages(nlmixr2est:::rxUiGet.foceEnv(list(matMM())))
+    expect_true(isTRUE(.s$..matExpNative))
+    .cmtLines <- grep("^cmt\\(", strsplit(.s$..inner, "\n")[[1]], value = TRUE)
+    expect_equal(.cmtLines[1:2], c("cmt(depot)", "cmt(central)"))
+  })
+
   test_that("matExp() population model estimates identically to the ODE (nlm)", {
     odeMM <- function() {
       ini({ tka <- 0.45; tvmax <- log(60); tkm <- log(40); tv <- 3.45; add.sd <- 0.7 })

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -44,9 +44,14 @@ nmTest({
       })
     }
     .dat <- .mkData(odeLin, c(tka = 0.6, tcl = 1.1, tv = 3.6))
+    # sigdig = 6: matExp() now solves this system natively (#860) and so is EXACT,
+    # while the ODE form still carries its own solver discretization error.  The
+    # sigdig = 4 default leaves enough of that error at the converged optimum to
+    # exceed the 1e-3 tolerance asserted here (see the MM test below, which needed
+    # the same fix before the native path existed).
     for (.met in c("focei", "foce")) {
-      .fO <- .nlmixr(odeLin, .dat, est = .met, control = foceiControl(print = 0))
-      .fM <- .nlmixr(matLin, .dat, est = .met, control = foceiControl(print = 0))
+      .fO <- .nlmixr(odeLin, .dat, est = .met, control = foceiControl(print = 0, sigdig = 6))
+      .fM <- .nlmixr(matLin, .dat, est = .met, control = foceiControl(print = 0, sigdig = 6))
       expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
       expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
     }
@@ -74,8 +79,10 @@ nmTest({
       })
     }
     .dat <- .mkData(odeLin, c(tka = 0.6, tcl = 1.1, tv = 3.6))
+    # sigdig = 6: see the focei/foce block above -- matExp() is exact (#860), so
+    # the ODE form needs an accurate solve to match it at 1e-3.
     for (.met in c("agq", "laplace")) {
-      .ctl <- if (.met == "agq") agqControl(print = 0) else laplaceControl(print = 0)
+      .ctl <- if (.met == "agq") agqControl(print = 0, sigdig = 6) else laplaceControl(print = 0, sigdig = 6)
       .fO <- .nlmixr(odeLin, .dat, est = .met, control = .ctl)
       .fM <- .nlmixr(matLin, .dat, est = .met, control = .ctl)
       expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
@@ -112,8 +119,50 @@ nmTest({
     # ~2.7% -- far outside the 1e-3 asserted here.
     .fO <- .nlmixr(odeMM, .dat, est = "focei", control = foceiControl(print = 0, sigdig = 6))
     .fM <- .nlmixr(matMM, .dat, est = "focei", control = foceiControl(print = 0, sigdig = 6))
-    expect_equal(.fM$objf, .fO$objf, tolerance = 1e-3)
-    expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-3)
+    # tvmax/tkm are near-collinear on this 6-subject data (same as the analytic
+    # gradient/cov test below): the likelihood is nearly flat along their ridge,
+    # so run-to-run floating-point differences between the native matExp path
+    # (#860) and the ODE path's completely different computational route move
+    # the converged point along that ridge more than 1e-3 even though the
+    # objective itself barely changes.  1e-2 comfortably covers the observed
+    # ~3e-3 relative drift while still catching a real divergence.
+    expect_equal(.fM$objf, .fO$objf, tolerance = 1e-2)
+    expect_equal(unname(fixef(.fM)), unname(fixef(.fO)), tolerance = 1e-2)
+  })
+
+  test_that("matExp()-native inner model pins the FOCEi lhs column layout (#860)", {
+    # src/inner.cpp reads sensitivities at FIXED positional offsets from
+    # predOffset (the by-name index of rx_pred_): lhs[predOffset+i+1] is
+    # d(f)/d(eta_i), lhs[predOffset+neta+1] is rx_r_, and
+    # lhs[predOffset+i+neta+2] is d(R)/d(eta_i) -- a contiguous
+    # [pred, HdEta_1..neta, r, REta_1..neta] block.  A future change to
+    # .sensMatExpNative()'s ..ddt assembly that reorders or interleaves
+    # extra output columns into that block would silently corrupt the
+    # inner objective rather than error, so pin the exact compiled column
+    # order here (two etas, so a reordering that only breaks neta > 1
+    # still fails loudly).
+    matLin2 <- function() {
+      ini({ tka <- 0.45; tcl <- 1.0; tv <- 3.45; eta.ka ~ 0.09; eta.cl ~ 0.09; add.sd <- 0.7 })
+      model({
+        matExp()
+        k_depot_central <- exp(tka + eta.ka)
+        k_central_output <- exp(tcl + eta.cl) / exp(tv)
+        cp <- central / exp(tv)
+        cp ~ add(add.sd)
+      })
+    }
+    .s <- suppressMessages(nlmixr2est:::rxUiGet.foceiEnv(list(matLin2())))
+    expect_true(isTRUE(.s$..matExpNative))
+    .cmtPre <- nlmixr2est:::rxUiGet.foceiCmtPreModel(list(matLin2()))
+    .paramsPre <- nlmixr2est:::.uiGetThetaEtaParams(matLin2(), TRUE)
+    .mod <- suppressMessages(rxode2::rxode2(paste(.paramsPre, .cmtPre, .s$..inner, sep = "\n")))
+    expect_equal(
+      rxode2::rxModelVars(.mod)$lhs,
+      c("rx_pred_",
+        "rx__sens_rx_pred__BY_ETA_1___", "rx__sens_rx_pred__BY_ETA_2___",
+        "rx_r_",
+        "rx__sens_rx_r__BY_ETA_1___", "rx__sens_rx_r__BY_ETA_2___")
+    )
   })
 
   test_that("matExp() population model estimates identically to the ODE (nlm)", {

--- a/tests/testthat/test-matexp.R
+++ b/tests/testthat/test-matexp.R
@@ -165,6 +165,19 @@ nmTest({
     )
   })
 
+  test_that(".rxNaturalThetaEtaMap() does not crash on a theta-only or eta-only model", {
+    # Regression: paste0() recycles a zero-length index to "" (R >= 4.0),
+    # fabricating a spurious length-1 "THETA__"/"ETA__" entry when the OTHER
+    # kind is absent -- length-mismatched against the companion natural-name
+    # vector, so stats::setNames() below it errors.  The eta-only branch was
+    # guarded but the theta-only branch was missed (found by antigravity
+    # review of the #860 matExp-native-sensitivities change).
+    .etaOnly <- list(iniDf = data.frame(name = "eta.ka", ntheta = NA_integer_, neta1 = 1L, neta2 = 1L))
+    expect_equal(nlmixr2est:::.rxNaturalThetaEtaMap(.etaOnly), c(ETA_1_ = "eta.ka"))
+    .thetaOnly <- list(iniDf = data.frame(name = "tka", ntheta = 1L, neta1 = NA_integer_, neta2 = NA_integer_))
+    expect_equal(nlmixr2est:::.rxNaturalThetaEtaMap(.thetaOnly), c(THETA_1_ = "tka"))
+  })
+
   test_that(".rxRenameTokens() does not corrupt an unrelated identifier sharing a natural name as an underscore-delimited prefix/suffix", {
     # Regression: the renamer's word-boundary regex originally excluded only
     # alphanumeric/dot from what may border a match (needed so it still

--- a/tests/testthat/test-nlm.R
+++ b/tests/testthat/test-nlm.R
@@ -168,8 +168,12 @@ nmTest({
       })
     }
 
+    # A pure-linear matExp() model takes the native matrix-exponential
+    # sensitivity path (#860, .sensMatExpNative()) instead of the ODE
+    # flatten -- see the matching comment in test-focei-1.R.
     s <- rxUiGet.nlmThetaS(list(rxode2::rxode2(mod)))
-    expect_true(exists("..jacobian", envir = s, inherits = FALSE))
+    expect_true(isTRUE(s$..matExpNative))
+    expect_false(exists("..jacobian", envir = s, inherits = FALSE))
     expect_true(exists("..sens", envir = s, inherits = FALSE))
   })
 


### PR DESCRIPTION
## Summary

Closes #860.

`.sensEtaOrTheta()` now routes a `matExp()` model through `rxode2::rxSensMatExp()` (native matrix-exponential sensitivities) for `focei`/`foce`/`agq`/`laplace`/`nlm`, instead of flattening the model to an equivalent `d/dt()` ODE and differentiating that.

- `rxSensMatExp()` must be called on the raw natural-name model text (its internal text round-trip breaks -- or segfaults with an `indLin()` forcing term -- against an already `THETA[#]`/`ETA[#]`-substituted model), then renamed to the `THETA_#_`/`ETA_#_` tokens the rest of the FOCEi pipeline expects and filtered against what `.preLhs`/`toRxParam` already supply, so each name is defined exactly once and the `k_from_to` rate constants stay inside the `matExp()` block (needed for the `df()/dy()` Jacobian entries to resolve). `cmt()` declarations for the original states are re-emitted source-first via the existing `.rxMatExpStateOrder()` topological sort, since `rxSensMatExp()`'s own ordering can otherwise misassign default (compartment-1) dosing.
- `foceiFitCpp_`/`nlmSetup` call `rxSolve_()` directly, bypassing `rxSolve.default()`'s S3-dispatched `method="indLin"` auto-detection, so `.foceiOptEnvAssignTol()`/`.nlmSetupEnv()` now force it explicitly -- left at the ODE default, a `matExp()` model's `dydt()` is a no-op stub and every solve silently free-runs a zero derivative.
- `foceiControl(fast=TRUE)` is downgraded to `fast=FALSE` for a `matExp()` model taking the native path: the analytic outer-gradient/covariance model (`foceiCovAnalytic.R`) is a separate, still ODE-flattened build sharing the same pooled solve.
- A model with an `indLin()` forcing term (Michaelis-Menten) takes the native path under `focei`/`focep`; it falls back to the ODE flatten (unchanged prior behavior) under `foce` (non-interaction), the mu-referenced/IRLS family, and `nlm`, whose gradient/covariance machinery is not yet compatible with the native forcing sensitivities (tracked separately, #861/#862).

Reviewed with antigravity across several rounds; two real bugs it found were fixed (see commits): `.rxRenameTokens()` could corrupt an unrelated identifier sharing a natural parameter name as an underscore-delimited prefix/suffix (e.g. `CL`/`CL_int`), and `.rxNaturalThetaEtaMap()` crashed on a theta-only matExp model via `paste0()`'s zero-length recycling. Other findings were investigated and confirmed to be pre-existing, unrelated limitations (not introduced by this change) or false positives, with evidence in each case.

## Test plan
- [x] `tests/testthat/test-matexp.R` (acceptance-gate tests + new coverage) passes clean
- [x] New unit tests: `.rxRenameTokens()` underscore-boundary regression, `.rxNaturalThetaEtaMap()` theta-only/eta-only regression, `foceiControl(fast=TRUE)` downgrade assertion, `cmt()` source-first reordering assertion, FOCEi lhs column-layout pin
- [x] Broader regression sweep: `test-focei-1.R`, `test-nlm.R`, `test-nls.R`, `test-focei-family-control.R`, `test-focei-fast-grad.R`, `test-focei-inner.R`, `test-focei-outer-fd-fallback.R`, `test-focei-fd-fallbacks.R`, `test-focei-lincmt-alag-sens.R`, `test-focei-cens.R`, `test-focei-ll-fast-grad.R`, `test-focei-foce-plus.R`, `test-nlme.R`, and others all pass
- [x] Two outdated unit-test assertions (checking for `..jacobian`, an ODE-flatten-only artifact) updated to check `..matExpNative` instead