### PR TITLE
fix(nlm): recover rx_r_ from rx_rll_ for censored normal endpoints (#976)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -113,7 +113,10 @@
   the correction for every censored observation. `rx_rll_` (the standard
   deviation actually used to build the log-density) is emitted immediately
   beforehand in the same branch, so it is now squared back into `rx_r_`
-  instead of being discarded.
+  instead of being discarded. For an `ar()` endpoint this restores a sane,
+  self-consistent (marginal) censoring correction rather than a corrupted
+  one; getting the exact AR(1)-conditional correction is a larger, separate
+  change tracked in #1001.
 
 - `est="saem"` with a `pow()` residual error model (`rmPow`/`rmAddPow`/
   `rmPowLam`/`rmAddPowLam`) never applied the estimated power exponent in the

--- a/R/nlm.R
+++ b/R/nlm.R
@@ -415,7 +415,12 @@ getValidNlmixrCtl.nlm <- function(control) {
 #' independent of `ar()` (#976).  `rx_rll_` (the standard deviation actually
 #' fed into `llikNorm()`/`llikT()`/`llikCauchy()`) is emitted immediately
 #' before `rx_r_` in the same branch, so square it back into `rx_r_` instead
-#' of leaving the hardcoded 0.
+#' of leaving the hardcoded 0.  Reference the `rx_rll_` VARIABLE, not its
+#' defining expression: for a transformed prop()/pow() error model (e.g.
+#' `propT()`), that expression contains the symbol `rx_pred_`, which is
+#' overwritten with the scalar log-likelihood between the `rx_rll_` and
+#' `rx_r_` lines -- re-inlining it would silently read the log-likelihood
+#' value back in as the mean.
 #'
 #' @param lines A single endpoint's list of quoted model lines, as returned
 #'   by `rxGetDistributionFoceiLines()` for one `predDf` row.
@@ -425,20 +430,16 @@ getValidNlmixrCtl.nlm <- function(control) {
 #' @noRd
 .nlmFixCensRLine <- function(lines) {
   if (!is.list(lines)) return(lines)
-  .rll <- NULL
-  for (.l in lines) {
-    if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
-        identical(.l[[2]], quote(rx_rll_))) {
-      .rll <- .l[[3]]
-      break
-    }
-  }
-  if (is.null(.rll)) return(lines)
+  .hasRll <- any(vapply(lines, function(.l) {
+    is.call(.l) && identical(.l[[1]], quote(`~`)) &&
+      identical(.l[[2]], quote(rx_rll_))
+  }, logical(1)))
+  if (!.hasRll) return(lines)
   lapply(lines, function(.l) {
     if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
         identical(.l[[2]], quote(rx_r_)) &&
         identical(.l[[3]], 0)) {
-      bquote(rx_r_ ~ .(.rll)^2)
+      quote(rx_r_ ~ rx_rll_^2)
     } else {
       .l
     }

--- a/tests/testthat/test-nlm-cens.R
+++ b/tests/testthat/test-nlm-cens.R
@@ -235,4 +235,45 @@ nmTest({
     }
   })
 
+  test_that("nlm-family M3-censored propT() parameter estimates match focei (#976)", {
+    # #976 follow-up (antigravity review): .nlmFixCensRLine originally
+    # rebuilt rx_r_ by re-inlining rx_rll_'s defining EXPRESSION (e.g.
+    # sqrt((b*rx_pred_)^2) for propT()/powT(), whose F is the TRANSFORMED
+    # prediction, i.e. the symbol rx_pred_ itself -- see
+    # .rxGetVarianceForErrorPropOrPowF()).  That expression is placed at the
+    # rx_r_ ~ 0 line's position, which comes AFTER rx_pred_ has already been
+    # overwritten with the scalar log-likelihood (rx_pred_ <- llikNorm(dv,
+    # rx_pred_, rx_rll_)).  Re-evaluating the AST there silently fed the
+    # log-likelihood value back in as the propT() mean, corrupting rx_r_ for
+    # any transformed prop()/pow() error model.  The fix instead references
+    # the already-computed rx_rll_ VARIABLE (rx_r_ ~ rx_rll_^2), which still
+    # holds its original value at that point.  A plain add()/prop() (F =
+    # rx_pred_f_, a column untouched by the llik overwrite) would not have
+    # caught this -- propT() is required to exercise the bug.
+    one.cmt.propT <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- log(c(0, 2.7, 100))
+        tv <- 3.45
+        prop.sd <- c(0, 0.3)
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        linCmt() ~ propT(prop.sd)
+      })
+    }
+    f.focei <- .nlmixr(one.cmt.propT, .datM3, est = "focei", control = foceiControl(print = 0))
+    fit <- .nlmixr(one.cmt.propT, .datM3, est = "bobyqa", control = nlmControl(print = 0))
+    expect_equal(as.numeric(fit$theta[["tka"]]), as.numeric(f.focei$theta[["tka"]]),
+                 tolerance = 0.15)
+    expect_equal(as.numeric(fit$theta[["tcl"]]), as.numeric(f.focei$theta[["tcl"]]),
+                 tolerance = 0.15)
+    expect_equal(as.numeric(fit$theta[["tv"]]), as.numeric(f.focei$theta[["tv"]]),
+                 tolerance = 0.15)
+    expect_equal(as.numeric(fit$theta[["prop.sd"]]), as.numeric(f.focei$theta[["prop.sd"]]),
+                 tolerance = 0.15)
+  })
+
 })


