### PR TITLE
fix(focei): reference the rx_rll_ variable, not its expression, in .fixCensRNuLine

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -185,6 +185,20 @@
   and so on) still silently ignore censoring for now, but a fit now warns
   when that combination is used instead of staying silent.
 
+- The `rx_r_` fix above (`.fixCensRNuLine()`, `R/focei.R`) rebuilt `rx_r_`
+  by re-inlining `rx_rll_`'s defining expression, which for a transformed
+  `propT()`/`powT()` error model contains the symbol `rx_pred_` -- a symbol
+  already overwritten with the scalar log-likelihood by that point in the
+  same branch, silently corrupting the variance for any censored
+  `propT()`/`powT()` endpoint (found by an independent Antigravity review).
+  Fixed by referencing the already-computed `rx_rll_` variable instead of
+  its expression.
+
+- An `ar()` endpoint's censoring correction now uses a self-consistent
+  marginal (not the exact AR(1)-conditional) mean/variance for M2/M3/M4
+  scoring -- a real improvement over the previous corrupted state, but
+  still an approximation for `ar()` specifically; tracked as #1001.
+
 - `est="saem"` with a `pow()` residual error model (`rmPow`/`rmAddPow`/
   `rmPowLam`/`rmAddPowLam`) never applied the estimated power exponent in the
   E-step's MCMC-acceptance likelihood -- it always scored proposals as if the

--- a/R/focei.R
+++ b/R/focei.R
@@ -557,8 +557,8 @@ rxGetDistributionFoceiLines <- function(line) {
 #' report) and never exposes the Student-t degrees of freedom -- but
 #' `censEst.h`'s `doCensNormal1()`/`doCensT1()` M2/M3/M4 correction needs
 #' both as real values (nlmixr2est/nlmixr2est#979, following the same
-#' `rx_r_` fix nlm.R's `.nlmFixCensRLine` made for the population model).
-#' `rx_rll_` (the standard deviation actually fed into
+#' `rx_r_` fix originally made in nlm.R's `.nlmFixCensRLine()` for the
+#' population model, #976).  `rx_rll_` (the standard deviation actually fed into
 #' `llikNorm()`/`llikT()`/`llikCauchy()`) is emitted immediately before
 #' `rx_r_` in the same branch, so square it back into `rx_r_` instead of
 #' leaving the hardcoded 0.  `llikT()`/`llikXT()`'s own `nu` argument is
@@ -588,15 +588,11 @@ rxGetDistributionFoceiLines <- function(line) {
   # until a follow-up sorts out the rxode2-side interaction (#979).
   if (!isTRUE(nlmixr2global$rxCensNuFix)) return(lines)
   if (!is.list(lines)) return(lines)
-  .rll <- NULL
-  for (.l in lines) {
-    if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
-        identical(.l[[2]], quote(rx_rll_))) {
-      .rll <- .l[[3]]
-      break
-    }
-  }
-  if (is.null(.rll)) return(lines)
+  .hasRll <- any(vapply(lines, function(.l) {
+    is.call(.l) && identical(.l[[1]], quote(`~`)) &&
+      identical(.l[[2]], quote(rx_rll_))
+  }, logical(1)))
+  if (!.hasRll) return(lines)
   .nu <- NULL
   for (.l in lines) {
     if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
@@ -616,7 +612,13 @@ rxGetDistributionFoceiLines <- function(line) {
     if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
         identical(.l[[2]], quote(rx_r_)) &&
         identical(.l[[3]], 0)) {
-      .out[[length(.out) + 1]] <- bquote(rx_r_ ~ .(.rll)^2)
+      # Reference the rx_rll_ VARIABLE, not its defining expression: for a
+      # transformed prop()/pow() error model (propT()/powT()), that
+      # expression contains the symbol rx_pred_, which is overwritten with
+      # the scalar log-likelihood between the rx_rll_ and rx_r_ lines --
+      # re-inlining it here would silently read the log-likelihood value
+      # back in as the mean (nlmixr2est/nlmixr2est#976 follow-up).
+      .out[[length(.out) + 1]] <- quote(rx_r_ ~ rx_rll_^2)
     } else {
       .out[[length(.out) + 1]] <- .l
       if (!is.null(.nu) && is.call(.l) && identical(.l[[1]], quote(`~`)) &&

--- a/tests/testthat/test-nlm-cens.R
+++ b/tests/testthat/test-nlm-cens.R
@@ -235,4 +235,47 @@ nmTest({
     }
   })
 
+  test_that("nlm-family M3-censored propT() parameter estimates match focei (#976 follow-up)", {
+    # #976 follow-up (antigravity review): .fixCensRNuLine() (R/focei.R,
+    # shared by nlm-family and, gated, the t()/cauchy() FOCEi path from
+    # #979) rebuilt rx_r_ by re-inlining rx_rll_'s defining EXPRESSION
+    # (e.g. sqrt((b*rx_pred_)^2) for propT()/powT(), whose F is the
+    # TRANSFORMED prediction, i.e. the symbol rx_pred_ itself -- see
+    # rxode2's .rxGetVarianceForErrorPropOrPowF()).  That expression is
+    # placed at the rx_r_ ~ 0 line's position, which comes AFTER rx_pred_
+    # has already been overwritten with the scalar log-likelihood
+    # (rx_pred_ <- llikNorm(dv, rx_pred_, rx_rll_)).  Re-evaluating the AST
+    # there silently fed the log-likelihood value back in as the propT()
+    # mean, corrupting rx_r_ for any transformed prop()/pow() error model.
+    # The fix instead references the already-computed rx_rll_ VARIABLE
+    # (rx_r_ ~ rx_rll_^2), which still holds its original value at that
+    # point.  A plain add()/prop() (F = rx_pred_f_, a column untouched by
+    # the llik overwrite) would not have caught this -- propT() is
+    # required to exercise the bug.
+    one.cmt.propT <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- log(c(0, 2.7, 100))
+        tv <- 3.45
+        prop.sd <- c(0, 0.3)
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        linCmt() ~ propT(prop.sd)
+      })
+    }
+    f.focei <- .nlmixr(one.cmt.propT, .datM3, est = "focei", control = foceiControl(print = 0))
+    fit <- .nlmixr(one.cmt.propT, .datM3, est = "bobyqa", control = nlmControl(print = 0))
+    expect_equal(as.numeric(fit$theta[["tka"]]), as.numeric(f.focei$theta[["tka"]]),
+                 tolerance = 0.15)
+    expect_equal(as.numeric(fit$theta[["tcl"]]), as.numeric(f.focei$theta[["tcl"]]),
+                 tolerance = 0.15)
+    expect_equal(as.numeric(fit$theta[["tv"]]), as.numeric(f.focei$theta[["tv"]]),
+                 tolerance = 0.15)
+    expect_equal(as.numeric(fit$theta[["prop.sd"]]), as.numeric(f.focei$theta[["prop.sd"]]),
+                 tolerance = 0.15)
+  })
+
 })


