### PR TITLE
perf(saem): drop duplicate THETA/ETA alias assignments in saemModelPred

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Internal
 
+- The SAEM `predOnly` model (used for residuals, tables and the covariance
+  step) no longer emits a THETA/ETA alias assignment that exactly duplicates
+  one the mu-reference replacement block already emitted.  These were trailing
+  dead stores that rxode2 repeated in both `dydt` and `calc_lhs`; the emitted
+  model, its solve column layout, and every value it produces are unchanged.
+
 - A covariate whose value is carried on the model in `rxode2::rxForcedPars()` is
   no longer required to be a column of the data.  Such a covariate is supplied
   by the model itself, so demanding it from the data rejected a well-specified

--- a/R/saemRxUiGetModel.R
+++ b/R/saemRxUiGetModel.R
@@ -588,11 +588,12 @@ attr(rxUiGet.interpLinesStr, "rstudio") <- ""
 #' @param names Character vector of variable names to look for
 #' @return Logical, one per `names`: TRUE when the text assigns (`=`, `<-` or
 #'   `~`) to that plain name.  A non-name target such as `d/dt(x)` or `f(x)`
-#'   never counts.
+#'   never counts, and `=(?!=)` keeps a comparison (`x == 1`) from reading as
+#'   an assignment to `x`.
 #' @author Matthew L. Fidler
 #' @noRd
 .lhsAssignedIn <- function(modelText, names) {
-  .lhs <- trimws(sub("[ \t]*(<-|=|~).*$", "", modelText))
+  .lhs <- trimws(sub("[ \t]*(<-|~|=(?!=)).*$", "", modelText, perl=TRUE))
   names %in% .lhs[grepl("^[A-Za-z._][A-Za-z0-9._]*$", .lhs)]
 }
 

--- a/R/saemRxUiGetModel.R
+++ b/R/saemRxUiGetModel.R
@@ -653,15 +653,36 @@ rxUiGet.saemModelPred <- function(x, ...) {
     .ret2
   ), collapse = "\n")
   .interp <- rxUiGet.interpLinesStr(x, ...)
+  ## The mu-reference replacement block (paste(names(.replaceLst), ...))
+  ## and the THETA/ETA alias block (.uiGetThetaEta()) can emit the *exact*
+  ## same `lhs <- rhs` assignment, which is then duplicated into both dydt
+  ## and calc_lhs by codegen.  Drop the THETA/ETA alias lines that are exact
+  ## duplicates (same lhs AND same rhs) of the replacement block, keeping the
+  ## first occurrence.  Lines whose rhs differs (e.g. a mu-referenced combined
+  ## `lhs <- THETA[k] + ETA[j]` in the replacement block vs the split
+  ## `lhs <- THETA[k]` alias) are NOT exact duplicates and are preserved, so
+  ## the emitted model is numerically identical.
+  .replaceLines <- paste(names(.replaceLst), "<-", .replaceLst)
+  .thetaEtaLines <- vapply(.uiGetThetaEta(x[[1]]), deparse1, character(1), USE.NAMES=FALSE)
+  .normAssign <- function(.l) {
+    vapply(.l, function(.s) {
+      .p <- try(parse(text=.s)[[1]], silent=TRUE)
+      if (inherits(.p, "try-error")) return(.s)
+      deparse1(.p)
+    }, character(1), USE.NAMES=FALSE)
+  }
+  if (length(.thetaEtaLines) > 0L && length(.replaceLines) > 0L) {
+    .thetaEtaLines <- .thetaEtaLines[!(.normAssign(.thetaEtaLines) %in% .normAssign(.replaceLines))]
+  }
   ## as in rxUiGet.saemModel(), splitBolus() is left out: the events this model
   ## solves have already been split
   .ret <- c(rxUiGet.foceiParams(x, ...),
             rxUiGet.foceiCmtPreModel(x, ...),
             .interp,
             "rx_pred_=NA\nrx_r_=NA\n",
-            paste(names(.replaceLst), "<-", .replaceLst),
+            .replaceLines,
             .ret,
-            vapply(.uiGetThetaEta(x[[1]]), deparse1, character(1), USE.NAMES=FALSE),
+            .thetaEtaLines,
             .foceiToCmtLinesAndDvid(x[[1]]))
   .ret <- .ret[.ret != ""]
   .ret <- list(predOnly=.nlmixr2estRxode2(paste(.ret, collapse="\n"), "rxSaemPred"))

