### PR TITLE
focei: M2/M3/M4 censoring for llik-forced t()/cauchy()/dnorm() endpoints (#992)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -188,6 +188,12 @@
   "censoring ignored" note in `$runInfo`.  An `ar()` endpoint is excluded: its
   reported scale is the marginal, not the conditional, one.
 
+- The persisted FOCEi model cache (`rxUiGet.foceiModelCache()`) now keys on the
+  `nlmixr2est` version.  That cache lives in rxode2's user cache directory when
+  `rxode2::rxCreateCache()` has been run, so it survives an upgrade: any release
+  that changes the generated inner-model text (the censoring columns above, for
+  one) was silently ignored for a model already cached there.
+
 - `est="impmap"`'s inner Hessian (`impGetHessian`), which builds the
   importance-sampling proposal, could read a stale cached `linCmtB()`
   Jacobian on a `linCmt()` model with a non-mu structural theta (a theta with

--- a/NEWS.md
+++ b/NEWS.md
@@ -188,6 +188,13 @@
   "censoring ignored" note in `$runInfo`.  An `ar()` endpoint is excluded: its
   reported scale is the marginal, not the conditional, one.
 
+- `foceiControl(fast=TRUE)` now downgrades to `fast=FALSE` for a CENSORED
+  log-likelihood endpoint, as the documentation already said it did.  Both the
+  augmented outer-gradient model and the exact second-order inner Hessian
+  differentiate the uncensored log-density, which the M2/M3/M4 correction
+  replaces for a censored row; the outer gradient already refused such a fit at
+  run time, but the inner Hessian did not.
+
 - The persisted FOCEi model cache (`rxUiGet.foceiModelCache()`) now keys on the
   `nlmixr2est` version.  That cache lives in rxode2's user cache directory when
   `rxode2::rxCreateCache()` has been run, so it survives an upgrade: any release

--- a/NEWS.md
+++ b/NEWS.md
@@ -182,8 +182,8 @@
   completing #979 which covered the nlm family only).  Such an endpoint is
   compiled to a scalar log-density, which hid the location, scale and degrees
   of freedom the correction needs; the inner model now carries them (together
-  with `d(f)/d(eta)`, so the inner eta gradient is corrected as well, not just
-  the objective).  A censored `t()`/`cauchy()` fit under these methods changes
+  with `d(f)/d(eta)` and `d(R)/d(eta)`, so the inner eta gradient is corrected as
+  well, not just the objective).  A censored `t()`/`cauchy()` fit under these methods changes
   its objective and its parameter estimates, and no longer emits the
   "censoring ignored" note in `$runInfo`.  An `ar()` endpoint is excluded: its
   reported scale is the marginal, not the conditional, one.

--- a/NEWS.md
+++ b/NEWS.md
@@ -175,6 +175,19 @@
 
 ## Bug fixes
 
+- The FOCEi family (`focei`, `foce`, `focep`, `laplace`, `agq`, `posthoc`, and
+  their `i`/`m` prefixed variants) now applies the M2/M3/M4 censoring
+  correction to a `t()`, `cauchy()` or `dnorm()` endpoint instead of silently
+  scoring a censored row with its ordinary, uncensored density (#992,
+  completing #979 which covered the nlm family only).  Such an endpoint is
+  compiled to a scalar log-density, which hid the location, scale and degrees
+  of freedom the correction needs; the inner model now carries them (together
+  with `d(f)/d(eta)`, so the inner eta gradient is corrected as well, not just
+  the objective).  A censored `t()`/`cauchy()` fit under these methods changes
+  its objective and its parameter estimates, and no longer emits the
+  "censoring ignored" note in `$runInfo`.  An `ar()` endpoint is excluded: its
+  reported scale is the marginal, not the conditional, one.
+
 - `est="impmap"`'s inner Hessian (`impGetHessian`), which builds the
   importance-sampling proposal, could read a stale cached `linCmtB()`
   Jacobian on a `linCmt()` model with a non-mu structural theta (a theta with

--- a/R/focei.R
+++ b/R/focei.R
@@ -3484,7 +3484,16 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     # cannot supply the gradient and the fit uses finite
     # differences.  (linCmt() passes the scope gate but its unsupported 2nd-order
     # expansion makes it fall back to finite differences at build time.)
-    if (isTRUE(.control$fast) && !.foceiLLGradInScope(.ui)) {
+    # Censoring is one of the out-of-scope cases, but `.foceiLLGradInScope()`
+    # only sees the model.  A censored row's contribution is REPLACED by
+    # doCensT1()/doCensNormal1() (#992), so neither the augmented outer-gradient
+    # model nor the exact 2nd-order inner Hessian -- both built from the
+    # UNCENSORED log-density -- describes it.  gradPooledCoreLL refuses such a
+    # fit at run time already; downgrading here takes the inner Hessian down
+    # with it and says why.
+    if (isTRUE(.control$fast) &&
+          (!.foceiLLGradInScope(.ui) ||
+             .nlmixrDataHasCens(env$data))) {
       .minfo("log-likelihood endpoint: the analytic 'fast' gradient does not apply -- using fast = FALSE")
       .control$fast <- FALSE
     }

--- a/R/focei.R
+++ b/R/focei.R
@@ -1213,7 +1213,12 @@ attr(rxUiGet.foceiThetaS, "rstudio") <- emptyenv()
 #' @noRd
 #' @author Matthew L. Fidler
 .foceiPredFEtaSens <- function(.s, .grd) {
-  if (!exists("rx_pred_f_", envir = .s)) return(character(0))
+  # An AR(1) endpoint already emits these exact names (..arEtaSens, real lhs
+  # ahead of rx_pred_), so never emit them twice.
+  if (!isTRUE(nlmixr2global$rxCensNuFix) || !.getRxPredLlikOption() ||
+        !is.null(.s$..arEtaSens) || !exists("rx_pred_f_", envir = .s)) {
+    return(character(0))
+  }
   .nms <- character(nrow(.grd))
   .txt <- character(nrow(.grd))
   for (.n in seq_len(nrow(.grd))) {
@@ -1248,16 +1253,8 @@ rxUiGet.foceiHdEta <- function(x, ...) {
     .arCorr <- .rxFoceiArEtaCorrect(.s, .grd)
   }
   # M2/M3/M4 censoring for a llik-forced endpoint (#992) needs the STRUCTURAL
-  # d(f)/d(eta) as well.  Computed here, with the same pre-apply ordering the
-  # AR(1) correction uses.  An AR endpoint already emits these exact names
-  # (..arEtaSens, real lhs ahead of rx_pred_), so never emit them twice.
-  .s$..predFEtaSens <- if (isTRUE(nlmixr2global$rxCensNuFix) &&
-                             .getRxPredLlikOption() &&
-                             is.null(.s$..arEtaSens)) {
-    .foceiPredFEtaSens(.s, .grd)
-  } else {
-    character(0)
-  }
+  # d(f)/d(eta) as well; same pre-apply ordering as the AR(1) correction.
+  .s$..predFEtaSens <- .foceiPredFEtaSens(.s, .grd)
   rxode2::rxProgress(dim(.grd)[1])
   # Guard the abort so a clean rxProgressStop() below prevents the generic
   # "Aborted calculation" from masking the informative error we raise here

--- a/R/focei.R
+++ b/R/focei.R
@@ -2244,7 +2244,15 @@ rxUiGet.foceiModelDigest <- function(x, ...) {
   .constCovs <- paste(sort(rxode2::rxGetControl(.ui, "foceiConstCovs", NULL)), collapse=",")
   ## combined eta+theta sensitivity build (#958) changes the inner model text
   .combSens <- isTRUE(rxode2::rxGetControl(.ui, "combSens", FALSE))
-  digest::digest(c(all(is.na(.iniDf$neta1)), .combSens,
+  ## The persisted cache lives in rxode2's user cache directory, so it OUTLIVES
+  ## the session (and the installed package) whenever `rxCreateCache()` has been
+  ## run.  Any release that changes the generated model text -- #992 gave the
+  ## llik-forced t()/cauchy()/dnorm() inner model its rx_pred_f_/rx_nu_
+  ## censoring columns, for one -- would otherwise be silently ignored for a
+  ## model already in that cache, with no error to show for it.  Key on the
+  ## package version so an upgrade rebuilds instead.
+  .pkgVersion <- as.character(utils::packageVersion("nlmixr2est"))
+  digest::digest(c(all(is.na(.iniDf$neta1)), .combSens, .pkgVersion,
                    rxode2::rxGetControl(.ui, "interaction", 1L),
                    .iniDf$name,
                    .sumProd, .optExpression, .predMinusDv,

--- a/R/focei.R
+++ b/R/focei.R
@@ -1394,6 +1394,35 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
 }
 
 
+#' `rx_pred_f_`/`rx_nu_` output lines for a llik-forced censored endpoint
+#'
+#' A llik-forced `t()`/`cauchy()`/`dnorm()` endpoint collapses to a scalar
+#' log-density in `rx_pred_`, hiding the location and degrees of freedom
+#' `censEst.h`'s M2/M3/M4 correction needs (`rx_r_` is already an output
+#' column).  Both are suppressed (`~`) intermediates in the generated error
+#' lines, so they have to be pulled out of the symengine environment and
+#' re-emitted as real lhs -- the same thing `.nlmGetFRLines()` does for
+#' nlm-family (#979, #992).  Empty unless `.fixCensRNuLine()` was active for
+#' this build.
+#'
+#' @param .s symengine environment
+#' @return character vector of `=` assignment lines (possibly empty)
+#' @noRd
+#' @author Matthew L. Fidler
+.foceiCensLlikCols <- function(.s) {
+  if (!isTRUE(nlmixr2global$rxCensNuFix) || !.getRxPredLlikOption() ||
+        !exists("rx_pred_f_", envir = .s)) {
+    return(character(0))
+  }
+  .predF <- get("rx_pred_f_", envir = .s)
+  .ret <- paste0("rx_pred_f_=", rxode2::rxFromSE(.predF))
+  if (exists("rx_nu_", envir = .s)) {
+    .nuSym <- get("rx_nu_", envir = .s)
+    .ret <- c(.ret, paste0("rx_nu_=", rxode2::rxFromSE(.nuSym)))
+  }
+  .ret
+}
+
 #' Finalize inner rxode2 based on symengine saved info
 #'
 #' @param .s Symengine/rxode2 object
@@ -1503,19 +1532,7 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   # rx_pred_f_, rx_nu_ and d(rx_pred_f_)/d(eta) are added -- APPENDED AFTER the
   # block (like .combTheta) because likInner0 reads predOffset+k arithmetically
   # through rx__sens_rx_r__BY_ETA_<neta>___; inner.cpp resolves these by name.
-  .censCols <- character(0)
-  if (isTRUE(nlmixr2global$rxCensNuFix) && .getRxPredLlikOption() &&
-        exists("rx_pred_f_", envir = .s)) {
-    .predF <- get("rx_pred_f_", envir = .s)
-    .censCols <- paste0("rx_pred_f_=", rxode2::rxFromSE(.predF))
-    if (exists("rx_nu_", envir = .s)) {
-      .nuSym <- get("rx_nu_", envir = .s)
-      .censCols <- c(.censCols, paste0("rx_nu_=", rxode2::rxFromSE(.nuSym)))
-    }
-    if (length(.s$..predFEtaSens) > 0L) {
-      .censCols <- c(.censCols, .s$..predFEtaSens)
-    }
-  }
+  .censCols <- c(.foceiCensLlikCols(.s), .s$..predFEtaSens)
   .s$..inner <- paste(c(
     .preLhs,
     .ddt,
@@ -1819,6 +1836,13 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
   }
   .preLhs <- if (.isMatExp) sub("^([^=]+)=", "\\1~", .lhs) else .lagDefs
   .postLhs <- if (.isMatExp) character(0) else .restLhs
+  # M2/M3/M4 censoring inputs for a llik-forced endpoint (#992), same as
+  # .rxFinalizeInner()'s.  This is the model a POPULATION-ONLY (neta == 0)
+  # FOCEi fit registers as its inner model (predOnlyLlik), so without them a
+  # no-random-effect t()/cauchy() fit would silently skip the correction.
+  # Only the Llik variant is touched -- the plain predOnly model backs the
+  # output tables and must keep its column set.
+  .censCols <- .foceiCensLlikCols(.s)
   .s$..pred <- paste(c(
     .s$..stateInfo["state"],
     .lhs0,
@@ -1832,6 +1856,7 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
     .low,
     .prd,
     .r,
+    .censCols,
     .postLhs,
     .s$..stateInfo["statef"],
     .s$..stateInfo["dvid"],

--- a/R/focei.R
+++ b/R/focei.R
@@ -2161,8 +2161,11 @@ rxUiGet.focei <- function(x, ...) {
   # ar() endpoints emit the whitened residual in Gaussian norm (mean/variance)
   # form so the exact eta-Hessian is used (not the llik path).
   nlmixr2global$rxArNorm <- TRUE
-  on.exit({nlmixr2global$rxPredLlik <- FALSE; nlmixr2global$rxArNorm <- FALSE
-    nlmixr2global$rxCensNuFix <- FALSE})
+  on.exit({
+    nlmixr2global$rxPredLlik <- FALSE
+    nlmixr2global$rxArNorm <- FALSE
+    nlmixr2global$rxCensNuFix <- FALSE
+  })
   .s <- rxUiGet.foceiEnv(x, ...)
   .ret <-  .innerInternal(.ui, .s)
   .predDf <- .ui$predDfFocei
@@ -2194,8 +2197,11 @@ rxUiGet.foce <- function(x, ...) {
   .ui <- x[[1]]
   nlmixr2global$rxPredLlik <- FALSE
   nlmixr2global$rxArNorm <- TRUE
-  on.exit({nlmixr2global$rxPredLlik <- FALSE; nlmixr2global$rxArNorm <- FALSE
-    nlmixr2global$rxCensNuFix <- FALSE})
+  on.exit({
+    nlmixr2global$rxPredLlik <- FALSE
+    nlmixr2global$rxArNorm <- FALSE
+    nlmixr2global$rxCensNuFix <- FALSE
+  })
   .s <- rxUiGet.foceEnv(x, ...)
   .ret <- .innerInternal(.ui, .s)
   .predDf <- .ui$predDfFocei
@@ -2228,8 +2234,11 @@ rxUiGet.ebe <- function(x, ...) {
   .ui <-x[[1]]
   nlmixr2global$rxPredLlik <- FALSE
   nlmixr2global$rxArNorm <- TRUE
-  on.exit({nlmixr2global$rxPredLlik <- FALSE; nlmixr2global$rxArNorm <- FALSE
-    nlmixr2global$rxCensNuFix <- FALSE})
+  on.exit({
+    nlmixr2global$rxPredLlik <- FALSE
+    nlmixr2global$rxArNorm <- FALSE
+    nlmixr2global$rxCensNuFix <- FALSE
+  })
   .s <- rxUiGet.getEBEEnv(x, ...)
   .ret <- .innerInternal(.ui, .s)
   .predDf <- .ui$predDfFocei

--- a/R/focei.R
+++ b/R/focei.R
@@ -1421,6 +1421,14 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
 #' @author Matthew L. Fidler
 .foceiCensLlikCols <- function(.s) {
   if (!.foceiCensLlikOn(.s)) return(character(0))
+  # `.fixCensRNuLine()` declines some endpoints -- an `ar()` one, whose
+  # `rx_rll_` is the marginal rather than the conditional scale -- and leaves
+  # rxode2's hardcoded `rx_r_ ~ 0` in place.  Emitting rx_pred_f_ anyway would
+  # ARM the C++ side (predFOffset/predROffset both resolve) and hand
+  # doCensNormal1() a zero variance for a `dnorm()` endpoint, which has no
+  # rx_nu_ to disarm it.  A zero rx_r_ IS the "declined" signal, so honor it.
+  .rSym <- get("rx_r_", envir = .s)
+  if (paste(.rSym) %in% c("0", "0.0", "-0")) return(character(0))
   .predF <- get("rx_pred_f_", envir = .s)
   .ret <- paste0("rx_pred_f_=", rxode2::rxFromSE(.predF))
   if (exists("rx_nu_", envir = .s)) {

--- a/R/focei.R
+++ b/R/focei.R
@@ -576,18 +576,23 @@ rxGetDistributionFoceiLines <- function(line) {
 #' @author Matthew L. Fidler
 #' @noRd
 .fixCensRNuLine <- function(lines) {
-  # nlm-family (population-only, neta=0) ONLY for now: giving a llik-forced
-  # endpoint a real (nonzero) rx_r_ is exactly what FOCEi's eta-sensitivity
-  # generation does not expect once real etas are present -- turning it on
-  # unconditionally crashes symengine's eta-derivative pass ("user function
-  # 'get' requires 5 arguments") for ANY t()/cauchy()+eta FOCEi/FOCE fit,
-  # censored or not (measured: reproduces with plain cauchy(), no CENS data
-  # at all, and disappears when this function is a no-op).  nlm has no etas
-  # and is unaffected, so gate on the flag only `rxUiGet.nlmModel0` sets;
-  # FOCEi/FOCE/AGQ/Laplace keep today's (silent-ignore, now warned) behavior
-  # until a follow-up sorts out the rxode2-side interaction (#979).
+  # Set by `rxUiGet.nlmModel0` (nlm-family) and by the FOCEi/FOCE/EBE llik
+  # bundle builders (`rxUiGet.focei`/`.foce`/`.ebe`); off everywhere else, so
+  # simulation and the saem/nls llik lines keep the plain `rx_r_ ~ 0`.
   if (!isTRUE(nlmixr2global$rxCensNuFix)) return(lines)
   if (!is.list(lines)) return(lines)
+  # AR(1) (`ar()`) endpoint: `rx_rll_` is the MARGINAL sd -- the conditional
+  # scale actually handed to llikT()/llikCauchy() is `rx_rll_*sqrt(1-phi^2)`
+  # (.rxArEstLlikLines, rxode2) -- so squaring rx_rll_ back into rx_r_ would
+  # hand the censoring correction the wrong scale (and rx_pred_f_ the marginal,
+  # not conditional, location).  Leave the AR lines alone; censoring stays
+  # uncorrected (and warned, .preProcessCensDistWarn) for those endpoints.
+  if (any(vapply(lines, function(.l) {
+    is.call(.l) && length(.l) == 3L && is.name(.l[[2]]) &&
+      grepl("^rx_arPhi_", as.character(.l[[2]]))
+  }, logical(1)))) {
+    return(lines)
+  }
   .hasRll <- any(vapply(lines, function(.l) {
     is.call(.l) && identical(.l[[1]], quote(`~`)) &&
       identical(.l[[2]], quote(rx_rll_))
@@ -1189,6 +1194,37 @@ attr(rxUiGet.foceiThetaS, "rstudio") <- emptyenv()
   paste0("-(", .phi, ")*lag0(", .snNames, ",1)")
 }
 
+#' Structural-prediction eta sensitivities for the censored llik endpoint
+#'
+#' A llik-forced `t()`/`cauchy()`/`dnorm()` endpoint replaces `rx_pred_` with
+#' the scalar log-density, so `rx__sens_rx_pred__BY_ETA_n___` is
+#' d(logLik)/d(eta), not d(f)/d(eta).  `censEst.h`'s `dCensT1()`/
+#' `dCensNormal1()` M2/M3/M4 gradient correction needs the STRUCTURAL
+#' d(f)/d(eta), so emit it separately as `rx__sens_rx_pred_f__BY_ETA_n___`
+#' (the same names, and the same chain rule, `.rxFoceiArEtaCorrect()` already
+#' uses for the AR(1) correction).  Stored on `..predFEtaSens`; appended after
+#' the FOCEi eta block by `.rxFinalizeInner()` and located by name in C++
+#' (#992).
+#'
+#' @param .s symengine environment
+#' @param .grd `rxExpandFEta_()` grid (one row per eta)
+#' @return character vector of `rx__sens_rx_pred_f__BY_ETA_n___=` lines, or
+#'   `character(0)` when the model has no `rx_pred_f_`
+#' @noRd
+#' @author Matthew L. Fidler
+.foceiPredFEtaSens <- function(.s, .grd) {
+  if (!exists("rx_pred_f_", envir = .s)) return(character(0))
+  .nms <- character(nrow(.grd))
+  .txt <- character(nrow(.grd))
+  for (.n in seq_len(nrow(.grd))) {
+    .calc <- gsub("rx_pred_", "rx_pred_f_", .grd[.n, "calc"], fixed = TRUE)
+    .basic <- eval(parse(text = .calc))
+    .nms[.n] <- gsub("rx_pred_", "rx_pred_f_", .grd[.n, "dfe"], fixed = TRUE)
+    .txt[.n] <- rxode2::rxFromSE(.basic)
+  }
+  paste0(.nms, "=", .txt)
+}
+
 #' @export
 rxUiGet.foceiHdEta <- function(x, ...) {
   .s <- rxUiGet.foceiEtaS(x)
@@ -1210,6 +1246,17 @@ rxUiGet.foceiHdEta <- function(x, ...) {
   .arCorr <- NULL
   if (isTRUE(rxode2::rxHasAr(x[[1]]))) {
     .arCorr <- .rxFoceiArEtaCorrect(.s, .grd)
+  }
+  # M2/M3/M4 censoring for a llik-forced endpoint (#992) needs the STRUCTURAL
+  # d(f)/d(eta) as well.  Computed here, with the same pre-apply ordering the
+  # AR(1) correction uses.  An AR endpoint already emits these exact names
+  # (..arEtaSens, real lhs ahead of rx_pred_), so never emit them twice.
+  .s$..predFEtaSens <- if (isTRUE(nlmixr2global$rxCensNuFix) &&
+                             .getRxPredLlikOption() &&
+                             is.null(.s$..arEtaSens)) {
+    .foceiPredFEtaSens(.s, .grd)
+  } else {
+    character(0)
   }
   rxode2::rxProgress(dim(.grd)[1])
   # Guard the abort so a clean rxProgressStop() below prevents the generic
@@ -1449,6 +1496,26 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
     }
     .combTheta <- c(.combDf, .combDv, .combDl)
   }
+  # M2/M3/M4 censoring inputs for a llik-forced t()/cauchy()/dnorm() endpoint
+  # (#992).  rx_pred_ is the scalar log-density, so the location/scale/degrees
+  # of freedom censEst.h needs are invisible; expose them as real lhs.  rx_r_
+  # (and its eta sensitivities) are already part of the FOCEi block, so only
+  # rx_pred_f_, rx_nu_ and d(rx_pred_f_)/d(eta) are added -- APPENDED AFTER the
+  # block (like .combTheta) because likInner0 reads predOffset+k arithmetically
+  # through rx__sens_rx_r__BY_ETA_<neta>___; inner.cpp resolves these by name.
+  .censCols <- character(0)
+  if (isTRUE(nlmixr2global$rxCensNuFix) && .getRxPredLlikOption() &&
+        exists("rx_pred_f_", envir = .s)) {
+    .predF <- get("rx_pred_f_", envir = .s)
+    .censCols <- paste0("rx_pred_f_=", rxode2::rxFromSE(.predF))
+    if (exists("rx_nu_", envir = .s)) {
+      .nuSym <- get("rx_nu_", envir = .s)
+      .censCols <- c(.censCols, paste0("rx_nu_=", rxode2::rxFromSE(.nuSym)))
+    }
+    if (length(.s$..predFEtaSens) > 0L) {
+      .censCols <- c(.censCols, .s$..predFEtaSens)
+    }
+  }
   .s$..inner <- paste(c(
     .preLhs,
     .ddt,
@@ -1468,6 +1535,7 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
     .r,
     .s$..REta,
     .combTheta,
+    .censCols,
     .adjLhs,
     .s$..stateInfo["statef"],
     .s$..stateInfo["dvid"],
@@ -2025,13 +2093,18 @@ rxUiGet.focei <- function(x, ...) {
   # ar() endpoints emit the whitened residual in Gaussian norm (mean/variance)
   # form so the exact eta-Hessian is used (not the llik path).
   nlmixr2global$rxArNorm <- TRUE
-  on.exit({nlmixr2global$rxPredLlik <- FALSE; nlmixr2global$rxArNorm <- FALSE})
+  on.exit({nlmixr2global$rxPredLlik <- FALSE; nlmixr2global$rxArNorm <- FALSE
+    nlmixr2global$rxCensNuFix <- FALSE})
   .s <- rxUiGet.foceiEnv(x, ...)
   .ret <-  .innerInternal(.ui, .s)
   .predDf <- .ui$predDfFocei
   if (any(.predDf$distribution %in% c("t", "cauchy", "dnorm"))) {
     nlmixr2global$rxPredLlik <- TRUE
     nlmixr2global$rxArNorm <- FALSE
+    # expose the censoring inputs (a real rx_r_, plus rx_nu_) that the
+    # llik-forced endpoint otherwise hides inside its scalar log-density
+    # (.fixCensRNuLine, #992)
+    nlmixr2global$rxCensNuFix <- TRUE
     .s <- rxUiGet.foceiEnv(x, ...)
     .s2 <- .innerInternal(.ui, .s)
     .w <- vapply(seq_along(.s2),
@@ -2053,13 +2126,18 @@ rxUiGet.foce <- function(x, ...) {
   .ui <- x[[1]]
   nlmixr2global$rxPredLlik <- FALSE
   nlmixr2global$rxArNorm <- TRUE
-  on.exit({nlmixr2global$rxPredLlik <- FALSE; nlmixr2global$rxArNorm <- FALSE})
+  on.exit({nlmixr2global$rxPredLlik <- FALSE; nlmixr2global$rxArNorm <- FALSE
+    nlmixr2global$rxCensNuFix <- FALSE})
   .s <- rxUiGet.foceEnv(x, ...)
   .ret <- .innerInternal(.ui, .s)
   .predDf <- .ui$predDfFocei
   if (any(.predDf$distribution %in% c("t", "cauchy", "dnorm"))) {
     nlmixr2global$rxPredLlik <- TRUE
     nlmixr2global$rxArNorm <- FALSE
+    # expose the censoring inputs (a real rx_r_, plus rx_nu_) that the
+    # llik-forced endpoint otherwise hides inside its scalar log-density
+    # (.fixCensRNuLine, #992)
+    nlmixr2global$rxCensNuFix <- TRUE
     .s <- rxUiGet.foceEnv(x, ...)
     .s2 <- .innerInternal(.ui, .s)
     .w <- vapply(seq_along(.s2),
@@ -2082,13 +2160,18 @@ rxUiGet.ebe <- function(x, ...) {
   .ui <-x[[1]]
   nlmixr2global$rxPredLlik <- FALSE
   nlmixr2global$rxArNorm <- TRUE
-  on.exit({nlmixr2global$rxPredLlik <- FALSE; nlmixr2global$rxArNorm <- FALSE})
+  on.exit({nlmixr2global$rxPredLlik <- FALSE; nlmixr2global$rxArNorm <- FALSE
+    nlmixr2global$rxCensNuFix <- FALSE})
   .s <- rxUiGet.getEBEEnv(x, ...)
   .ret <- .innerInternal(.ui, .s)
   .predDf <- .ui$predDfFocei
   if (any(.predDf$distribution %in% c("t", "cauchy", "dnorm"))) {
     nlmixr2global$rxPredLlik <- TRUE
     nlmixr2global$rxArNorm <- FALSE
+    # expose the censoring inputs (a real rx_r_, plus rx_nu_) that the
+    # llik-forced endpoint otherwise hides inside its scalar log-density
+    # (.fixCensRNuLine, #992)
+    nlmixr2global$rxCensNuFix <- TRUE
     .s <- rxUiGet.getEBEEnv(x, ...)
     .s2 <- .innerInternal(.ui, .s)
     .w <- vapply(seq_along(.s2),

--- a/R/focei.R
+++ b/R/focei.R
@@ -1215,8 +1215,7 @@ attr(rxUiGet.foceiThetaS, "rstudio") <- emptyenv()
 .foceiPredFEtaSens <- function(.s, .grd) {
   # An AR(1) endpoint already emits these exact names (..arEtaSens, real lhs
   # ahead of rx_pred_), so never emit them twice.
-  if (!isTRUE(nlmixr2global$rxCensNuFix) || !.getRxPredLlikOption() ||
-        !is.null(.s$..arEtaSens) || !exists("rx_pred_f_", envir = .s)) {
+  if (!.foceiCensLlikOn(.s) || !is.null(.s$..arEtaSens)) {
     return(character(0))
   }
   .nms <- character(nrow(.grd))
@@ -1391,6 +1390,21 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
 }
 
 
+#' Is this build emitting the llik-forced endpoint's censoring inputs?
+#'
+#' True only while `.fixCensRNuLine()` is active for the build in progress:
+#' `rxUiGet.nlmModel0` (nlm-family) and `rxUiGet.focei`/`.foce`/`.ebe` set the
+#' flag, everything else leaves it off (#992).
+#'
+#' @param .s symengine environment
+#' @return logical
+#' @noRd
+#' @author Matthew L. Fidler
+.foceiCensLlikOn <- function(.s) {
+  isTRUE(nlmixr2global$rxCensNuFix) && .getRxPredLlikOption() &&
+    exists("rx_pred_f_", envir = .s)
+}
+
 #' `rx_pred_f_`/`rx_nu_` output lines for a llik-forced censored endpoint
 #'
 #' A llik-forced `t()`/`cauchy()`/`dnorm()` endpoint collapses to a scalar
@@ -1399,18 +1413,14 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
 #' column).  Both are suppressed (`~`) intermediates in the generated error
 #' lines, so they have to be pulled out of the symengine environment and
 #' re-emitted as real lhs -- the same thing `.nlmGetFRLines()` does for
-#' nlm-family (#979, #992).  Empty unless `.fixCensRNuLine()` was active for
-#' this build.
+#' nlm-family (#979, #992).
 #'
 #' @param .s symengine environment
 #' @return character vector of `=` assignment lines (possibly empty)
 #' @noRd
 #' @author Matthew L. Fidler
 .foceiCensLlikCols <- function(.s) {
-  if (!isTRUE(nlmixr2global$rxCensNuFix) || !.getRxPredLlikOption() ||
-        !exists("rx_pred_f_", envir = .s)) {
-    return(character(0))
-  }
+  if (!.foceiCensLlikOn(.s)) return(character(0))
   .predF <- get("rx_pred_f_", envir = .s)
   .ret <- paste0("rx_pred_f_=", rxode2::rxFromSE(.predF))
   if (exists("rx_nu_", envir = .s)) {
@@ -1529,7 +1539,7 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   # rx_pred_f_, rx_nu_ and d(rx_pred_f_)/d(eta) are added -- APPENDED AFTER the
   # block (like .combTheta) because likInner0 reads predOffset+k arithmetically
   # through rx__sens_rx_r__BY_ETA_<neta>___; inner.cpp resolves these by name.
-  .censCols <- c(.foceiCensLlikCols(.s), .s$..predFEtaSens)
+  .censCols <- c(.foceiCensLlikCols(.s), .s$..predFEtaSens, .s$..censREta)
   .s$..inner <- paste(c(
     .preLhs,
     .ddt,
@@ -1636,8 +1646,20 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
 }
 
 #' @export
-rxUiGet.foceiEnv <- function(x, ...) {
-  .s <- rxUiGet.foceiHdEta(x, ...)
+#' Generate the `rx__sens_rx_r__BY_ETA_n___` (d(R)/d(eta)) model lines
+#'
+#' The FOCEi eta-epsilon interaction term needs these; FOCE does not (it does
+#' not differentiate R), but a censored llik-forced endpoint does either way --
+#' `dCensT1()`/`dCensNormal1()` take both d(f)/d(eta) and d(R)/d(eta), and for a
+#' `prop()`/`pow()` error R moves with eta.  Shared so the FOCE build can emit
+#' them (appended after its block, located by name) without duplicating the
+#' linCmt() moving-boundary correction below.
+#'
+#' @param .s symengine environment carrying the eta sensitivities
+#' @return character vector of `rx__sens_rx_r__BY_ETA_n___=` lines
+#' @noRd
+#' @author Matthew L. Fidler
+.foceiREtaLines <- function(.s) {
   .stateVars <- .rxode2stateOdeNoOutput(.s)
   .grd <- rxode2::rxExpandFEta_(.stateVars, .s$..maxEta, FALSE)
   if (rxode2::.useUtf()) {
@@ -1659,8 +1681,9 @@ rxUiGet.foceiEnv <- function(x, ...) {
   .linCmtExtraR <- .rxFoceiLinCmtEventChain(
     get("rx_r_", envir = .s), get("rx_pred_", envir = .s), .s$..linCmtExtraPred)
   rxode2::rxProgress(dim(.grd)[1])
+  .stopped <- FALSE
   on.exit({
-    rxode2::rxProgressAbort()
+    if (!.stopped) rxode2::rxProgressAbort()
   })
   .ret <- apply(.grd, 1, function(x) {
     .l <- x["calc"]
@@ -1673,9 +1696,15 @@ rxUiGet.foceiEnv <- function(x, ...) {
     rxode2::rxTick()
     .ret
   })
-
-  .s$..REta <- .ret
   rxode2::rxProgressStop()
+  .stopped <- TRUE
+  .ret
+}
+
+#' @export
+rxUiGet.foceiEnv <- function(x, ...) {
+  .s <- rxUiGet.foceiHdEta(x, ...)
+  .s$..REta <- .foceiREtaLines(.s)
   # fast=TRUE generalized (ll()) endpoint: add the second-order eta expansion.  The exact
   # d2(logLik)/deta2 (rx__d2pred_i_j__) is compiled into a SEPARATE model (..innerHess2),
   # which calcEtaHessian re-solves per subject at eta* to assemble the EXACT inner Hessian
@@ -1698,6 +1727,15 @@ attr(rxUiGet.foceiEnv, "rstudio") <- emptyenv()
 rxUiGet.foceEnv <- function(x, ...) {
   .s <- rxUiGet.foceiHdEta(x, ...)
   .s$..REta <- NULL
+  # A censored llik-forced endpoint still needs d(R)/d(eta) -- for a
+  # prop()/pow() error R moves with eta, and dCensT1()/dCensNormal1() take it
+  # (#992).  Emitted at the END of the inner model (.rxFinalizeInner) and read
+  # by name, so FOCE's own column layout is untouched.
+  .s$..censREta <- if (.foceiCensLlikOn(.s)) {
+    .foceiREtaLines(.s)
+  } else {
+    character(0)
+  }
   .s <- .foceiMaybeAddHdEta2(x, .s)   # ll()/generalized (interaction=0) fast fits route through foce
   ## FOCE leaves rx_r_ untouched (a clean single-linCmt inner model with correct
   ## d(f)/d(eta)) for both `foce` modes; the choice of R happens at runtime in C++

--- a/R/nlm.R
+++ b/R/nlm.R
@@ -409,14 +409,13 @@ rxUiGet.nlmModel0 <- function(x, ...) {
   .ui <- rxode2::rxUiDecompress(x[[1]])
   # on.exit() registered BEFORE mutating either flag: an interrupt landing
   # between setting a flag and registering its reset would otherwise leak
-  # it TRUE for the rest of the R session -- for rxCensNuFix specifically,
-  # that would crash a later FOCEi t()/cauchy()+eta fit (see the guard's
-  # own comment for why it must stay OFF for FOCEi/FOCE, #979).
+  # it TRUE for the rest of the R session, changing how a later fit's model
+  # is generated.
   on.exit(nlmixr2global$rxCensNuFix <- FALSE, add = TRUE)
   on.exit(nlmixr2global$rxPredLlik <- FALSE, add = TRUE)
   nlmixr2global$rxPredLlik <- TRUE
-  # nlm is population-only (no etas), so .fixCensRNuLine's real (nonzero)
-  # rx_r_/rx_nu_ for a llik-forced endpoint is safe here.
+  # expose the censoring inputs (a real rx_r_, plus rx_nu_) for the
+  # llik-forced endpoint (.fixCensRNuLine, R/focei.R)
   nlmixr2global$rxCensNuFix <- TRUE
   .predDf <- .ui$predDf
   .save <- .predDf

--- a/R/preProcessCensDistWarn.R
+++ b/R/preProcessCensDistWarn.R
@@ -1,15 +1,14 @@
 #' Warn when CENS/LIMIT data meets a distribution with no M2/M3/M4 support
 #'
 #' `censEst.h`'s M2/M3/M4 correction only understands normal (`add`/`prop`/
-#' `pow`/combined, `lnorm`/`logitNorm`/`probitNorm` transforms, `dnorm`) and,
-#' for nlm-family only, `t()`/`cauchy()` (`doCensT1()`, #979).  Every other
-#' generalized-likelihood distribution (`pois`, `binom`, `beta`, `chisq`,
-#' `dexp`, `f`, `geom`, `unif`, `weibull`, `dgamma`, `ordinal`, a general
-#' `ll()`) -- and, for now, `t()`/`cauchy()` under FOCEi/FOCE/AGQ/Laplace --
-#' silently scores a censored row with its ordinary (uncensored) density
-#' instead of erroring or refusing (unlike `est="nls"`, which hard-stops).
-#' This warns instead of leaving that silent, so it is at least visible in
-#' the fit's `$runInfo`.
+#' `pow`/combined, `lnorm`/`logitNorm`/`probitNorm` transforms, `dnorm`) and
+#' `t()`/`cauchy()` (`doCensT1()`, #979/#992).  Every other generalized-
+#' likelihood distribution (`pois`, `binom`, `beta`, `chisq`, `dexp`, `f`,
+#' `geom`, `unif`, `weibull`, `dgamma`, `ordinal`, a general `ll()`) silently
+#' scores a censored row with its ordinary (uncensored) density instead of
+#' erroring or refusing (unlike `est="nls"`, which hard-stops).  This warns
+#' instead of leaving that silent, so it is at least visible in the fit's
+#' `$runInfo`.
 #'
 #' @param ui rxode2 ui
 #' @inheritParams nlmixr2
@@ -17,13 +16,19 @@
 #' @noRd
 .preProcessCensDistWarn <- function(ui, est, data, control) {
   if (identical(est, "nls")) return(list(ui = ui))
-  # Methods sharing src/nlm.cpp's population-only kernel: t()/cauchy() are
-  # safe there (doCensT1(), no etas to worry about).  Every other method
-  # (FOCEi/FOCE/AGQ/Laplace/SAEM/imp/...) keeps t()/cauchy() in the unsafe
-  # set until the FOCEi-side gap (src/inner.cpp's KNOWN GAP comment) closes.
+  # t()/cauchy() M2/M3/M4 is wired for two kernels: src/nlm.cpp's
+  # population-only one (#979) and src/inner.cpp's likInner0 (#992, which also
+  # supplies the eta gradient).  Methods built on some OTHER kernel -- SAEM,
+  # the importance-sampling family (imp/impmap/qrpem), nlme, the nonparametric
+  # engines -- keep t()/cauchy() in the unsafe set.
   .nlmFamily <- c("nlm", "bobyqa", "lbfgsb3c", "n1qn1", "newuoa", "nlminb",
                   "optim", "uobyqa")
-  .safe <- if (isTRUE(est %in% .nlmFamily)) {
+  # `fo`/`foi` are deliberately absent: they hard-stop on censoring rather
+  # than ignoring it.
+  .foceiFamily <- c("focei", "foce", "focep", "laplace", "agq", "posthoc",
+                    "ifocei", "ifoce", "ifocep", "ilaplace", "iagq",
+                    "mfocei", "mfoce", "mfocep", "mlaplace", "magq")
+  .safe <- if (isTRUE(est %in% c(.nlmFamily, .foceiFamily))) {
     c("norm", "dnorm", "t", "cauchy")
   } else {
     c("norm", "dnorm")

--- a/R/preProcessCensDistWarn.R
+++ b/R/preProcessCensDistWarn.R
@@ -14,6 +14,26 @@
 #' @inheritParams nlmixr2
 #' @return list with the ui (unmodified; this hook only warns)
 #' @noRd
+NULL
+
+#' Does this dataset carry any censoring information?
+#'
+#' A non-zero `CENS` (M3/M4) or a finite `LIMIT` (M2) on any row.  Shared with
+#' `.foceiFamilyControl()`, which downgrades `fast = TRUE` for a censored
+#' log-likelihood endpoint (#992).
+#'
+#' @inheritParams nlmixr2
+#' @return logical
+#' @noRd
+.nlmixrDataHasCens <- function(data) {
+  if (!is.data.frame(data)) return(FALSE)
+  .nms <- tolower(names(data))
+  .w <- which(.nms == "cens")
+  if (length(.w) == 1L && isTRUE(any(data[[.w]] != 0, na.rm = TRUE))) return(TRUE)
+  .w <- which(.nms == "limit")
+  length(.w) == 1L && isTRUE(any(is.finite(data[[.w]]), na.rm = TRUE))
+}
+
 .preProcessCensDistWarn <- function(ui, est, data, control) {
   if (identical(est, "nls")) return(list(ui = ui))
   # t()/cauchy() M2/M3/M4 is wired for two kernels: src/nlm.cpp's
@@ -37,17 +57,7 @@
   if (is.null(.predDf) || nrow(.predDf) == 0) return(list(ui = ui))
   .unsafeDist <- unique(.predDf$distribution[!(.predDf$distribution %in% .safe)])
   if (length(.unsafeDist) == 0) return(list(ui = ui))
-  .nms <- tolower(names(data))
-  .hasCens <- FALSE
-  .wCens <- which(.nms == "cens")
-  if (length(.wCens) == 1L) {
-    .hasCens <- isTRUE(any(data[[.wCens]] != 0, na.rm = TRUE))
-  }
-  .wLimit <- which(.nms == "limit")
-  if (!.hasCens && length(.wLimit) == 1L) {
-    .hasCens <- isTRUE(any(is.finite(data[[.wLimit]]), na.rm = TRUE))
-  }
-  if (!.hasCens) return(list(ui = ui))
+  if (!.nlmixrDataHasCens(data)) return(list(ui = ui))
   for (.d in .unsafeDist) {
     warning(paste0("censoring ignored for '", .d, "' endpoint(s)"), call. = FALSE)
   }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -322,6 +322,12 @@ struct focei_options {
   // should, so a reordered model disarms the gradient correction instead of
   // reading the wrong column).
   int predFEtaOffset = -1;
+  // Same, for d(rx_r_)/d(eta) (rx__sens_rx_r__BY_ETA_1___).  Resolved by NAME
+  // rather than from predOffset arithmetic because FOCE's inner model has no
+  // such block in the FOCEi position -- .rxFinalizeInner() appends one at the
+  // end for a censored llik-forced endpoint (#992), and R does move with eta
+  // for a prop()/pow() error.
+  int predREtaOffset = -1;
   // fast=TRUE log-likelihood/generalized endpoint: a SEPARATE compiled model (rxHess2)
   // carries the exact second-order eta expansion rx__d2pred_i_j__ = d2(logLik)/deta_i deta_j
   // (upper triangle i<=j, j-outer/i-inner order).  This offset is the lhs index of its first
@@ -2408,9 +2414,11 @@ static inline double focei_tCensLl(int dist, int cens, double dv, double limit,
 
 // M2/M3/M4 eta-gradient counterpart of focei_tCensLl().  `dll` is the
 // uncensored d(logLik)/d(eta_i) (the rx__sens_rx_pred__BY_ETA_ column); the
-// returned value replaces it.  d(f)/d(eta_i) comes from the appended
-// rx__sens_rx_pred_f__BY_ETA_ block and d(R)/d(eta_i) from the FOCEi block
-// (zero for FOCE, which does not differentiate R).
+// returned value replaces it.  d(f)/d(eta_i) and d(R)/d(eta_i) come from the
+// rx__sens_rx_pred_f__BY_ETA_ / rx__sens_rx_r__BY_ETA_ blocks, both located by
+// name -- FOCE has no R block in the FOCEi position, so .rxFinalizeInner()
+// appends one for this path (R moves with eta for a prop()/pow() error, so
+// dropping it made the gradient disagree with the objective by a few percent).
 //
 // KNOWN GAP (#992): the transformed prediction's eta sensitivity is taken as
 // d(rx_pred_f_)/d(eta) -- exact for an identity transform, which is the only
@@ -2420,12 +2428,12 @@ static inline double focei_tCensLl(int dist, int cens, double dv, double limit,
 // gradient; the inner Hessian follows the gradient by finite difference.
 static inline double focei_tCensDll(int dist, int cens, double dv, double limit,
                                     double dll, double fT, double *lhs,
-                                    int etaIdx, double dr) {
+                                    int etaIdx) {
   bool isT = (dist == rxDistributionT || dist == rxDistributionCauchy);
   bool isDnorm = (dist == rxDistributionDnorm);
   if ((!isT && !isDnorm) ||
       op_focei.predFOffset < 0 || op_focei.predROffset < 0 ||
-      op_focei.predFEtaOffset < 0 ||
+      op_focei.predFEtaOffset < 0 || op_focei.predREtaOffset < 0 ||
       (isT && op_focei.predNuOffset < 0)) {
     return dll;
   }
@@ -2433,6 +2441,7 @@ static inline double focei_tCensDll(int dist, int cens, double dv, double limit,
   if (!isCensObs) return dll;
   double r = lhs[op_focei.predROffset];
   double df = lhs[op_focei.predFEtaOffset + etaIdx];
+  double dr = lhs[op_focei.predREtaOffset + etaIdx];
   if (isT) {
     double nu = lhs[op_focei.predNuOffset];
     return dCensT1((double)cens, dv, limit, dll, fT, r, nu, df, dr);
@@ -2947,9 +2956,8 @@ double likInner0(double *eta, int id) {
                   // the uncensored d(logLik)/d(eta) (#992).
                   lp(i, 0) += fpm;
                 } else {
-                  double drCens = lhs[op_focei.predOffset + i + op_focei.neta + 2];
                   lp(i, 0) += focei_tCensDll(dist, cens, dv, limit, fpm,
-                                             fCensT, lhs, i, drCens);
+                                             fCensT, lhs, i);
                 }
               }
               // Eq #10
@@ -2983,11 +2991,8 @@ double likInner0(double *eta, int id) {
                 } else if (predSolve || op_focei.etaFD[i] == 1) {
                   lp(i, 0) += fpm;
                 } else {
-                  // interaction=0 (FOCE): rx_r_ carries no eta sensitivities in
-                  // this model, so d(R)/d(eta)=0 -- consistent with FOCE itself
-                  // not differentiating R.
                   lp(i, 0) += focei_tCensDll(dist, cens, dv, limit, fpm,
-                                             fCensT, lhs, i, 0.0);
+                                             fCensT, lhs, i);
                 }
               }
               // Eq #10
@@ -6371,17 +6376,21 @@ static inline void foceiSetupTheta_(List mvi,
     // appended after the FOCEi eta block by .rxFinalizeInner() in eta order,
     // but a model built some other way must disarm rather than misread.
     op_focei.predFEtaOffset = -1;
+    op_focei.predREtaOffset = -1;
     if (op_focei.neta > 0) {
-      int _ife = odeSwapLhsIndex(odeSlotInner, "rx__sens_rx_pred_f__BY_ETA_1___");
-      if (_ife >= 0) {
-        char _nm[64];
-        snprintf(_nm, sizeof(_nm), "rx__sens_rx_pred_f__BY_ETA_%d___",
-                 (int)op_focei.neta);
-        int _ifeLast = odeSwapLhsIndex(odeSlotInner, _nm);
-        if (_ifeLast == _ife + (int)op_focei.neta - 1) {
-          op_focei.predFEtaOffset = _ife;
-        }
-      }
+      // both blocks are emitted one line per eta, in eta order, so only the
+      // first index is needed once the last one confirms the block is intact
+      auto contiguousEtaBlock = [](const char *fmt) -> int {
+        char nm[64];
+        snprintf(nm, sizeof(nm), fmt, 1);
+        int first = odeSwapLhsIndex(odeSlotInner, nm);
+        if (first < 0) return -1;
+        snprintf(nm, sizeof(nm), fmt, (int)op_focei.neta);
+        int last = odeSwapLhsIndex(odeSlotInner, nm);
+        return (last == first + (int)op_focei.neta - 1) ? first : -1;
+      };
+      op_focei.predFEtaOffset = contiguousEtaBlock("rx__sens_rx_pred_f__BY_ETA_%d___");
+      op_focei.predREtaOffset = contiguousEtaBlock("rx__sens_rx_r__BY_ETA_%d___");
     }
     // The exact-Hessian rx__d2pred_ columns live in the SEPARATE 2nd-order model (rxHess2),
     // located in foceiFitCpp_ after this setup; predHess2Offset is set there, not here.

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -2390,11 +2390,12 @@ static inline double likInner0Contrib(int id, int k, int dist, int cens,
 // needs, so both come from the extra lhs columns .rxFinalizeInner() appends
 // for this path (rx_pred_f_/rx_r_/rx_nu_).  When any of them is missing the
 // endpoint is scored uncensored, exactly as before.
-static inline double focei_tCensLl(int dist, int cens, double dv, double limit,
-                                   double llVal, double fT, double *lhs) {
+static inline double focei_tCensLl(bool lhsOk, int dist, int cens, double dv,
+                                   double limit, double llVal, double fT,
+                                   double *lhs) {
   bool isT = (dist == rxDistributionT || dist == rxDistributionCauchy);
   bool isDnorm = (dist == rxDistributionDnorm);
-  if ((!isT && !isDnorm) ||
+  if (!lhsOk || (!isT && !isDnorm) ||
       op_focei.predFOffset < 0 || op_focei.predROffset < 0 ||
       (isT && op_focei.predNuOffset < 0)) {
     return llVal;
@@ -2426,12 +2427,12 @@ static inline double focei_tCensLl(int dist, int cens, double dv, double limit,
 // transform-both-sides censored t()/cauchy() row therefore gets the correct
 // VALUE (fT is transformed) with a chain-rule factor missing from its
 // gradient; the inner Hessian follows the gradient by finite difference.
-static inline double focei_tCensDll(int dist, int cens, double dv, double limit,
-                                    double dll, double fT, double *lhs,
-                                    int etaIdx) {
+static inline double focei_tCensDll(bool lhsOk, int dist, int cens, double dv,
+                                    double limit, double dll, double fT,
+                                    double *lhs, int etaIdx) {
   bool isT = (dist == rxDistributionT || dist == rxDistributionCauchy);
   bool isDnorm = (dist == rxDistributionDnorm);
-  if ((!isT && !isDnorm) ||
+  if (!lhsOk || (!isT && !isDnorm) ||
       op_focei.predFOffset < 0 || op_focei.predROffset < 0 ||
       op_focei.predFEtaOffset < 0 || op_focei.predREtaOffset < 0 ||
       (isT && op_focei.predNuOffset < 0)) {
@@ -2828,8 +2829,14 @@ double likInner0(double *eta, int id) {
           // there, so the location has to come from the appended rx_pred_f_
           // column -- which is the RAW prediction, hence the tbs() to put it on
           // the same scale as dv/limit above.
-          double fCensT = 0.0;
-          if (op_focei.predFOffset >= 0) fCensT = tbs(lhs[op_focei.predFOffset]);
+          //
+          // KNOWN GAP: the pred (finite-difference) fallback solves predNoLhs
+          // and normalizes ONLY rx_pred_/rx_r_ into the inner layout above, so
+          // none of the censoring columns are present in `lhs` -- reading them
+          // there would return another model's values.  Such a subject scores
+          // its censored rows uncensored, exactly as it did before #992.
+          bool censLhsOk = !predSolve && op_focei.predFOffset >= 0;
+          double fCensT = censLhsOk ? tbs(lhs[op_focei.predFOffset]) : 0.0;
           tbsJac = tbsL(dv0);
           fInd->tbsLik+=tbsJac;
           // fInd->err(k, 0) = lhs[0] - getIndDv(ind, k); // pred-dv
@@ -2868,7 +2875,7 @@ double likInner0(double *eta, int id) {
               fInd->llik += ll;
               fInd->nObs++;
             } else {
-              double llT = focei_tCensLl(dist, cens, dv, limit, f, fCensT, lhs);
+              double llT = focei_tCensLl(censLhsOk, dist, cens, dv, limit, f, fCensT, lhs);
               llikObs[kk] = llT;
               fInd->llik += llT;
               fInd->nNonNormal++;
@@ -2956,7 +2963,7 @@ double likInner0(double *eta, int id) {
                   // the uncensored d(logLik)/d(eta) (#992).
                   lp(i, 0) += fpm;
                 } else {
-                  lp(i, 0) += focei_tCensDll(dist, cens, dv, limit, fpm,
+                  lp(i, 0) += focei_tCensDll(censLhsOk, dist, cens, dv, limit, fpm,
                                              fCensT, lhs, i);
                 }
               }
@@ -2972,7 +2979,7 @@ double likInner0(double *eta, int id) {
                  fInd->llik +=  ll;
                  fInd->nObs++;
                } else {
-                 double llT = focei_tCensLl(dist, cens, dv, limit, f, fCensT, lhs);
+                 double llT = focei_tCensLl(censLhsOk, dist, cens, dv, limit, f, fCensT, lhs);
                  llikObs[kk] = llT;
                  fInd->llik += llT;
                  fInd->nNonNormal++;
@@ -2991,7 +2998,7 @@ double likInner0(double *eta, int id) {
                 } else if (predSolve || op_focei.etaFD[i] == 1) {
                   lp(i, 0) += fpm;
                 } else {
-                  lp(i, 0) += focei_tCensDll(dist, cens, dv, limit, fpm,
+                  lp(i, 0) += focei_tCensDll(censLhsOk, dist, cens, dv, limit, fpm,
                                              fCensT, lhs, i);
                 }
               }
@@ -3004,7 +3011,7 @@ double likInner0(double *eta, int id) {
                 fInd->llik +=  ll;
                 fInd->nObs++;
               } else {
-                double llT = focei_tCensLl(dist, cens, dv, limit, f, fCensT, lhs);
+                double llT = focei_tCensLl(censLhsOk, dist, cens, dv, limit, f, fCensT, lhs);
                 llikObs[kk] = llT;
                 fInd->llik += llT;
                 fInd->nNonNormal++;

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -2403,6 +2403,11 @@ static inline double focei_tCensLl(bool lhsOk, int dist, int cens, double dv,
   bool isCensObs = (cens != 0) || (R_FINITE(limit) && !ISNA(limit));
   if (!isCensObs) return llVal;
   double r = lhs[op_focei.predROffset];
+  // A zero/non-finite rx_r_ means the R side left rxode2's hardcoded
+  // `rx_r_ ~ 0` for this row (a multi-endpoint model can do that per endpoint),
+  // so there is no scale to correct against -- score the row uncensored rather
+  // than hand doCensT1()/doCensNormal1() a floored variance.
+  if (!R_FINITE(r) || r <= 0.0) return llVal;
   if (isT) {
     double nu = lhs[op_focei.predNuOffset];
     return doCensT1((double)cens, dv, limit, llVal, fT, r, nu);
@@ -2441,6 +2446,7 @@ static inline double focei_tCensDll(bool lhsOk, int dist, int cens, double dv,
   bool isCensObs = (cens != 0) || (R_FINITE(limit) && !ISNA(limit));
   if (!isCensObs) return dll;
   double r = lhs[op_focei.predROffset];
+  if (!R_FINITE(r) || r <= 0.0) return dll;   // see focei_tCensLl()
   double df = lhs[op_focei.predFEtaOffset + etaIdx];
   double dr = lhs[op_focei.predREtaOffset + etaIdx];
   if (isT) {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -12154,6 +12154,18 @@ Environment foceiFitCpp_(Environment e){
           op_focei.hess2Neq = odeSwapNeq(odeSlotHess2);
           op_focei.hess2Nlhs = odeSwapNlhs(odeSlotHess2);
           op_focei.predHess2Offset = odeSwapLhsIndex(odeSlotHess2, "rx__d2pred_1_1__");
+          // rx__d2pred_ is the second derivative of the UNCENSORED log-density, and
+          // doCensT1()/doCensNormal1() REPLACE a censored row's contribution -- so once
+          // the M2/M3/M4 correction is armed (predFOffset >= 0, #992) that curvature is
+          // stale for those rows.  Disarm the exact-Hessian branch and let
+          // calcEtaHessian fall back to the Shi21 finite difference of the inner
+          // gradient, which does carry the correction.  (gradPooledCoreLL already
+          // refuses a censored fit outright, so the analytic outer gradient is
+          // unaffected.)
+          if (op_focei.predFOffset >= 0 &&
+              (hasRxCens(getRxSolve_()) || hasRxLimit(getRxSolve_()))) {
+            op_focei.predHess2Offset = -1;
+          }
           // pin the 1st-order inner Newton solves to innerNeq (pool sized for rxHess2)
           if (op_focei.predHess2Offset >= 0 && op_focei.innerNeq > 0) {
             impSetInnerNeqOverride();

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -2426,15 +2426,13 @@ static inline double focei_tCensLl(bool lhsOk, int dist, int cens, double dv,
 // appends one for this path (R moves with eta for a prop()/pow() error, so
 // dropping it made the gradient disagree with the objective by a few percent).
 //
-// KNOWN GAP (#992): the transformed prediction's eta sensitivity is taken as
-// d(rx_pred_f_)/d(eta) -- exact for an identity transform, which is the only
-// case doCensT1()/doCensNormal1() themselves are set up for here.  A
-// transform-both-sides censored t()/cauchy() row therefore gets the correct
-// VALUE (fT is transformed) with a chain-rule factor missing from its
-// gradient; the inner Hessian follows the gradient by finite difference.
+// rx_pred_f_ is the RAW prediction, so its eta sensitivity needs the
+// transform's own Jacobian to become d(fT)/d(eta) -- `fJac` = d(tbs)/d(f),
+// 1 for an identity transform.  rx_r_ is already on the transformed scale
+// (it is the variance the llik itself uses), so its sensitivity needs none.
 static inline double focei_tCensDll(bool lhsOk, int dist, int cens, double dv,
                                     double limit, double dll, double fT,
-                                    double *lhs, int etaIdx) {
+                                    double fJac, double *lhs, int etaIdx) {
   bool isT = (dist == rxDistributionT || dist == rxDistributionCauchy);
   bool isDnorm = (dist == rxDistributionDnorm);
   if (!lhsOk || (!isT && !isDnorm) ||
@@ -2447,7 +2445,7 @@ static inline double focei_tCensDll(bool lhsOk, int dist, int cens, double dv,
   if (!isCensObs) return dll;
   double r = lhs[op_focei.predROffset];
   if (!R_FINITE(r) || r <= 0.0) return dll;   // see focei_tCensLl()
-  double df = lhs[op_focei.predFEtaOffset + etaIdx];
+  double df = fJac * lhs[op_focei.predFEtaOffset + etaIdx];
   double dr = lhs[op_focei.predREtaOffset + etaIdx];
   if (isT) {
     double nu = lhs[op_focei.predNuOffset];
@@ -2842,7 +2840,12 @@ double likInner0(double *eta, int id) {
           // there would return another model's values.  Such a subject scores
           // its censored rows uncensored, exactly as it did before #992.
           bool censLhsOk = !predSolve && op_focei.predFOffset >= 0;
-          double fCensT = censLhsOk ? tbs(lhs[op_focei.predFOffset]) : 0.0;
+          double fCensT = 0.0, fCensJac = 1.0;
+          if (censLhsOk) {
+            double _fRaw = lhs[op_focei.predFOffset];
+            fCensT = tbs(_fRaw);
+            fCensJac = tbsD(_fRaw);   // chain d(rx_pred_f_)/d(eta) onto fCensT
+          }
           tbsJac = tbsL(dv0);
           fInd->tbsLik+=tbsJac;
           // fInd->err(k, 0) = lhs[0] - getIndDv(ind, k); // pred-dv
@@ -2970,7 +2973,7 @@ double likInner0(double *eta, int id) {
                   lp(i, 0) += fpm;
                 } else {
                   lp(i, 0) += focei_tCensDll(censLhsOk, dist, cens, dv, limit, fpm,
-                                             fCensT, lhs, i);
+                                             fCensT, fCensJac, lhs, i);
                 }
               }
               // Eq #10
@@ -3005,7 +3008,7 @@ double likInner0(double *eta, int id) {
                   lp(i, 0) += fpm;
                 } else {
                   lp(i, 0) += focei_tCensDll(censLhsOk, dist, cens, dv, limit, fpm,
-                                             fCensT, lhs, i);
+                                             fCensT, fCensJac, lhs, i);
                 }
               }
               // Eq #10

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -316,6 +316,12 @@ struct focei_options {
   int predFOffset = -1;
   int predROffset = -1;
   int predNuOffset = -1;
+  // First d(rx_pred_f_)/d(eta) column (rx__sens_rx_pred_f__BY_ETA_1___); the
+  // remaining etas follow contiguously.  -1 unless the whole eta block was
+  // found (setup verifies the last eta's column sits where contiguity says it
+  // should, so a reordered model disarms the gradient correction instead of
+  // reading the wrong column).
+  int predFEtaOffset = -1;
   // fast=TRUE log-likelihood/generalized endpoint: a SEPARATE compiled model (rxHess2)
   // carries the exact second-order eta expansion rx__d2pred_i_j__ = d2(logLik)/deta_i deta_j
   // (upper triangle i<=j, j-outer/i-inner order).  This offset is the lhs index of its first
@@ -2367,50 +2373,71 @@ static inline double likInner0Contrib(int id, int k, int dist, int cens,
   return llAdd;
 }
 
-// M2/M3/M4 censored log-likelihood VALUE for a t()/cauchy() observation
-// (#979).  `llVal` is the already-computed llikT()/llikCauchy() log-density
-// (what every `dist != rxDistributionNorm` branch uses verbatim today).
-// Reads RAW (untransformed) dv/limit against RAW rx_pred_f_ -- the same
-// convention nlm.cpp's doCensT1 call uses -- since rx_pred_f_ is
-// `.rxGetPredictionF()` (pre-transform), unlike the tbs()-transformed
-// dv/limit locals likInner0 computes for the NORMAL branch.
+// M2/M3/M4 censored log-likelihood VALUE for a llik-forced endpoint (#979,
+// #992).  `llVal` is the already-computed llikT()/llikCauchy()/llikNorm()
+// log-density (what every `dist != rxDistributionNorm` branch uses verbatim
+// today) and `fT` is the TRANSFORMED structural prediction -- rx_pred_f_ run
+// through the endpoint's tbs() -- so it lines up with the transformed
+// dv/limit likInner0 already computed for the NORMAL branch.
 //
-// KNOWN GAP (two layers, #979):
-//  1. This function currently NEVER fires for FOCEi/FOCE/AGQ/Laplace:
-//     predNuOffset stays -1 there (see its setup comment above, in the
-//     alloc block) because the R side only emits rx_nu_/a real rx_r_ for
-//     nlm-family.  nlm-family (src/nlm.cpp) IS fully corrected -- value
-//     AND gradient, since nlm has no etas to worry about.
-//  2. Once FOCEi's R-side gap closes, only the VALUE would be corrected
-//     here.  The eta-gradient (`lp`, via the analytic d(llikT)/d(eta)
-//     sensitivity column already read into `fpm`/`a(k,i)`) and the inner-
-//     Hessian curvature (`cHff`/`cHfr`/`cHrr`, Gauss-Newton fallback) would
-//     still score a censored t()/cauchy() row as if uncensored -- closing
-//     THAT requires a d(rx_pred_f_)/d(eta) sensitivity column rxode2 does
-//     not currently emit.
-// This function is exercised and validated end-to-end today only via
-// nlm-family's identical doCensT1 call; it is deliberately-ready, currently
-// inert infrastructure for FOCEi, not dead code.
-static inline double focei_tCensLl(rx_solving_options_ind *ind, int kk,
-                                   int dist, int cens, double llVal,
-                                   double *lhs) {
-  if ((dist != rxDistributionT && dist != rxDistributionCauchy) ||
+// The scalar log-density in rx_pred_ hides the location/scale the correction
+// needs, so both come from the extra lhs columns .rxFinalizeInner() appends
+// for this path (rx_pred_f_/rx_r_/rx_nu_).  When any of them is missing the
+// endpoint is scored uncensored, exactly as before.
+static inline double focei_tCensLl(int dist, int cens, double dv, double limit,
+                                   double llVal, double fT, double *lhs) {
+  bool isT = (dist == rxDistributionT || dist == rxDistributionCauchy);
+  bool isDnorm = (dist == rxDistributionDnorm);
+  if ((!isT && !isDnorm) ||
       op_focei.predFOffset < 0 || op_focei.predROffset < 0 ||
-      op_focei.predNuOffset < 0) {
+      (isT && op_focei.predNuOffset < 0)) {
     return llVal;
-  }
-  double limit = R_NegInf;
-  if (hasRxLimit(rx)) {
-    limit = getIndLimit(ind, kk);
-    if (ISNA(limit)) limit = R_NegInf;
   }
   bool isCensObs = (cens != 0) || (R_FINITE(limit) && !ISNA(limit));
   if (!isCensObs) return llVal;
-  double dv = getIndDv(ind, kk);
-  double f = lhs[op_focei.predFOffset];
   double r = lhs[op_focei.predROffset];
-  double nu = lhs[op_focei.predNuOffset];
-  return doCensT1((double)cens, dv, limit, llVal, f, r, nu);
+  if (isT) {
+    double nu = lhs[op_focei.predNuOffset];
+    return doCensT1((double)cens, dv, limit, llVal, fT, r, nu);
+  }
+  // dnorm(): the llik-forced Gaussian.  adjLik is already folded into the
+  // llikNorm() density, so pass 0 (doCensNormal1's adjLik only re-adds the
+  // -log(sqrt(2*pi)) the FOCEi -0.5*(err^2/r + log r) kernel drops).
+  return doCensNormal1((double)cens, dv, limit, llVal, fT, r, 0);
+}
+
+// M2/M3/M4 eta-gradient counterpart of focei_tCensLl().  `dll` is the
+// uncensored d(logLik)/d(eta_i) (the rx__sens_rx_pred__BY_ETA_ column); the
+// returned value replaces it.  d(f)/d(eta_i) comes from the appended
+// rx__sens_rx_pred_f__BY_ETA_ block and d(R)/d(eta_i) from the FOCEi block
+// (zero for FOCE, which does not differentiate R).
+//
+// KNOWN GAP (#992): the transformed prediction's eta sensitivity is taken as
+// d(rx_pred_f_)/d(eta) -- exact for an identity transform, which is the only
+// case doCensT1()/doCensNormal1() themselves are set up for here.  A
+// transform-both-sides censored t()/cauchy() row therefore gets the correct
+// VALUE (fT is transformed) with a chain-rule factor missing from its
+// gradient; the inner Hessian follows the gradient by finite difference.
+static inline double focei_tCensDll(int dist, int cens, double dv, double limit,
+                                    double dll, double fT, double *lhs,
+                                    int etaIdx, double dr) {
+  bool isT = (dist == rxDistributionT || dist == rxDistributionCauchy);
+  bool isDnorm = (dist == rxDistributionDnorm);
+  if ((!isT && !isDnorm) ||
+      op_focei.predFOffset < 0 || op_focei.predROffset < 0 ||
+      op_focei.predFEtaOffset < 0 ||
+      (isT && op_focei.predNuOffset < 0)) {
+    return dll;
+  }
+  bool isCensObs = (cens != 0) || (R_FINITE(limit) && !ISNA(limit));
+  if (!isCensObs) return dll;
+  double r = lhs[op_focei.predROffset];
+  double df = lhs[op_focei.predFEtaOffset + etaIdx];
+  if (isT) {
+    double nu = lhs[op_focei.predNuOffset];
+    return dCensT1((double)cens, dv, limit, dll, fT, r, nu, df, dr);
+  }
+  return dCensNormal1((double)cens, dv, limit, dll, fT, r, df, dr);
 }
 
 double likInner0(double *eta, int id) {
@@ -2787,6 +2814,13 @@ double likInner0(double *eta, int id) {
           cens = 0;
           if (hasRxCens(rx)) cens = getIndCens(ind, kk);
           if (cens != 0) anyCens = 1;
+          // Transformed structural prediction for a llik-forced endpoint's
+          // censoring correction (#992).  rx_pred_ is the scalar log-density
+          // there, so the location has to come from the appended rx_pred_f_
+          // column -- which is the RAW prediction, hence the tbs() to put it on
+          // the same scale as dv/limit above.
+          double fCensT = 0.0;
+          if (op_focei.predFOffset >= 0) fCensT = tbs(lhs[op_focei.predFOffset]);
           tbsJac = tbsL(dv0);
           fInd->tbsLik+=tbsJac;
           // fInd->err(k, 0) = lhs[0] - getIndDv(ind, k); // pred-dv
@@ -2825,7 +2859,7 @@ double likInner0(double *eta, int id) {
               fInd->llik += ll;
               fInd->nObs++;
             } else {
-              double llT = focei_tCensLl(ind, kk, dist, cens, f, lhs);
+              double llT = focei_tCensLl(dist, cens, dv, limit, f, fCensT, lhs);
               llikObs[kk] = llT;
               fInd->llik += llT;
               fInd->nNonNormal++;
@@ -2907,8 +2941,15 @@ double likInner0(double *eta, int id) {
                   double lpCur = 0.25 * err * err * B(k, 0) * c(k, i) -
                     0.5 * c(k, i) - 0.5 * err * fpm * B(k, 0);
                   lp(i, 0) += dCensNormal1((double)cens, dv, limit, lpCur, f, r, fpm, rp);
-                } else {
+                } else if (predSolve || op_focei.etaFD[i] == 1) {
+                  // finite-difference eta: no d(rx_pred_f_)/d(eta) column to
+                  // chain the censoring correction through, so this eta keeps
+                  // the uncensored d(logLik)/d(eta) (#992).
                   lp(i, 0) += fpm;
+                } else {
+                  double drCens = lhs[op_focei.predOffset + i + op_focei.neta + 2];
+                  lp(i, 0) += focei_tCensDll(dist, cens, dv, limit, fpm,
+                                             fCensT, lhs, i, drCens);
                 }
               }
               // Eq #10
@@ -2923,7 +2964,7 @@ double likInner0(double *eta, int id) {
                  fInd->llik +=  ll;
                  fInd->nObs++;
                } else {
-                 double llT = focei_tCensLl(ind, kk, dist, cens, f, lhs);
+                 double llT = focei_tCensLl(dist, cens, dv, limit, f, fCensT, lhs);
                  llikObs[kk] = llT;
                  fInd->llik += llT;
                  fInd->nNonNormal++;
@@ -2939,8 +2980,14 @@ double likInner0(double *eta, int id) {
                 if (dist == rxDistributionNorm) {
                   double lpCur = -0.5 * err * fpm * B(k, 0);
                   lp(i, 0) += dCensNormal1((double)cens, dv, limit, lpCur, f, r, fpm, rp);
-                } else {
+                } else if (predSolve || op_focei.etaFD[i] == 1) {
                   lp(i, 0) += fpm;
+                } else {
+                  // interaction=0 (FOCE): rx_r_ carries no eta sensitivities in
+                  // this model, so d(R)/d(eta)=0 -- consistent with FOCE itself
+                  // not differentiating R.
+                  lp(i, 0) += focei_tCensDll(dist, cens, dv, limit, fpm,
+                                             fCensT, lhs, i, 0.0);
                 }
               }
               // Eq #10
@@ -2952,7 +2999,7 @@ double likInner0(double *eta, int id) {
                 fInd->llik +=  ll;
                 fInd->nObs++;
               } else {
-                double llT = focei_tCensLl(ind, kk, dist, cens, f, lhs);
+                double llT = focei_tCensLl(dist, cens, dv, limit, f, fCensT, lhs);
                 llikObs[kk] = llT;
                 fInd->llik += llT;
                 fInd->nNonNormal++;
@@ -6315,17 +6362,27 @@ static inline void foceiSetupTheta_(List mvi,
     op_focei.predOffset = (_ipi < 0) ? 0 : _ipi;
     op_focei.predFOffset = odeSwapLhsIndex(odeSlotInner, "rx_pred_f_");
     op_focei.predROffset = odeSwapLhsIndex(odeSlotInner, "rx_r_");
-    // predNuOffset is currently ALWAYS -1 for FOCEi/FOCE/AGQ/Laplace: the R
-    // side (.fixCensRNuLine, R/focei.R) only emits rx_nu_ for nlm-family
-    // (nlmixr2global$rxCensNuFix), because doing so for FOCEi's llik-forced
-    // t()/cauchy() endpoint crashes rxode2's eta-sensitivity generation once
-    // real etas are present ("user function 'get' requires 5 arguments";
-    // reproduces with plain cauchy(), no censoring at all).  focei_tCensLl()
-    // below is written and validated against a real fit already (nlm-family
-    // uses the identical doCensT1 path), so this is deliberately-inert,
-    // ready infrastructure -- KNOWN GAP pending a fix to that rxode2-side
-    // interaction, not a TODO in this file (#979).
+    // rx_nu_ only exists for a llik-forced t()/cauchy() endpoint whose R-side
+    // censoring inputs were emitted (.fixCensRNuLine, R/focei.R); -1 otherwise,
+    // which leaves focei_tCensLl() inert (#992).
     op_focei.predNuOffset = odeSwapLhsIndex(odeSlotInner, "rx_nu_");
+    // d(rx_pred_f_)/d(eta) block for the censored eta-gradient.  Arm it only
+    // when the whole block is where contiguity says it is; the columns are
+    // appended after the FOCEi eta block by .rxFinalizeInner() in eta order,
+    // but a model built some other way must disarm rather than misread.
+    op_focei.predFEtaOffset = -1;
+    if (op_focei.neta > 0) {
+      int _ife = odeSwapLhsIndex(odeSlotInner, "rx__sens_rx_pred_f__BY_ETA_1___");
+      if (_ife >= 0) {
+        char _nm[64];
+        snprintf(_nm, sizeof(_nm), "rx__sens_rx_pred_f__BY_ETA_%d___",
+                 (int)op_focei.neta);
+        int _ifeLast = odeSwapLhsIndex(odeSlotInner, _nm);
+        if (_ifeLast == _ife + (int)op_focei.neta - 1) {
+          op_focei.predFEtaOffset = _ife;
+        }
+      }
+    }
     // The exact-Hessian rx__d2pred_ columns live in the SEPARATE 2nd-order model (rxHess2),
     // located in foceiFitCpp_ after this setup; predHess2Offset is set there, not here.
   } else if (!op_focei.alloc){

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -69,7 +69,8 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   c("focei-wang2007-lognormal", "cov-analytic", "focei-wang2007-power",
     "cov-condition", "agq-cov", "cov-decouple-saimp"),
   # batch 3
-  c("focei-wang2007-boxcox-half", "nlm-cens", "issue-429", "issue-470",
+  c("focei-wang2007-boxcox-half", "nlm-cens", "focei-cens-t-fit",
+    "issue-429", "issue-470",
     "focei-wang2007-bounded", "saem-loglik", "mu-timevarying", "saem-nearpd",
     "saem-nonmutheta", "focei-theta-reset-bounds",
     "saem-cov-analytic", "focei-shi21-bounds", "splitbolus-interp",

--- a/tests/testthat/test-cens-dist-warn.R
+++ b/tests/testthat/test-cens-dist-warn.R
@@ -54,14 +54,24 @@ nmTest({
                           fixed = TRUE)))
   })
 
-  test_that("t() + CENS warns on focei (not yet supported there) but not on nlm", {
+  test_that("t() + CENS does not warn on nlm or focei (#979, #992)", {
+    # both kernels apply doCensT1() now -- src/nlm.cpp for the population-only
+    # family, src/inner.cpp's likInner0 for the FOCEi family
     fitNlm <- suppressMessages(suppressWarnings(
       nlmixr2(one.cmt.t, .dat, est = "nlm", control = list(print = 0))))
     expect_false(any(grepl("censoring ignored", fitNlm$runInfo, fixed = TRUE)))
 
     fitFocei <- suppressMessages(suppressWarnings(
       nlmixr2(one.cmt.t, .dat, est = "focei", control = list(print = 0))))
-    expect_true(any(grepl("censoring ignored for 't'", fitFocei$runInfo,
+    expect_false(any(grepl("censoring ignored", fitFocei$runInfo, fixed = TRUE)))
+  })
+
+  test_that("pois() + CENS still warns on focei", {
+    # only norm/dnorm/t/cauchy have an M2/M3/M4 correction; a generalized
+    # endpoint on any kernel still scores a censored row uncensored
+    fit <- suppressMessages(suppressWarnings(
+      nlmixr2(one.cmt.pois, .dat, est = "focei", control = list(print = 0))))
+    expect_true(any(grepl("censoring ignored for 'pois'", fit$runInfo,
                           fixed = TRUE)))
   })
 

--- a/tests/testthat/test-focei-cens-t-fit.R
+++ b/tests/testthat/test-focei-cens-t-fit.R
@@ -356,6 +356,28 @@ nmTest({
         cp ~ prop(prop.sd) + cauchy()
       })
     }
+    # a transform-both-sides endpoint: rx_pred_f_ is the RAW prediction, so its
+    # eta sensitivity only matches d(fT)/d(eta) once the transform's own
+    # Jacobian is chained on
+    .lnormM <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.2
+        eta.cl ~ 0.1
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ lnorm(add.sd) + cauchy()
+      })
+    }
     .d <- .censTheo()
     .N <- length(unique(.d$ID))
     .testSeed(11)
@@ -369,8 +391,9 @@ nmTest({
         (likInner(.ep, id) - likInner(.em, id)) / (2 * h)
       }, numeric(1))
     }
-    for (.err in c("add", "prop")) {
-      .ui <- rxode2::assertRxUi(if (.err == "add") .addM else .propM)
+    .models <- list(add = .addM, prop = .propM, lnorm = .lnormM)
+    for (.err in names(.models)) {
+      .ui <- rxode2::assertRxUi(.models[[.err]])
       for (.mode in c("m3", "m4", "m2")) {
         .dat <- .censDat(.d, .mode, limit = if (.mode == "m2") 0.25 else 0.5)
         suppressWarnings(.vaeInnerSetup(.ui, .dat, .etaMat, vaeControl()))

--- a/tests/testthat/test-focei-cens-t-fit.R
+++ b/tests/testthat/test-focei-cens-t-fit.R
@@ -16,16 +16,61 @@
 # Multiple fits per test -- weekly-batched via .slowBatches in tests/testthat.R,
 # so do NOT add skip_on_ci().
 
-nmTest({
+.censTheo <- function(n = 4L) {
+  .d <- nlmixr2data::theo_sd
+  .d[.d$ID <= n, ]
+}
+# rows censored below the LLOQ, with DV replaced by the LLOQ itself
+.censRows <- function(d, lloq = 4) {
+  which(d$EVID == 0 & d$DV < lloq & d$DV > 0)
+}
+# one dataset per censoring mode: "none", "m3" (CENS=1 at the LLOQ),
+# "m4" (M3 plus a finite LIMIT), "m2" (LIMIT only, nothing censored)
+.censDat <- function(d, mode, lloq = 4, limit = 0.5) {
+  .lo <- .censRows(d, lloq)
+  d$CENS <- 0L
+  d$LIMIT <- NA_real_
+  if (mode %in% c("m3", "m4")) {
+    d$CENS[.lo] <- 1L
+    d$DV[.lo] <- lloq
+  }
+  if (mode == "m4") d$LIMIT[.lo] <- limit
+  if (mode == "m2") d$LIMIT[d$EVID == 0] <- limit
+  d
+}
+# the same rows, as plain covariate columns for the hand-written ll() model
+.manDat <- function(d, mode, lloq = 4, limit = 0.5) {
+  .lo <- .censRows(d, lloq)
+  d$CENSF <- 0
+  d$LOQ <- lloq
+  d$LIM <- limit
+  if (mode %in% c("m3", "m4")) {
+    d$CENSF[.lo] <- 1
+    d$DV[.lo] <- lloq
+  }
+  d
+}
 
-  .theo <- function(n = 4L) {
-    .d <- nlmixr2data::theo_sd
-    .d[.d$ID <= n, ]
+# censored Student-t log-likelihood, straight out of Beal (2001) -- the R
+# counterpart of censEst.h's doCensT1()
+.refLl <- function(dv, cens, lim, f, sd, nu) {
+  .z <- function(x) (x - f) / sd
+  if (cens != 0) {
+    if (is.finite(lim)) {
+      return(log(stats::pt(cens * .z(dv), nu) - stats::pt(cens * .z(lim), nu)) -
+               stats::pt(cens * .z(lim), nu, lower.tail = FALSE, log.p = TRUE))
+    }
+    return(stats::pt(cens * .z(dv), nu, log.p = TRUE))
   }
-  # rows censored below the LLOQ, with DV replaced by the LLOQ itself
-  .censRows <- function(d, lloq = 4) {
-    which(d$EVID == 0 & d$DV < lloq & d$DV > 0)
+  .ll <- stats::dt(.z(dv), nu, log = TRUE) - log(sd)
+  if (is.finite(lim)) {
+    .zz <- ifelse(lim < f, 1, -1) * (lim - f) / sd
+    .ll <- .ll - stats::pt(.zz, nu, lower.tail = FALSE, log.p = TRUE)
   }
+  .ll
+}
+
+nmTest({
 
   ## ---------------------------------------------------------------- 1. value
   .popT <- function() {
@@ -40,52 +85,27 @@ nmTest({
     })
   }
 
-  # censored Student-t log-likelihood, straight out of Beal (2001) -- the R
-  # counterpart of censEst.h's doCensT1()
-  .refLl <- function(dv, cens, lim, f, sd, nu) {
-    .z <- function(x) (x - f) / sd
-    if (cens != 0) {
-      if (is.finite(lim)) {
-        return(log(stats::pt(cens * .z(dv), nu) - stats::pt(cens * .z(lim), nu)) -
-                 stats::pt(cens * .z(lim), nu, lower.tail = FALSE, log.p = TRUE))
-      }
-      return(stats::pt(cens * .z(dv), nu, log.p = TRUE))
-    }
-    .ll <- stats::dt(.z(dv), nu, log = TRUE) - log(sd)
-    if (is.finite(lim)) {
-      .zz <- ifelse(lim < f, 1, -1) * (lim - f) / sd
-      .ll <- .ll - stats::pt(.zz, nu, lower.tail = FALSE, log.p = TRUE)
-    }
-    .ll
-  }
-
   test_that("population-only FOCEi t() censoring matches the closed form (#992)", {
     skip_on_cran(); skip_if_not_installed("nlmixr2data")
-    .d <- .theo()
+    .d <- .censTheo()
     .lo <- .censRows(.d)
-    .cases <- list(
-      none = .d,
-      m3 = local({.x <- .d; .x$CENS <- 0L; .x$CENS[.lo] <- 1L; .x$DV[.lo] <- 4; .x}),
-      m4 = local({.x <- .d; .x$CENS <- 0L; .x$CENS[.lo] <- 1L; .x$DV[.lo] <- 4
-        .x$LIMIT <- NA_real_; .x$LIMIT[.lo] <- 0.5; .x}),
-      m2 = local({.x <- .d; .x$LIMIT <- NA_real_
-        .x$LIMIT[.x$EVID == 0] <- 0.25; .x}))
-    for (.nm in names(.cases)) {
-      .dat <- .cases[[.nm]]
+    # -2*(sum ll - nObs*log(sqrt(2*pi))) IS the neta == 0 objective, with the
+    # fit's own IPRED standing in for f so no ODE tolerance enters
+    .refObjf <- function(fit, dat) {
+      .obs <- dat[dat$EVID == 0, ]
+      .f <- as.data.frame(fit)$IPRED
+      expect_equal(length(.f), nrow(.obs))
+      .ll <- vapply(seq_along(.f), function(k) {
+        .refLl(.obs$DV[k], .obs$CENS[k], .obs$LIMIT[k], .f[k], 0.7, 5)
+      }, numeric(1))
+      -2 * (sum(.ll) - length(.ll) * log(sqrt(2 * pi)))
+    }
+    for (.nm in c("none", "m3", "m4", "m2")) {
+      .dat <- .censDat(.d, .nm, limit = 0.25)
       .fit <- .nlmixr(.popT, .dat, est = "focei",
                       foceiControl(print = 0L, covMethod = "",
                                    maxOuterIterations = 0L))
-      .obs <- .dat[.dat$EVID == 0, ]
-      .f <- as.data.frame(.fit)$IPRED
-      expect_equal(length(.f), nrow(.obs))
-      .cens <- if (is.null(.obs$CENS)) rep(0L, nrow(.obs)) else .obs$CENS
-      .lim <- if (is.null(.obs$LIMIT)) rep(NA_real_, nrow(.obs)) else .obs$LIMIT
-      .ll <- vapply(seq_along(.f), function(k) {
-        .refLl(.obs$DV[k], .cens[k], .lim[k], .f[k], 0.7, 5)
-      }, numeric(1))
-      # neta == 0: objf is -2*(sum ll - nObs*log(sqrt(2*pi)))
-      .ref <- -2 * (sum(.ll) - length(.ll) * log(sqrt(2 * pi)))
-      expect_equal(as.numeric(.fit$objf), .ref, tolerance = 1e-8,
+      expect_equal(as.numeric(.fit$objf), .refObjf(.fit, .dat), tolerance = 1e-8,
                    info = paste("case", .nm))
     }
   })
@@ -146,35 +166,26 @@ nmTest({
 
   test_that("FOCEi t()/cauchy() censoring matches a hand-written ll() (#992)", {
     skip_on_cran(); skip_if_not_installed("nlmixr2data")
-    .d <- .theo()
-    .lo <- .censRows(.d)
-    .obs <- .d$EVID == 0
+    .d <- .censTheo()
     .ctl <- foceiControl(print = 0L, covMethod = "", calcTables = FALSE,
                          maxOuterIterations = 0L)
     .run <- function(m, dat) as.numeric(.nlmixr(m, dat, est = "focei", .ctl)$objf)
 
-    .autoM3 <- .d; .autoM3$CENS <- 0L; .autoM3$CENS[.lo] <- 1L; .autoM3$DV[.lo] <- 4
-    .manD <- .d; .manD$CENSF <- 0; .manD$CENSF[.lo] <- 1
-    .manD$LOQ <- 4; .manD$DV[.lo] <- 4
-    expect_equal(.run(.etaCauchy, .autoM3), .run(.manM3, .manD), tolerance = 1e-6)
-
-    .autoM4 <- .autoM3; .autoM4$LIMIT <- NA_real_; .autoM4$LIMIT[.lo] <- 0.5
-    .manD4 <- .manD; .manD4$LIM <- 0.5
-    expect_equal(.run(.etaCauchy, .autoM4), .run(.manM4, .manD4), tolerance = 1e-5)
-
-    .autoM2 <- .d; .autoM2$LIMIT <- NA_real_; .autoM2$LIMIT[.obs] <- 0.25
-    .manD2 <- .d; .manD2$LIM <- 0.25
-    expect_equal(.run(.etaCauchy, .autoM2), .run(.manM2, .manD2), tolerance = 1e-6)
+    expect_equal(.run(.etaCauchy, .censDat(.d, "m3")),
+                 .run(.manM3, .manDat(.d, "m3")), tolerance = 1e-6)
+    expect_equal(.run(.etaCauchy, .censDat(.d, "m4")),
+                 .run(.manM4, .manDat(.d, "m4")), tolerance = 1e-5)
+    expect_equal(.run(.etaCauchy, .censDat(.d, "m2", limit = 0.25)),
+                 .run(.manM2, .manDat(.d, "m2", limit = 0.25)), tolerance = 1e-6)
   })
 
   ## ------------------------------------------------ mechanism-used evidence
   test_that("FOCEi reports the censoring method it applied (#992)", {
     skip_on_cran(); skip_if_not_installed("nlmixr2data")
-    .d <- .theo(2L)
-    .lo <- .censRows(.d, 3)
+    .d <- .censTheo(2L)
     .ctl <- foceiControl(print = 0L, covMethod = "", calcTables = FALSE,
                          maxOuterIterations = 0L)
-    .m3 <- .d; .m3$CENS <- 0L; .m3$CENS[.lo] <- 1L; .m3$DV[.lo] <- 3
+    .m3 <- .censDat(.d, "m3", lloq = 3)
     .naive <- .m3; .naive$CENS <- 0L
     .fitCens <- .nlmixr(.etaCauchy, .m3, est = "focei", .ctl)
     .fitNaive <- .nlmixr(.etaCauchy, .naive, est = "focei", .ctl)
@@ -216,15 +227,11 @@ nmTest({
         ll(err) ~ CENSF * lcens + (1 - CENSF) * lunc
       })
     }
-    .d <- .theo()
-    .lo <- .censRows(.d)
+    .d <- .censTheo()
     .ctl <- foceiControl(print = 0L, covMethod = "", calcTables = FALSE,
                          maxOuterIterations = 0L)
-    .auto <- .d; .auto$CENS <- 0L; .auto$CENS[.lo] <- 1L; .auto$DV[.lo] <- 4
-    .man <- .d; .man$CENSF <- 0; .man$CENSF[.lo] <- 1
-    .man$LOQ <- 4; .man$DV[.lo] <- 4
-    expect_equal(as.numeric(.nlmixr(.dn, .auto, est = "focei", .ctl)$objf),
-                 as.numeric(.nlmixr(.manDn, .man, est = "focei", .ctl)$objf),
+    expect_equal(as.numeric(.nlmixr(.dn, .censDat(.d, "m3"), est = "focei", .ctl)$objf),
+                 as.numeric(.nlmixr(.manDn, .manDat(.d, "m3"), est = "focei", .ctl)$objf),
                  tolerance = 1e-6)
   })
   ## ------------------------------------------------------- 3. eta gradient
@@ -246,32 +253,23 @@ nmTest({
       })
     }
     .ui <- rxode2::assertRxUi(.m)
-    .d <- .theo()
-    .lo <- .censRows(.d)
+    .d <- .censTheo()
     .N <- length(unique(.d$ID))
     .testSeed(11)
     .etaMat <- matrix(stats::rnorm(.N * 2, 0, 0.1), .N, 2)
+    .fdLp <- function(eta, id, h = 1e-5) {
+      vapply(seq_along(eta), function(j) {
+        .ep <- eta; .ep[j] <- .ep[j] + h
+        .em <- eta; .em[j] <- .em[j] - h
+        (likInner(.ep, id) - likInner(.em, id)) / (2 * h)
+      }, numeric(1))
+    }
     for (.mode in c("m3", "m4", "m2")) {
-      .dat <- .d
-      .dat$CENS <- 0L
-      .dat$LIMIT <- NA_real_
-      if (.mode %in% c("m3", "m4")) {
-        .dat$CENS[.lo] <- 1L
-        .dat$DV[.lo] <- 4
-      }
-      if (.mode == "m4") .dat$LIMIT[.lo] <- 0.5
-      if (.mode == "m2") .dat$LIMIT[.dat$EVID == 0] <- 0.25
+      .dat <- .censDat(.d, .mode, limit = if (.mode == "m2") 0.25 else 0.5)
       suppressWarnings(.vaeInnerSetup(.ui, .dat, .etaMat, vaeControl()))
-      .h <- 1e-5
       for (.id in seq_len(.N)) {
-        .e0 <- .etaMat[.id, ]
-        .g <- foceiInnerLp(.e0, .id)
-        .gfd <- vapply(seq_along(.e0), function(j) {
-          .ep <- .e0; .ep[j] <- .ep[j] + .h
-          .em <- .e0; .em[j] <- .em[j] - .h
-          (likInner(.ep, .id) - likInner(.em, .id)) / (2 * .h)
-        }, numeric(1))
-        expect_equal(as.numeric(.g), .gfd, tolerance = 1e-3,
+        expect_equal(as.numeric(foceiInnerLp(.etaMat[.id, ], .id)),
+                     .fdLp(.etaMat[.id, ], .id), tolerance = 1e-3,
                      info = paste(.mode, "id", .id))
       }
       .vaeInnerFree()

--- a/tests/testthat/test-focei-cens-t-fit.R
+++ b/tests/testthat/test-focei-cens-t-fit.R
@@ -74,10 +74,17 @@ nmTest({
 
   ## ---------------------------------------------------------------- 1. value
   .popT <- function() {
-    ini({tka <- fix(0.45); tcl <- fix(1); tv <- fix(3.45); add.sd <- 0.7
-      nu <- fix(5)})
+    ini({
+      tka <- fix(0.45)
+      tcl <- fix(1)
+      tv <- fix(3.45)
+      add.sd <- 0.7
+      nu <- fix(5)
+    })
     model({
-      ka <- exp(tka); cl <- exp(tcl); v <- exp(tv)
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      v <- exp(tv)
       d/dt(depot) <- -ka * depot
       d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
@@ -86,7 +93,8 @@ nmTest({
   }
 
   test_that("population-only FOCEi t() censoring matches the closed form (#992)", {
-    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
     .d <- .censTheo()
     .lo <- .censRows(.d)
     # -2*(sum ll - nObs*log(sqrt(2*pi))) IS the neta == 0 objective, with the
@@ -112,9 +120,17 @@ nmTest({
 
   ## ------------------------------------------------- 2. value, with etas
   .etaCauchy <- function() {
-    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- c(0, 0.7)
+      eta.ka ~ 0.2
+    })
     model({
-      ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
       d/dt(depot) <- -ka * depot
       d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
@@ -124,26 +140,44 @@ nmTest({
   # pcauchy(q, loc, scale) = 0.5 + atan((q-loc)/scale)/pi -- so the censored
   # cauchy likelihood is writable as a plain general ll() endpoint
   .manM3 <- function() {
-    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- c(0, 0.7)
+      eta.ka ~ 0.2
+    })
     model({
-      ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
       d/dt(depot) <- -ka * depot
       d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
-      sdv <- abs(add.sd); zz <- (DV - cp) / sdv
+      sdv <- abs(add.sd)
+      zz <- (DV - cp) / sdv
       lcens <- log(0.5 + atan((LOQ - cp) / sdv) / pi)
       lunc <- -log(pi * sdv) - log(1 + zz * zz)
       ll(err) ~ CENSF * lcens + (1 - CENSF) * lunc
     })
   }
   .manM4 <- function() {
-    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- c(0, 0.7)
+      eta.ka ~ 0.2
+    })
     model({
-      ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
       d/dt(depot) <- -ka * depot
       d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
-      sdv <- abs(add.sd); zz <- (DV - cp) / sdv
+      sdv <- abs(add.sd)
+      zz <- (DV - cp) / sdv
       pHi <- 0.5 + atan((LOQ - cp) / sdv) / pi
       pLo <- 0.5 + atan((LIM - cp) / sdv) / pi
       lcens <- log(pHi - pLo) - log(1 - pLo)
@@ -152,20 +186,30 @@ nmTest({
     })
   }
   .manM2 <- function() {
-    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- c(0, 0.7)
+      eta.ka ~ 0.2
+    })
     model({
-      ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
       d/dt(depot) <- -ka * depot
       d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
-      sdv <- abs(add.sd); zz <- (DV - cp) / sdv
+      sdv <- abs(add.sd)
+      zz <- (DV - cp) / sdv
       zl <- (2 * (LIM < cp) - 1) * (LIM - cp) / sdv
       ll(err) ~ -log(pi * sdv) - log(1 + zz * zz) - log(0.5 - atan(zl) / pi)
     })
   }
 
   test_that("FOCEi t()/cauchy() censoring matches a hand-written ll() (#992)", {
-    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
     .d <- .censTheo()
     .ctl <- foceiControl(print = 0L, covMethod = "", calcTables = FALSE,
                          maxOuterIterations = 0L)
@@ -190,12 +234,14 @@ nmTest({
 
   ## ------------------------------------------------ mechanism-used evidence
   test_that("FOCEi reports the censoring method it applied (#992)", {
-    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
     .d <- .censTheo(2L)
     .ctl <- foceiControl(print = 0L, covMethod = "", calcTables = FALSE,
                          maxOuterIterations = 0L)
     .m3 <- .censDat(.d, "m3", lloq = 3)
-    .naive <- .m3; .naive$CENS <- 0L
+    .naive <- .m3
+    .naive$CENS <- 0L
     .fitCens <- .nlmixr(.etaCauchy, .m3, est = "focei", .ctl)
     .fitNaive <- .nlmixr(.etaCauchy, .naive, est = "focei", .ctl)
     # the FOCEi family appends the inner-Hessian censoring treatment
@@ -209,14 +255,23 @@ nmTest({
   })
 
   test_that("a llik-forced dnorm() endpoint honors censoring too (#992)", {
-    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
     # dnorm() takes the same llik-forced path as t()/cauchy() (rx_pred_ is the
     # log-density), so it needs the same rx_pred_f_/rx_r_ columns -- routed
     # through doCensNormal1() rather than doCensT1().
     .dn <- function() {
-      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.2
+      })
       model({
-        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
         d/dt(depot) <- -ka * depot
         d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
@@ -224,13 +279,22 @@ nmTest({
       })
     }
     .manDn <- function() {
-      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.2
+      })
       model({
-        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
         d/dt(depot) <- -ka * depot
         d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
-        sdv <- abs(add.sd); zz <- (DV - cp) / sdv
+        sdv <- abs(add.sd)
+        zz <- (DV - cp) / sdv
         lcens <- log(pnorm((LOQ - cp) / sdv))
         lunc <- -0.5 * log(2 * pi) - log(sdv) - 0.5 * zz * zz
         ll(err) ~ CENSF * lcens + (1 - CENSF) * lunc
@@ -249,12 +313,21 @@ nmTest({
   # this before a fit-based test would leak M2/M3/M4 into that fit's
   # $censInformation.
   test_that("the censored inner eta-gradient matches central differences (#992)", {
-    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
     .addM <- function() {
-      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7)
-        eta.ka ~ 0.2; eta.cl ~ 0.1})
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.2
+        eta.cl ~ 0.1
+      })
       model({
-        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv)
         d/dt(depot) <- -ka * depot
         d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
@@ -265,10 +338,18 @@ nmTest({
     # with central differences if d(R)/d(eta) reaches dCensT1 -- FOCE's inner
     # model has no such column in the FOCEi position, so it is appended
     .propM <- function() {
-      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; prop.sd <- c(0, 0.3)
-        eta.ka ~ 0.2; eta.cl ~ 0.1})
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        prop.sd <- c(0, 0.3)
+        eta.ka ~ 0.2
+        eta.cl ~ 0.1
+      })
       model({
-        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv)
         d/dt(depot) <- -ka * depot
         d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
@@ -281,8 +362,10 @@ nmTest({
     .etaMat <- matrix(stats::rnorm(.N * 2, 0, 0.1), .N, 2)
     .fdLp <- function(eta, id, h = 1e-5) {
       vapply(seq_along(eta), function(j) {
-        .ep <- eta; .ep[j] <- .ep[j] + h
-        .em <- eta; .em[j] <- .em[j] - h
+        .ep <- eta
+        .ep[j] <- .ep[j] + h
+        .em <- eta
+        .em[j] <- .em[j] - h
         (likInner(.ep, id) - likInner(.em, id)) / (2 * h)
       }, numeric(1))
     }

--- a/tests/testthat/test-focei-cens-t-fit.R
+++ b/tests/testthat/test-focei-cens-t-fit.R
@@ -1,0 +1,281 @@
+# End-to-end numeric validation of M2/M3/M4 censoring for a llik-forced
+# t()/cauchy()/dnorm() endpoint under FOCEi (#992).  Three independent
+# references, because a self-consistent-but-wrong wiring (reading the wrong
+# lhs column, say) would satisfy any one of them alone:
+#
+#  1. population-only (neta == 0): objf is exactly -2*(sum ll - nobs*log(sqrt(2pi))),
+#     so it is compared against the censored t() log-likelihood recomputed in R
+#     from the fit's own IPRED.
+#  2. with etas: the same censored likelihood written out by hand as a general
+#     ll() endpoint (pcauchy via atan) must give the SAME objective -- both go
+#     through the identical FOCEi log-likelihood machinery, so log|H| and the
+#     adjLik bookkeeping cancel exactly.
+#  3. the analytic inner eta-gradient must match central differences of the
+#     inner objective (focei_tCensDll vs focei_tCensLl).
+#
+# Multiple fits per test -- weekly-batched via .slowBatches in tests/testthat.R,
+# so do NOT add skip_on_ci().
+
+nmTest({
+
+  .theo <- function(n = 4L) {
+    .d <- nlmixr2data::theo_sd
+    .d[.d$ID <= n, ]
+  }
+  # rows censored below the LLOQ, with DV replaced by the LLOQ itself
+  .censRows <- function(d, lloq = 4) {
+    which(d$EVID == 0 & d$DV < lloq & d$DV > 0)
+  }
+
+  ## ---------------------------------------------------------------- 1. value
+  .popT <- function() {
+    ini({tka <- fix(0.45); tcl <- fix(1); tv <- fix(3.45); add.sd <- 0.7
+      nu <- fix(5)})
+    model({
+      ka <- exp(tka); cl <- exp(tcl); v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd) + t(nu)
+    })
+  }
+
+  # censored Student-t log-likelihood, straight out of Beal (2001) -- the R
+  # counterpart of censEst.h's doCensT1()
+  .refLl <- function(dv, cens, lim, f, sd, nu) {
+    .z <- function(x) (x - f) / sd
+    if (cens != 0) {
+      if (is.finite(lim)) {
+        return(log(stats::pt(cens * .z(dv), nu) - stats::pt(cens * .z(lim), nu)) -
+                 stats::pt(cens * .z(lim), nu, lower.tail = FALSE, log.p = TRUE))
+      }
+      return(stats::pt(cens * .z(dv), nu, log.p = TRUE))
+    }
+    .ll <- stats::dt(.z(dv), nu, log = TRUE) - log(sd)
+    if (is.finite(lim)) {
+      .zz <- ifelse(lim < f, 1, -1) * (lim - f) / sd
+      .ll <- .ll - stats::pt(.zz, nu, lower.tail = FALSE, log.p = TRUE)
+    }
+    .ll
+  }
+
+  test_that("population-only FOCEi t() censoring matches the closed form (#992)", {
+    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    .d <- .theo()
+    .lo <- .censRows(.d)
+    .cases <- list(
+      none = .d,
+      m3 = local({.x <- .d; .x$CENS <- 0L; .x$CENS[.lo] <- 1L; .x$DV[.lo] <- 4; .x}),
+      m4 = local({.x <- .d; .x$CENS <- 0L; .x$CENS[.lo] <- 1L; .x$DV[.lo] <- 4
+        .x$LIMIT <- NA_real_; .x$LIMIT[.lo] <- 0.5; .x}),
+      m2 = local({.x <- .d; .x$LIMIT <- NA_real_
+        .x$LIMIT[.x$EVID == 0] <- 0.25; .x}))
+    for (.nm in names(.cases)) {
+      .dat <- .cases[[.nm]]
+      .fit <- .nlmixr(.popT, .dat, est = "focei",
+                      foceiControl(print = 0L, covMethod = "",
+                                   maxOuterIterations = 0L))
+      .obs <- .dat[.dat$EVID == 0, ]
+      .f <- as.data.frame(.fit)$IPRED
+      expect_equal(length(.f), nrow(.obs))
+      .cens <- if (is.null(.obs$CENS)) rep(0L, nrow(.obs)) else .obs$CENS
+      .lim <- if (is.null(.obs$LIMIT)) rep(NA_real_, nrow(.obs)) else .obs$LIMIT
+      .ll <- vapply(seq_along(.f), function(k) {
+        .refLl(.obs$DV[k], .cens[k], .lim[k], .f[k], 0.7, 5)
+      }, numeric(1))
+      # neta == 0: objf is -2*(sum ll - nObs*log(sqrt(2*pi)))
+      .ref <- -2 * (sum(.ll) - length(.ll) * log(sqrt(2 * pi)))
+      expect_equal(as.numeric(.fit$objf), .ref, tolerance = 1e-8,
+                   info = paste("case", .nm))
+    }
+  })
+
+  ## ------------------------------------------------- 2. value, with etas
+  .etaCauchy <- function() {
+    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+    model({
+      ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd) + cauchy()
+    })
+  }
+  # pcauchy(q, loc, scale) = 0.5 + atan((q-loc)/scale)/pi -- so the censored
+  # cauchy likelihood is writable as a plain general ll() endpoint
+  .manM3 <- function() {
+    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+    model({
+      ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      sdv <- abs(add.sd); zz <- (DV - cp) / sdv
+      lcens <- log(0.5 + atan((LOQ - cp) / sdv) / pi)
+      lunc <- -log(pi * sdv) - log(1 + zz * zz)
+      ll(err) ~ CENSF * lcens + (1 - CENSF) * lunc
+    })
+  }
+  .manM4 <- function() {
+    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+    model({
+      ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      sdv <- abs(add.sd); zz <- (DV - cp) / sdv
+      pHi <- 0.5 + atan((LOQ - cp) / sdv) / pi
+      pLo <- 0.5 + atan((LIM - cp) / sdv) / pi
+      lcens <- log(pHi - pLo) - log(1 - pLo)
+      lunc <- -log(pi * sdv) - log(1 + zz * zz)
+      ll(err) ~ CENSF * lcens + (1 - CENSF) * lunc
+    })
+  }
+  .manM2 <- function() {
+    ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+    model({
+      ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      sdv <- abs(add.sd); zz <- (DV - cp) / sdv
+      zl <- (2 * (LIM < cp) - 1) * (LIM - cp) / sdv
+      ll(err) ~ -log(pi * sdv) - log(1 + zz * zz) - log(0.5 - atan(zl) / pi)
+    })
+  }
+
+  test_that("FOCEi t()/cauchy() censoring matches a hand-written ll() (#992)", {
+    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    .d <- .theo()
+    .lo <- .censRows(.d)
+    .obs <- .d$EVID == 0
+    .ctl <- foceiControl(print = 0L, covMethod = "", calcTables = FALSE,
+                         maxOuterIterations = 0L)
+    .run <- function(m, dat) as.numeric(.nlmixr(m, dat, est = "focei", .ctl)$objf)
+
+    .autoM3 <- .d; .autoM3$CENS <- 0L; .autoM3$CENS[.lo] <- 1L; .autoM3$DV[.lo] <- 4
+    .manD <- .d; .manD$CENSF <- 0; .manD$CENSF[.lo] <- 1
+    .manD$LOQ <- 4; .manD$DV[.lo] <- 4
+    expect_equal(.run(.etaCauchy, .autoM3), .run(.manM3, .manD), tolerance = 1e-6)
+
+    .autoM4 <- .autoM3; .autoM4$LIMIT <- NA_real_; .autoM4$LIMIT[.lo] <- 0.5
+    .manD4 <- .manD; .manD4$LIM <- 0.5
+    expect_equal(.run(.etaCauchy, .autoM4), .run(.manM4, .manD4), tolerance = 1e-5)
+
+    .autoM2 <- .d; .autoM2$LIMIT <- NA_real_; .autoM2$LIMIT[.obs] <- 0.25
+    .manD2 <- .d; .manD2$LIM <- 0.25
+    expect_equal(.run(.etaCauchy, .autoM2), .run(.manM2, .manD2), tolerance = 1e-6)
+  })
+
+  ## ------------------------------------------------ mechanism-used evidence
+  test_that("FOCEi reports the censoring method it applied (#992)", {
+    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    .d <- .theo(2L)
+    .lo <- .censRows(.d, 3)
+    .ctl <- foceiControl(print = 0L, covMethod = "", calcTables = FALSE,
+                         maxOuterIterations = 0L)
+    .m3 <- .d; .m3$CENS <- 0L; .m3$CENS[.lo] <- 1L; .m3$DV[.lo] <- 3
+    .naive <- .m3; .naive$CENS <- 0L
+    .fitCens <- .nlmixr(.etaCauchy, .m3, est = "focei", .ctl)
+    .fitNaive <- .nlmixr(.etaCauchy, .naive, est = "focei", .ctl)
+    # the FOCEi family appends the inner-Hessian censoring treatment
+    expect_equal(as.character(.fitCens$censInformation), "M3 censoring (gauss)")
+    expect_equal(as.character(.fitNaive$censInformation), "No censoring")
+    # the correction has to MOVE the objective; that it ran is not enough
+    expect_true(abs(.fitCens$objf - .fitNaive$objf) > 1e-6)
+    # ...and it must no longer warn that censoring was ignored
+    expect_no_warning(suppressMessages(
+      nlmixr2(.etaCauchy, .m3, est = "focei", .ctl)))
+  })
+
+  test_that("a llik-forced dnorm() endpoint honors censoring too (#992)", {
+    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    # dnorm() takes the same llik-forced path as t()/cauchy() (rx_pred_ is the
+    # log-density), so it needs the same rx_pred_f_/rx_r_ columns -- routed
+    # through doCensNormal1() rather than doCensT1().
+    .dn <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd) + dnorm()
+      })
+    }
+    .manDn <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        sdv <- abs(add.sd); zz <- (DV - cp) / sdv
+        lcens <- log(pnorm((LOQ - cp) / sdv))
+        lunc <- -0.5 * log(2 * pi) - log(sdv) - 0.5 * zz * zz
+        ll(err) ~ CENSF * lcens + (1 - CENSF) * lunc
+      })
+    }
+    .d <- .theo()
+    .lo <- .censRows(.d)
+    .ctl <- foceiControl(print = 0L, covMethod = "", calcTables = FALSE,
+                         maxOuterIterations = 0L)
+    .auto <- .d; .auto$CENS <- 0L; .auto$CENS[.lo] <- 1L; .auto$DV[.lo] <- 4
+    .man <- .d; .man$CENSF <- 0; .man$CENSF[.lo] <- 1
+    .man$LOQ <- 4; .man$DV[.lo] <- 4
+    expect_equal(as.numeric(.nlmixr(.dn, .auto, est = "focei", .ctl)$objf),
+                 as.numeric(.nlmixr(.manDn, .man, est = "focei", .ctl)$objf),
+                 tolerance = 1e-6)
+  })
+  ## ------------------------------------------------------- 3. eta gradient
+  # LAST in the file on purpose: .vaeInnerSetup()'s direct likInner() calls set
+  # censEst.h's globalCensFlag, which only a completed FIT resets -- running
+  # this before a fit-based test would leak M2/M3/M4 into that fit's
+  # $censInformation.
+  test_that("the censored inner eta-gradient matches central differences (#992)", {
+    skip_on_cran(); skip_if_not_installed("nlmixr2data")
+    .m <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7)
+        eta.ka ~ 0.2; eta.cl ~ 0.1})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd) + cauchy()
+      })
+    }
+    .ui <- rxode2::assertRxUi(.m)
+    .d <- .theo()
+    .lo <- .censRows(.d)
+    .N <- length(unique(.d$ID))
+    .testSeed(11)
+    .etaMat <- matrix(stats::rnorm(.N * 2, 0, 0.1), .N, 2)
+    for (.mode in c("m3", "m4", "m2")) {
+      .dat <- .d
+      .dat$CENS <- 0L
+      .dat$LIMIT <- NA_real_
+      if (.mode %in% c("m3", "m4")) {
+        .dat$CENS[.lo] <- 1L
+        .dat$DV[.lo] <- 4
+      }
+      if (.mode == "m4") .dat$LIMIT[.lo] <- 0.5
+      if (.mode == "m2") .dat$LIMIT[.dat$EVID == 0] <- 0.25
+      suppressWarnings(.vaeInnerSetup(.ui, .dat, .etaMat, vaeControl()))
+      .h <- 1e-5
+      for (.id in seq_len(.N)) {
+        .e0 <- .etaMat[.id, ]
+        .g <- foceiInnerLp(.e0, .id)
+        .gfd <- vapply(seq_along(.e0), function(j) {
+          .ep <- .e0; .ep[j] <- .ep[j] + .h
+          .em <- .e0; .em[j] <- .em[j] - .h
+          (likInner(.ep, .id) - likInner(.em, .id)) / (2 * .h)
+        }, numeric(1))
+        expect_equal(as.numeric(.g), .gfd, tolerance = 1e-3,
+                     info = paste(.mode, "id", .id))
+      }
+      .vaeInnerFree()
+    }
+  })
+
+})

--- a/tests/testthat/test-focei-cens-t-fit.R
+++ b/tests/testthat/test-focei-cens-t-fit.R
@@ -241,7 +241,7 @@ nmTest({
   # $censInformation.
   test_that("the censored inner eta-gradient matches central differences (#992)", {
     skip_on_cran(); skip_if_not_installed("nlmixr2data")
-    .m <- function() {
+    .addM <- function() {
       ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7)
         eta.ka ~ 0.2; eta.cl ~ 0.1})
       model({
@@ -252,7 +252,20 @@ nmTest({
         cp ~ add(add.sd) + cauchy()
       })
     }
-    .ui <- rxode2::assertRxUi(.m)
+    # a prop() error makes R itself eta-dependent, so this one only agrees
+    # with central differences if d(R)/d(eta) reaches dCensT1 -- FOCE's inner
+    # model has no such column in the FOCEi position, so it is appended
+    .propM <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; prop.sd <- c(0, 0.3)
+        eta.ka ~ 0.2; eta.cl ~ 0.1})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ prop(prop.sd) + cauchy()
+      })
+    }
     .d <- .censTheo()
     .N <- length(unique(.d$ID))
     .testSeed(11)
@@ -264,15 +277,18 @@ nmTest({
         (likInner(.ep, id) - likInner(.em, id)) / (2 * h)
       }, numeric(1))
     }
-    for (.mode in c("m3", "m4", "m2")) {
-      .dat <- .censDat(.d, .mode, limit = if (.mode == "m2") 0.25 else 0.5)
-      suppressWarnings(.vaeInnerSetup(.ui, .dat, .etaMat, vaeControl()))
-      for (.id in seq_len(.N)) {
-        expect_equal(as.numeric(foceiInnerLp(.etaMat[.id, ], .id)),
-                     .fdLp(.etaMat[.id, ], .id), tolerance = 1e-3,
-                     info = paste(.mode, "id", .id))
+    for (.err in c("add", "prop")) {
+      .ui <- rxode2::assertRxUi(if (.err == "add") .addM else .propM)
+      for (.mode in c("m3", "m4", "m2")) {
+        .dat <- .censDat(.d, .mode, limit = if (.mode == "m2") 0.25 else 0.5)
+        suppressWarnings(.vaeInnerSetup(.ui, .dat, .etaMat, vaeControl()))
+        for (.id in seq_len(.N)) {
+          expect_equal(as.numeric(foceiInnerLp(.etaMat[.id, ], .id)),
+                       .fdLp(.etaMat[.id, ], .id), tolerance = 1e-3,
+                       info = paste(.err, .mode, "id", .id))
+        }
+        .vaeInnerFree()
       }
-      .vaeInnerFree()
     }
   })
 

--- a/tests/testthat/test-focei-cens-t-fit.R
+++ b/tests/testthat/test-focei-cens-t-fit.R
@@ -173,6 +173,15 @@ nmTest({
 
     expect_equal(.run(.etaCauchy, .censDat(.d, "m3")),
                  .run(.manM3, .manDat(.d, "m3")), tolerance = 1e-6)
+    # est="foce" reaches the same place by a different route -- it is the
+    # explicit form of the interaction=0 build .foceiFitInternal picks anyway
+    .runFoce <- function(m, dat) {
+      as.numeric(.nlmixr(m, dat, est = "foce", foceiControl(
+        print = 0L, covMethod = "", calcTables = FALSE,
+        maxOuterIterations = 0L))$objf)
+    }
+    expect_equal(.runFoce(.etaCauchy, .censDat(.d, "m3")),
+                 .runFoce(.manM3, .manDat(.d, "m3")), tolerance = 1e-6)
     expect_equal(.run(.etaCauchy, .censDat(.d, "m4")),
                  .run(.manM4, .manDat(.d, "m4")), tolerance = 1e-5)
     expect_equal(.run(.etaCauchy, .censDat(.d, "m2", limit = 0.25)),

--- a/tests/testthat/test-focei-cens-t.R
+++ b/tests/testthat/test-focei-cens-t.R
@@ -1,0 +1,156 @@
+# Model-generation side of M2/M3/M4 censoring for a llik-forced
+# t()/cauchy()/dnorm() endpoint under the FOCEi family (#992).  The
+# log-density in rx_pred_ hides the location/scale/degrees of freedom
+# censEst.h needs, so .fixCensRNuLine() restores a real rx_r_/rx_nu_ and
+# .rxFinalizeInner()/.rxFinalizePred() emit them (plus d(f)/d(eta)) as real
+# lhs.  Cheap (no fits) -- the end-to-end numeric validation lives in
+# test-focei-cens-t-fit.R.
+
+nmTest({
+
+  .withCensNuFix <- function(code) {
+    .old <- nlmixr2global$rxCensNuFix
+    .oldLlik <- nlmixr2global$rxPredLlik
+    on.exit({
+      nlmixr2global$rxCensNuFix <- .old
+      nlmixr2global$rxPredLlik <- .oldLlik
+    })
+    nlmixr2global$rxCensNuFix <- TRUE
+    nlmixr2global$rxPredLlik <- TRUE
+    force(code)
+  }
+
+  .cauchyLines <- function() {
+    list(quote(rx_yj_ ~ 122),
+         quote(rx_lambda_ ~ 1),
+         quote(rx_pred_f_ ~ cp),
+         quote(rx_pred_ ~ rx_pred_f_),
+         quote(rx_rll_ ~ sqrt((add.sd)^2)),
+         quote(rx_pred_ ~ llikCauchy(DV, rx_pred_, rx_rll_)),
+         quote(rx_r_ ~ 0))
+  }
+
+  .tLines <- function() {
+    list(quote(rx_pred_f_ ~ cp),
+         quote(rx_pred_ ~ rx_pred_f_),
+         quote(rx_rll_ ~ sqrt((add.sd)^2)),
+         quote(rx_pred_ ~ llikT(DV, nu, rx_pred_, rx_rll_)),
+         quote(rx_r_ ~ 0))
+  }
+
+  test_that(".fixCensRNuLine only fires when the censoring flag is set", {
+    .lines <- .cauchyLines()
+    .old <- nlmixr2global$rxCensNuFix
+    on.exit(nlmixr2global$rxCensNuFix <- .old)
+    nlmixr2global$rxCensNuFix <- FALSE
+    expect_identical(.fixCensRNuLine(.lines), .lines)
+  })
+
+  test_that(".fixCensRNuLine restores rx_r_ and adds rx_nu_ for cauchy()", {
+    .out <- .withCensNuFix(.fixCensRNuLine(.cauchyLines()))
+    # cauchy is Student-t with nu=1
+    expect_true(any(vapply(.out, identical, logical(1), quote(rx_nu_ ~ 1))))
+    expect_true(any(vapply(.out, identical, logical(1), quote(rx_r_ ~ rx_rll_^2))))
+    # ...and the hardcoded zero is gone
+    expect_false(any(vapply(.out, identical, logical(1), quote(rx_r_ ~ 0))))
+  })
+
+  test_that(".fixCensRNuLine picks up t()'s own degrees of freedom", {
+    .out <- .withCensNuFix(.fixCensRNuLine(.tLines()))
+    expect_true(any(vapply(.out, identical, logical(1), quote(rx_nu_ ~ nu))))
+    expect_true(any(vapply(.out, identical, logical(1), quote(rx_r_ ~ rx_rll_^2))))
+  })
+
+  test_that(".fixCensRNuLine leaves an ar() endpoint alone", {
+    # rx_rll_ is the MARGINAL sd for an AR(1) endpoint; the conditional scale
+    # handed to llikCauchy() is rx_rll_*sqrt(1-phi^2), so squaring rx_rll_ back
+    # into rx_r_ would feed the correction the wrong scale.
+    .lines <- c(.cauchyLines()[1:5],
+                list(quote(rx_arPhi_cp <- rx_arNf_cp * cor^rx_arDt_cp)),
+                .cauchyLines()[6:7])
+    expect_identical(.withCensNuFix(.fixCensRNuLine(.lines)), .lines)
+  })
+
+  test_that(".fixCensRNuLine leaves a distribution with no rx_rll_ alone", {
+    .lines <- list(quote(rx_pred_f_ ~ cp), quote(rx_pred_ ~ rx_pred_f_),
+                   quote(rx_r_ ~ 0))
+    expect_identical(.withCensNuFix(.fixCensRNuLine(.lines)), .lines)
+  })
+
+  .cauchyUi <- function() {
+    .f <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7)
+        eta.ka ~ 0.2; eta.cl ~ 0.1})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd) + cauchy()
+      })
+    }
+    rxode2::rxUiDecompress(rxode2::rxode2(.f))
+  }
+
+  .innerText <- function(censFix) {
+    .old <- nlmixr2global$rxCensNuFix
+    .oldLlik <- nlmixr2global$rxPredLlik
+    on.exit({
+      nlmixr2global$rxCensNuFix <- .old
+      nlmixr2global$rxPredLlik <- .oldLlik
+    })
+    nlmixr2global$rxCensNuFix <- censFix
+    nlmixr2global$rxPredLlik <- TRUE
+    .s <- suppressMessages(rxUiGet.foceiEnv(list(.cauchyUi(), TRUE)))
+    .s$..inner
+  }
+
+  test_that("the llik inner model exposes the censoring inputs (#992)", {
+    .on <- suppressMessages(.innerText(TRUE))
+    # the location and the degrees of freedom become real (read-back) lhs
+    expect_match(.on, "rx_pred_f_=", fixed = TRUE)
+    expect_match(.on, "rx_nu_=", fixed = TRUE)
+    # ...and so does d(f)/d(eta), which the eta-gradient correction chains through
+    expect_match(.on, "rx__sens_rx_pred_f__BY_ETA_1___=", fixed = TRUE)
+    expect_match(.on, "rx__sens_rx_pred_f__BY_ETA_2___=", fixed = TRUE)
+    # rx_r_ is no longer the hardcoded zero rxode2 emits for a llik endpoint
+    expect_false(any(strsplit(.on, "\n")[[1]] == "rx_r_=0"))
+    # they are APPENDED after the FOCEi eta block, which likInner0 reads
+    # arithmetically from predOffset -- rx_r_'s last eta column must still
+    # precede them
+    expect_lt(regexpr("rx__sens_rx_r__BY_ETA_2___=", .on, fixed = TRUE),
+              regexpr("rx_pred_f_=", .on, fixed = TRUE))
+  })
+
+  test_that("without the flag the llik inner model is unchanged (#992)", {
+    .off <- suppressMessages(.innerText(FALSE))
+    expect_true(any(strsplit(.off, "\n")[[1]] == "rx_r_=0"))
+    expect_false(grepl("rx_nu_=", .off, fixed = TRUE))
+    expect_false(grepl("rx__sens_rx_pred_f__BY_ETA_1___=", .off, fixed = TRUE))
+  })
+
+  test_that("censoring is no longer reported as ignored for focei t()/cauchy()", {
+    .f <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd) + cauchy()
+      })
+    }
+    .ui <- rxode2::rxUiDecompress(rxode2::rxode2(.f))
+    .d <- nlmixr2data::theo_sd
+    .d <- .d[.d$ID <= 2, ]
+    .d$CENS <- ifelse(.d$EVID == 0 & .d$DV < 3, 1L, 0L)
+    for (.est in c("focei", "foce", "laplace", "agq", "posthoc", "nlm")) {
+      expect_no_warning(.preProcessCensDistWarn(.ui, .est, .d, NULL))
+    }
+    # a method on a kernel that has no t()/cauchy() correction still warns
+    for (.est in c("saem", "imp", "npag")) {
+      expect_warning(.preProcessCensDistWarn(.ui, .est, .d, NULL),
+                     "censoring ignored")
+    }
+  })
+})

--- a/tests/testthat/test-focei-cens-t.R
+++ b/tests/testthat/test-focei-cens-t.R
@@ -122,6 +122,33 @@ nmTest({
               regexpr("rx_pred_f_=", .on, fixed = TRUE))
   })
 
+  test_that("the FOCE llik inner model gets its own d(R)/d(eta) block (#992)", {
+    # rxUiGet.foceEnv drops ..REta entirely (FOCE does not differentiate R), so
+    # the censored gradient's d(R)/d(eta) has to be patched back in as
+    # ..censREta -- appended at the end and found by name.  Every non-normal
+    # endpoint runs here, because .foceiFitInternal forces interaction = 0 for
+    # one, and rxUiGet.foceiModel then picks the FOCE builder.
+    .old <- nlmixr2global$rxCensNuFix
+    .oldLlik <- nlmixr2global$rxPredLlik
+    on.exit({
+      nlmixr2global$rxCensNuFix <- .old
+      nlmixr2global$rxPredLlik <- .oldLlik
+    })
+    nlmixr2global$rxCensNuFix <- TRUE
+    nlmixr2global$rxPredLlik <- TRUE
+    .s <- suppressMessages(rxUiGet.foceEnv(list(.cauchyUi(), TRUE)))
+    expect_null(.s$..REta)
+    expect_length(.s$..censREta, 2L)   # one line per eta
+    .inner <- .s$..inner
+    expect_match(.inner, "rx__sens_rx_r__BY_ETA_1___=", fixed = TRUE)
+    expect_match(.inner, "rx__sens_rx_r__BY_ETA_2___=", fixed = TRUE)
+    expect_match(.inner, "rx_pred_f_=", fixed = TRUE)
+    expect_match(.inner, "rx_nu_=", fixed = TRUE)
+    # appended AFTER rx_r_, so the FOCE column layout ahead of it is untouched
+    expect_lt(regexpr("rx_r_=", .inner, fixed = TRUE),
+              regexpr("rx__sens_rx_r__BY_ETA_1___=", .inner, fixed = TRUE))
+  })
+
   test_that("without the flag the llik inner model is unchanged (#992)", {
     .off <- suppressMessages(.innerText(FALSE))
     expect_true(any(strsplit(.off, "\n")[[1]] == "rx_r_=0"))

--- a/tests/testthat/test-focei-cens-t.R
+++ b/tests/testthat/test-focei-cens-t.R
@@ -79,10 +79,18 @@ nmTest({
 
   .cauchyUi <- function() {
     .f <- function() {
-      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7)
-        eta.ka ~ 0.2; eta.cl ~ 0.1})
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.2
+        eta.cl ~ 0.1
+      })
       model({
-        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv)
         d/dt(depot) <- -ka * depot
         d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
@@ -158,10 +166,18 @@ nmTest({
 
   .arDnormUi <- function() {
     .f <- function() {
-      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7)
-        phi <- c(0, 0.5, 1); eta.ka ~ 0.2})
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        phi <- c(0, 0.5, 1)
+        eta.ka ~ 0.2
+      })
       model({
-        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
         d/dt(depot) <- -ka * depot
         d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
@@ -204,11 +220,63 @@ nmTest({
     expect_false(identical(rxUiGet.foceiModelDigest(list(.ui, TRUE)), .d0))
   })
 
+  test_that("fast=TRUE downgrades for a CENSORED llik endpoint (#992)", {
+    # the exact 2nd-order inner Hessian (rx__d2pred_) and the augmented
+    # outer-gradient model both differentiate the UNCENSORED log-density, which
+    # doCensT1() replaces for a censored row
+    .f <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.2
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd) + cauchy()
+      })
+    }
+    .d <- nlmixr2data::theo_sd
+    .d <- .d[.d$ID <= 2, ]
+    .fastOf <- function(dat) {
+      .env <- new.env(parent = emptyenv())
+      .env$ui <- rxode2::rxUiDecompress(rxode2::rxode2(.f))
+      .env$data <- dat
+      .env$est <- "focei"
+      .env$control <- foceiControl(print = 0L, fast = TRUE)
+      # .foceiFamilyControl() writes the resolved control back onto the ui
+      suppressMessages(.foceiFamilyControl(.env))
+      isTRUE(rxode2::rxGetControl(.env$ui, "fast", FALSE))
+    }
+    expect_true(.fastOf(.d))
+    .m3 <- .d
+    .m3$CENS <- ifelse(.m3$EVID == 0 & .m3$DV < 3, 1L, 0L)
+    expect_false(.fastOf(.m3))
+    # M2 (LIMIT only, nothing flagged censored) counts too
+    .m2 <- .d
+    .m2$LIMIT <- ifelse(.m2$EVID == 0, 0.25, NA_real_)
+    expect_false(.fastOf(.m2))
+  })
+
   test_that("censoring is no longer reported as ignored for focei t()/cauchy()", {
     .f <- function() {
-      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- c(0, 0.7)
+        eta.ka ~ 0.2
+      })
       model({
-        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
         d/dt(depot) <- -ka * depot
         d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v

--- a/tests/testthat/test-focei-cens-t.R
+++ b/tests/testthat/test-focei-cens-t.R
@@ -129,6 +129,54 @@ nmTest({
     expect_false(grepl("rx__sens_rx_pred_f__BY_ETA_1___=", .off, fixed = TRUE))
   })
 
+  .arDnormUi <- function() {
+    .f <- function() {
+      ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7)
+        phi <- c(0, 0.5, 1); eta.ka ~ 0.2})
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl); v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd) + ar(phi) + dnorm()
+      })
+    }
+    rxode2::rxUiDecompress(rxode2::rxode2(.f))
+  }
+
+  test_that("an ar() endpoint keeps the censoring correction disarmed (#992)", {
+    # .fixCensRNuLine() declines an ar() endpoint (rx_rll_ is the marginal, not
+    # the conditional, scale), so rx_r_ stays rxode2's hardcoded 0.  Emitting
+    # rx_pred_f_ anyway would ARM focei_tCensLl for a dnorm() endpoint -- which
+    # has no rx_nu_ to disarm it -- and hand doCensNormal1() a zero variance.
+    .old <- nlmixr2global$rxCensNuFix
+    .oldLlik <- nlmixr2global$rxPredLlik
+    on.exit({
+      nlmixr2global$rxCensNuFix <- .old
+      nlmixr2global$rxPredLlik <- .oldLlik
+    })
+    nlmixr2global$rxCensNuFix <- TRUE
+    nlmixr2global$rxPredLlik <- TRUE
+    .s <- suppressMessages(rxUiGet.foceiEnv(list(.arDnormUi(), TRUE)))
+    expect_true(any(strsplit(.s$..inner, "\n")[[1]] == "rx_r_=0"))
+    expect_false(grepl("rx_pred_f_=", .s$..inner, fixed = TRUE))
+    expect_false(grepl("rx_nu_=", .s$..inner, fixed = TRUE))
+    # the generator itself declines on a zero rx_r_, whatever produced it
+    expect_identical(.foceiCensLlikCols(.s), character(0))
+  })
+
+  test_that("the persisted model cache keys on the package version (#992)", {
+    # the cache lives in rxode2's user cache directory, so it outlives an
+    # upgrade; a release that changes the generated model text must not be
+    # silently ignored for a model already cached there
+    .ui <- .cauchyUi()
+    .d0 <- rxUiGet.foceiModelDigest(list(.ui, TRUE))
+    testthat::local_mocked_bindings(
+      packageVersion = function(...) package_version("99.9.9"),
+      .package = "utils")
+    expect_false(identical(rxUiGet.foceiModelDigest(list(.ui, TRUE)), .d0))
+  })
+
   test_that("censoring is no longer reported as ignored for focei t()/cauchy()", {
     .f <- function() {
       ini({tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- c(0, 0.7); eta.ka ~ 0.2})


### PR DESCRIPTION
Fixes #992.

## What #992 turned out to be

The reported symptom -- `Error: user function 'get' requires 5 arguments (supplied 2)` from rxode2's eta-sensitivity generation as soon as a llik-forced `t()`/`cauchy()` endpoint got a real `rx_r_` -- **does not reproduce** against current rxode2 (5.1.7). I re-checked it across nine error/transform shapes (`add`, `prop`, `propT`, `add+prop`, `pow`, `lnorm`, `boxCox`, with `t()`, `cauchy()` and `dnorm()`), plus `linCmt()` and multi-endpoint models: every one builds and fits. That message is the signature of an `rxFromSE(<call>)` being deparsed instead of evaluated (`rxFromSE` is NSE), so it came from the experimental patch, not from anything shipped.

With the crash gone, the rest of #992's checklist is what this PR does.

## The fix

A llik-forced `t()`/`cauchy()`/`dnorm()` endpoint collapses to a scalar log-density in `rx_pred_`, which hides the location, scale and degrees of freedom `censEst.h`'s M2/M3/M4 correction needs. The inner model now carries them:

- `.fixCensRNuLine()` (already restoring `rx_r_ ~ rx_rll_^2` and adding `rx_nu_` for nlm-family) is turned on for `rxUiGet.focei`/`.foce`/`.ebe`.
- `.rxFinalizeInner()`/`.rxFinalizePred()` re-emit `rx_pred_f_`, `rx_nu_`, `d(rx_pred_f_)/d(eta)` and -- for the FOCE build, which drops `..REta` -- `d(rx_r_)/d(eta)`, **appended after** the FOCEi eta block so `likInner0`'s `predOffset + k` arithmetic is untouched. C++ resolves them by name.
- `focei_tCensLl()` (written in #990, inert until now) applies the value correction, against the **transformed** structural prediction so it lines up with the transformed `dv`/`limit` `likInner0` already computes. It also covers a llik-forced `dnorm()` endpoint via `doCensNormal1()`.
- `focei_tCensDll()` is the matching eta gradient. Without it the inner Newton would converge to the *uncensored* mode while the objective reported the censored value.
- `.preProcessCensDistWarn()` no longer claims censoring is ignored for `t()`/`cauchy()` under the FOCEi family.

`ar()` endpoints are excluded: their `rx_rll_` is the marginal sd, not the conditional scale handed to `llikT()`/`llikCauchy()`.

## Validation

Three independent references, because a self-consistent-but-wrong wiring satisfies any one of them alone:

1. **Population-only (`neta == 0`)**: `objf` is exactly `-2*(sum ll - nobs*log(sqrt(2*pi)))`, compared against the censored Student-t log-likelihood recomputed in R from the fit's own IPRED. Matches to **0** (`5.7e-14` worst case) for none/M2/M3/M4.
2. **With etas**: the same censored likelihood written out by hand as a general `ll()` endpoint (`pcauchy` via `atan`) gives the same objective -- both go through the identical FOCEi log-likelihood machinery, so `log|H|` and the adjLik bookkeeping cancel exactly. M3 agrees to `2.3e-11`, M2 to `1.1e-8`, M4 to `2.9e-6` (`logspace_sub` vs the naive difference).
3. **Gradient**: `foceiInnerLp()` matches central differences of `likInner()` for M2/M3/M4 across `add()`, `prop()` (R eta-dependent) and `lnorm()` (transform Jacobian) error models.

Uncensored fits are **bit-identical** to `main` across all nine error/transform shapes.

## Also fixed along the way (found by the antigravity review rounds)

- An `ar()` + `dnorm()` endpoint armed the correction on a zero `rx_r_` (no `rx_nu_` to disarm it), handing `doCensNormal1()` a floored variance. `.foceiCensLlikCols()` now declines on a zero `rx_r_`, and C++ bails on a non-positive `r` (a multi-endpoint model can leave `rx_r_` zero on one endpoint's rows only).
- `foceiControl(fast=TRUE)` now really does downgrade for a **censored** log-likelihood endpoint, as `?foceiControl` already said. Both the augmented outer-gradient model and the exact second-order inner Hessian differentiate the uncensored log-density; `gradPooledCoreLL` already refused such a fit at run time, but `calcEtaHessian` used the stale curvature for the Laplace determinant and the Newton step.
- The persisted FOCEi model cache (`rxUiGet.foceiModelCache()`) keys on the package version. It lives in rxode2's user cache directory once `rxCreateCache()` has been run, so it outlives an upgrade -- any release changing the generated model text (these censoring columns included) was silently ignored for a model already cached there.
- `likInner0`'s pred (finite-difference) fallback normalizes only `rx_pred_`/`rx_r_` into the inner layout, so the censoring columns are not in that buffer; the correction is gated off there and such a subject scores its censored rows uncensored, as before.

## Notes / out of scope

- `est="saem"`, the importance-sampling family and the nonparametric engines keep `t()`/`cauchy()` in the warned set -- they are built on other kernels.
- The `neta == 0` and `neta > 0` llik paths apply the `adjLik` constant with opposite signs (pre-existing; `-2(sum ll - n*c)` vs `-2(sum ll) - 2n*c`). Not touched here -- changing it would move every existing `t()`/`cauchy()`/`dnorm()` objective.

## Testing

- `tests/testthat/test-focei-cens-t.R` (essential): model-generation unit coverage -- the gate, the AR decline, the emitted columns and their placement, the FOCE `..censREta` route, the `fast` downgrade, the cache key, and the warning classification.
- `tests/testthat/test-focei-cens-t-fit.R` (weekly batch 3): the three numeric references above, `est="foce"`, `dnorm()`, and `censInformation`/objective-moved evidence.
- `test-cens-dist-warn.R` updated (it asserted the pre-#992 behavior) and given a `pois()` case so the warning path stays covered on focei.
- Regression: `test-focei-cens`, `test-nlm-cens`, `test-nlm-cens-t`, `test-cens-dist-warn`, `test-ar-est`, `test-npag-npb-cens-978`, `test-focei-ptrs`, `test-nlm-ptrs` all clean. `test-npag-general-lik` has one failure that reproduces identically on `main`.

Reviewed with antigravity (gemini-3.1-pro-high) over four rounds; every finding is either fixed above or rejected with a measurement.