### PR DESCRIPTION
## Summary

Fixes #976: every NLM-family method (`nlm`, `bobyqa`, `newuoa`, `uobyqa`,
`n1qn1`, `lbfgsb3c`, `optim`, `nlminb`) silently mis-scored any M2/M3/M4-censored
normal endpoint, independent of `ar()`.

- `est="nlm"` forces every normal endpoint through the log-likelihood
  (`dnorm`) path so a single scalar objective can be emitted
  (`rxUiGet.nlmModel0`). That path always sets `rx_r_ ~ 0` (a full
  log-density has no separate variance to report), but `src/nlm.cpp`'s
  M2/M3/M4 censoring correction (`doCensNormal1()`) reads `rx_r_` as a
  real variance -- a hardcoded 0 corrupted every censored normal
  endpoint's contribution.
- Fixed in `R/nlm.R` only (no C++/rxode2 changes): a new helper
  `.nlmFixCensRLine()` walks each endpoint's quoted model lines and
  replaces `rx_r_ ~ 0` with `rx_r_ ~ rx_rll_^2` -- `rx_rll_` is the
  standard deviation rxode2 already computes and feeds into
  `llikNorm()`/`llikT()`/`llikCauchy()`, emitted immediately beforehand
  in the same branch.
- The fix references the `rx_rll_` **variable**, not its defining
  expression -- an antigravity review round caught that re-inlining the
  expression corrupts `propT()`/`powT()` (transformed prop/pow) models,
  since that expression contains the symbol `rx_pred_`, which is
  overwritten with the scalar log-likelihood between the `rx_rll_` and
  `rx_r_` lines.

**Verified:** `bobyqa`/`newuoa`/`uobyqa`/`nlminb` (derivative-free/FD-gradient
nlm-family members) recover parameters matching `focei` to ~1-2 decimals on
an M3-censored `theo_sd`/`linCmt()` reproduction, for both a plain `add()`
endpoint and a `propT()` endpoint.

**Known limitations, filed as follow-ups (not fixed here, same pattern as
this issue's own #979 carve-out):**
- #979 -- M2/M3/M4 censoring is silently ignored for `t()`/`cauchy()`
  endpoints everywhere (pre-existing, unrelated to this fix).
- #1001 -- combining `ar()` with censoring now gets a sane,
  self-consistent **marginal** approximation (a real fix from the totally
  invalid `r=0` state), rather than the exact AR(1)-**conditional**
  likelihood FOCEI/FOCE/Laplace/AGQ compute. Getting the exact conditional
  correction needs a larger, separate change to how nlm's censoring path
  reads the AR-whitened mean/variance.
- The analytic-gradient nlm-family members (`nlm` itself via `stats::nlm`,
  `n1qn1`, `lbfgsb3c`, `optim`) have a separate, pre-existing convergence
  stall on the bounded-`tcl` test model, present identically with or
  without censoring -- out of scope, so the new tests only assert
  parameter accuracy for the derivative-free/`nlminb` subset.

Reviewed with two rounds of an independent (Gemini-based) antigravity code
review; round 2 reported no remaining issues.

## Test plan

- [x] `tests/testthat/test-nlm-cens.R`: existing regression tests pass
- [x] New test: nlm-family M3-censored parameter estimates match `focei`
      for a plain `add()` endpoint (#976)
- [x] New test: nlm-family M3-censored parameter estimates match `focei`
      for a `propT()` endpoint (catches the antigravity-review-found
      AST-substitution bug)
- [x] Manual repro comparing pre-fix vs post-fix `bobyqa` output confirms
      the fix materially improves accuracy for both `add()` and `propT()`