--- a/R/saemRxUiGetModel.R
+++ b/R/saemRxUiGetModel.R
@@ -582,6 +582,20 @@ attr(rxUiGet.interpLinesStr, "rstudio") <- ""
   }, character(1), USE.NAMES=FALSE)
 }
 
+#' Which of `names` does this model text assign to?
+#'
+#' @param modelText Character vector of rxode2 model lines
+#' @param names Character vector of variable names to look for
+#' @return Logical, one per `names`: TRUE when the text assigns (`=`, `<-` or
+#'   `~`) to that plain name.  A non-name target such as `d/dt(x)` or `f(x)`
+#'   never counts.
+#' @author Matthew L. Fidler
+#' @noRd
+.lhsAssignedIn <- function(modelText, names) {
+  .lhs <- trimws(sub("[ \t]*(<-|=|~).*$", "", modelText))
+  names %in% .lhs[grepl("^[A-Za-z._][A-Za-z0-9._]*$", .lhs)]
+}
+
 #' @export
 rxUiGet.saemModelPred <- function(x, ...) {
   .ui0 <- x[[1]]
@@ -670,15 +684,20 @@ rxUiGet.saemModelPred <- function(x, ...) {
   .interp <- rxUiGet.interpLinesStr(x, ...)
   ## The mu-reference replacement block and the trailing THETA/ETA alias block
   ## can emit the same `lhs <- rhs` twice; codegen then repeats it in dydt and
-  ## calc_lhs as a dead store.  Drop an alias line only when it is an exact
-  ## duplicate (same lhs AND same rhs, after parse/deparse normalization) of a
-  ## replacement line -- a mu-referenced `lhs <- THETA[k] + ETA[j]` and the
-  ## split `lhs <- THETA[k]` are not duplicates and both survive, so the model
-  ## the solver sees is unchanged.
+  ## calc_lhs as a dead store.  Drop an alias line when it is an exact duplicate
+  ## (same lhs AND same rhs, after parse/deparse normalization) of a replacement
+  ## line AND the model body does not assign that lhs.  A mu-referenced
+  ## `lhs <- THETA[k] + ETA[j]` and the split `lhs <- THETA[k]` are not
+  ## duplicates, so both survive.  The body check matters because a model may
+  ## legally write to a parameter's own name (`tv <- tv + 1`): there the trailing
+  ## alias is what puts THETA[k] back into that output column, so it is a live
+  ## store, not a dead one.
   .replaceLines <- paste(names(.replaceLst), "<-", .replaceLst)
   .thetaEtaLines <- vapply(.uiGetThetaEta(x[[1]]), deparse1, character(1), USE.NAMES=FALSE)
-  .thetaEtaLines <- .thetaEtaLines[!(.normAssign(.thetaEtaLines) %in%
-                                       .normAssign(.replaceLines))]
+  .dupAlias <- .normAssign(.thetaEtaLines) %in% .normAssign(.replaceLines)
+  .aliasLhs <- sub("[ \t]*(<-|=|~).*$", "", .thetaEtaLines)
+  .thetaEtaLines <-
+    .thetaEtaLines[!(.dupAlias & !.lhsAssignedIn(strsplit(.ret, "\n")[[1]], .aliasLhs))]
   ## as in rxUiGet.saemModel(), splitBolus() is left out: the events this model
   ## solves have already been split
   .ret <- c(rxUiGet.foceiParams(x, ...),

--- a/R/saemRxUiGetModel.R
+++ b/R/saemRxUiGetModel.R
@@ -567,6 +567,21 @@ rxUiGet.interpLinesStr <- function(x, ...) {
 }
 attr(rxUiGet.interpLinesStr, "rstudio") <- ""
 
+#' Normalize `lhs <- rhs` assignment strings for comparison
+#'
+#' @param lines Character vector of assignment lines
+#' @return The lines re-deparsed from their parsed form; a line that does not
+#'   parse as a single expression is returned unchanged
+#' @author Bill Denney
+#' @noRd
+.normAssign <- function(lines) {
+  vapply(lines, function(.s) {
+    .p <- try(str2lang(.s), silent=TRUE)
+    if (inherits(.p, "try-error")) return(.s)
+    deparse1(.p)
+  }, character(1), USE.NAMES=FALSE)
+}
+
 #' @export
 rxUiGet.saemModelPred <- function(x, ...) {
   .ui0 <- x[[1]]
@@ -653,27 +668,17 @@ rxUiGet.saemModelPred <- function(x, ...) {
     .ret2
   ), collapse = "\n")
   .interp <- rxUiGet.interpLinesStr(x, ...)
-  ## The mu-reference replacement block (paste(names(.replaceLst), ...))
-  ## and the THETA/ETA alias block (.uiGetThetaEta()) can emit the *exact*
-  ## same `lhs <- rhs` assignment, which is then duplicated into both dydt
-  ## and calc_lhs by codegen.  Drop the THETA/ETA alias lines that are exact
-  ## duplicates (same lhs AND same rhs) of the replacement block, keeping the
-  ## first occurrence.  Lines whose rhs differs (e.g. a mu-referenced combined
-  ## `lhs <- THETA[k] + ETA[j]` in the replacement block vs the split
-  ## `lhs <- THETA[k]` alias) are NOT exact duplicates and are preserved, so
-  ## the emitted model is numerically identical.
+  ## The mu-reference replacement block and the trailing THETA/ETA alias block
+  ## can emit the same `lhs <- rhs` twice; codegen then repeats it in dydt and
+  ## calc_lhs as a dead store.  Drop an alias line only when it is an exact
+  ## duplicate (same lhs AND same rhs, after parse/deparse normalization) of a
+  ## replacement line -- a mu-referenced `lhs <- THETA[k] + ETA[j]` and the
+  ## split `lhs <- THETA[k]` are not duplicates and both survive, so the model
+  ## the solver sees is unchanged.
   .replaceLines <- paste(names(.replaceLst), "<-", .replaceLst)
   .thetaEtaLines <- vapply(.uiGetThetaEta(x[[1]]), deparse1, character(1), USE.NAMES=FALSE)
-  .normAssign <- function(.l) {
-    vapply(.l, function(.s) {
-      .p <- try(parse(text=.s)[[1]], silent=TRUE)
-      if (inherits(.p, "try-error")) return(.s)
-      deparse1(.p)
-    }, character(1), USE.NAMES=FALSE)
-  }
-  if (length(.thetaEtaLines) > 0L && length(.replaceLines) > 0L) {
-    .thetaEtaLines <- .thetaEtaLines[!(.normAssign(.thetaEtaLines) %in% .normAssign(.replaceLines))]
-  }
+  .thetaEtaLines <- .thetaEtaLines[!(.normAssign(.thetaEtaLines) %in%
+                                       .normAssign(.replaceLines))]
   ## as in rxUiGet.saemModel(), splitBolus() is left out: the events this model
   ## solves have already been split
   .ret <- c(rxUiGet.foceiParams(x, ...),

--- a/tests/testthat/test-saem-model-pred-dedup.R
+++ b/tests/testthat/test-saem-model-pred-dedup.R
@@ -53,7 +53,7 @@ nmTest({
     expect_equal(.nAssign("add.sd"), 1L)
   })
 
-  test_that("a mu-referenced parameter keeps both the combined and split form", {
+  test_that("a mu-referenced parameter keeps combined and split form", {
     expect_equal(.nAssign("tka"), 2L)
     expect_true(any(grepl("^tka=THETA\\[1\\]\\+ETA\\[1\\];?$", .lines)))
     expect_true(any(grepl("^tka=THETA\\[1\\];?$", .lines)))
@@ -71,9 +71,9 @@ nmTest({
     .thetaEta <- vapply(.uiGetThetaEta(.ui), deparse1, character(1),
                         USE.NAMES=FALSE)
     .split <- max(which(!grepl("^(cmt|dvid)\\(", .lines)))
-    .dup <- suppressMessages(rxode2::rxode2(paste(
-      c(.lines[seq_len(.split)], .thetaEta, .lines[-seq_len(.split)]),
-      collapse="\n")))
+    .withDup <- c(.lines[seq_len(.split)], .thetaEta,
+                  .lines[-seq_len(.split)])
+    .dup <- suppressMessages(rxode2::rxode2(paste(.withDup, collapse="\n")))
     # the solve column layout must not shift
     expect_equal(.pred$params, .dup$params)
     expect_equal(.pred$lhs, .dup$lhs)

--- a/tests/testthat/test-saem-model-pred-dedup.R
+++ b/tests/testthat/test-saem-model-pred-dedup.R
@@ -1,0 +1,91 @@
+nmTest({
+  # rxUiGet.saemModelPred() emits the mu-reference replacement block before the
+  # model body and the THETA/ETA alias block after it.  The alias lines that
+  # exactly duplicate a replacement line are dropped; the ones whose rhs differs
+  # (mu-referenced `THETA[k] + ETA[j]` vs the split `THETA[k]`) are kept.
+
+  .mod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      pow <- 1.1
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / v * central
+      cp <- central / v * pow
+      cp ~ add(add.sd)
+    })
+  }
+
+  .ui <- .mod()
+  .pred <- suppressMessages(rxUiGet.saemModelPred(list(.ui))$predOnly)
+  .lines <- strsplit(rxode2::rxNorm(.pred), "\n")[[1]]
+  # count the assignments to a single variable
+  .nAssign <- function(v) {
+    sum(grepl(paste0("^", gsub(".", "\\.", v, fixed=TRUE), "="), .lines))
+  }
+
+  test_that(".normAssign() normalizes only parseable single assignments", {
+    expect_equal(.normAssign(c("tka<-THETA[1]", "tka <-  THETA[1]")),
+                 c("tka <- THETA[1]", "tka <- THETA[1]"))
+    # an empty rhs (a placeholder non-mu eta) does not parse and is left alone
+    expect_equal(.normAssign("eta.cl1 <- "), "eta.cl1 <- ")
+    expect_equal(.normAssign(character(0)), character(0))
+  })
+
+  test_that("saem predOnly emits no duplicated line", {
+    expect_false(any(duplicated(.lines)))
+  })
+
+  test_that("a non-mu-referenced parameter is aliased once", {
+    # tv/pow/add.sd carry no eta, so the replacement block and the alias block
+    # emit the identical assignment and only one survives
+    expect_equal(.nAssign("tv"), 1L)
+    expect_equal(.nAssign("pow"), 1L)
+    expect_equal(.nAssign("add.sd"), 1L)
+  })
+
+  test_that("a mu-referenced parameter keeps both the combined and split form", {
+    expect_equal(.nAssign("tka"), 2L)
+    expect_true(any(grepl("^tka=THETA\\[1\\]\\+ETA\\[1\\];?$", .lines)))
+    expect_true(any(grepl("^tka=THETA\\[1\\];?$", .lines)))
+    # the combined form comes first, so the trailing split alias still wins the
+    # reported `tka` column exactly as it did before the de-duplication
+    expect_lt(which(grepl("^tka=THETA\\[1\\]\\+ETA\\[1\\];?$", .lines)),
+              which(grepl("^tka=THETA\\[1\\];?$", .lines)))
+    expect_equal(.nAssign("eta.ka"), 1L)
+    expect_equal(.nAssign("eta.cl"), 1L)
+  })
+
+  test_that("the dropped aliases were dead stores", {
+    # rebuild the pre-de-duplication model: the full THETA/ETA alias block
+    # re-appended after the model body, ahead of the trailing cmt()/dvid()
+    .thetaEta <- vapply(.uiGetThetaEta(.ui), deparse1, character(1),
+                        USE.NAMES=FALSE)
+    .split <- max(which(!grepl("^(cmt|dvid)\\(", .lines)))
+    .dup <- suppressMessages(rxode2::rxode2(paste(
+      c(.lines[seq_len(.split)], .thetaEta, .lines[-seq_len(.split)]),
+      collapse="\n")))
+    # the solve column layout must not shift
+    expect_equal(.pred$params, .dup$params)
+    expect_equal(.pred$lhs, .dup$lhs)
+    expect_equal(.pred$state, .dup$state)
+    .p <- c("THETA[1]"=0.45, "THETA[2]"=1, "THETA[3]"=3.45, "THETA[4]"=1.1,
+            "THETA[5]"=0.7, "ETA[1]"=0.2, "ETA[2]"=-0.3)
+    .et <- rxode2::et(amt=320, cmt="depot")
+    .et <- rxode2::et(.et, seq(0, 24, by=0.5))
+    .s1 <- rxode2::rxSolve(.pred, .p, .et, returnType="data.frame",
+                           addDosing=FALSE)
+    .s2 <- rxode2::rxSolve(.dup, .p, .et, returnType="data.frame",
+                           addDosing=FALSE)
+    expect_equal(.s1, .s2)
+  })
+})

--- a/tests/testthat/test-saem-model-pred-dedup.R
+++ b/tests/testthat/test-saem-model-pred-dedup.R
@@ -65,6 +65,54 @@ nmTest({
     expect_equal(.nAssign("eta.cl"), 1L)
   })
 
+  test_that(".lhsAssignedIn() sees plain-name targets only", {
+    .body <- c("rx_expr__0~1+tv", "tv=rx_expr__0", "d/dt(depot)=-ka*depot",
+               "f(depot)=1", "cmt(cp)", "  add.sd <- 2")
+    expect_equal(.lhsAssignedIn(.body, c("tv", "rx_expr__0", "add.sd")),
+                 c(TRUE, TRUE, TRUE))
+    # d/dt(depot) and f(depot) are not assignments to the name `depot`
+    expect_equal(.lhsAssignedIn(.body, c("depot", "cp", "ka")),
+                 c(FALSE, FALSE, FALSE))
+  })
+
+  test_that("an alias the model body overwrites is kept", {
+    # a model may legally write to a parameter's own name.  Both blocks then
+    # emit an identical `tv <- THETA[3]`, but the body reassigns tv between
+    # them, so the trailing alias is a LIVE store -- it is what puts THETA[3]
+    # back into the reported tv column.  Dropping it would silently report
+    # THETA[3] + 1 instead.
+    .reassign <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.ka ~ 0.6
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        tv <- tv + 1
+        cl <- exp(tcl)
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .p2 <- suppressMessages(rxUiGet.saemModelPred(list(.reassign()))$predOnly)
+    .l2 <- strsplit(rxode2::rxNorm(.p2), "\n")[[1]]
+    expect_equal(sum(grepl("^tv[=~]", .l2)), 3L)
+    # tcl and add.sd are NOT touched by the body, so they still de-duplicate
+    expect_equal(sum(grepl("^tcl[=~]", .l2)), 1L)
+    expect_equal(sum(grepl("^add\\.sd[=~]", .l2)), 1L)
+    .p <- c("THETA[1]"=0.45, "THETA[2]"=1, "THETA[3]"=3.45, "THETA[4]"=0.7,
+            "ETA[1]"=0.2)
+    .et <- rxode2::et(amt=320)
+    .et <- rxode2::et(.et, seq(0, 24, by=6))
+    .s <- rxode2::rxSolve(.p2, .p, .et, returnType="data.frame",
+                          addDosing=FALSE)
+    # the parameter's own value, not the body's tv + 1
+    expect_equal(unique(.s$tv), 3.45)
+  })
+
   test_that("the dropped aliases were dead stores", {
     # rebuild the pre-de-duplication model: the full THETA/ETA alias block
     # re-appended after the model body, ahead of the trailing cmt()/dvid()

--- a/tests/testthat/test-saem-model-pred-dedup.R
+++ b/tests/testthat/test-saem-model-pred-dedup.R
@@ -73,6 +73,10 @@ nmTest({
     # d/dt(depot) and f(depot) are not assignments to the name `depot`
     expect_equal(.lhsAssignedIn(.body, c("depot", "cp", "ka")),
                  c(FALSE, FALSE, FALSE))
+    # a comparison is not an assignment to its left operand
+    expect_false(.lhsAssignedIn(c("tv == 1", "tv==1"), "tv"))
+    # ... but a comparison on the rhs of a real assignment still counts
+    expect_true(.lhsAssignedIn("cl=exp(tcl)*(WT==70)", "cl"))
   })
 
   test_that("an alias the model body overwrites is kept", {


### PR DESCRIPTION
The SAEM predOnly model assembled in rxUiGet.saemModelPred concatenated two alias-emitting blocks: the mu-reference replacement block (paste(names(.replaceLst), ...)) and the THETA/ETA alias block (.uiGetThetaEta()). For the common non-combined case these emit the *exact same* `lhs <- rhs` assignments (e.g. `tke <- THETA[1]`, `eta_DoT_ke <- ETA[1]`), which codegen then duplicated into both dydt and calc_lhs as trailing dead-store assignments.

Filter the THETA/ETA alias lines, dropping only those that are exact duplicates (same lhs AND same rhs, compared after parse+deparse normalization) of the replacement block, keeping the first occurrence. Lines whose rhs differs (mu-referenced combined
`lhs <- THETA[k] + ETA[j]` vs the split `lhs <- THETA[k]`) are not exact duplicates and are preserved unchanged, so the generated model is numerically identical; only redundant dead-store aliases are removed.