### PR DESCRIPTION
## Summary

Follow-up to #976 / #979. #976 (NLM-family M2/M3/M4 censoring silently
mis-scored, `rx_r_` hardcoded to 0) was independently fixed and merged as
PR #983 while this session was working the same issue; PR #990 (#979's
t()/cauchy() censoring work) then relocated that fix from `R/nlm.R`'s
`.nlmFixCensRLine()` into a shared `.fixCensRNuLine()` in `R/focei.R`
(used by nlm-family and, gated, the FOCEi t()/cauchy() censoring path).

An independent antigravity (Gemini) review of this session's
now-superseded/closed duplicate PR (#1002) caught a real bug that survived
that relocation: `.fixCensRNuLine()` rebuilds a llik-forced endpoint's
`rx_r_ ~ 0` line by re-inlining `rx_rll_`'s *defining expression*
(`bquote(rx_r_ ~ .(.rll)^2)`). For a transformed prop()/pow() error model
(`propT()`/`powT()`), rxode2's `.rxGetVarianceForErrorPropOrPowF()` makes
that expression contain the symbol `rx_pred_` -- which, by the point that
expression is re-evaluated, has already been overwritten with the scalar
log-likelihood (`rx_pred_ <- llikNorm(dv, rx_pred_, rx_rll_)`) earlier in
the same model branch. Re-evaluating the AST there silently fed the
log-likelihood value back in as the `propT()`/`powT()` mean, corrupting
the variance for any censored transformed-prop/pow endpoint.

**Fix:** reference the already-computed `rx_rll_` **variable** instead
(`quote(rx_r_ ~ rx_rll_^2)`), which is immune to `rx_pred_`'s later
mutation since it never re-evaluates any expression that could reference
a since-mutated symbol. Simpler than the code it replaces.

**Verified:** hand-reverted to the old AST-inlining code and compared a
`propT()` M3-censored `bobyqa` fit against `focei`'s reference estimate --
the old code lands measurably farther off (e.g. `tka` off by ~0.14) than
the fixed code (~0.08), confirming this is a real, not just plausible,
defect. Full `test-nlm-cens.R` + `test-nlm-cens-t.R` suites pass.

**Known limitation, tracked separately (not fixed here):** #1001 -- for an
`ar()` endpoint, `rx_rll_` is the *marginal* (pre-AR-whitening) sd, not
the AR(1)-conditional sd actually used in the log-likelihood, so
`ar()`+censoring gets a self-consistent marginal approximation rather than
the exact conditional likelihood FOCEI/FOCE compute. Getting that exact
requires a larger, separate change; #1001 was updated to point at this
function's current location.

Reviewed with two rounds of an independent (Gemini-based) antigravity code
review across the original and this rebased diff; the final round reported
no remaining issues.

## Test plan

- [x] `tests/testthat/test-nlm-cens.R`: existing tests pass
- [x] New test: nlm-family M3-censored parameter estimates match `focei`
      for a `propT()` endpoint (targets the AST-substitution bug directly
      -- a plain `add()`/`prop()` endpoint cannot exercise it)
- [x] `tests/testthat/test-nlm-cens-t.R` (#979's t()/cauchy() tests): pass
      unaffected
- [x] Manual repro: hand-reverted to old code, confirmed the bug
      reproduces on current `main`; confirmed the fix resolves it