### PR TITLE
fix(rxSolve): stop re-deriving the model from a fit on every solve

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,21 @@
 
 ## Internal
 
+- `rxode2::rxSolve()` on a fit no longer re-derives the model on every call
+  (nlmixr2/rxode2#1289).  Each call used to lower the fit to an rxode2
+  simulation model *and* re-run the pre-process hooks to build `$simInfo`;
+  for an ODE model that was most of the ~0.1 s per call, and it grew process
+  memory by a couple of MB per call that neither `gc()` nor
+  `rxode2::rxUnloadAll()` gave back, so simulating from a fit in a loop
+  eventually exhausted memory.  The lowered simulation model is now cached
+  (keyed on the fitted model itself, so a piped or refit model gets its own;
+  set `options(nlmixr2.simModelCache = FALSE)` to disable), and `$simInfo` is
+  only derived when the simulation actually uses the model's uncertainty --
+  which a plain `rxSolve(fit, events)` does not.  On the issue's reprex
+  (one-compartment ODE fit of `theo_sd`) repeated `rxSolve(fit, ev)` went from
+  0.106 s and +2.0 MB per call to 0.008 s and no measurable growth; the solved
+  results are unchanged, seed for seed.
+
 - A covariate whose value is carried on the model in `rxode2::rxForcedPars()` is
   no longer required to be a column of the data.  Such a covariate is supplied
   by the model itself, so demanding it from the data rejected a well-specified

--- a/R/focei.R
+++ b/R/focei.R
@@ -17,7 +17,7 @@ use.utf <- function() {
   } else {
     l10n_info()$`UTF-8` && !is.latex()
   }
- }
+}
 
 is.latex <- function() {
   if (!("knitr" %in% loadedNamespaces())) {
@@ -45,9 +45,10 @@ is.latex <- function() {
   .ctl$iprint <- 0L
   .ctl <- .ctl[names(.ctl) %in% c("npt", "rhobeg", "rhoend", "iprint", "maxfun")]
   .ret <- minqa::uobyqa(par, fn,
-                        control = .ctl,
-                        lower = lower,
-                        upper = upper)
+    control = .ctl,
+    lower = lower,
+    upper = upper
+  )
   .ret$x <- .ret$par
   .ret$message <- .ret$msg
   .ret$convergence <- .ret$ierr
@@ -61,10 +62,10 @@ is.latex <- function() {
   .ctl$iprint <- 0L
   .ctl <- .ctl[names(.ctl) %in% c("npt", "rhobeg", "rhoend", "iprint", "maxfun")]
   .ret <- minqa::bobyqa(par, fn,
-                        control = .ctl,
-                        lower = lower,
-                        upper = upper
-                        )
+    control = .ctl,
+    lower = lower,
+    upper = upper
+  )
   .ret$x <- .ret$par
   .ret$message <- .ret$msg
   .ret$convergence <- .ret$ierr
@@ -90,7 +91,8 @@ is.latex <- function() {
   .par <- pmin(pmax(par, .lo + 1e-8 * (.hi - .lo)), .hi - 1e-8 * (.hi - .lo))
   if (.n == 1L) {
     .o <- try(stats::optimize(function(x) fn(x), lower = .lo, upper = .hi),
-              silent = TRUE)
+      silent = TRUE
+    )
     if (inherits(.o, "try-error")) {
       return(list(x = par, value = NA_real_, convergence = -42L))
     }
@@ -136,7 +138,7 @@ is.latex <- function() {
   .ret
 }
 
-.optimize <- function(par, fn, gr, lower=-Inf, upper=Inf, control=list(), ...) {
+.optimize <- function(par, fn, gr, lower = -Inf, upper = Inf, control = list(), ...) {
   # focei assumes par is the initial estimate (ignored in Brent's method)
   # fn  is the function to calculate the objective function
   # gr  is the function to calculate the gradient (ignored)
@@ -149,12 +151,12 @@ is.latex <- function() {
   f <- function(x) {
     fn(rxode2::logit(x))
   }
-  .ret <- stats::optimize(f, c(.lower, .upper), tol=control$abstol)
+  .ret <- stats::optimize(f, c(.lower, .upper), tol = control$abstol)
   f <- fn
-  .range <- rxode2::logit(.ret$minimum) + c(-4,4)*control$abstol
+  .range <- rxode2::logit(.ret$minimum) + c(-4, 4) * control$abstol
   .range[1] <- max(lower, .range[1])
   .range[2] <- min(upper, .range[2])
-  .ret <- stats::optimize(f, .range, tol=control$abstol)
+  .ret <- stats::optimize(f, .range, tol = control$abstol)
   .ret$x <- .ret$minimum
   .ret$message <- "stats::optimize for 1 dimensional optimization"
   .ret$convergence <- 0L
@@ -295,7 +297,9 @@ is.latex <- function() {
 #' @return `states` reordered source-first; unchanged when no graph is available
 #' @noRd
 .rxMatExpStateOrder <- function(states, kNames) {
-  if (length(states) < 2L) return(states)
+  if (length(states) < 2L) {
+    return(states)
+  }
   .from <- character(0)
   .to <- character(0)
   for (.k in kNames) {
@@ -305,7 +309,9 @@ is.latex <- function() {
       .to <- c(.to, .m[3L])
     }
   }
-  if (length(.from) == 0L) return(states)
+  if (length(.from) == 0L) {
+    return(states)
+  }
   .indeg <- stats::setNames(integer(length(states)), states)
   for (.t in .to) .indeg[.t] <- .indeg[.t] + 1L
   .ord <- character(0)
@@ -353,8 +359,10 @@ is.latex <- function() {
     .forceName <- base::paste0("rx__indLinForce_", .st, "__")
     if (base::exists(.forceName, envir = s, inherits = FALSE)) {
       .force <- base::get(.forceName, envir = s, inherits = FALSE)
-      .ddt[[.st]] <- base::paste0(.ddt[[.st]], "+(",
-                                  rxode2::rxFromSE(.force), ")")
+      .ddt[[.st]] <- base::paste0(
+        .ddt[[.st]], "+(",
+        rxode2::rxFromSE(.force), ")"
+      )
     }
   }
   s$..ddt <- base::paste0("d/dt(", .states, ")=", .ddt)
@@ -426,7 +434,7 @@ is.latex <- function() {
   .etas <- NULL
   if (length(.w) > 0) {
     .thetas <- lapply(.w, function(i) {
-      eval(parse(text=paste0("quote(", .iniDf$name[i], " <- THETA[", .iniDf$ntheta[i],"])")))
+      eval(parse(text = paste0("quote(", .iniDf$name[i], " <- THETA[", .iniDf$ntheta[i], "])")))
     })
     .i2 <- .iniDf[-.w, ]
   } else {
@@ -436,7 +444,7 @@ is.latex <- function() {
   if (length(.i2$name) > 0) {
     .i2 <- .i2[.i2$neta1 == .i2$neta2, ]
     .etas <- lapply(seq_along(.i2$name), function(i) {
-      eval(parse(text=paste0("quote(", .i2$name[i], " <- ETA[", .i2$neta1[i], "])")))
+      eval(parse(text = paste0("quote(", .i2$name[i], " <- ETA[", .i2$neta1[i], "])")))
     })
   }
   c(.thetas, .etas)
@@ -448,14 +456,14 @@ is.latex <- function() {
 #' @return The params eirxode2 UI
 #' @author Matthew L. Fidler
 #' @noRd
-.uiGetThetaEtaParams <- function(rxui, str=FALSE) {
+.uiGetThetaEtaParams <- function(rxui, str = FALSE) {
   .iniDf <- rxui$iniDf
   .w <- which(!is.na(.iniDf$ntheta))
   .etas <- NULL
   if (length(.w) > 0) {
     .thetas <- vapply(.w, function(i) {
-      paste0("THETA[", .iniDf$ntheta[i],"]")
-    }, character(1), USE.NAMES=FALSE)
+      paste0("THETA[", .iniDf$ntheta[i], "]")
+    }, character(1), USE.NAMES = FALSE)
     .i2 <- .iniDf[-.w, ]
   } else {
     .etas <- NULL
@@ -465,21 +473,21 @@ is.latex <- function() {
   if (length(.i2$name) > 0) {
     .i2 <- .i2[.i2$neta1 == .i2$neta2, ]
     .etas <- vapply(seq_along(.i2$name), function(i) {
-      paste0("ETA[", .i2$neta1[i],"]")
-    }, character(1), USE.NAMES=FALSE)
+      paste0("ETA[", .i2$neta1[i], "]")
+    }, character(1), USE.NAMES = FALSE)
   }
-  .str <- paste(c(.thetas, .etas, rxui$covariates), collapse=", ")
+  .str <- paste(c(.thetas, .etas, rxui$covariates), collapse = ", ")
   if (str) {
     paste0("params(", .str, ")")
   } else {
-    eval(parse(text=paste0("quote(params(", .str, "))")))
+    eval(parse(text = paste0("quote(params(", .str, "))")))
   }
 }
 
 #' @export
 rxUiGet.foceiParams <- function(x, ...) {
   .ui <- x[[1]]
-  .uiGetThetaEtaParams(.ui, str=TRUE)
+  .uiGetThetaEtaParams(.ui, str = TRUE)
 }
 attr(rxUiGet.foceiParams, "rstudio") <- "params(THETA[1], ETA[1])"
 
@@ -487,12 +495,14 @@ attr(rxUiGet.foceiParams, "rstudio") <- "params(THETA[1], ETA[1])"
 rxUiGet.foceiCmtPreModel <- function(x, ...) {
   .ui <- x[[1]]
   .state <- .rxode2stateOdeNoOutput(.ui$mv0)
-  if (length(.state) == 0) return("")
+  if (length(.state) == 0) {
+    return("")
+  }
   .mv <- .ui$mv0
   if (is.list(.mv$indLin) && length(.mv$indLin) == 4L) {
     .state <- .rxMatExpStateOrder(.state, .mv$lhs)
   }
-  paste(paste0("cmt(", .state, ")"), collapse="\n")
+  paste(paste0("cmt(", .state, ")"), collapse = "\n")
 }
 attr(rxUiGet.foceiCmtPreModel, "rstudio") <- ""
 
@@ -530,7 +540,7 @@ rxGetDistributionFoceiLines <- function(line) {
 #' @author Matthew L. Fidler
 #'
 #' @noRd
-.getRxPredLlikOption <-function() {
+.getRxPredLlikOption <- function() {
   nlmixr2global$rxPredLlik
 }
 
@@ -579,8 +589,12 @@ rxGetDistributionFoceiLines <- function(line) {
   # Set by `rxUiGet.nlmModel0` (nlm-family) and by the FOCEi/FOCE/EBE llik
   # bundle builders (`rxUiGet.focei`/`.foce`/`.ebe`); off everywhere else, so
   # simulation and the saem/nls llik lines keep the plain `rx_r_ ~ 0`.
-  if (!isTRUE(nlmixr2global$rxCensNuFix)) return(lines)
-  if (!is.list(lines)) return(lines)
+  if (!isTRUE(nlmixr2global$rxCensNuFix)) {
+    return(lines)
+  }
+  if (!is.list(lines)) {
+    return(lines)
+  }
   # AR(1) (`ar()`) endpoint: `rx_rll_` is the MARGINAL sd -- the conditional
   # scale actually handed to llikT()/llikCauchy() is `rx_rll_*sqrt(1-phi^2)`
   # (.rxArEstLlikLines, rxode2) -- so squaring rx_rll_ back into rx_r_ would
@@ -597,11 +611,13 @@ rxGetDistributionFoceiLines <- function(line) {
     is.call(.l) && identical(.l[[1]], quote(`~`)) &&
       identical(.l[[2]], quote(rx_rll_))
   }, logical(1)))
-  if (!.hasRll) return(lines)
+  if (!.hasRll) {
+    return(lines)
+  }
   .nu <- NULL
   for (.l in lines) {
     if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
-        identical(.l[[2]], quote(rx_pred_)) && is.call(.l[[3]])) {
+      identical(.l[[2]], quote(rx_pred_)) && is.call(.l[[3]])) {
       .fn <- as.character(.l[[3]][[1]])
       if (.fn == "llikT") {
         .nu <- .l[[3]][[3]]
@@ -615,8 +631,8 @@ rxGetDistributionFoceiLines <- function(line) {
   .out <- vector("list", 0)
   for (.l in lines) {
     if (is.call(.l) && identical(.l[[1]], quote(`~`)) &&
-        identical(.l[[2]], quote(rx_r_)) &&
-        identical(.l[[3]], 0)) {
+      identical(.l[[2]], quote(rx_r_)) &&
+      identical(.l[[3]], 0)) {
       # Reference the rx_rll_ VARIABLE, not its defining expression: for a
       # transformed prop()/pow() error model (propT()/powT()), that
       # expression contains the symbol rx_pred_, which is overwritten with
@@ -627,7 +643,7 @@ rxGetDistributionFoceiLines <- function(line) {
     } else {
       .out[[length(.out) + 1]] <- .l
       if (!is.null(.nu) && is.call(.l) && identical(.l[[1]], quote(`~`)) &&
-          identical(.l[[2]], quote(rx_rll_))) {
+        identical(.l[[2]], quote(rx_rll_))) {
         .out[[length(.out) + 1]] <- bquote(rx_nu_ ~ .(.nu))
       }
     }
@@ -642,8 +658,9 @@ rxGetDistributionFoceiLines.norm <- function(line) {
   .errNum <- line[[3]]
   if (rxode2hasLlik()) {
     rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
-                                                 rxPredLlik=.getRxPredLlikOption(),
-                                                 arNorm=.getRxArNormOption())
+      rxPredLlik = .getRxPredLlikOption(),
+      arNorm = .getRxArNormOption()
+    )
   } else {
     rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1)
   }
@@ -657,9 +674,11 @@ rxGetDistributionFoceiLines.t <- function(line) {
     .errNum <- line[[3]]
     .fixCensRNuLine(
       rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
-                                                   rxPredLlik=.getRxPredLlikOption()))
+        rxPredLlik = .getRxPredLlikOption()
+      )
+    )
   } else {
-    stop("t is not supported", call.=FALSE)
+    stop("t is not supported", call. = FALSE)
   }
 }
 
@@ -671,23 +690,27 @@ rxGetDistributionFoceiLines.cauchy <- function(line) {
     .errNum <- line[[3]]
     .fixCensRNuLine(
       rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
-                                                   rxPredLlik=.getRxPredLlikOption()))
+        rxPredLlik = .getRxPredLlikOption()
+      )
+    )
   } else {
-    stop("t is not supported", call.=FALSE)
+    stop("t is not supported", call. = FALSE)
   }
 }
 
 #' @export
-rxGetDistributionFoceiLines.default  <- function(line) {
+rxGetDistributionFoceiLines.default <- function(line) {
   if (rxode2hasLlik()) {
     env <- line[[1]]
     pred1 <- line[[2]]
     .errNum <- line[[3]]
     .fixCensRNuLine(
       rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
-                                                   rxPredLlik=.getRxPredLlikOption()))
+        rxPredLlik = .getRxPredLlikOption()
+      )
+    )
   } else {
-    stop("unknown distribution", call.=FALSE)
+    stop("unknown distribution", call. = FALSE)
   }
 }
 
@@ -703,14 +726,16 @@ rxGetDistributionFoceiLines.rxUi <- function(line) {
 #' @export
 rxUiGet.foceiModel0 <- function(x, ...) {
   .f <- x[[1]]
-  rxode2::rxCombineErrorLines(.f, errLines=rxGetDistributionFoceiLines(.f),
-                              prefixLines=.uiGetThetaEta(.f),
-                              paramsLine=NA, #.uiGetThetaEtaParams(.f),
-                              modelVars=TRUE,
-                              cmtLines=FALSE,
-                              dvidLine=FALSE)
+  rxode2::rxCombineErrorLines(.f,
+    errLines = rxGetDistributionFoceiLines(.f),
+    prefixLines = .uiGetThetaEta(.f),
+    paramsLine = NA, # .uiGetThetaEtaParams(.f),
+    modelVars = TRUE,
+    cmtLines = FALSE,
+    dvidLine = FALSE
+  )
 }
-#attr(rxUiGet.foceiModel0, "desc") <- "FOCEi model base"
+# attr(rxUiGet.foceiModel0, "desc") <- "FOCEi model base"
 attr(rxUiGet.foceiModel0, "rstudio") <- quote(rxModelVars({}))
 
 #' @export
@@ -718,18 +743,20 @@ rxUiGet.foceiModel0ll <- function(x, ...) {
   nlmixr2global$rxPredLlik <- TRUE
   on.exit(nlmixr2global$rxPredLlik <- FALSE)
   .f <- x[[1]]
-  rxode2::rxCombineErrorLines(.f, errLines=rxGetDistributionFoceiLines(.f),
-                              prefixLines=.uiGetThetaEta(.f),
-                              paramsLine=NA, #.uiGetThetaEtaParams(.f),
-                              modelVars=TRUE,
-                              cmtLines=FALSE,
-                              dvidLine=FALSE)
+  rxode2::rxCombineErrorLines(.f,
+    errLines = rxGetDistributionFoceiLines(.f),
+    prefixLines = .uiGetThetaEta(.f),
+    paramsLine = NA, # .uiGetThetaEtaParams(.f),
+    modelVars = TRUE,
+    cmtLines = FALSE,
+    dvidLine = FALSE
+  )
 }
 
 attr(rxUiGet.foceiModel0ll, "rstudio") <- quote(rxModelVars({}))
 
 
-.foceiPrune <- function(x, fullModel=TRUE) {
+.foceiPrune <- function(x, fullModel = TRUE) {
   .x <- x[[1]]
   .x <- .x$foceiModel0[[-1]]
   .env <- new.env(parent = emptyenv())
@@ -748,8 +775,10 @@ attr(rxUiGet.foceiModel0ll, "rstudio") <- quote(rxModelVars({}))
       .malert("pruning branches ({.code if}/{.code else}) of model...")
     }
   }
-  .ret <- rxode2::.rxPrune(.x, envir = .env,
-                           strAssign=rxode2::rxModelVars(x[[1]])$strAssign)
+  .ret <- rxode2::.rxPrune(.x,
+    envir = .env,
+    strAssign = rxode2::rxModelVars(x[[1]])$strAssign
+  )
   .mv <- rxode2::rxModelVars(.ret)
   ## Need to convert to a function
   if (rxode2::.rxIsLinCmt() == 1L) {
@@ -788,7 +817,7 @@ attr(rxUiGet.foceiModel0ll, "rstudio") <- quote(rxModelVars({}))
   }
   .ret <- rxode2::rxS(newmod, TRUE, promoteLinSens = promoteLinSens)
   if (inherits(.ret$rx_r_, "numeric")) {
-    assign("rx_r_", symengine::S(as.character(.ret$rx_r_)), envir=.ret)
+    assign("rx_r_", symengine::S(as.character(.ret$rx_r_)), envir = .ret)
   }
   .ret
 }
@@ -797,14 +826,14 @@ attr(rxUiGet.foceiModel0ll, "rstudio") <- quote(rxModelVars({}))
 rxUiGet.loadPruneSens <- function(x, ...) {
   .loadSymengine(.foceiPrune(x), promoteLinSens = TRUE)
 }
-#attr(rxUiGet.loadPruneSens, "desc") <- "load sensitivity with linCmt() promoted"
+# attr(rxUiGet.loadPruneSens, "desc") <- "load sensitivity with linCmt() promoted"
 attr(rxUiGet.loadPruneSens, "rstudio") <- emptyenv()
 
 #' @export
 rxUiGet.loadPrune <- function(x, ...) {
   .loadSymengine(.foceiPrune(x), promoteLinSens = FALSE)
 }
-#attr(rxUiGet.loadPrune, "desc") <- "load sensitivity without linCmt() promoted"
+# attr(rxUiGet.loadPrune, "desc") <- "load sensitivity without linCmt() promoted"
 attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
 
 #' Map every model theta/eta to its canonical `THETA_#_`/`ETA_#_` sensitivity token
@@ -918,7 +947,8 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
   .nat <- .map[etaVars]
   if (any(is.na(.nat))) {
     stop("cannot map matExp() sensitivity parameter(s) to a model theta/eta",
-         call. = FALSE)
+      call. = FALSE
+    )
   }
   .rawTxt <- rxode2::rxModelVars(rxui)$model["normModel"]
   .code0 <- rxode2::rxSensMatExp(model = .rawTxt, calcSens = unname(.nat))
@@ -943,15 +973,19 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
   }
   .dropFromPreLhs <- .knownLhs[vapply(.knownLhs, .isOrigRateConst, logical(1))]
   .dedupNames <- setdiff(.knownLhs, .dropFromPreLhs)
-  .specialNames <- c("rx_pred_", "rx_pred_f_", "rx_r_", "rx_yj_", "rx_lambda_",
-                     "rx_hi_", "rx_low_")
+  .specialNames <- c(
+    "rx_pred_", "rx_pred_f_", "rx_r_", "rx_yj_", "rx_lambda_",
+    "rx_hi_", "rx_low_"
+  )
   .keep <- vapply(.lines, function(.ln) {
     # cmt() declarations are kept for ALL states, including the original ones
     # (also declared via toRxParam/rxUiGet.foceiCmtPreModel): a state's
     # df()/dy() Jacobian entry only resolves against a cmt() declared inside
     # the SAME matExp() block, not one declared earlier in the model text.
     .m <- regmatches(.ln, regexec("^([A-Za-z_.][A-Za-z0-9_.]*)\\s*[=~]", .ln))[[1]]
-    if (length(.m) < 2L) return(TRUE) # matExp()/cmt()/df()/dy()/indLin() declarations
+    if (length(.m) < 2L) {
+      return(TRUE)
+    } # matExp()/cmt()/df()/dy()/indLin() declarations
     !(.m[2] %in% c(.dedupNames, .specialNames))
   }, logical(1))
   .lines <- .lines[.keep]
@@ -1017,7 +1051,7 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
 #' @noRd
 .rxDropMatExpNativeLhs <- function(lhs, s) {
   if (!isTRUE(s$..matExpNative) || length(s$..matExpNativeDropLhs) == 0L ||
-        length(lhs) == 0L) {
+    length(lhs) == 0L) {
     return(lhs)
   }
   .nm <- sub("^([^=~]+)[=~].*", "\\1", lhs)
@@ -1047,8 +1081,8 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
 #' @author Matthew L. Fidler
 #' @export
 #' @keywords internal
-.sensEtaOrTheta <- function(s, theta=FALSE, extraThetaVars=NULL, rxui=NULL,
-                            matExpForcing=TRUE) {
+.sensEtaOrTheta <- function(s, theta = FALSE, extraThetaVars = NULL, rxui = NULL,
+                            matExpForcing = TRUE) {
   .etaVars <- NULL
   if (theta && exists("..maxTheta", s)) {
     .etaVars <- paste0("THETA_", seq(1, s$..maxTheta), "_")
@@ -1068,7 +1102,7 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
   # flattening to an ordinary variational ODE via .rxInjectMatExpDdt().
   .mv <- rxode2::rxModelVars(s)
   if (is.list(.mv$indLin) && length(.mv$indLin) == 4L && !is.null(rxui) &&
-        (matExpForcing || is.null(.mv$indLin$f))) {
+    (matExpForcing || is.null(.mv$indLin$f))) {
     return(.sensMatExpNative(s, rxui, .etaVars, .stateVars))
   }
   rxode2::.rxJacobian(s, c(.stateVars, .etaVars))
@@ -1113,7 +1147,7 @@ attr(rxUiGet.loadPrune, "rstudio") <- emptyenv()
 }
 
 #' @export
-rxUiGet.foceiEtaS <- function(x, ..., theta=FALSE) {
+rxUiGet.foceiEtaS <- function(x, ..., theta = FALSE) {
   .s <- rxUiGet.loadPruneSens(x, ...)
   .extra <- NULL
   if (isTRUE(rxode2::rxGetControl(x[[1]], "combSens", FALSE))) {
@@ -1134,21 +1168,25 @@ rxUiGet.foceiEtaS <- function(x, ..., theta=FALSE) {
   # see .foceiMatExpForcingOk(): mu-referenced/IRLS and non-interaction
   # (foce) fits fall back to the ODE flatten for a forcing (indLin()) matExp
   # model, same pattern as nlm's matExpForcing=FALSE.
-  .sensEtaOrTheta(.s, extraThetaVars = .extra, rxui = x[[1]],
-                  matExpForcing = .foceiMatExpForcingOk(x[[1]]))
+  .sensEtaOrTheta(.s,
+    extraThetaVars = .extra, rxui = x[[1]],
+    matExpForcing = .foceiMatExpForcingOk(x[[1]])
+  )
 }
-#attr(rxUiGet.foceiEtaS, "desc") <- "Get symengine environment with eta sensitivities"
+# attr(rxUiGet.foceiEtaS, "desc") <- "Get symengine environment with eta sensitivities"
 attr(rxUiGet.foceiEtaS, "rstudio") <- emptyenv()
 
 
 #' @export
-rxUiGet.foceiThetaS <- function(x, ..., theta=FALSE) {
+rxUiGet.foceiThetaS <- function(x, ..., theta = FALSE) {
   .s <- rxUiGet.loadPruneSens(x, ...)
   # see rxUiGet.foceiEtaS()
-  .sensEtaOrTheta(.s, theta=TRUE, rxui = x[[1]],
-                  matExpForcing = .foceiMatExpForcingOk(x[[1]]))
+  .sensEtaOrTheta(.s,
+    theta = TRUE, rxui = x[[1]],
+    matExpForcing = .foceiMatExpForcingOk(x[[1]])
+  )
 }
-#attr(rxUiGet.foceiEtaS, "desc") <- "Get symengine environment with eta sensitivities"
+# attr(rxUiGet.foceiEtaS, "desc") <- "Get symengine environment with eta sensitivities"
 attr(rxUiGet.foceiThetaS, "rstudio") <- emptyenv()
 
 #' Add the exact AR(1) lagged-residual term to the inner d(f)/d(eta)
@@ -1169,14 +1207,18 @@ attr(rxUiGet.foceiThetaS, "rstudio") <- emptyenv()
 .rxFoceiArEtaCorrect <- function(.s, .grd) {
   .vars <- ls(envir = .s)
   .arEp <- .vars[grepl("^rx_arEp_", .vars)]
-  if (length(.arEp) != 1L || !exists("rx_pred_f_", envir = .s)) return(NULL)
+  if (length(.arEp) != 1L || !exists("rx_pred_f_", envir = .s)) {
+    return(NULL)
+  }
   # D(rx_pred_, rx_arEp_) = phi in the norm form (mean is linear in e_prev), so
   # this yields the phi expression directly (expanded over kept lag symbols).
   # assign() returns its value; eval() of the "assign(..envir=.s)" string yields
   # the Basic (get() is masked here).  Keep the temp name neutral (no trailing
   # "_", no "Dmean" substring).
-  .phiBasic <- eval(parse(text = paste0("assign(\"rxArDmpVar\", with(.s, D(rx_pred_, ",
-                                        .arEp, ")), envir=.s)")))
+  .phiBasic <- eval(parse(text = paste0(
+    "assign(\"rxArDmpVar\", with(.s, D(rx_pred_, ",
+    .arEp, ")), envir=.s)"
+  )))
   # S_n = d(rx_pred_f_)/d(eta_n) is lag()-free, so rxFromSE() it inline.
   .snNames <- character(nrow(.grd))
   .snText <- character(nrow(.grd))
@@ -1276,8 +1318,10 @@ rxUiGet.foceiHdEta <- function(x, ...) {
   # rows (and every model with no eligible pair) are byte-identical to
   # before.  See foceiLinCmtCarry.R.  (nolint: lintr resolves cross-file
   # helpers against the installed package, not this source tree)
-  .carryPairs <- .rxFoceiLinCmtCarryPairsForBuild(x, .s, .linCmtEtaVars, # nolint: object_usage_linter.
-                                                  .linCmtExtraPred)
+  .carryPairs <- .rxFoceiLinCmtCarryPairsForBuild(
+    x, .s, .linCmtEtaVars, # nolint: object_usage_linter.
+    .linCmtExtraPred
+  )
   .ret <- apply(.grd, 1, function(x) {
     .l <- x["calc"]
     .l <- eval(parse(text = .l))
@@ -1309,10 +1353,11 @@ rxUiGet.foceiHdEta <- function(x, ...) {
     rxode2::rxProgressStop()
     .progressStopped <- TRUE
     stop("none of the model predictions depend on a random effect ('ETA'); ",
-         "check that each endpoint's distribution parameter is linked to an ",
-         "eta-varying model quantity (for example 'y ~ dpois(rate)' needs ",
-         "'rate' to be a model-predicted value, not a fixed population parameter)",
-         call. = FALSE)
+      "check that each endpoint's distribution parameter is linked to an ",
+      "eta-varying model quantity (for example 'y ~ dpois(rate)' needs ",
+      "'rate' to be a model-predicted value, not a fixed population parameter)",
+      call. = FALSE
+    )
   }
   if (.any.zero) {
     warning("some of the predictions do not depend on 'ETA'", call. = FALSE)
@@ -1365,20 +1410,30 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   .neta <- .s$..maxEta
   .etaVars <- paste0("ETA_", seq_len(.neta), "_")
   .st <- rxode2::rxStateOde(.s)
-  .s2 <- rxode2::.rxSens(.s, .etaVars, .etaVars)   # 2nd-order state-sensitivity ODEs (rx__sens_<st>_BY_ETA_i__BY_ETA_j__)
+  .s2 <- rxode2::.rxSens(.s, .etaVars, .etaVars) # 2nd-order state-sensitivity ODEs (rx__sens_<st>_BY_ETA_i__BY_ETA_j__)
   .pred <- get("rx_pred_", .s)
   .Dn <- function(.e, .v) symengine::D(.e, symengine::S(.v))
   .sn1 <- function(.j, ...) symengine::S(paste0("rx__sens_", .j, "_BY_", paste(c(...), collapse = "_BY_"), "__"))
   .toRx <- function(.l) rxode2::rxFromSE(.l)
   # eta directions are always model directions, so the aug-model .g1/.g2 direction guards
   # are unconditionally true here.
-  .g1 <- function(.ex, .p) { .e <- .Dn(.ex, .p); for (.j in .st) .e <- .e + .Dn(.ex, .j) * .sn1(.j, .p); .e }
-  .g2 <- function(.ex, .p, .q) { .gq <- .g1(.ex, .q); .e <- .Dn(.gq, .p)
+  .g1 <- function(.ex, .p) {
+    .e <- .Dn(.ex, .p)
+    for (.j in .st) .e <- .e + .Dn(.ex, .j) * .sn1(.j, .p)
+    .e
+  }
+  .g2 <- function(.ex, .p, .q) {
+    .gq <- .g1(.ex, .q)
+    .e <- .Dn(.gq, .p)
     for (.k in .st) .e <- .e + .Dn(.gq, .k) * .sn1(.k, .p)
-    for (.j in .st) .e <- .e + .Dn(.ex, .j) * .sn1(.j, .p, .q); .e }
-  .lines <- character(0)                           # upper triangle i<=j (C++ mirrors H(j,i)=H(i,j))
-  for (.j in seq_len(.neta)) for (.i in seq_len(.j)) {
-    .lines <- c(.lines, paste0("rx__d2pred_", .i, "_", .j, "__=", .toRx(.g2(.pred, .etaVars[.i], .etaVars[.j]))))
+    for (.j in .st) .e <- .e + .Dn(.ex, .j) * .sn1(.j, .p, .q)
+    .e
+  }
+  .lines <- character(0) # upper triangle i<=j (C++ mirrors H(j,i)=H(i,j))
+  for (.j in seq_len(.neta)) {
+    for (.i in seq_len(.j)) {
+      .lines <- c(.lines, paste0("rx__d2pred_", .i, "_", .j, "__=", .toRx(.g2(.pred, .etaVars[.i], .etaVars[.j]))))
+    }
   }
   .s$..HdEta2 <- .lines
   .s$..sens2 <- .s2
@@ -1396,9 +1451,11 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   # linCmt() sensitivity carry (3b.3): no second-order carry exists, so a
   # model with a carry-eligible pair keeps the Shi21 finite-difference
   # inner Hessian (which differentiates the carry-corrected gradient).
-  if (!is.null(.s$..linCmtCarryPairs)) return(.s)
+  if (!is.null(.s$..linCmtCarryPairs)) {
+    return(.s)
+  }
   if (isTRUE(as.logical(rxode2::rxGetControl(x[[1]], "fast", FALSE))) &&
-        .foceiLLGradInScope(x[[1]])) {
+    .foceiLLGradInScope(x[[1]])) {
     .malert("calculate d2(f)/d(eta) for the analytic log-likelihood inner Hessian")
     # A model whose 2nd-order symengine expansion is unsupported (e.g. some linCmt() /
     # special-function forms) leaves ..HdEta2/..sens2 unset -> no innerHess2 is built and
@@ -1440,7 +1497,9 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
 #' @noRd
 #' @author Matthew L. Fidler
 .foceiCensLlikCols <- function(.s) {
-  if (!.foceiCensLlikOn(.s)) return(character(0))
+  if (!.foceiCensLlikOn(.s)) {
+    return(character(0))
+  }
   # `.fixCensRNuLine()` declines some endpoints -- an `ar()` one, whose
   # `rx_rll_` is the marginal rather than the conditional scale -- and leaves
   # rxode2's hardcoded `rx_r_ ~ 0` in place.  Emitting rx_pred_f_ anyway would
@@ -1448,7 +1507,9 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   # doCensNormal1() a zero variance for a `dnorm()` endpoint, which has no
   # rx_nu_ to disarm it.  A zero rx_r_ IS the "declined" signal, so honor it.
   .rSym <- get("rx_r_", envir = .s)
-  if (paste(.rSym) %in% c("0", "0.0", "-0")) return(character(0))
+  if (paste(.rSym) %in% c("0", "0.0", "-0")) {
+    return(character(0))
+  }
   .predF <- get("rx_pred_f_", envir = .s)
   .ret <- paste0("rx_pred_f_=", rxode2::rxFromSE(.predF))
   if (exists("rx_nu_", envir = .s)) {
@@ -1539,23 +1600,35 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
     .idxAll <- .s$..combThetaIdx
     .idxStruct <- .s$..combThetaStruct
     .combDf <- vapply(.idxAll, function(j) {
-      paste0("rx__sens_rx_pred__BY_THETA_", j, "___=",
-             .impmapChainRule(.s, "rx_pred_", j, .stV, .idxStruct))
+      paste0(
+        "rx__sens_rx_pred__BY_THETA_", j, "___=",
+        .impmapChainRule(.s, "rx_pred_", j, .stV, .idxStruct)
+      )
     }, character(1))
     .combDv <- vapply(.idxAll, function(j) {
-      paste0("rx__sens_rx_r__BY_THETA_", j, "___=",
-             .impmapChainRule(.s, "rx_r_", j, .stV, .idxStruct))
+      paste0(
+        "rx__sens_rx_r__BY_THETA_", j, "___=",
+        .impmapChainRule(.s, "rx_r_", j, .stV, .idxStruct)
+      )
     }, character(1))
     .combDl <- character(0)
     .lambdaSym <- get("rx_lambda_", envir = .s)
     if (inherits(.lambdaSym, "Basic")) {
-      .dl <- vapply(.idxAll,
-                    function(j) .impmapChainRule(.s, "rx_lambda_", j, .stV,
-                                                 .idxStruct),
-                    character(1))
+      .dl <- vapply(
+        .idxAll,
+        function(j) {
+          .impmapChainRule(
+            .s, "rx_lambda_", j, .stV,
+            .idxStruct
+          )
+        },
+        character(1)
+      )
       if (any(!(.dl %in% c("0", "0.0", "-0")))) {
-        .combDl <- paste0("rx__sens_rx_lambda__BY_THETA_", .idxAll, "___=",
-                          .dl)
+        .combDl <- paste0(
+          "rx__sens_rx_lambda__BY_THETA_", .idxAll, "___=",
+          .dl
+        )
       }
     }
     .combTheta <- c(.combDf, .combDv, .combDl)
@@ -1643,10 +1716,11 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
     .r,
     .s$..REta,
     .adjLhs,
-    paste0("rx__ETA", seq_len(.s$..maxEta), "=ETA[",seq_len(.s$..maxEta), "]"),
+    paste0("rx__ETA", seq_len(.s$..maxEta), "=ETA[", seq_len(.s$..maxEta), "]"),
     .s$..stateInfo["statef"],
     .s$..stateInfo["dvid"],
-    ""))
+    ""
+  ))
   if (sum.prod) {
     .malert("stabilizing round off errors in inner problem...")
     .s$..inner <- rxode2::rxSumProdModel(.s$..inner)
@@ -1656,19 +1730,24 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   }
   if (optExpression) {
     .s$..inner <- rxode2::rxOptExpr(.s$..inner,
-                                    ifelse(.getRxPredLlikOption(),
-                                           "inner llik model",
-                                           "inner model"),
-                                    parallel = cores)
+      ifelse(.getRxPredLlikOption(),
+        "inner llik model",
+        "inner model"
+      ),
+      parallel = cores
+    )
     suppressMessages(.s$..innerOeta <- rxode2::rxOptExpr(.s$..innerOeta,
-                                                         ifelse(.getRxPredLlikOption(),
-                                                                "inner llik model",
-                                                                "inner model"),
-                                                         parallel = cores))
+      ifelse(.getRxPredLlikOption(),
+        "inner llik model",
+        "inner model"
+      ),
+      parallel = cores
+    ))
     if (!is.null(.s$..innerHess2)) {
       suppressMessages(.s$..innerHess2 <- rxode2::rxOptExpr(.s$..innerHess2,
-                                                            "inner Hessian model",
-                                                            parallel = cores))
+        "inner Hessian model",
+        parallel = cores
+      ))
     }
   }
 }
@@ -1707,7 +1786,8 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   # already run) errors on the poisoned env with "user function '[[' requires
   # 0 arguments" when rendering the cached extra terms.
   .linCmtExtraR <- .rxFoceiLinCmtEventChain(
-    get("rx_r_", envir = .s), get("rx_pred_", envir = .s), .s$..linCmtExtraPred)
+    get("rx_r_", envir = .s), get("rx_pred_", envir = .s), .s$..linCmtExtraPred
+  )
   # linCmt() sensitivity carry (3b.3): rx_r_ embeds rx_pred_'s linCmtB()
   # call by value, so its naive d(rx_r_)/d(eta) rows inherit the same
   # uncarried terms.  For a carry-eligible eta whose ONLY path into rx_r_
@@ -1720,14 +1800,18 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
   .carrySubR <- NULL
   if (!is.null(.s$..linCmtCarryPairs)) {
     .carryPh <- symengine::S("rx__linCmtCarryPh__")
-    .carrySubR <- symengine::subs(get("rx_r_", envir = .s),
-                                  get("rx_pred_", envir = .s), .carryPh)
+    .carrySubR <- symengine::subs(
+      get("rx_r_", envir = .s),
+      get("rx_pred_", envir = .s), .carryPh
+    )
     .carryR <- symengine::D(.carrySubR, .carryPh)
     if (paste(.carryR) %in% c("0", "0.0")) {
       .carryR <- NULL
     } else {
-      .carryR <- symengine::subs(.carryR, .carryPh,
-                                 get("rx_pred_", envir = .s))
+      .carryR <- symengine::subs(
+        .carryR, .carryPh,
+        get("rx_pred_", envir = .s)
+      )
     }
   }
   rxode2::rxProgress(dim(.grd)[1])
@@ -1750,9 +1834,11 @@ attr(rxUiGet.foceiHdEta2, "rstudio") <- emptyenv()
       # prediction (a direct eta dependence, pred held fixed, keeps the
       # status quo row -- bias to false)
       if (length(.w) == 1L &&
-            paste(symengine::D(.carrySubR, symengine::S(.p))) %in% c("0", "0.0")) {
-        .ret <- paste0(x["dfe"], "=(", rxode2::rxFromSE(.carryR),
-                       ")*rx__sens_rx_pred__BY_", .p, "__")
+        paste(symengine::D(.carrySubR, symengine::S(.p))) %in% c("0", "0.0")) {
+        .ret <- paste0(
+          x["dfe"], "=(", rxode2::rxFromSE(.carryR),
+          ")*rx__sens_rx_pred__BY_", .p, "__"
+        )
       }
     }
     rxode2::rxTick()
@@ -1782,7 +1868,7 @@ rxUiGet.foceiEnv <- function(x, ...) {
   .s$..outer <- NULL
   .s
 }
-#attr(rxUiGet.foceiEnv, "desc") <- "Get the focei environment"
+# attr(rxUiGet.foceiEnv, "desc") <- "Get the focei environment"
 attr(rxUiGet.foceiEnv, "rstudio") <- emptyenv()
 
 #' @export
@@ -1798,7 +1884,7 @@ rxUiGet.foceEnv <- function(x, ...) {
   } else {
     character(0)
   }
-  .s <- .foceiMaybeAddHdEta2(x, .s)   # ll()/generalized (interaction=0) fast fits route through foce
+  .s <- .foceiMaybeAddHdEta2(x, .s) # ll()/generalized (interaction=0) fast fits route through foce
   ## FOCE leaves rx_r_ untouched (a clean single-linCmt inner model with correct
   ## d(f)/d(eta)) for both `foce` modes; the choice of R happens at runtime in C++
   ## (likInner0), not by rewriting the model here.  `foce = "nonmem"` freezes R at
@@ -1814,7 +1900,7 @@ rxUiGet.foceEnv <- function(x, ...) {
   .s$..outer <- NULL
   .s
 }
-#attr(rxUiGet.foceEnv, "desc") <- "Get the foce environment"
+# attr(rxUiGet.foceEnv, "desc") <- "Get the foce environment"
 attr(rxUiGet.foceEnv, "rstudio") <- emptyenv()
 
 
@@ -1829,7 +1915,7 @@ rxUiGet.getEBEEnv <- function(x, ...) {
   .rxFinalizePred(.s, .sumProd, .optExpression, .optExprCores(x[[1]]))
   .s
 }
-#attr(rxUiGet.getEBEEnv, "desc") <- "Get the EBE environment"
+# attr(rxUiGet.getEBEEnv, "desc") <- "Get the EBE environment"
 attr(rxUiGet.getEBEEnv, "rstudio") <- emptyenv()
 
 .toRx <- function(x, msg, eventSens = "fd", role = NULL) {
@@ -1865,25 +1951,24 @@ attr(rxUiGet.getEBEEnv, "rstudio") <- emptyenv()
 #' @export
 rxUiGet.predDfFocei <- function(x, ...) {
   .ui <- x[[1]]
-  if (exists(".predDfFocei", envir=.ui)) {
-    get(".predDfFocei", envir=.ui)
+  if (exists(".predDfFocei", envir = .ui)) {
+    get(".predDfFocei", envir = .ui)
   } else {
     .predDf <- .ui$predDf
     if (all(.predDf$distribution == "norm")) {
-      assign(".predDfFocei", .predDf, envir=.ui)
+      assign(".predDfFocei", .predDf, envir = .ui)
       .predDf
     } else {
       .w <- which(.predDf$distribution == "norm")
       if (length(.w) > 0) {
         .predDf$distribution[.w] <- "dnorm"
       }
-      assign(".predDfFocei", .predDf, envir=.ui)
+      assign(".predDfFocei", .predDf, envir = .ui)
       .predDf
     }
   }
 }
 attr(rxUiGet.predDfFocei, "rstudio") <- NA
-
 
 
 .rxFinalizePred <- function(.s, sum.prod = FALSE,
@@ -1985,18 +2070,19 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
   }
   if (optExpression) {
     .s$..pred <- rxode2::rxOptExpr(.s$..pred,
-                                   ifelse(.getRxPredLlikOption(),"Llik EBE model","EBE model"),
-                                   parallel = cores)
+      ifelse(.getRxPredLlikOption(), "Llik EBE model", "EBE model"),
+      parallel = cores
+    )
   }
 }
 
 .innerInternal <- function(ui, s) {
   ## Interpolation is carried into the generated models, splitBolus() is not:
   ## these models solve the pre-split $dataSav (see .foceiPreProcessData()).
-  .cmt <-  ui$foceiCmtPreModel
+  .cmt <- ui$foceiCmtPreModel
   .interp <- ui$interpLinesStr
   if (.interp != "") {
-    .cmt <-paste0(.cmt, "\n", .interp)
+    .cmt <- paste0(.cmt, "\n", .interp)
   }
   .paramStr <- .uiGetThetaEtaParams(ui, TRUE)
   if (.getRxPredLlikOption()) {
@@ -2016,8 +2102,10 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
     }
   }
   nlmixr2global$toRxParam <-
-    paste0(.paramStr, "\n",
-           .cmt, "\n")
+    paste0(
+      .paramStr, "\n",
+      .cmt, "\n"
+    )
   nlmixr2global$toRxDvidCmt <- .foceiToCmtLinesAndDvid(ui)
   if (exists("..maxTheta", s)) {
     .eventTheta <- rep(0L, s$..maxTheta)
@@ -2062,13 +2150,19 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
   pred.opt <- NULL
   ## Build the inner (sensitivity) model with the requested event-sensitivity
   ## method.  "jump" enables rxode2's analytic dosing-parameter sensitivities.
-  inner <- .toRx(s$..inner, "compiling inner model...", eventSens = .compileEventSens,
-                 role = "rxInner")
+  inner <- .toRx(s$..inner, "compiling inner model...",
+    eventSens = .compileEventSens,
+    role = "rxInner"
+  )
   # fast=TRUE ll(): the separate 2nd-order inner model (exact-Hessian re-solve at eta*).
   innerHess2 <- if (!is.null(s$..innerHess2)) {
-    .toRx(s$..innerHess2, "compiling inner Hessian model...", eventSens = .compileEventSens,
-          role = "rxHess2")
-  } else NULL
+    .toRx(s$..innerHess2, "compiling inner Hessian model...",
+      eventSens = .compileEventSens,
+      role = "rxHess2"
+    )
+  } else {
+    NULL
+  }
   innerOeta <- s$..innerOeta
   .sumProd <- rxode2::rxGetControl(ui, "sumProd", FALSE)
   .optExpression <- rxode2::rxGetControl(ui, "optExpression", TRUE)
@@ -2088,8 +2182,9 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
     }
     if (.optExpression) {
       s$..pred.nolhs <- rxode2::rxOptExpr(s$..pred.nolhs,
-                                          ifelse(.getRxPredLlikOption(),"Llik FD model","FD model"),
-                                          parallel = .optExprCores(ui))
+        ifelse(.getRxPredLlikOption(), "Llik FD model", "FD model"),
+        parallel = .optExprCores(ui)
+      )
     }
     s$..pred.nolhs <- paste(c(
       paste0("params(", paste(inner$params, collapse = ","), ")"),
@@ -2104,18 +2199,21 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
   # NOTE: the *inner* model intentionally keeps the mixest==k symengine form
   # (nMix == 0) because inner.cpp manages mixture selection itself; using mix()
   # there would trigger a double-optimisation conflict.
-  .mixProbs <- try(ui$mixProbs, silent=TRUE)
+  .mixProbs <- try(ui$mixProbs, silent = TRUE)
   .hasMix <- !inherits(.mixProbs, "try-error") && length(.mixProbs) > 0L
   .predOnly <- if (.hasMix) {
     .prunedStr <- paste(c(.foceiPrune(list(ui)), "tad=tad()", "dosenum=dosenum()", ""),
-                        collapse="\n")
+      collapse = "\n"
+    )
     .toRx(.prunedStr, role = "rxPredPruned", ifelse(.getRxPredLlikOption(),
-                             "compiling Llik EBE model (mixture)...",
-                             "compiling EBE model (mixture)..."))
+      "compiling Llik EBE model (mixture)...",
+      "compiling EBE model (mixture)..."
+    ))
   } else {
     .toRx(s$..pred, role = "rxPredOnly", ifelse(.getRxPredLlikOption(),
-                           "compiling Llik EBE model...",
-                           "compiling EBE model..."))
+      "compiling Llik EBE model...",
+      "compiling EBE model..."
+    ))
   }
   # Augmented outer-gradient model (fast=TRUE): built here, once, with the compiled
   # rxode2 model at top level (`outer`) so rxUiGet.foceiModel's rxLoad reloads
@@ -2140,9 +2238,14 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
     # model that declares 29 lhs whose calc_lhs computes only 4, which drops the
     # analytic gradient for a whole fit.  Event sensitivities stay ON for every
     # sensitivity (inner/outer) model so only one variant per text is ever built.
-    outer = if (is.null(.outerAm)) .toRx(s$..outer, "compiling outer model...",
-                                         eventSens = "jump",
-                                         role = "rxOuterFb") else .outerAm$augMod,
+    outer = if (is.null(.outerAm)) {
+      .toRx(s$..outer, "compiling outer model...",
+        eventSens = "jump",
+        role = "rxOuterFb"
+      )
+    } else {
+      .outerAm$augMod
+    },
     # ALL the aug-model metadata except the compiled model itself: the batched
     # solve/assembly needs fDirs/P2r/hasRvar/sigTh/hasTrans/cols/cores too -- a
     # subset breaks the live gradient (E$R/E$aR never filled)
@@ -2184,14 +2287,16 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
     # delay-history column map is then built from a pool model that already carries the
     # delays.  test-dde-focei.R covers it.
     outerPoolOk = tryCatch(!is.null(ui$predDf) && nrow(ui$predDf) >= 1L,
-                           error = function(e) FALSE),
+      error = function(e) FALSE
+    ),
     # AGQ node model (1st order), NULL for nAGQ<=1.  Same split as outer/outerMeta: model at
     # top level so the rxLoad reloads it, metadata separately.
     outerNode = if (is.null(.nodeAm)) NULL else .nodeAm$augMod,
     outerNodeMeta = if (is.null(.nodeAm)) NULL else .nodeAm[setdiff(names(.nodeAm), "augMod")],
     predNoLhs = .toRx(pred.opt, role = "rxPredNoLhs", ifelse(.getRxPredLlikOption(),
-                                       "compiling events Llik FD model...",
-                                       "compiling events FD model...")),
+      "compiling events Llik FD model...",
+      "compiling events FD model..."
+    )),
     theta = NULL,
     ## warn=.zeroSens,
     pred.minus.dv = .predMinusDv,
@@ -2221,7 +2326,7 @@ rxUiGet.focei <- function(x, ...) {
     nlmixr2global$rxCensNuFix <- FALSE
   })
   .s <- rxUiGet.foceiEnv(x, ...)
-  .ret <-  .innerInternal(.ui, .s)
+  .ret <- .innerInternal(.ui, .s)
   .predDf <- .ui$predDfFocei
   if (any(.predDf$distribution %in% c("t", "cauchy", "dnorm"))) {
     nlmixr2global$rxPredLlik <- TRUE
@@ -2233,18 +2338,20 @@ rxUiGet.focei <- function(x, ...) {
     .s <- rxUiGet.foceiEnv(x, ...)
     .s2 <- .innerInternal(.ui, .s)
     .w <- vapply(seq_along(.s2),
-                 function(i) {
-                   inherits(.s2[[i]], "rxode2")
-                 }, logical(1), USE.NAMES=FALSE)
+      function(i) {
+        inherits(.s2[[i]], "rxode2")
+      }, logical(1),
+      USE.NAMES = FALSE
+    )
     .s2 <- .s2[.w]
     names(.s2) <- paste0(names(.s2), "Llik")
     .cls <- class(.ret)
     .ret <- c(.ret, .s2)
-    class(.ret) <-.cls
+    class(.ret) <- .cls
   }
   .ret
 }
-#attr(rxUiGet.focei, "desc") <- "Get the FOCEi foceiModelList object"
+# attr(rxUiGet.focei, "desc") <- "Get the FOCEi foceiModelList object"
 
 #' @export
 rxUiGet.foce <- function(x, ...) {
@@ -2269,23 +2376,25 @@ rxUiGet.foce <- function(x, ...) {
     .s <- rxUiGet.foceEnv(x, ...)
     .s2 <- .innerInternal(.ui, .s)
     .w <- vapply(seq_along(.s2),
-                 function(i) {
-                   inherits(.s2[[i]], "rxode2")
-                 }, logical(1), USE.NAMES=FALSE)
+      function(i) {
+        inherits(.s2[[i]], "rxode2")
+      }, logical(1),
+      USE.NAMES = FALSE
+    )
     .s2 <- .s2[.w]
     names(.s2) <- paste0(names(.s2), "Llik")
     .cls <- class(.ret)
     .ret <- c(.ret, .s2)
-    class(.ret) <-.cls
+    class(.ret) <- .cls
   }
   .ret
 }
-#attr(rxUiGet.foce, "desc") <- "Get the FOCE foceiModelList object"
+# attr(rxUiGet.foce, "desc") <- "Get the FOCE foceiModelList object"
 
 
 #' @export
 rxUiGet.ebe <- function(x, ...) {
-  .ui <-x[[1]]
+  .ui <- x[[1]]
   nlmixr2global$rxPredLlik <- FALSE
   nlmixr2global$rxArNorm <- TRUE
   on.exit({
@@ -2306,18 +2415,20 @@ rxUiGet.ebe <- function(x, ...) {
     .s <- rxUiGet.getEBEEnv(x, ...)
     .s2 <- .innerInternal(.ui, .s)
     .w <- vapply(seq_along(.s2),
-                 function(i) {
-                   inherits(.s2[[i]], "rxode2")
-                 }, logical(1), USE.NAMES=FALSE)
+      function(i) {
+        inherits(.s2[[i]], "rxode2")
+      }, logical(1),
+      USE.NAMES = FALSE
+    )
     .s2 <- .s2[.w]
     names(.s2) <- paste0(names(.s2), "Llik")
     .cls <- class(.ret)
     .ret <- c(.ret, .s2)
-    class(.ret) <-.cls
+    class(.ret) <- .cls
   }
   .ret
 }
-#attr(rxUiGet.ebe, "desc") <- "Get the EBE foceiModelList object"
+# attr(rxUiGet.ebe, "desc") <- "Get the EBE foceiModelList object"
 
 #' @export
 rxUiGet.foceiModelDigest <- function(x, ...) {
@@ -2325,7 +2436,7 @@ rxUiGet.foceiModelDigest <- function(x, ...) {
   .iniDf <- get("iniDf", .ui)
   .sumProd <- rxode2::rxGetControl(.ui, "sumProd", FALSE)
   .optExpression <- rxode2::rxGetControl(.ui, "optExpression", TRUE)
-  .predMinusDv   <- rxode2::rxGetControl(.ui, "predMinusDv", TRUE)
+  .predMinusDv <- rxode2::rxGetControl(.ui, "predMinusDv", TRUE)
   ## eventSens changes the inner model codegen (analytic jump sensitivities) and
   ## the eventEta/eventTheta finite-difference flags, so it must be part of the
   ## cache key -- otherwise a "jump" build would reuse a cached "fd" model.
@@ -2350,7 +2461,7 @@ rxUiGet.foceiModelDigest <- function(x, ...) {
   ## symbolic sensitivity build) and on the sigma-skip toggle -- both change the outer model
   ## text, so they must key the persisted cache too, else two fits of the same model
   ## whose datasets differ only in covariate-constancy would collide.
-  .constCovs <- paste(sort(rxode2::rxGetControl(.ui, "foceiConstCovs", NULL)), collapse=",")
+  .constCovs <- paste(sort(rxode2::rxGetControl(.ui, "foceiConstCovs", NULL)), collapse = ",")
   ## combined eta+theta sensitivity build (#958) changes the inner model text
   .combSens <- isTRUE(rxode2::rxGetControl(.ui, "combSens", FALSE))
   ## linCmt() sensitivity-carry substitution (3b.3) changes the inner model
@@ -2358,10 +2469,13 @@ rxUiGet.foceiModelDigest <- function(x, ...) {
   ## the carry sentinels, so both key the cache.
   ## covsInterpolation gates the substitution ("linear" skips it), so it must
   ## key the cache too, else a locf build would be reused for a linear fit
-  .linCmtCarry <- paste0(rxode2::rxGetControl(.ui, "linCmtSensCarry", "auto"),
-                         ",", .rxFoceiLinCmtCarryCapable(), ",",
-                         paste(rxode2::rxGetControl(.ui, "rxControl", NULL)$covsInterpolation,
-                               collapse = ","))
+  .linCmtCarry <- paste0(
+    rxode2::rxGetControl(.ui, "linCmtSensCarry", "auto"),
+    ",", .rxFoceiLinCmtCarryCapable(), ",",
+    paste(rxode2::rxGetControl(.ui, "rxControl", NULL)$covsInterpolation,
+      collapse = ","
+    )
+  )
   ## The persisted cache lives in rxode2's user cache directory, so it OUTLIVES
   ## the session (and the installed package) whenever `rxCreateCache()` has been
   ## run.  Any release that changes the generated model text -- #992 gave the
@@ -2370,24 +2484,28 @@ rxUiGet.foceiModelDigest <- function(x, ...) {
   ## model already in that cache, with no error to show for it.  Key on the
   ## package version so an upgrade rebuilds instead.
   .pkgVersion <- as.character(utils::packageVersion("nlmixr2est"))
-  digest::digest(c(all(is.na(.iniDf$neta1)), .combSens, .linCmtCarry, .pkgVersion,
-                   rxode2::rxGetControl(.ui, "interaction", 1L),
-                   .iniDf$name,
-                   .sumProd, .optExpression, .predMinusDv,
-                   .eventSens, .sensMethod, .rxMethod, .fast, .foceType, .agqNodes,
-                   .constCovs, Sys.getenv("FOCEI_NO_SIGMA_SKIP"),
-                   rxode2::rxGetControl(.ui, "addProp", getOption("rxode2.addProp", "combined2")),
-                   .ui$lstExpr))
+  digest::digest(c(
+    all(is.na(.iniDf$neta1)), .combSens, .linCmtCarry, .pkgVersion,
+    rxode2::rxGetControl(.ui, "interaction", 1L),
+    .iniDf$name,
+    .sumProd, .optExpression, .predMinusDv,
+    .eventSens, .sensMethod, .rxMethod, .fast, .foceType, .agqNodes,
+    .constCovs, Sys.getenv("FOCEI_NO_SIGMA_SKIP"),
+    rxode2::rxGetControl(.ui, "addProp", getOption("rxode2.addProp", "combined2")),
+    .ui$lstExpr
+  ))
 }
-#attr(rxUiGet.foceiModelDigest, "desc") <- "Get the md5 digest for the focei model"
+# attr(rxUiGet.foceiModelDigest, "desc") <- "Get the md5 digest for the focei model"
 attr(rxUiGet.foceiModelDigest, "rstudio") <- "hash"
 
 #' @export
 rxUiGet.foceiModelCache <- function(x, ...) {
-  file.path(rxode2::rxTempDir(),
-            paste0("focei-", rxUiGet.foceiModelDigest(x, ...), ".rds"))
+  file.path(
+    rxode2::rxTempDir(),
+    paste0("focei-", rxUiGet.foceiModelDigest(x, ...), ".rds")
+  )
 }
-#attr(rxUiGet.foceiModelCache, "desc") <- "Get the focei cache file for a model"
+# attr(rxUiGet.foceiModelCache, "desc") <- "Get the focei cache file for a model"
 attr(rxUiGet.foceiModelCache, "rstudio") <- "file"
 
 #' Cached-model bundle element -> storable form: an rxode2 model is stored
@@ -2399,7 +2517,8 @@ attr(rxUiGet.foceiModelCache, "rstudio") <- "file"
 .foceiModelCacheDeflate <- function(el) {
   if (inherits(el, "rxode2")) {
     return(structure(list(norm = rxode2::rxNorm(el)),
-                     class = "nlmixr2estFoceiNorm"))
+      class = "nlmixr2estFoceiNorm"
+    ))
   }
   el
 }
@@ -2450,7 +2569,7 @@ rxUiGet.foceiFixed <- function(x, ...) {
   .dft <- .df[is.na(.df$ntheta), ]
   c(.fix, .dft$fix)
 }
-#attr(rxUiGet.foFixed, "desc") <- "focei theta fixed vector"
+# attr(rxUiGet.foFixed, "desc") <- "focei theta fixed vector"
 attr(rxUiGet.foceiFixed, "rstudio") <- c(FALSE, TRUE)
 
 #' @export
@@ -2460,7 +2579,7 @@ rxUiGet.foceiEtaNames <- function(x, ...) {
   .dft <- .df[is.na(.df$ntheta), ]
   .dft[.dft$neta1 == .dft$neta2, "name"]
 }
-#attr(rxUiGet.foceiEtaNames, "desc") <- "focei eta names"
+# attr(rxUiGet.foceiEtaNames, "desc") <- "focei eta names"
 attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
 
 #' This assigns the tolerances based on a different tolerance for the
@@ -2492,7 +2611,7 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
     }
   }
   if (!is.null(env$model$inner) &&
-      isTRUE(rxode2::rxModelVars(env$model$inner)$flags[["hasDelay"]] == 1L)) {
+    isTRUE(rxode2::rxModelVars(env$model$inner)$flags[["hasDelay"]] == 1L)) {
     .rxControl2 <- rxode2::rxGetControl(ui, "rxControl", rxode2::rxControl())
     if (isTRUE(unname(.rxControl2$method) == 2L)) {
       .rxControl2$method <- 0L
@@ -2511,8 +2630,8 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
   # their post-dose values, and the EBE inner Newton optimizer reads a
   # frozen (zero) gradient and never moves eta.
   if (!is.null(env$model$inner) &&
-      is.list(rxode2::rxModelVars(env$model$inner)$indLin) &&
-      length(rxode2::rxModelVars(env$model$inner)$indLin) == 4L) {
+    is.list(rxode2::rxModelVars(env$model$inner)$indLin) &&
+    length(rxode2::rxModelVars(env$model$inner)$indLin) == 4L) {
     .rxControl3 <- rxode2::rxGetControl(ui, "rxControl", rxode2::rxControl())
     if (!isTRUE(unname(.rxControl3$method) == 3L)) {
       .rxControl3$method <- 3L
@@ -2537,7 +2656,7 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
       } else {
         0L
       }
-    }, integer(1), USE.NAMES=FALSE))
+    }, integer(1), USE.NAMES = FALSE))
     if (.maxLl > 0) {
       .env <- nlmixr2global$nlmixrEvalEnv$envir
       if (!is.environment(.env)) {
@@ -2565,12 +2684,12 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
   .om <- om
   .bad <- !is.finite(.om)
   .om[.bad] <- 0
-  .r <- try(nmNearPD(.om), silent=TRUE)
+  .r <- try(nmNearPD(.om), silent = TRUE)
   if (!inherits(.r, "try-error") &&
-        !inherits(try(chol(.r), silent=TRUE), "try-error")) {
+    !inherits(try(chol(.r), silent = TRUE), "try-error")) {
     dimnames(.r) <- dimnames(om)
     if (any(.bad)) {
-      warning("non-finite omega values zeroed for tables", call.=FALSE)
+      warning("non-finite omega values zeroed for tables", call. = FALSE)
     }
     return(.r)
   }
@@ -2578,9 +2697,9 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
   .pos <- .d[is.finite(.d) & .d > 0]
   .floor <- if (length(.pos) > 0L) max(1e-8, 1e-6 * max(.pos)) else 1e-6
   .d[!is.finite(.d) | .d < .floor] <- .floor
-  .ret <- diag(.d, nrow=length(.d))
+  .ret <- diag(.d, nrow = length(.d))
   dimnames(.ret) <- dimnames(om)
-  warning("singular omega; used a floored diagonal for tables", call.=FALSE)
+  warning("singular omega; used a floored diagonal for tables", call. = FALSE)
   .ret
 }
 
@@ -2596,31 +2715,39 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
   .w <- which(!is.na(.iniDf$ntheta))
   if (length(.w) > 0) {
     .lower <- vapply(.w,
-                     function(i) {
-                       .low <- .iniDf$lower[i]
-                       .zeroRep <- rxode2::rxGetControl(ui, "sdLowerFact", 0.001)
-                       if (.zeroRep <= 0) return(.low)
-                       if (.low <= 0 &&
-                             .iniDf$err[i] %in% c("add",
-                                                  "lnorm", "logitNorm", "probitNorm",
-                                                  "prop", "propT", "propF",
-                                                  "pow", "powF", "powT", "ar")) {
-                         .low <- .iniDf$est[i] * 0.001
-                       }
-                       .low
-                     }, numeric(1), USE.NAMES=FALSE)
+      function(i) {
+        .low <- .iniDf$lower[i]
+        .zeroRep <- rxode2::rxGetControl(ui, "sdLowerFact", 0.001)
+        if (.zeroRep <= 0) {
+          return(.low)
+        }
+        if (.low <= 0 &&
+          .iniDf$err[i] %in% c(
+            "add",
+            "lnorm", "logitNorm", "probitNorm",
+            "prop", "propT", "propF",
+            "pow", "powF", "powT", "ar"
+          )) {
+          .low <- .iniDf$est[i] * 0.001
+        }
+        .low
+      }, numeric(1),
+      USE.NAMES = FALSE
+    )
     .upper <- vapply(.w,
-                     function(i) {
-                       .up <- .iniDf$upper[i]
-                       # ar() correlation is [0, 1): keep the optimizer strictly
-                       # below 1 so the whitened variance R*(1-cor^(2dt)) never
-                       # hits 0 (cor==1 floors the log term -> spurious spike,
-                       # collapsing the residual sd).
-                       if (identical(.iniDf$err[i], "ar") && (is.na(.up) || .up >= 1)) {
-                         .up <- 1 - 1e-4
-                       }
-                       .up
-                     }, numeric(1), USE.NAMES=FALSE)
+      function(i) {
+        .up <- .iniDf$upper[i]
+        # ar() correlation is [0, 1): keep the optimizer strictly
+        # below 1 so the whitened variance R*(1-cor^(2dt)) never
+        # hits 0 (cor==1 floors the log term -> spurious spike,
+        # collapsing the residual sd).
+        if (identical(.iniDf$err[i], "ar") && (is.na(.up) || .up >= 1)) {
+          .up <- 1 - 1e-4
+        }
+        .up
+      }, numeric(1),
+      USE.NAMES = FALSE
+    )
     env$thetaIni <- ui$thetaIniMix
     env$mixIdx <- ui$thetaMixIndex
     env$thetaIni <- setNames(env$thetaIni, paste0("THETA[", seq_along(env$thetaIni), "]"))
@@ -2646,7 +2773,7 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
     # whose inverse/chol fails when building the sym-inv-chol env and aborts the
     # whole fit at the residual/table step.  Repair the omega in that case so
     # post-fit diagnostics still run; the reported fit omega is left unchanged.
-    if (inherits(try(chol(.om0), silent=TRUE), "try-error")) {
+    if (inherits(try(chol(.om0), silent = TRUE), "try-error")) {
       .om0 <- .foceiRepairOmega(.om0)
     }
     env$rxInv <- rxode2::rxSymInvCholCreate(mat = .om0, diag.xform = .diagXform)
@@ -2690,9 +2817,13 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
 #' @noRd
 .guardScaleC <- function(sc, init, lo = 0.1, hi = 10, mid = FALSE) {
   .inband <- function(v) length(v) == 1L && !is.na(v) && is.finite(v) && v > 0 && v >= lo && v <= hi
-  if (.inband(sc)) return(sc)      # preferred: the derivative-based formula, in band
+  if (.inband(sc)) {
+    return(sc)
+  } # preferred: the derivative-based formula, in band
   .v <- abs(init)
-  if (.inband(.v)) return(.v)      # second: the parameter's native magnitude |init|, in band
+  if (.inband(.v)) {
+    return(.v)
+  } # second: the parameter's native magnitude |init|, in band
   # Neither in band.  Bounded transforms (mid=TRUE) have a bounded safe range, so
   # the geometric middle of the band is the safe choice.  Linear / additive and the
   # other structural transforms (mid=FALSE) keep native |init| at any magnitude --
@@ -2723,7 +2854,8 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
   } else if (.len < .lenC) {
     .scaleC <- .scaleC[seq(1, .lenC)]
     warning("'scaleC' control option has more options than estimated population parameters, please check",
-            call.=FALSE)
+      call. = FALSE
+    )
   }
 
   .ini <- ui$iniDf
@@ -2767,34 +2899,36 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
             # rxode2 reports gamma() as curEval "lgammafn".
             .scaleC[.j] <- 1 / digamma(.ini$est[.j])
           } else if (.curEval == "log") {
-            #1/D(log(log(x)), x)
+            # 1/D(log(log(x)), x)
             .scaleC[.j] <- log(abs(.ini$est[.j])) * abs(.ini$est[.j])
           } else if (.curEval == "logit") {
             # 1/D(log(logit(x, a, b)))
             .a <- .muRefCurEval$low[.i]
             .b <- .muRefCurEval$hi[.i]
             .x <- .ini$est[.j]
-            .scaleC[.j] <- -1.0*(-.a + .x)^2*(-1.0 + 1.0*(-.a + .b)/(-.a + .x))*log(abs(-1.0 + 1.0*(-.a + .b)/(-.a + .x)))/(-.a + .b)
+            .scaleC[.j] <- -1.0 * (-.a + .x)^2 * (-1.0 + 1.0 * (-.a + .b) / (-.a + .x)) * log(abs(-1.0 + 1.0 * (-.a + .b) / (-.a + .x))) / (-.a + .b)
           } else if (.curEval == "expit") {
             # 1/D(log(expit(x, a, b)))
             .a <- .muRefCurEval$low[.i]
             .b <- .muRefCurEval$hi[.i]
             .x <- .ini$est[.j]
-            .scaleC[.j] <- 1.0*exp(.x)*(1.0 + exp(-.x))^2*(.a + 1.0*(-.a + .b)/(1.0 + exp(-.x)))/(-.a + .b)
+            .scaleC[.j] <- 1.0 * exp(.x) * (1.0 + exp(-.x))^2 * (.a + 1.0 * (-.a + .b) / (1.0 + exp(-.x))) / (-.a + .b)
           } else if (.curEval == "probitInv") {
             .a <- .muRefCurEval$low[.i]
             .b <- .muRefCurEval$hi[.i]
             .x <- .ini$est[.j]
-            .scaleC[.j] <- 1.4142135623731*exp(0.5*.x^2)*sqrt(pi)*(.a + 0.5*(-.a + .b)*(1.0 + rxode2::erf(0.707106781186547*.x)))/(-.a + .b)
+            .scaleC[.j] <- 1.4142135623731 * exp(0.5 * .x^2) * sqrt(pi) * (.a + 0.5 * (-.a + .b) * (1.0 + rxode2::erf(0.707106781186547 * .x))) / (-.a + .b)
           } else if (.curEval == "probit") {
             .a <- .muRefCurEval$low[.i]
             .b <- .muRefCurEval$hi[.i]
             .x <- .ini$est[.j]
-            erfinvF  <- function(y) {
-              if(abs(y) > 1) return(NA_real_)
-              sqrt(qchisq(abs(y),1)/2) * sign(y)
+            erfinvF <- function(y) {
+              if (abs(y) > 1) {
+                return(NA_real_)
+              }
+              sqrt(qchisq(abs(y), 1) / 2) * sign(y)
             }
-            .scaleC[.j] <- sqrt(2)*(-.a+.b)*erfinvF(-1+2*(-.a+.x)/(-.a+.b))/sqrt(pi)/2*exp(((erfinvF(-1+2*(-.a+.x)/(-.a+.b))) ^ 2))
+            .scaleC[.j] <- sqrt(2) * (-.a + .b) * erfinvF(-1 + 2 * (-.a + .x) / (-.a + .b)) / sqrt(pi) / 2 * exp(((erfinvF(-1 + 2 * (-.a + .x) / (-.a + .b)))^2))
           }
           # Per-transform guard: each transform's derivative-based scaleC is valid
           # over its OWN range, so it is guarded to a band tailored to that
@@ -2818,17 +2952,23 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
             #  * expit()/probitInv(): an UNBOUNDED parameter maps into (low, hi);
             #    N = E/(hi-low) with E the transformed value, and M = 1/(s(1-s)),
             #    singular (-> large) at saturation.
-            .lo <- .muRefCurEval$low[.i]; .hi <- .muRefCurEval$hi[.i]
-            .x  <- .ini$est[.j]; .wd <- .hi - .lo
-            .N <- NA_real_; .frac <- NULL
+            .lo <- .muRefCurEval$low[.i]
+            .hi <- .muRefCurEval$hi[.i]
+            .x <- .ini$est[.j]
+            .wd <- .hi - .lo
+            .N <- NA_real_
+            .frac <- NULL
             if (.curEval %in% c("logit", "probit")) {
               .N <- (.x - .lo) * (.hi - .x) / .wd
-              .frac <- c(4e-4, 40)          # excludes the midpoint (M -> 0)
+              .frac <- c(4e-4, 40) # excludes the midpoint (M -> 0)
             } else if (.curEval %in% c("expit", "probitInv")) {
-              .E <- if (.curEval == "expit") .lo + .wd / (1 + exp(-.x))
-                    else .lo + 0.5 * .wd * (1 + rxode2::erf(.x / sqrt(2)))
+              .E <- if (.curEval == "expit") {
+                .lo + .wd / (1 + exp(-.x))
+              } else {
+                .lo + 0.5 * .wd * (1 + rxode2::erf(.x / sqrt(2)))
+              }
               .N <- .E / .wd
-              .frac <- c(1, 100)            # excludes saturation (M -> large)
+              .frac <- c(1, 100) # excludes saturation (M -> large)
             }
             if (!is.null(.frac) && isTRUE(.N > 0)) {
               .band <- .N * .frac
@@ -2836,12 +2976,13 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
               # non-bounded transforms keep their own fixed bands (M is already
               # dimensionless for them); a degenerate N (<= 0) falls through here too
               .band <- switch(.curEval,
-                "exp"       = c(0, Inf),   # always 1; never guarded
-                "log"       = c(0.1, 10),  # excludes init <= 1 (scaleC <= 0) and the large tail
-                "factorial" = c(0.1, 10),  # excludes the digamma-zero pole (-> Inf)
+                "exp"       = c(0, Inf), # always 1; never guarded
+                "log"       = c(0.1, 10), # excludes init <= 1 (scaleC <= 0) and the large tail
+                "factorial" = c(0.1, 10), # excludes the digamma-zero pole (-> Inf)
                 "gamma"     = c(0.1, 10),
-                "lgammafn"  = c(0.1, 10),  # rxode2 reports gamma() as "lgammafn"
-                c(.scLo, .scHi))           # fallback: the linear scaleCband
+                "lgammafn"  = c(0.1, 10), # rxode2 reports gamma() as "lgammafn"
+                c(.scLo, .scHi)
+              ) # fallback: the linear scaleCband
             }
             # midpoint / saturation fallback only for bounded transforms
             .mid <- .curEval %in% c("logit", "probit", "expit", "probitInv")
@@ -2872,7 +3013,7 @@ attr(rxUiGet.foceiEtaNames, "rstudio") <- c("eta.ka", "eta.cl", "eta.vc")
 #' @export
 rxUiGet.scaleCtheta <- function(x, ...) {
   .ui <- x[[1]]
-  .env <- new.env(parent=emptyenv())
+  .env <- new.env(parent = emptyenv())
   .env$lower <- .ui$iniDf[!is.na(.ui$iniDf$ntheta), "lower"]
   .foceiOptEnvSetupScaleC(.ui, .env)
   .env$scaleC[!.ui$iniDf$fix]
@@ -2882,7 +3023,7 @@ attr(rxUiGet.scaleCtheta, "rstudio") <- c(1.0, NA_real_)
 #' @export
 rxUiGet.scaleCnls <- function(x, ...) {
   .ui <- x[[1]]
-  .env <- new.env(parent=emptyenv())
+  .env <- new.env(parent = emptyenv())
   .env$lower <- .ui$iniDf[!is.na(.ui$iniDf$ntheta), "lower"]
   .foceiOptEnvSetupScaleC(.ui, .env)
   .env$scaleC[!.ui$iniDf$fix & !(.ui$iniDf$err %in% c("add", "prop", "pow", "ar"))]
@@ -2903,14 +3044,22 @@ rxUiGet.foceiMuRefVector <- function(x, ...) {
     .i2 <- .i2[.i2$neta1 == .i2$neta2, ]
     .i2 <- .i2[order(.i2$neta1), ]
     vapply(seq_along(.i2$neta1), function(i) {
-      if (.i2$fix[i]) return(-1L)
+      if (.i2$fix[i]) {
+        return(-1L)
+      }
       .name <- .i2$name[i]
       .w <- which(.muRefDataFrame$eta == .name)
-      if (length(.w) != 1) return(-1L)
+      if (length(.w) != 1) {
+        return(-1L)
+      }
       .name <- .muRefDataFrame$theta[.w]
       .w <- which(.iniDf$name == .name)
-      if (length(.w) != 1) return(-1L)
-      if (.iniDf$fix[.w]) return(-1L)
+      if (length(.w) != 1) {
+        return(-1L)
+      }
+      if (.iniDf$fix[.w]) {
+        return(-1L)
+      }
       # `ntheta` is normally an integer column, but a programmatically rebuilt model
       # (e.g. the VAE injecting covariate-coefficient thetas via ini()) can leave it a
       # double; coerce so the vapply(..., integer(1)) contract holds.
@@ -2920,7 +3069,7 @@ rxUiGet.foceiMuRefVector <- function(x, ...) {
     integer(0)
   }
 }
-#attr(rxUiGet.foceiMuRefVector, "desc") <- "focei mu ref vector"
+# attr(rxUiGet.foceiMuRefVector, "desc") <- "focei mu ref vector"
 attr(rxUiGet.foceiMuRefVector, "rstudio") <- c(0L, -1L)
 
 # focei.mu.cov.eta
@@ -2959,7 +3108,7 @@ attr(rxUiGet.foceiMuCovEtaVector, "rstudio") <- c(0L, 1L)
 #' @export
 rxUiGet.foceiSkipCov <- function(x, ...) {
   .ui <- x[[1]]
-  .maxTheta <- max(.ui$iniDf$ntheta, na.rm=TRUE)
+  .maxTheta <- max(.ui$iniDf$ntheta, na.rm = TRUE)
   if (!is.finite(.maxTheta)) {
     logical(0)
   } else {
@@ -2980,7 +3129,7 @@ rxUiGet.foceiSkipCov <- function(x, ...) {
     .skipCov
   }
 }
-#attr(rxUiGet.foceiSkipCov, "desc") <- "what covariance elements to skip"
+# attr(rxUiGet.foceiSkipCov, "desc") <- "what covariance elements to skip"
 attr(rxUiGet.foceiSkipCov, "rstudio") <- c(FALSE, TRUE)
 
 #'  Setup the skip covariate function
@@ -2996,27 +3145,29 @@ attr(rxUiGet.foceiSkipCov, "rstudio") <- c(FALSE, TRUE)
   if (is.null(env$skipCov)) {
     env$skipCov <- ui$foceiSkipCov
   }
-  .maxTheta <- max(ui$iniDf$ntheta, na.rm=TRUE)
+  .maxTheta <- max(ui$iniDf$ntheta, na.rm = TRUE)
   if (!is.finite(.maxTheta)) {
     .maxTheta <- 0
   }
   if (length(env$skipCov) > .maxTheta) {
     if (all(env$skipCov[-seq_len(.maxTheta)])) {
-      assign("skipCov",env$skipCov[seq_len(.maxTheta)], env)
+      assign("skipCov", env$skipCov[seq_len(.maxTheta)], env)
     }
   }
-  assign("nEstOmega", length(which(!is.na(ui$iniDf$neta1) & !ui$iniDf$fix)),
-         env)
+  assign(
+    "nEstOmega", length(which(!is.na(ui$iniDf$neta1) & !ui$iniDf$fix)),
+    env
+  )
   if (length(env$skipCov) != .maxTheta) {
     .iniTheta <- ui$iniDf[!is.na(ui$iniDf$ntheta), ]
     env$skipCov <- is.na(.iniTheta$err)
-    warning("'skipCov' improperly specified, reset", call.=FALSE)
+    warning("'skipCov' improperly specified, reset", call. = FALSE)
   }
 }
 
 .foceiOptEnvLik <- function(ui, env) {
-  #if (!exists("noLik", envir = env)){
-  if (!exists("model", envir=env)) {
+  # if (!exists("noLik", envir = env)){
+  if (!exists("model", envir = env)) {
     env$model <- rxUiGet.foceiModel(list(ui))
   }
   # impmap: add the dedicated theta-sensitivity model (d(f)/d(theta)) used by the
@@ -3027,9 +3178,9 @@ attr(rxUiGet.foceiSkipCov, "rstudio") <- c(FALSE, TRUE)
   # thetaSensLoad is foceiLikLoad(thetaSens=TRUE) (#939): an external caller
   # wants the same model without being an imp/advi estimation.
   if ((rxode2::rxGetControl(ui, "est", "") %in% c("impmap", "imp", "qrpem", "advi") ||
-         isTRUE(rxode2::rxGetControl(ui, "thetaSensLoad", FALSE))) &&
-        !isTRUE(rxode2::rxGetControl(ui, "combSens", FALSE)) &&
-        is.null(env$model$thetaSens)) {
+    isTRUE(rxode2::rxGetControl(ui, "thetaSensLoad", FALSE))) &&
+    !isTRUE(rxode2::rxGetControl(ui, "combSens", FALSE)) &&
+    is.null(env$model$thetaSens)) {
     # (combSens (#958): the INNER model carries the theta columns, so the
     # separate theta-sensitivity model is neither built nor compiled)
     # eventSens follows the control (same source as the inner model): with
@@ -3038,13 +3189,17 @@ attr(rxUiGet.foceiSkipCov, "rstudio") <- c(FALSE, TRUE)
     # than silently zero (#946)
     env$model$thetaSens <- tryCatch(
       .impmapThetaSensModel(ui,
-                            eventSens = rxode2::rxGetControl(ui, "eventSens",
-                                                             "jump")),
-      error = function(e) NULL)
+        eventSens = rxode2::rxGetControl(
+          ui, "eventSens",
+          "jump"
+        )
+      ),
+      error = function(e) NULL
+    )
   }
-  #} else {
-  #env$model <- rxUiGet.ebe(list(ui))
-  #}
+  # } else {
+  # env$model <- rxUiGet.ebe(list(ui))
+  # }
   .foceiOptEnvAssignTol(ui, env)
   .foceiOptEnvAssignNllik(ui, env)
   .foceiOptEnvSetupBounds(ui, env)
@@ -3055,7 +3210,7 @@ attr(rxUiGet.foceiSkipCov, "rstudio") <- c(FALSE, TRUE)
   # saem's .cfg$xform / nlm's .ctl$iterPrintXform.
   env$xform <- .iterPrintXParFromUi(ui)
   .foceiSetupSkipCov(ui, env)
-  env$control <- get("control", envir=ui)
+  env$control <- get("control", envir = ui)
   env$control$nF <- 0
   env$control$printTop <- TRUE
   env
@@ -3064,11 +3219,11 @@ attr(rxUiGet.foceiSkipCov, "rstudio") <- c(FALSE, TRUE)
 #' @export
 rxUiGet.foceiOptEnv <- function(x, ...) {
   .x <- x[[1]]
-  if (exists("foceiEnv", envir=.x)) {
-    .env <- get("foceiEnv", envir=.x)
-    rm("foceiEnv", envir=.x)
+  if (exists("foceiEnv", envir = .x)) {
+    .env <- get("foceiEnv", envir = .x)
+    rm("foceiEnv", envir = .x)
   } else {
-    .env <- new.env(parent=emptyenv())
+    .env <- new.env(parent = emptyenv())
   }
   .env$etaNames <- rxUiGet.foceiEtaNames(x, ...)
   .env$thetaFixed <- rxUiGet.foceiFixed(x, ...)
@@ -3079,8 +3234,10 @@ rxUiGet.foceiOptEnv <- function(x, ...) {
   # needs the dataset and is wired separately in .foceiFamilyReturn() once
   # env$dataSav exists.
   .muModelStr <- rxode2::rxGetControl(.x, "muModel", "none")
-  rxode2::rxAssignControlValue(.x, "foceiMuModel",
-                               c(none = 0L, lin = 1L, irls = 2L)[[.muModelStr]])
+  rxode2::rxAssignControlValue(
+    .x, "foceiMuModel",
+    c(none = 0L, lin = 1L, irls = 2L)[[.muModelStr]]
+  )
   if (!identical(.muModelStr, "none")) {
     # The imp-family EM methods run with muModel="lin" but do their own
     # plain-mu M-step (.impmapFamilyFit, R/impmap.R) built as muRefDataFrame
@@ -3093,19 +3250,23 @@ rxUiGet.foceiOptEnv <- function(x, ...) {
       .ctlClass <- class(get("control", envir = .x))[1]
     }
     .muPlain <- !(rxode2::rxGetControl(.x, "est", "") %in%
-                    c("impmap", "imp", "qrpem", "advi",
-                      "npag", "npb", "mnpag", "inpag", "mnpb", "inpb")) &&
+      c(
+        "impmap", "imp", "qrpem", "advi",
+        "npag", "npb", "mnpag", "inpag", "mnpb", "inpb"
+      )) &&
       !(.ctlClass %in% c("impmapControl", "impControl", "qrpemControl", "emviControl"))
     # muModel != "none" is the clamped family: bounded mu parameters stay
     # grouped and updateMuGroups() clamps their regression update
     .muGroupSetup <- .muRefCppGroupSetup(.x, plain = .muPlain, clamp = TRUE)
   } else {
-    .muGroupSetup <- list(muGroupTheta = integer(0), muGroupEta = integer(0),
-                          muGroupCovStart = integer(0), muGroupCovCount = integer(0),
-                          muGroupCovTheta = integer(0), muGroupCovUserFixed = integer(0),
-                          muGroupThetaLower = numeric(0), muGroupThetaUpper = numeric(0),
-                          muGroupCovLower = numeric(0), muGroupCovUpper = numeric(0),
-                          muGroupCovNames = character(0))
+    .muGroupSetup <- list(
+      muGroupTheta = integer(0), muGroupEta = integer(0),
+      muGroupCovStart = integer(0), muGroupCovCount = integer(0),
+      muGroupCovTheta = integer(0), muGroupCovUserFixed = integer(0),
+      muGroupThetaLower = numeric(0), muGroupThetaUpper = numeric(0),
+      muGroupCovLower = numeric(0), muGroupCovUpper = numeric(0),
+      muGroupCovNames = character(0)
+    )
   }
   # Every group eta (covariate or plain) is managed by updateMuGroups() and
   # must be protected from the eta drift-reset mechanisms; union the plain
@@ -3132,12 +3293,18 @@ rxUiGet.foceiOptEnv <- function(x, ...) {
   # fields (originally written for the superseded R-level restart loop) to
   # bound the in-C++ inner regress/re-optimize cycle (updateMuGroups(),
   # src/inner.cpp) that now runs once per real outer iteration.
-  rxode2::rxAssignControlValue(.x, "foceiMuGroupTol",
-                               rxode2::rxGetControl(.x, "muModelTol", 1e-3))
-  rxode2::rxAssignControlValue(.x, "foceiMuGroupMaxCycles",
-                               rxode2::rxGetControl(.x, "muModelMaxCycles", 10L))
-  rxode2::rxAssignControlValue(.x, "foceiMuGroupClampRetries",
-                               rxode2::rxGetControl(.x, "muModelClampRetries", 10L))
+  rxode2::rxAssignControlValue(
+    .x, "foceiMuGroupTol",
+    rxode2::rxGetControl(.x, "muModelTol", 1e-3)
+  )
+  rxode2::rxAssignControlValue(
+    .x, "foceiMuGroupMaxCycles",
+    rxode2::rxGetControl(.x, "muModelMaxCycles", 10L)
+  )
+  rxode2::rxAssignControlValue(
+    .x, "foceiMuGroupClampRetries",
+    rxode2::rxGetControl(.x, "muModelClampRetries", 10L)
+  )
   # Stash the covariate names on the ui so .foceiFamilyReturn() can build
   # the values matrix once the dataset is available, without recomputing
   # .muRefCppGroupSetup() a second time.
@@ -3166,7 +3333,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
 #' @author Matthew L. Fidler
 #' @keywords internal
 #' @export
-.foceiPreProcessData <- function(data, env, ui, rxControl=NULL) {
+.foceiPreProcessData <- function(data, env, ui, rxControl = NULL) {
   if (is.null(rxControl)) {
     .env <- nlmixr2global$nlmixrEvalEnv$envir
     if (!is.environment(.env)) {
@@ -3220,13 +3387,15 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   }
   data$nlmixrRowNums <- seq_len(nrow(data))
   .keep <- unique(c("nlmixrRowNums", env$table$keep))
-  .et <- rxode2::etTrans(inData=data, obj=.mod,
-                         addCmt=TRUE, dropUnits=TRUE,
-                         keep=unique(c("nlmixrRowNums", env$table$keep)),
-                         allTimeVar=TRUE, keepDosingOnly=FALSE,
-                         addlKeepsCov = rxControl$addlKeepsCov,
-                         addlDropSs = rxControl$addlDropSs,
-                         ssAtDoseTime = rxControl$ssAtDoseTime)
+  .et <- rxode2::etTrans(
+    inData = data, obj = .mod,
+    addCmt = TRUE, dropUnits = TRUE,
+    keep = unique(c("nlmixrRowNums", env$table$keep)),
+    allTimeVar = TRUE, keepDosingOnly = FALSE,
+    addlKeepsCov = rxControl$addlKeepsCov,
+    addlDropSs = rxControl$addlDropSs,
+    ssAtDoseTime = rxControl$ssAtDoseTime
+  )
   .lst <- attr(class(.et), ".rxode2.lst")
   .keepL <- .lst$keepL[[1]]
   .idLvl <- .lst$idLvl
@@ -3248,7 +3417,9 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   # pre-issue-#606 behavior these callers rely on.
   if (length(.dropId) > 0L && length(.obsId) > 0L) {
     warning("IDs without observations dropped: ",
-            paste(.idLvl[.dropId], collapse = " "), call. = FALSE)
+      paste(.idLvl[.dropId], collapse = " "),
+      call. = FALSE
+    )
     .dat <- .dat[.dat$ID %in% .obsId, , drop = FALSE]
     .keepLvl <- .idLvl[.obsId]
     .dat$ID <- match(.idLvl[.dat$ID], .keepLvl)
@@ -3268,13 +3439,14 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
 #' @noRd
 .foceiFitInternal <- function(.ret) {
   if (exists("objective", .ret)) {
-    checkmate::assertNumeric(.ret$objective, len=1, .var.name="fitEnv$objective")
+    checkmate::assertNumeric(.ret$objective, len = 1, .var.name = "fitEnv$objective")
   }
   if (exists("etaObf", .ret)) {
-    checkmate::assertDataFrame(.ret$etaObf, .var.name="fitEnv$etaObf")
+    checkmate::assertDataFrame(.ret$etaObf, .var.name = "fitEnv$etaObf")
     if (!(names(.ret$etaObf)[1] == "ID")) {
       stop("the first column of fitEnv$etaObj needs to be an integer and named ID",
-           call.=FALSE)
+        call. = FALSE
+      )
     }
     # On a theta-reset restart .ret carries the previous fit's etaObf, whose ID
     # column foceiEtas() built as a factor of the original subject IDs; coerce it
@@ -3282,9 +3454,9 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     if (is.factor(.ret$etaObf$ID)) {
       .ret$etaObf$ID <- as.integer(.ret$etaObf$ID)
     }
-    checkmate::assertInteger(.ret$etaObf$ID, any.missing=FALSE, min=1, .var.name="fitEnv$etaObj$ID")
+    checkmate::assertInteger(.ret$etaObf$ID, any.missing = FALSE, min = 1, .var.name = "fitEnv$etaObj$ID")
   }
-  this.env <- new.env(parent=emptyenv())
+  this.env <- new.env(parent = emptyenv())
   assign("err", "theta reset", this.env)
   ## Event ("jump") sensitivities: when requested, point rxode2's event-
   ## sensitivity globals at the inner (sensitivity) model right before the C++
@@ -3292,12 +3464,13 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   ## never goes through rxSolve()/.rxSetEventSensDims()).  The handle_evid jump
   ## injection is compartment-count guarded, so the smaller pred model solved in
   ## the same loop skips it safely.  Reset on exit.
-  .eventSens <- tryCatch(.ret$control$eventSens, error=function(e) "jump")
+  .eventSens <- tryCatch(.ret$control$eventSens, error = function(e) "jump")
   if (identical(.eventSens, "jump") &&
-        exists("model", .ret) && !is.null(.ret$model$inner)) {
+    exists("model", .ret) && !is.null(.ret$model$inner)) {
     .esLoaded <- tryCatch(
       rxode2::rxEventSensLoadModel(.ret$model$inner),
-      error=function(e) FALSE)
+      error = function(e) FALSE
+    )
     if (isTRUE(.esLoaded)) {
       ## Tell the C++ core which model the event path is now bound to.  handle_evid
       ## sizes its scratch from the effective neq but calls the INSTALLED model's
@@ -3305,10 +3478,13 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       ## cannot see this R-side install on its own.  Roles: 0 pred, 1 inner,
       ## 2 outer, 3 hess2 -- a focei problem sets up 1, 2 and 3.
       odeSwapEsNoteInstalled_(1L)
-      on.exit({
-        rxode2::rxEventSensDeactivate()
-        odeSwapEsNoteInstalled_(-1L)
-      }, add=TRUE)
+      on.exit(
+        {
+          rxode2::rxEventSensDeactivate()
+          odeSwapEsNoteInstalled_(-1L)
+        },
+        add = TRUE
+      )
     }
   }
   .thetaReset$thetaNames <- .ret$thetaNames
@@ -3329,23 +3505,24 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       }
       assign("err", "", this.env)
       .ret0 <- tryCatch(
-      {
-        foceiFitCpp_(.ret)
-      },
-      error = function(e) {
-        if (regexpr("theta reset", e$message) != -1) {
-          assign("zeroOuter", FALSE, this.env)
-          assign("zeroGrad", FALSE, this.env)
-          if (regexpr("theta reset0", e$message) != -1) {
-            assign("zeroGrad", TRUE, this.env)
-          }  else if (regexpr("theta resetZ", e$message) != -1) {
-            assign("zeroOuter", TRUE, this.env)
+        {
+          foceiFitCpp_(.ret)
+        },
+        error = function(e) {
+          if (regexpr("theta reset", e$message) != -1) {
+            assign("zeroOuter", FALSE, this.env)
+            assign("zeroGrad", FALSE, this.env)
+            if (regexpr("theta reset0", e$message) != -1) {
+              assign("zeroGrad", TRUE, this.env)
+            } else if (regexpr("theta resetZ", e$message) != -1) {
+              assign("zeroOuter", TRUE, this.env)
+            }
+            assign("err", "theta reset", this.env)
+          } else {
+            assign("err", e$message, this.env)
           }
-          assign("err", "theta reset", this.env)
-        } else {
-          assign("err", e$message, this.env)
         }
-      })
+      )
       if (this.env$err == "theta reset") {
         # A restart must recompute its OWN objective.  nlmixr2EnvSetup() (inner.cpp)
         # computes one only when the environment does not already carry it -- otherwise
@@ -3367,16 +3544,16 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
         .ret$control$etaMat <- .thetaReset$etaMat
         .ret$control$maxInnerIterations <- .thetaReset$maxInnerIterations
         .ret$control$nF <- .thetaReset$nF
-        #.ret$control$gillRetC <- .thetaReset$gillRetC
-        #.ret$control$gillRet <- .thetaReset$gillRet
-        #.ret$control$gillRet <- .thetaReset$gillRet
-        #.ret$control$gillDf <- .thetaReset$gillDf
-        #.ret$control$gillDf2 <- .thetaReset$gillDf2
-        #.ret$control$gillErr <- .thetaReset$gillErr
-        #.ret$control$rEps <- .thetaReset$rEps
-        #.ret$control$aEps <- .thetaReset$aEps
-        #.ret$control$rEpsC <- .thetaReset$rEpsC
-        #.ret$control$aEpsC <- .thetaReset$aEpsC
+        # .ret$control$gillRetC <- .thetaReset$gillRetC
+        # .ret$control$gillRet <- .thetaReset$gillRet
+        # .ret$control$gillRet <- .thetaReset$gillRet
+        # .ret$control$gillDf <- .thetaReset$gillDf
+        # .ret$control$gillDf2 <- .thetaReset$gillDf2
+        # .ret$control$gillErr <- .thetaReset$gillErr
+        # .ret$control$rEps <- .thetaReset$rEps
+        # .ret$control$aEps <- .thetaReset$aEps
+        # .ret$control$rEpsC <- .thetaReset$rEpsC
+        # .ret$control$aEpsC <- .thetaReset$aEpsC
         .ret$control$c1 <- .thetaReset$c1
         .ret$control$c2 <- .thetaReset$c2
         if (this.env$zeroOuter) {
@@ -3419,7 +3596,8 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   "mfocepControl", "ifocepControl",
   "agqControl", "magqControl", "iagqControl",
   "laplaceControl", "mlaplaceControl", "ilaplaceControl",
-  "impmapControl")
+  "impmapControl"
+)
 
 # TRUE for foceiControl and every control built from it (see
 # .nlmixrFoceiFamilyControlClasses).
@@ -3428,27 +3606,39 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
 }
 
 .nlmixrCheckFoceiEnvironment <- function(ret) {
-  checkmate::assertDataFrame(ret$dataSav, .var.name="focei$dataSav")
-  checkmate::assertNumeric(ret$thetaIni, any.missing=FALSE,
-                           null.ok=TRUE, .var.name="focei$thetaIni")
-  checkmate::assertLogical(ret$skipCov, null.ok=TRUE,
-                           any.missing=FALSE, .var.name="focei$skipCov")
+  checkmate::assertDataFrame(ret$dataSav, .var.name = "focei$dataSav")
+  checkmate::assertNumeric(ret$thetaIni,
+    any.missing = FALSE,
+    null.ok = TRUE, .var.name = "focei$thetaIni"
+  )
+  checkmate::assertLogical(ret$skipCov,
+    null.ok = TRUE,
+    any.missing = FALSE, .var.name = "focei$skipCov"
+  )
   if (!inherits(ret$rxInv, "rxSymInvCholEnv")) {
     stop("focei$rxInv needs to be of class'rxSymInvCholEnv'",
-         call.=FALSE)
+      call. = FALSE
+    )
   }
-  checkmate::assertNumeric(ret$lower, null.ok=TRUE,
-                           any.missing=FALSE, .var.name="focei$lower")
-  checkmate::assertNumeric(ret$upper, null.ok=TRUE,
-                           any.missing=FALSE, .var.name="focei$upper")
+  checkmate::assertNumeric(ret$lower,
+    null.ok = TRUE,
+    any.missing = FALSE, .var.name = "focei$lower"
+  )
+  checkmate::assertNumeric(ret$upper,
+    null.ok = TRUE,
+    any.missing = FALSE, .var.name = "focei$upper"
+  )
   if (length(ret$etaMat) == 1L && is.na(ret$etaMat)) {
     ret$etaMat <- NULL
   }
-  checkmate::assertMatrix(ret$etaMat, mode="double", null.ok=TRUE,
-                          any.missing=FALSE, .var.name="focei$etaMat")
+  checkmate::assertMatrix(ret$etaMat,
+    mode = "double", null.ok = TRUE,
+    any.missing = FALSE, .var.name = "focei$etaMat"
+  )
   if (!.nlmixrIsFoceiFamilyControl(ret$control)) {
     stop("focei$control must be a focei control object",
-         call.=FALSE)
+      call. = FALSE
+    )
   }
 }
 
@@ -3477,7 +3667,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     }
     ## Maybe change scale?
     message(sprintf("Restart %s/%s", .n, control$nRetries))
-    if (is.na(control$zeroGradFirstReset) && .n ==control$nRetries) {
+    if (is.na(control$zeroGradFirstReset) && .n == control$nRetries) {
       .ret$control$zeroGradFirstReset <- TRUE
     }
     .ret$control$nF <- 0
@@ -3494,7 +3684,9 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
         } else {
           .estNew[.i]
         }
-      }, numeric(1), USE.NAMES=FALSE)
+      }, numeric(1),
+      USE.NAMES = FALSE
+    )
     .ret$thetaIni <- setNames(.estNew, names(.est0))
     .nlmixrCheckFoceiEnvironment(.ret)
     if (getOption("nlmixr2.retryFocei", TRUE)) {
@@ -3514,8 +3706,8 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
 #' @return nothing, called for side effects
 #' @author Matthew L. Fidler
 #' @noRd
-.foceiFamilyControl <- function(env, ..., type="foceiControl") {
-  .ui <- get("ui", envir=env)
+.foceiFamilyControl <- function(env, ..., type = "foceiControl") {
+  .ui <- get("ui", envir = env)
   .control <- env$control
   if (is.null(.control)) {
     .control <- do.call(type)
@@ -3527,32 +3719,34 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     .control$est <- env$est
   }
   if (inherits(nlmixr2global$etaMat, "nlmixr2FitCore") &&
-        is.null(.control[["etaMat"]])) {
+    is.null(.control[["etaMat"]])) {
     warning("Passed the initial etas from the last fit",
-            call.=FALSE)
+      call. = FALSE
+    )
     .control[["etaMat"]] <- nlmixr2global$etaMat$etaMat
   }
   # Change control when there is only 1 item being optimized
-  .iniDf <- get("iniDf", envir=.ui)
-  .est <- .iniDf[!.iniDf$fix,,drop=FALSE]
+  .iniDf <- get("iniDf", envir = .ui)
+  .est <- .iniDf[!.iniDf$fix, , drop = FALSE]
   if (length(.est$name) == 0L) {
-    .etas <- .iniDf[!is.na(.iniDf$neta1),, drop = FALSE]
+    .etas <- .iniDf[!is.na(.iniDf$neta1), , drop = FALSE]
     if (length(.etas$name) == 0L) {
-      stop("no parameters to estimate", call.=FALSE)
+      stop("no parameters to estimate", call. = FALSE)
     } else {
       .minfo("no population parameters to estimate; changing to a EBE estimation")
       .control$maxOuterIterations <- 0L # no outer optimization
-      .control$normType <- 6L #"constant"
+      .control$normType <- 6L # "constant"
       .control$interaction <- 0L # focei
       .control$covMethod <- 0L # ""
       warning("no population parameters to estimate; changing to a EBE estimation",
-              call.=FALSE)
+        call. = FALSE
+      )
     }
   } else if (length(.est$name) == 1L) {
     .minfo("only one parameter to estimate, using stats::optimize")
     .control$outerOpt <- -1L
     .control$outerOptFun <- .optimize
-    .control$normType <- 6L #"constant"
+    .control$normType <- 6L # "constant"
     .control$outerOptTxt <- "stats::optimize"
   }
   .optimHess <- any(.ui$predDfFocei$distribution != "norm")
@@ -3578,8 +3772,8 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     # fit at run time already; downgrading here takes the inner Hessian down
     # with it and says why.
     if (isTRUE(.control$fast) &&
-          (!.foceiLLGradInScope(.ui) ||
-             .nlmixrDataHasCens(env$data))) {
+      (!.foceiLLGradInScope(.ui) ||
+        .nlmixrDataHasCens(env$data))) {
       .minfo("log-likelihood endpoint: the analytic 'fast' gradient does not apply -- using fast = FALSE")
       .control$fast <- FALSE
     }
@@ -3592,7 +3786,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   # component 0 regardless of which won, and picking the winner still drops the
   # probability weighting and the derivative of the weights themselves.
   if (isTRUE(.control$fast) &&
-        isTRUE(tryCatch(length(.ui$thetaMixIndex) > 0L, error = function(e) FALSE))) {
+    isTRUE(tryCatch(length(.ui$thetaMixIndex) > 0L, error = function(e) FALSE))) {
     .minfo("mixture model: the analytic 'fast' gradient does not apply yet -- using fast = FALSE")
     .control$fast <- FALSE
   }
@@ -3625,7 +3819,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     if (is.list(.mv0$indLin) && length(.mv0$indLin) == 4L) {
       .isForcingFlattened <- !is.null(.mv0$indLin$f) &&
         (isTRUE(!identical(.control$muModel, "none") && isTRUE(.control$muRefCovAlg)) ||
-           !isTRUE(if (is.null(.control$interaction)) TRUE else .control$interaction))
+          !isTRUE(if (is.null(.control$interaction)) TRUE else .control$interaction))
       if (!.isForcingFlattened) {
         .minfo("matExp() model: the analytic 'fast' gradient does not apply -- using fast = FALSE")
         .control$fast <- FALSE
@@ -3650,7 +3844,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   # rxPriorBuildSpec() itself, here, before any estimation starts.
   .priorMethod <- .control$priorMethod
   if (is.null(.priorMethod)) .priorMethod <- "auto"
-  .control["priorSpec"] <- list(.nlmixr2BuildPriorSpec(.ui, method=.priorMethod))
+  .control["priorSpec"] <- list(.nlmixr2BuildPriorSpec(.ui, method = .priorMethod))
   if (!is.null(.control$priorSpec)) {
     # FOCEi's shared C++ kernel evaluates a prior on a population parameter
     # AND on an omega element (any of the "general"/"nwpri"/"tnpri"
@@ -3685,7 +3879,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       .control$covMethod <- 1L
     }
   }
-  assign("control", .control, envir=.ui)
+  assign("control", .control, envir = .ui)
 }
 
 #' Get the cmt() and dvid() lines
@@ -3696,11 +3890,19 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
 #' @noRd
 .foceiToCmtLinesAndDvid <- function(ui) {
   .cmtLines <- ui$cmtLines
-  paste(c("", vapply(seq_along(.cmtLines),
-                     function(i){deparse1(.cmtLines[[i]])},
-                     character(1), USE.NAMES=FALSE),
-          deparse1(ui$dvidLine)),
-        collapse="\n")
+  paste(
+    c(
+      "", vapply(seq_along(.cmtLines),
+        function(i) {
+          deparse1(.cmtLines[[i]])
+        },
+        character(1),
+        USE.NAMES = FALSE
+      ),
+      deparse1(ui$dvidLine)
+    ),
+    collapse = "\n"
+  )
 }
 #' Calculate the parameter history
 #'
@@ -3716,7 +3918,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   .tmp <- .tmp[.tmp$type == .type, names(.tmp) != "type"]
   .iter <- .tmp$iter
   .tmp <- .tmp[, names(.tmp) != "iter"]
-  data.frame(iter = .iter, .tmp, check.names=FALSE)
+  data.frame(iter = .iter, .tmp, check.names = FALSE)
 }
 
 #' Setup the par history information
@@ -3726,15 +3928,18 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
 #' @author Matthew L. Fidler
 #' @noRd
 .foceiSetupParHistData <- function(.ret) {
-  if (exists("parHistData", envir=.ret)) {
+  if (exists("parHistData", envir = .ret)) {
     .ret$parHistData$type <- factor(.ret$parHistData$type,
-                                    levels=c("Gill83 Gradient", "Mixed Gradient", "Forward Difference",
-                                             "Central Difference", "Scaled", "Unscaled",
-                                             "Back-Transformed", "Forward Sensitivity",
-                                             "Analytic Gradient",
-                                             "Analytic Gradient (relaxed)",
-                                             "Analytic Gradient (finite difference)",
-                                             "Analytic Gradient (Chartrand)"))
+      levels = c(
+        "Gill83 Gradient", "Mixed Gradient", "Forward Difference",
+        "Central Difference", "Scaled", "Unscaled",
+        "Back-Transformed", "Forward Sensitivity",
+        "Analytic Gradient",
+        "Analytic Gradient (relaxed)",
+        "Analytic Gradient (finite difference)",
+        "Analytic Gradient (Chartrand)"
+      )
+    )
     .ret$parHistData$iter <- as.integer(.ret$parHistData$iter)
     .ret$parHist <- .parHistCalc(.ret)
   }
@@ -3809,19 +4014,25 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
 #' @noRd
 .foceiMcetaMuRefFallback <- function(ui, control) {
   .mceta <- control$mceta
-  if (is.null(.mceta) || identical(as.integer(.mceta), -2L)) return(control)
+  if (is.null(.mceta) || identical(as.integer(.mceta), -2L)) {
+    return(control)
+  }
   .allEta <- ui$eta
-  if (length(.allEta) == 0L) return(control)
+  if (length(.allEta) == 0L) {
+    return(control)
+  }
   .muEta <- ui$muRefDataFrame$eta
   if (all(.allEta %in% .muEta)) {
     warning("all etas are mu-referenced (initial etas are zero), so 'mceta=", .mceta,
-            "' has no effect; using the default 'mceta=-2'", call.=FALSE)
+      "' has no effect; using the default 'mceta=-2'",
+      call. = FALSE
+    )
     control$mceta <- -2L
   }
   control
 }
 
-.foceiFamilyReturn <- function(env, ui, ..., method=NULL, est="none") {
+.foceiFamilyReturn <- function(env, ui, ..., method = NULL, est = "none") {
   .control <- ui$control
   .control <- .foceiMcetaMuRefFallback(ui, .control)
   .control$est <- est
@@ -3842,9 +4053,12 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       .cv <- tryCatch(ui$allCovs, error = function(e) character(0))
       .cv <- .cv[.cv %in% names(.rd)]
       if (length(.cv) > 0L && "ID" %in% names(.rd)) {
-        .const <- .cv[vapply(.cv, function(.c)
-          all(tapply(.rd[[.c]], .rd$ID,
-                     function(.v) length(unique(.v[!is.na(.v)])) <= 1L)), logical(1))]
+        .const <- .cv[vapply(.cv, function(.c) {
+          all(tapply(
+            .rd[[.c]], .rd$ID,
+            function(.v) length(unique(.v[!is.na(.v)])) <= 1L
+          ))
+        }, logical(1))]
         rxode2::rxAssignControlValue(ui, "foceiConstCovs", .const)
       }
     }
@@ -3858,9 +4072,13 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     if (!identical(rxode2::rxGetControl(ui, "linCmtSensCarry", "auto"), "auto")) {
       return(invisible(NULL))
     }
-    if (!.rxFoceiLinCmtCarryCapable()) return(invisible(NULL)) # nolint: object_usage_linter.
+    if (!.rxFoceiLinCmtCarryCapable()) {
+      return(invisible(NULL))
+    } # nolint: object_usage_linter.
     .rd <- tryCatch(as.data.frame(env$data), error = function(e) NULL)
-    if (is.null(.rd)) return(invisible(NULL))
+    if (is.null(.rd)) {
+      return(invisible(NULL))
+    }
     # "linear" covariate interpolation cannot be represented by linCmt()'s
     # one-sample-per-row evaluation: with a data-confirmed time-varying
     # covariate on an eligible pair this is an error, not a silent skip
@@ -3868,9 +4086,10 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     if (identical(as.integer(.interp), 0L) || identical(.interp, "linear")) {
       .s <- ui$foceiEtaS
       .rxFoceiLinCmtCarryEligible(list(ui), .s, # nolint: object_usage_linter.
-                                  paste0("ETA_", seq_len(.s$..maxEta), "_"),
-                                  data = .rd, interpolation = "linear",
-                                  render = FALSE)
+        paste0("ETA_", seq_len(.s$..maxEta), "_"),
+        data = .rd, interpolation = "linear",
+        render = FALSE
+      )
       return(invisible(NULL))
     }
     .rdUp <- .rd
@@ -3879,7 +4098,9 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       ("EVID" %in% names(.rdUp) && any(.rdUp[["EVID"]] == 2L, na.rm = TRUE))
     # only warn when the model would actually have used the carry
     .pairs <- tryCatch(.foceiLinCmtCarryPairs(ui), error = function(e) NULL) # nolint: object_usage_linter.
-    if (is.null(.pairs) || nrow(.pairs) == 0L) return(invisible(NULL))
+    if (is.null(.pairs) || nrow(.pairs) == 0L) {
+      return(invisible(NULL))
+    }
     .why <- if (.bad) "ss/evid=2 rows" else NULL
     if (is.null(.why)) {
       # a jump (f()/alag()) channel needs every dose in the modified
@@ -3895,7 +4116,8 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     if (!is.null(.why)) {
       rxode2::rxAssignControlValue(ui, "linCmtSensCarry", "none")
       warning(.why, ": linCmt() carry gradient off for this fit",
-              call. = FALSE)
+        call. = FALSE
+      )
     }
   })
   # Building the optimization environment (`ui$foceiOptEnv`) is where the
@@ -3932,8 +4154,10 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   if (!is.null(.env$cov)) {
     # Accept NA only for whole ill-identified parameter rows/columns (see
     # .nlmixr2RobustCov(), R/cov.R); any other missingness is malformed.
-    .validCov <- checkmate::testMatrix(.env$cov, min.rows=1, #.var.name="env$cov",
-                                       row.names="strict", col.names="strict")
+    .validCov <- checkmate::testMatrix(.env$cov,
+      min.rows = 1, # .var.name="env$cov",
+      row.names = "strict", col.names = "strict"
+    )
     if (.validCov && anyNA(.env$cov)) {
       .bad <- which(is.na(diag(.env$cov)))
       .good <- setdiff(seq_len(nrow(.env$cov)), .bad)
@@ -3987,26 +4211,27 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     .nlmixrFoceiRestartIfNeeded(.fit0, .env, .control)
   })
   if (inherits(.ret0, "try-error")) {
-    stop("Could not fit data\n  ", attr(.ret0, "condition")$message, call.=FALSE)
+    stop("Could not fit data\n  ", attr(.ret0, "condition")$message, call. = FALSE)
   }
   .ret <- nlmixrWithTiming("postprocess", {
     .ret <- .ret0
-    if (!is.null(method))
+    if (!is.null(method)) {
       .ret$method <- method
+    }
     .priorEnvTolFactor <- NULL
-    if (is.environment(ui) && exists("foceiEnv", envir=ui, inherits=FALSE)) {
+    if (is.environment(ui) && exists("foceiEnv", envir = ui, inherits = FALSE)) {
       .priorEnv <- ui$foceiEnv
-      if (is.environment(.priorEnv) && exists("tolFactor", envir=.priorEnv, inherits=FALSE)) {
+      if (is.environment(.priorEnv) && exists("tolFactor", envir = .priorEnv, inherits = FALSE)) {
         .priorEnvTolFactor <- .priorEnv$tolFactor
       }
     }
-    if (exists("ui", envir=.ret)) {
-      ui <- rxode2::rxUiDecompress(get("ui", envir=.ret))
+    if (exists("ui", envir = .ret)) {
+      ui <- rxode2::rxUiDecompress(get("ui", envir = .ret))
     } else {
       ui <- rxode2::rxUiDecompress(ui)
     }
-    if (exists(".predDfFocei", envir=ui)) {
-      rm(".predDfFocei", envir=ui)
+    if (exists(".predDfFocei", envir = ui)) {
+      rm(".predDfFocei", envir = ui)
     }
     ui <- rxode2::rxUiCompress(ui)
     .ret$ui <- ui
@@ -4014,28 +4239,28 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     # For mixture models: fix ranef (remove MIXEST), build mixList and mixNum
     .mixFix(.ret, ui)
     if (!all(is.na(ui$iniDf$neta1))) {
-      if (exists("etaExpected", envir=.ret)) {
+      if (exists("etaExpected", envir = .ret)) {
         .etas <- .ret$etaExpected
       } else {
         .etas <- .ret$ranef
       }
       .w <- which(names(.etas) %in% c("mixnum", "MIXEST"))
       if (length(.w) > 0L) {
-        .etas <- .etas[, -.w, drop=FALSE]
+        .etas <- .etas[, -.w, drop = FALSE]
       }
       .thetas <- .ret$fixef
       .pars <- .Call(`_nlmixr2est_nlmixr2Parameters`, .thetas, .etas)
       .ret$shrink <- .Call(`_nlmixr2est_calcShrinkOnly`, .ret$omega, .pars$eta.lst, length(.etas$ID))
     }
-    assign("est", est, envir=.ret)
+    assign("est", est, envir = .ret)
     # The FO/FOI estimation path (fo=TRUE, maxOuterIterations>0) returns the fit
     # env with an empty `control` binding, so downstream consumers such as
     # .updateParFixed() would see a NULL control and fall back to defaults
     # (issue #517).  Populate the raw binding from the fit's control so the
     # object carries its control (nmObjGetControl.default then surfaces it).
     if (is.environment(.ret) && !is.null(.control) &&
-          is.null(get0("control", envir=.ret, inherits=FALSE))) {
-      assign("control", .control, envir=.ret)
+      is.null(get0("control", envir = .ret, inherits = FALSE))) {
+      assign("control", .control, envir = .ret)
     }
     .foceiInstallAnalyticCov(.ret)
     .foceiInstallFdFullCov(.ret)
@@ -4045,8 +4270,8 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     }
     .nlmixr2FitUpdateParams(.ret)
     .ret$IDlabel <- rxode2::.getLastIdLvl()
-    .idLvl <- if (exists("idLvl", envir=.ret)) .ret$idLvl else character(0)
-    if (exists("tolFactor", envir=.ret)) {
+    .idLvl <- if (exists("idLvl", envir = .ret)) .ret$idLvl else character(0)
+    if (exists("tolFactor", envir = .ret)) {
       .tf <- .ret$tolFactor
       if (length(.tf) == length(.idLvl)) {
         .tf <- setNames(.tf, .idLvl)
@@ -4054,37 +4279,37 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       .ret$tolFactor <- .tf
     }
     if (!is.null(.priorEnvTolFactor) && length(.priorEnvTolFactor) == length(.idLvl)) {
-      .foceiTf <- if (exists("tolFactor", envir=.ret)) unname(.ret$tolFactor) else rep(1.0, length(.priorEnvTolFactor))
+      .foceiTf <- if (exists("tolFactor", envir = .ret)) unname(.ret$tolFactor) else rep(1.0, length(.priorEnvTolFactor))
       .ret$tolFactor <- setNames(pmax(.foceiTf, .priorEnvTolFactor), .idLvl)
     }
-    if (exists("skipTable", envir=.ret)) {
-      if (is.na(.ret$skipTable)) {
-      } else if (.ret$skipTable) {
+    if (exists("skipTable", envir = .ret)) {
+      if (is.na(.ret$skipTable)) {} else if (.ret$skipTable) {
         .control$calcTables <- FALSE
       }
     }
-    assign("skipCov", .env$skipCov, envir=.ret)
+    assign("skipCov", .env$skipCov, envir = .ret)
     nmObjHandleModelObject(.ret$model, .ret)
-    nmObjHandleControlObject(get("control", envir=.ret), .ret)
+    nmObjHandleControlObject(get("control", envir = .ret), .ret)
     .ret
   })
   nlmixr2global$currentTimingEnvironment <- .ret # add environment for updating timing info
   if (.control$calcTables) {
     .tmp <- try(addTable(.ret,
-                         updateObject="no",
-                         keep=.ret$table$keep,
-                         drop=.ret$table$drop,
-                         table=.ret$table), silent=TRUE)
+      updateObject = "no",
+      keep = .ret$table$keep,
+      drop = .ret$table$drop,
+      table = .ret$table
+    ), silent = TRUE)
     if (inherits(.tmp, "try-error")) {
-      warning("error calculating tables, returning without table step", call.=FALSE)
+      warning("error calculating tables, returning without table step", call. = FALSE)
     } else {
       .ret <- .mixFixTable(.tmp, .env, ui)
     }
   }
-  assign("sessioninfo", .sessionInfo(), envir=.env)
+  assign("sessioninfo", .sessionInfo(), envir = .env)
   nlmixrWithTiming("compress", {
     if (exists("saem", .env)) {
-      .saem <- get("saem", envir=.env)
+      .saem <- get("saem", envir = .env)
       .saemCfg <- attr(.saem, "saem.cfg")
       # Delete unneeded variables
       .saemCfg2 <- list()
@@ -4094,56 +4319,59 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
         .saemCfg2[[.v]] <- .saemCfg[[.v]]
       }
       attr(.saem, "saem.cfg") <- .saemCfg2
-      rm(list="saem", envir=.env)
+      rm(list = "saem", envir = .env)
       .env$saem0 <- .saem
     }
     if (.control$compress) {
       for (.item in c("origData", "parHistData", "phiM")) {
         if (exists(.item, .env)) {
-          .obj <- get(.item, envir=.env)
+          .obj <- get(.item, envir = .env)
           .size <- utils::object.size(.obj)
           .type <- rxode2::rxGetDefaultSerialize()
           # older rxode2 could return qs2/qdata here; those formats are no
           # longer written (stringfish/qs2 dependency dropped)
           if (!(.type %in% c("base", "bzip2", "xz"))) .type <- "bzip2"
           .objC <- switch(.type,
-                 bzip2 = {
-                   memCompress(serialize(.obj, NULL), type="bzip2")
-                 },
-                 xz = {
-                   memCompress(serialize(.obj, NULL), type="xz")
-                 },
-                 base = {
-                   serialize(.obj, NULL)
-                 })
+            bzip2 = {
+              memCompress(serialize(.obj, NULL), type = "bzip2")
+            },
+            xz = {
+              memCompress(serialize(.obj, NULL), type = "xz")
+            },
+            base = {
+              serialize(.obj, NULL)
+            }
+          )
           .size2 <- utils::object.size(.objC)
           if (.size2 < .size) {
             .size0 <- (.size - .size2)
-            .malert("compress {  .item } in nlmixr2 object, save { .size0 }" )
-            assign(.item, .objC, envir=.env)
+            .malert("compress {  .item } in nlmixr2 object, save { .size0 }")
+            assign(.item, .objC, envir = .env)
           }
         }
       }
     }
-    for (.item in c("adj", "adjLik", "diagXformInv", "etaMat", "etaNames",
-                    "fullTheta", "scaleC", "gillRet", "gillRetC",
-                    "xform",
-                    "lower", "noLik", "objf", "OBJF",
-                    "rxInv", "scaleC", "se", "skipCov", "thetaFixed", "thetaIni", "thetaNames", "upper",
-                    "xType", "IDlabel", "ODEmodel", "model",
-                    # times
-                    "optimTime", "setupTime", "covTime",
-                    "parHist", "dataSav", "idLvl", "theta",
-                    "missingTable", "missingControl", "missingEst")) {
+    for (.item in c(
+      "adj", "adjLik", "diagXformInv", "etaMat", "etaNames",
+      "fullTheta", "scaleC", "gillRet", "gillRetC",
+      "xform",
+      "lower", "noLik", "objf", "OBJF",
+      "rxInv", "scaleC", "se", "skipCov", "thetaFixed", "thetaIni", "thetaNames", "upper",
+      "xType", "IDlabel", "ODEmodel", "model",
+      # times
+      "optimTime", "setupTime", "covTime",
+      "parHist", "dataSav", "idLvl", "theta",
+      "missingTable", "missingControl", "missingEst"
+    )) {
       if (exists(.item, .env)) {
-        rm(list=.item, envir=.env)
+        rm(list = .item, envir = .env)
       }
     }
-    assign("ui", rxode2::rxUiCompress(.env$ui), envir=.env)
+    assign("ui", rxode2::rxUiCompress(.env$ui), envir = .env)
   })
   .nAGQ <- tryCatch(.ret$foceiControl$nAGQ, error = function(e) 0L)
   if (any(names(.ret) == "CWRES") && regexpr("^fo", est) == -1 &&
-        !isTRUE(.nAGQ > 0)) {
+    !isTRUE(.nAGQ > 0)) {
     # focei is available; add objective function.  Quadrature fits (laplace/agq,
     # nAGQ > 0) keep their own objective row active; use setOfv(fit, "focei") to
     # add the focei objective explicitly.
@@ -4152,24 +4380,26 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   .postFinalObjectHooksRun(.ret)
 }
 
-#'@rdname nlmixr2Est
-#'@export
+#' @rdname nlmixr2Est
+#' @export
 nlmixr2Est.focei <- function(env, ...) {
   .ui <- env$ui
   rxode2::assertRxUiIovNoCor(.ui, " for the estimation routine 'focei'",
-                             .var.name=.ui$modelName)
+    .var.name = .ui$modelName
+  )
   if (!rxode2hasLlik()) {
     rxode2::assertRxUiTransformNormal(.ui, " for the estimation routine 'focei'",
-                                      .var.name=.ui$modelName)
+      .var.name = .ui$modelName
+    )
   }
   .foceiFamilyControl(env, ...)
   on.exit({
-    if (is.environment(.ui) && exists("control", envir=.ui, inherits=FALSE)) {
-      rm("control", envir=.ui)
+    if (is.environment(.ui) && exists("control", envir = .ui, inherits = FALSE)) {
+      rm("control", envir = .ui)
     }
   })
   .ui <- env$ui
-  .ret <- .foceiFamilyReturn(env, .ui, ..., est="focei")
+  .ret <- .foceiFamilyReturn(env, .ui, ..., est = "focei")
   .ret
 }
 attr(nlmixr2Est.focei, "nlmixr2Priors") <- "general"
@@ -4207,17 +4437,17 @@ attr(nlmixr2Est.focei, "iov") <- TRUE
       .objDf1[["Condition#(Cor)"]] <- NA_real_
     }
   }
-  assign("objDf", rbind(.objDf1, objDf), envir=ret)
+  assign("objDf", rbind(.objDf1, objDf), envir = ret)
 }
 
 
-#'@rdname nlmixr2Est
-#'@export
+#' @rdname nlmixr2Est
+#' @export
 nlmixr2Est.output <- function(env, ...) {
   .ui <- env$ui
-  rxode2::assertRxUiRandomOnIdOnly(.ui, " for the estimation routine 'output'", .var.name=.ui$modelName)
+  rxode2::assertRxUiRandomOnIdOnly(.ui, " for the estimation routine 'output'", .var.name = .ui$modelName)
   if (!rxode2hasLlik()) {
-    rxode2::assertRxUiTransformNormal(.ui, " for the estimation routine 'output'", .var.name=.ui$modelName)
+    rxode2::assertRxUiTransformNormal(.ui, " for the estimation routine 'output'", .var.name = .ui$modelName)
   }
 
   .foceiFamilyControl(env, ...)
@@ -4225,12 +4455,12 @@ nlmixr2Est.output <- function(env, ...) {
   rxode2::rxAssignControlValue(.ui, "maxOuterIterations", 0L)
   rxode2::rxAssignControlValue(.ui, "maxInnerIterations", 0L)
   on.exit({
-    if (is.environment(.ui) && exists("control", envir=.ui, inherits=FALSE)) {
-      rm("control", envir=.ui)
+    if (is.environment(.ui) && exists("control", envir = .ui, inherits = FALSE)) {
+      rm("control", envir = .ui)
     }
   })
-  if (!exists("est", envir=env)) env$est <- "posthoc"
-  .foceiFamilyReturn(env, .ui, ..., est=env$est)
+  if (!exists("est", envir = env)) env$est <- "posthoc"
+  .foceiFamilyReturn(env, .ui, ..., est = env$est)
 }
 # "output" is not an estimation method: it takes a completed environment and
 # builds the tables/objDf for it (nlmixr2CreateOutputFromUi).  The priors were
@@ -4274,24 +4504,24 @@ attr(nlmixr2Est.output, "nlmixr2Priors") <- "all"
 #' @return nlmixr fit object
 #' @author Matthew L. Fidler
 #' @export
-nlmixr2CreateOutputFromUi <- function(ui, data=NULL, control=NULL, table=NULL, env=NULL, est="none") {
+nlmixr2CreateOutputFromUi <- function(ui, data = NULL, control = NULL, table = NULL, env = NULL, est = "none") {
   nlmixr2global$finalUiCompressed <- FALSE
   on.exit(nlmixr2global$finalUiCompressed <- TRUE)
   if (inherits(ui, "function")) {
     ui <- rxode2::rxode2(ui)
   }
   if (!inherits(ui, "rxUi")) {
-    stop("the first argument needs to be from rxode2 ui", call.=FALSE)
+    stop("the first argument needs to be from rxode2 ui", call. = FALSE)
   }
   ui <- rxode2::rxUiDecompress(ui)
   if (inherits(env, "environment")) {
-    assign("foceiEnv", env, envir=ui)
+    assign("foceiEnv", env, envir = ui)
   }
   if (!inherits(data, "data.frame")) {
-    stop("the 'data' argument must be a data.frame", call.=FALSE)
+    stop("the 'data' argument must be a data.frame", call. = FALSE)
   }
-  .env <- new.env(parent=emptyenv())
-  assign("ui", ui, envir=.env)
+  .env <- new.env(parent = emptyenv())
+  assign("ui", ui, envir = .env)
   .env$data <- data
   .env$control <- control
   .env$table <- table

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -1,33 +1,35 @@
-.foceiControlInternal <- c("genRxControl", "resetEtaSize", "foceType",
-                           "resetThetaSize", "resetThetaFinalSize",
-                           "outerOptFun", "outerOptTxt", "skipCov",
-                           "foceiMuRef", "foceiMuCovEta", "predNeq", "nfixed", "nomega",
-                           "neta", "ntheta", "nF", "printTop", "needOptimHess",
-                           "iterPrintControl", "est", "foceiMuModel", "foceiMuGroupTheta",
-                           "foceiMuGroupEta", "foceiMuGroupCovStart", "foceiMuGroupCovCount",
-                           "foceiMuGroupCovTheta", "foceiMuGroupCovUserFixed",
-                           "foceiMuGroupThetaLower", "foceiMuGroupThetaUpper",
-                           "foceiMuGroupCovLower", "foceiMuGroupCovUpper",
-                           "foceiMuGroupCovData", "foceiMuGroupTol",
-                           "foceiMuGroupMaxCycles", "foceiMuGroupClampRetries",
-                           # derived from covMethod ("analytic" vs the finite-difference
-                           # formulas); kept internal so a built control round-trips.
-                           "covType",
-                           # foreign covariance ("sa"/"imp") deferred to a post-fit
-                           # recompute; internal so a built control round-trips.
-                           "covMethodDeferred",
-                           # subject-constant covariates stashed by .foceiFamilyReturn
-                           # for the analytic covariate-coefficient reuse; internal so
-                           # a built control round-trips (e.g. posthoc re-validation).
-                           "foceiConstCovs",
-                           # TRUE when the outer optimizer was defaulted (not user
-                           # specified); lets *f wrappers re-default under fast=TRUE
-                           "outerOptDefault",
-                           # the built rx_prior_spec_t* external pointer
-                           # (.nlmixr2BuildPriorSpec(), R/priors.R); not a formal
-                           # argument, not deparseable/comparable, and rebuilt fresh
-                           # every fit -- internal so a built control round-trips.
-                           "priorSpec")
+.foceiControlInternal <- c(
+  "genRxControl", "resetEtaSize", "foceType",
+  "resetThetaSize", "resetThetaFinalSize",
+  "outerOptFun", "outerOptTxt", "skipCov",
+  "foceiMuRef", "foceiMuCovEta", "predNeq", "nfixed", "nomega",
+  "neta", "ntheta", "nF", "printTop", "needOptimHess",
+  "iterPrintControl", "est", "foceiMuModel", "foceiMuGroupTheta",
+  "foceiMuGroupEta", "foceiMuGroupCovStart", "foceiMuGroupCovCount",
+  "foceiMuGroupCovTheta", "foceiMuGroupCovUserFixed",
+  "foceiMuGroupThetaLower", "foceiMuGroupThetaUpper",
+  "foceiMuGroupCovLower", "foceiMuGroupCovUpper",
+  "foceiMuGroupCovData", "foceiMuGroupTol",
+  "foceiMuGroupMaxCycles", "foceiMuGroupClampRetries",
+  # derived from covMethod ("analytic" vs the finite-difference
+  # formulas); kept internal so a built control round-trips.
+  "covType",
+  # foreign covariance ("sa"/"imp") deferred to a post-fit
+  # recompute; internal so a built control round-trips.
+  "covMethodDeferred",
+  # subject-constant covariates stashed by .foceiFamilyReturn
+  # for the analytic covariate-coefficient reuse; internal so
+  # a built control round-trips (e.g. posthoc re-validation).
+  "foceiConstCovs",
+  # TRUE when the outer optimizer was defaulted (not user
+  # specified); lets *f wrappers re-default under fast=TRUE
+  "outerOptDefault",
+  # the built rx_prior_spec_t* external pointer
+  # (.nlmixr2BuildPriorSpec(), R/priors.R); not a formal
+  # argument, not deparseable/comparable, and rebuilt fresh
+  # every fit -- internal so a built control round-trips.
+  "priorSpec"
+)
 
 #' Control Options for FOCEi
 #'
@@ -877,13 +879,13 @@ foceiControl <- function(sigdig = 3, #
                          fdIndividualStep = TRUE, #
                          fdChartrand = TRUE, #
                          # norm of weights = 1/0.225
-                         #hessEps = (1/0.225*.Machine$double.eps)^(1 / 4), #
+                         # hessEps = (1/0.225*.Machine$double.eps)^(1 / 4), #
                          foceEbeTol = NULL, #
-                         hessEps =(.Machine$double.eps)^(1/3),
-                         #hessEpsLlik =(1/0.225*.Machine$double.eps)^(1/4),
-                         hessEpsLlik =(.Machine$double.eps)^(1/3),
+                         hessEps = (.Machine$double.eps)^(1 / 3),
+                         # hessEpsLlik =(1/0.225*.Machine$double.eps)^(1/4),
+                         hessEpsLlik = (.Machine$double.eps)^(1 / 3),
                          optimHessType = c("central", "forward"),
-                         optimHessCovType=c("central", "forward"),
+                         optimHessCovType = c("central", "forward"),
                          censOption = c("gauss", "laplace"),
                          eventType = c("central", "forward"), #
                          eventSens = c("jump", "fd"), #
@@ -895,13 +897,13 @@ foceiControl <- function(sigdig = 3, #
                          diagXform = c("sqrt", "log", "identity"), #
                          iovXform = c("sd", "var", "logsd", "logvar"), #
                          sumProd = FALSE, #
-                         optExpression = TRUE,#
-                         literalFix=TRUE,
-                         literalFixRes=TRUE,
+                         optExpression = TRUE, #
+                         literalFix = TRUE,
+                         literalFixRes = TRUE,
                          ci = 0.95, #
                          useColor = NULL, #
                          boundTol = NULL, #
-                         calcTables = TRUE,#
+                         calcTables = TRUE, #
                          noAbort = TRUE, #
                          interaction = TRUE, #
                          foce = c("nonmem", "foce+"), #
@@ -924,15 +926,17 @@ foceiControl <- function(sigdig = 3, #
                          cholSECov = FALSE, #
                          fo = FALSE, #
                          covTryHarder = FALSE, #
-                         outerOpt = c("bobyqa",
-                                      "nlminb",
-                                      "lbfgsb3c",
-                                      "L-BFGS-B",
-                                      "mma",
-                                      "lbfgsbLG",
-                                      "slsqp",
-                                      "uobyqa",
-                                      "newuoa"), #
+                         outerOpt = c(
+                           "bobyqa",
+                           "nlminb",
+                           "lbfgsb3c",
+                           "L-BFGS-B",
+                           "mma",
+                           "lbfgsbLG",
+                           "slsqp",
+                           "uobyqa",
+                           "newuoa"
+                         ), #
                          innerOpt = c("n1qn1", "BFGS"), #
                          ##
                          rhobeg = .2, #
@@ -954,25 +958,25 @@ foceiControl <- function(sigdig = 3, #
                          stateTrim = Inf, #
                          shi21maxOuter = 0L,
                          shi21maxInner = 20L,
-                         shi21maxInnerCov =20L,
-                         shi21maxFD=20L,
-                         shi21hMax=2.0,
-                         shi21hMin=1e-4,
+                         shi21maxInnerCov = 20L,
+                         shi21maxFD = 20L,
+                         shi21hMax = 2.0,
+                         shi21hMin = 1e-4,
                          gillK = 10L, #
                          gillStep = 4, #
                          gillFtol = 0, #
                          gillRtol = sqrt(.Machine$double.eps), #
                          gillKcov = 10L, #
-                         #gillKcovLlik = 20L,
+                         # gillKcovLlik = 20L,
                          gillKcovLlik = 10L,
                          gillStepCovLlik = 4.5,
-                         #gillStepCovLlik = 2,
+                         # gillStepCovLlik = 2,
                          gillStepCov = 2, #
                          gillFtolCov = 0, #
                          gillFtolCovLlik = 0, #
                          rmatNorm = TRUE, #
-                         #rmatNormLlik= FALSE, #
-                         rmatNormLlik= TRUE, #
+                         # rmatNormLlik= FALSE, #
+                         rmatNormLlik = TRUE, #
                          smatNorm = TRUE, #
                          ## smatNormLlik = FALSE,
                          smatNormLlik = TRUE,
@@ -985,13 +989,13 @@ foceiControl <- function(sigdig = 3, #
                          odeRecalcFactor = 10^(0.5), #
                          gradCalcCentralSmall = 1e-4, #
                          gradCalcCentralLarge = 1e4, #
-                         etaNudge = qnorm(1-0.05/2)/sqrt(3), #
-                         etaNudge2=qnorm(1-0.05/2) * sqrt(3/5), #
+                         etaNudge = qnorm(1 - 0.05 / 2) / sqrt(3), #
+                         etaNudge2 = qnorm(1 - 0.05 / 2) * sqrt(3 / 5), #
                          nRetries = 3, #
                          seed = 42, #
                          resetThetaCheckPer = 0.1, #
                          etaMat = NULL, #
-                         repeatGillMax = 1,#
+                         repeatGillMax = 1, #
                          stickyRecalcN = 4, #
                          outerMaxOdeRecalc = 5, #
                          outerOdeRecalcFactor = 10^(0.5), #
@@ -999,30 +1003,30 @@ foceiControl <- function(sigdig = 3, #
                          indTolRelax = TRUE, #
                          gradProgressOfvTime = 10, #
                          addProp = c("combined2", "combined1"),
-                         badSolveObjfAdj=100, #
-                         compress=FALSE, #
-                         rxControl=NULL,
-                         sigdigTable=NULL,
-                         fallbackFD=FALSE,
-                         smatPer=0.6,
-                         sdLowerFact=0.001,
-                         zeroGradFirstReset=TRUE,
-                         zeroGradRunReset=TRUE,
-                         zeroGradBobyqa=TRUE,
-                         mceta=-2L,
-                         warm=c("calc", "save"),
-                         nAGQ=0,
-                         agqLow=-Inf,
-                         agqHi=Inf,
+                         badSolveObjfAdj = 100, #
+                         compress = FALSE, #
+                         rxControl = NULL,
+                         sigdigTable = NULL,
+                         fallbackFD = FALSE,
+                         smatPer = 0.6,
+                         sdLowerFact = 0.001,
+                         zeroGradFirstReset = TRUE,
+                         zeroGradRunReset = TRUE,
+                         zeroGradBobyqa = TRUE,
+                         mceta = -2L,
+                         warm = c("calc", "save"),
+                         nAGQ = 0,
+                         agqLow = -Inf,
+                         agqHi = Inf,
                          sensMethod = c("default", "forward"),
                          linCmtSensCarry = c("auto", "none"),
-                         zeroTheta=0.001,
-                         boundedTransform=TRUE) { #
+                         zeroTheta = 0.001,
+                         boundedTransform = TRUE) { #
   ## sensMethod: forward (variational) ODE parameter sensitivities.
   sensMethod <- match.arg(sensMethod)
   linCmtSensCarry <- match.arg(linCmtSensCarry)
   if (!is.null(sigdig)) {
-    checkmate::assertNumeric(sigdig, lower=1, finite=TRUE, any.missing=TRUE, len=1)
+    checkmate::assertNumeric(sigdig, lower = 1, finite = TRUE, any.missing = TRUE, len = 1)
     if (is.null(boundTol)) {
       boundTol <- 5 * 10^(-sigdig + 1)
     }
@@ -1069,107 +1073,112 @@ foceiControl <- function(sigdig = 3, #
       sigdigTable <- sigdig
     }
   } else {
-    checkmate::assertNumeric(sigdigTable, lower=1, finite=TRUE, any.missing=TRUE, len=1)
+    checkmate::assertNumeric(sigdigTable, lower = 1, finite = TRUE, any.missing = TRUE, len = 1)
   }
 
-  checkmate::assertNumeric(epsilon, lower=0, finite=TRUE, any.missing=FALSE, len=1)
-  checkmate::assertIntegerish(maxInnerIterations, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertIntegerish(maxInnerIterations, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertIntegerish(maxOuterIterations, lower=0, any.missing=FALSE, len=1)
+  checkmate::assertNumeric(epsilon, lower = 0, finite = TRUE, any.missing = FALSE, len = 1)
+  checkmate::assertIntegerish(maxInnerIterations, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertIntegerish(maxInnerIterations, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertIntegerish(maxOuterIterations, lower = 0, any.missing = FALSE, len = 1)
 
-  checkmate::assertNumeric(sdLowerFact, lower=0, finite=TRUE, upper=0.1, any.missing=FALSE, len=1)
+  checkmate::assertNumeric(sdLowerFact, lower = 0, finite = TRUE, upper = 0.1, any.missing = FALSE, len = 1)
 
   if (is.null(n1qn1nsim)) {
     n1qn1nsim <- 10 * maxInnerIterations + 1
   }
-  checkmate::assertIntegerish(n1qn1nsim, len=1, lower=1, any.missing=FALSE)
+  checkmate::assertIntegerish(n1qn1nsim, len = 1, lower = 1, any.missing = FALSE)
   # Print args are absorbed/validated by iterPrintControl(); `iterPrintControl`
   # picked up from `...` handles the round-trip via do.call(foceiControl, .ctl).
-  .iterPrintControl <- .absorbIterPrintControl(print = print,
-                                               printNcol = printNcol,
-                                               useColor = useColor,
-                                               iterPrintControl = list(...)$iterPrintControl)
-  checkmate::assertNumeric(scaleTo, len=1, lower=0, any.missing=FALSE)
-  checkmate::assertNumeric(scaleObjective, len=1, lower=0, any.missing=FALSE)
-  checkmate::assertNumeric(scaleCmax, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(scaleCmin, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(scaleCband, lower=0, finite=TRUE, any.missing=FALSE, len=2)
+  .iterPrintControl <- .absorbIterPrintControl(
+    print = print,
+    printNcol = printNcol,
+    useColor = useColor,
+    iterPrintControl = list(...)$iterPrintControl
+  )
+  checkmate::assertNumeric(scaleTo, len = 1, lower = 0, any.missing = FALSE)
+  checkmate::assertNumeric(scaleObjective, len = 1, lower = 0, any.missing = FALSE)
+  checkmate::assertNumeric(scaleCmax, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(scaleCmin, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(scaleCband, lower = 0, finite = TRUE, any.missing = FALSE, len = 2)
   if (scaleCband[1] >= scaleCband[2]) {
-    stop("'scaleCband' must be an increasing pair (low, high)", call.=FALSE)
+    stop("'scaleCband' must be an increasing pair (low, high)", call. = FALSE)
   }
   if (!is.null(scaleC)) {
-    checkmate::assertNumeric(scaleC, lower=0, any.missing=FALSE)
+    checkmate::assertNumeric(scaleC, lower = 0, any.missing = FALSE)
   }
-  checkmate::assertNumeric(scaleC0, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(derivEps, lower=0, len=2, any.missing=FALSE)
-  checkmate::assertNumeric(derivSwitchTol, lower=0, len=1, any.missing=FALSE)
-  if (checkmate::testIntegerish(covTryHarder, lower=0, upper=1, any.missing=FALSE, len=1)) {
+  checkmate::assertNumeric(scaleC0, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(derivEps, lower = 0, len = 2, any.missing = FALSE)
+  checkmate::assertNumeric(derivSwitchTol, lower = 0, len = 1, any.missing = FALSE)
+  if (checkmate::testIntegerish(covTryHarder, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
     covTryHarder <- as.integer(covTryHarder)
   } else {
-    checkmate::assertLogical(covTryHarder, any.missing=FALSE, len=1)
-    checkmate::assertNumeric(fdOutlierZ, lower=0, finite=TRUE, any.missing=FALSE, len=1)
-    checkmate::assertLogical(fdOutlierScale, any.missing=FALSE, len=1)
+    checkmate::assertLogical(covTryHarder, any.missing = FALSE, len = 1)
+    checkmate::assertNumeric(fdOutlierZ, lower = 0, finite = TRUE, any.missing = FALSE, len = 1)
+    checkmate::assertLogical(fdOutlierScale, any.missing = FALSE, len = 1)
     fdRefine <- match.arg(fdRefine)
-    checkmate::assertIntegerish(fdLanczosM, lower=1, any.missing=FALSE, len=1)
-    checkmate::assertIntegerish(fdRichardsonR, lower=1, any.missing=FALSE, len=1)
-    checkmate::assertNumeric(fdRichardsonV, lower=1.0000001, finite=TRUE,
-                             any.missing=FALSE, len=1)
-    checkmate::assertLogical(fdChartrandAll, any.missing=FALSE, len=1)
-    checkmate::assertLogical(fdOutlierAny, any.missing=FALSE, len=1)
-    checkmate::assertLogical(fdIndividualStep, any.missing=FALSE, len=1)
-    checkmate::assertLogical(fdChartrand, any.missing=FALSE, len=1)
+    checkmate::assertIntegerish(fdLanczosM, lower = 1, any.missing = FALSE, len = 1)
+    checkmate::assertIntegerish(fdRichardsonR, lower = 1, any.missing = FALSE, len = 1)
+    checkmate::assertNumeric(fdRichardsonV,
+      lower = 1.0000001, finite = TRUE,
+      any.missing = FALSE, len = 1
+    )
+    checkmate::assertLogical(fdChartrandAll, any.missing = FALSE, len = 1)
+    checkmate::assertLogical(fdOutlierAny, any.missing = FALSE, len = 1)
+    checkmate::assertLogical(fdIndividualStep, any.missing = FALSE, len = 1)
+    checkmate::assertLogical(fdChartrand, any.missing = FALSE, len = 1)
     covTryHarder <- as.integer(covTryHarder)
   }
 
-  checkmate::assertNumeric(rhobeg, lower=0, len=1, finite=TRUE, any.missing=FALSE)
-  checkmate::assertNumeric(rhoend, lower=0, len=1, finite=TRUE, any.missing=FALSE)
+  checkmate::assertNumeric(rhobeg, lower = 0, len = 1, finite = TRUE, any.missing = FALSE)
+  checkmate::assertNumeric(rhoend, lower = 0, len = 1, finite = TRUE, any.missing = FALSE)
   if (rhoend >= rhobeg) {
     stop("the trust region method needs '0 < rhoend < rhobeg'",
-         call.=FALSE)
+      call. = FALSE
+    )
   }
   if (!is.null(npt)) {
-    checkmate::assertIntegerish(npt, lower=1, len=1, any.missing=FALSE)
+    checkmate::assertIntegerish(npt, lower = 1, len = 1, any.missing = FALSE)
   }
-  checkmate::assertIntegerish(eval.max, lower=1, len=1, any.missing=FALSE)
-  checkmate::assertIntegerish(iter.max, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(rel.tol, lower=0, len=1, any.missing=FALSE, finite=TRUE)
-  checkmate::assertNumeric(x.tol, lower=0, len=1, any.missing=FALSE, finite=TRUE)
-  checkmate::assertNumeric(abstol, lower=0, len=1, any.missing=FALSE, finite=TRUE)
-  checkmate::assertNumeric(reltol, lower=0, len=1, any.missing=FALSE, finite=TRUE)
+  checkmate::assertIntegerish(eval.max, lower = 1, len = 1, any.missing = FALSE)
+  checkmate::assertIntegerish(iter.max, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(rel.tol, lower = 0, len = 1, any.missing = FALSE, finite = TRUE)
+  checkmate::assertNumeric(x.tol, lower = 0, len = 1, any.missing = FALSE, finite = TRUE)
+  checkmate::assertNumeric(abstol, lower = 0, len = 1, any.missing = FALSE, finite = TRUE)
+  checkmate::assertNumeric(reltol, lower = 0, len = 1, any.missing = FALSE, finite = TRUE)
 
-  checkmate::assertIntegerish(gillK, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertIntegerish(gillKcov, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertIntegerish(gillKcovLlik, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(gillStep, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(gillStepCov, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(gillStepCovLlik, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(gillFtol, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(gillFtolCov, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(gillFtolCovLlik, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(gillRtol, lower=0, len=1, any.missing=FALSE, finite=TRUE)
+  checkmate::assertIntegerish(gillK, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertIntegerish(gillKcov, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertIntegerish(gillKcovLlik, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(gillStep, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(gillStepCov, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(gillStepCovLlik, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(gillFtol, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(gillFtolCov, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(gillFtolCovLlik, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(gillRtol, lower = 0, len = 1, any.missing = FALSE, finite = TRUE)
   # gillRtolCov is calculated in the `inner.cpp`
-  if (!checkmate::testIntegerish(rmatNorm, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(rmatNorm, any.missing=FALSE, len=1)
+  if (!checkmate::testIntegerish(rmatNorm, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(rmatNorm, any.missing = FALSE, len = 1)
   }
   rmatNorm <- as.integer(rmatNorm)
-  if (!checkmate::testIntegerish(rmatNormLlik, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(rmatNormLlik, any.missing=FALSE, len=1)
+  if (!checkmate::testIntegerish(rmatNormLlik, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(rmatNormLlik, any.missing = FALSE, len = 1)
   }
   rmatNormLlik <- as.integer(rmatNormLlik)
-  if (!checkmate::testIntegerish(smatNorm, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(smatNorm, any.missing=FALSE, len=1)
+  if (!checkmate::testIntegerish(smatNorm, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(smatNorm, any.missing = FALSE, len = 1)
   }
   smatNorm <- as.integer(smatNorm)
-  if (!checkmate::testIntegerish(smatNormLlik, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(smatNormLlik, any.missing=FALSE, len=1)
+  if (!checkmate::testIntegerish(smatNormLlik, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(smatNormLlik, any.missing = FALSE, len = 1)
   }
   smatNormLlik <- as.integer(smatNormLlik)
-  if (!checkmate::testIntegerish(covGillF, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(covGillF, any.missing=FALSE, len=1)
+  if (!checkmate::testIntegerish(covGillF, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(covGillF, any.missing = FALSE, len = 1)
   }
   covGillF <- as.integer(covGillF)
-  if (!checkmate::testIntegerish(optGillF, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(optGillF, any.missing=FALSE, len=1)
+  if (!checkmate::testIntegerish(optGillF, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(optGillF, any.missing = FALSE, len = 1)
   }
   optGillF <- as.integer(optGillF)
 
@@ -1178,36 +1187,36 @@ foceiControl <- function(sigdig = 3, #
   # sigdig made the analytic FOCE gradient available or not depending on the requested
   # digits.  Fixed at the value the routine shipped with.
   if (is.null(foceEbeTol)) foceEbeTol <- 1e-9
-  checkmate::assertNumeric(foceEbeTol, lower=0, finite=TRUE, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(hessEps, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(hessEpsLlik, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(centralDerivEps, lower=0, any.missing=FALSE, len=2)
+  checkmate::assertNumeric(foceEbeTol, lower = 0, finite = TRUE, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(hessEps, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(hessEpsLlik, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(centralDerivEps, lower = 0, any.missing = FALSE, len = 2)
 
-  checkmate::assertIntegerish(lbfgsLmm, lower=1L, any.missing=FALSE, len=1)
+  checkmate::assertIntegerish(lbfgsLmm, lower = 1L, any.missing = FALSE, len = 1)
   lbfgsLmm <- as.integer(lbfgsLmm)
-  checkmate::assertNumeric(lbfgsPgtol, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(lbfgsFactr, lower=0, any.missing=FALSE, len=1)
-  if (!checkmate::testIntegerish(eigen, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(eigen, any.missing=FALSE, len=1)
+  checkmate::assertNumeric(lbfgsPgtol, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(lbfgsFactr, lower = 0, any.missing = FALSE, len = 1)
+  if (!checkmate::testIntegerish(eigen, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(eigen, any.missing = FALSE, len = 1)
   }
   eigen <- as.integer(eigen)
 
-  checkmate::assertLogical(sumProd, any.missing=FALSE, len=1)
-  checkmate::assertLogical(optExpression, any.missing=FALSE, len=1)
-  checkmate::assertLogical(literalFix, any.missing=FALSE, len=1)
-  checkmate::assertLogical(literalFixRes, any.missing=FALSE, len=1)
+  checkmate::assertLogical(sumProd, any.missing = FALSE, len = 1)
+  checkmate::assertLogical(optExpression, any.missing = FALSE, len = 1)
+  checkmate::assertLogical(literalFix, any.missing = FALSE, len = 1)
+  checkmate::assertLogical(literalFixRes, any.missing = FALSE, len = 1)
 
-  checkmate::assertNumeric(ci, any.missing=FALSE, len=1, lower=0, upper=1)
-  checkmate::assertNumeric(boundTol, lower=0, any.missing=FALSE, len=1)
+  checkmate::assertNumeric(ci, any.missing = FALSE, len = 1, lower = 0, upper = 1)
+  checkmate::assertNumeric(boundTol, lower = 0, any.missing = FALSE, len = 1)
 
-  checkmate::assertLogical(calcTables, len=1, any.missing=FALSE)
-  if(!checkmate::testIntegerish(noAbort, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(noAbort, len=1, any.missing=FALSE)
+  checkmate::assertLogical(calcTables, len = 1, any.missing = FALSE)
+  if (!checkmate::testIntegerish(noAbort, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(noAbort, len = 1, any.missing = FALSE)
   }
   noAbort <- as.integer(noAbort)
 
-  if (!checkmate::testIntegerish(interaction, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(interaction, len=1, any.missing=FALSE)
+  if (!checkmate::testIntegerish(interaction, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(interaction, len = 1, any.missing = FALSE)
   }
   interaction <- as.integer(interaction)
 
@@ -1217,26 +1226,26 @@ foceiControl <- function(sigdig = 3, #
   ## Ignored when interaction=TRUE (FOCEi).
   foceType <- as.integer(foce == "foce+")
 
-  checkmate::assertNumeric(cholSEtol, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(cholAccept, lower=0, any.missing=FALSE, len=1)
+  checkmate::assertNumeric(cholSEtol, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(cholAccept, lower = 0, any.missing = FALSE, len = 1)
 
   ## .methodIdx <- c("lsoda"=1L, "dop853"=0L, "liblsoda"=2L);
   ## method <- as.integer(.methodIdx[method]);
-  if (checkmate::testIntegerish(scaleType, len=1, lower=1, upper=4, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(scaleType, len = 1, lower = 1, upper = 4, any.missing = FALSE)) {
     scaleType <- as.integer(scaleType)
   } else {
     .scaleTypeIdx <- c("norm" = 1L, "nlmixr2" = 2L, "mult" = 3L, "multAdd" = 4L)
     scaleType <- setNames(.scaleTypeIdx[match.arg(scaleType)], NULL)
   }
 
-  if (checkmate::testIntegerish(optimHessType, len=1, lower=1, upper=3, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(optimHessType, len = 1, lower = 1, upper = 3, any.missing = FALSE)) {
     optimHessType <- as.integer(optimHessType)
   } else {
     .optimHessTypeIdx <- c("central" = 1L, "forward" = 3L)
     optimHessType <- setNames(.optimHessTypeIdx[match.arg(optimHessType)], NULL)
   }
 
-  if (checkmate::testIntegerish(optimHessCovType, len=1, lower=1, upper=3, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(optimHessCovType, len = 1, lower = 1, upper = 3, any.missing = FALSE)) {
     optimHessCovType <- as.integer(optimHessCovType)
   } else {
     .optimHessCovTypeIdx <- c("central" = 1L, "forward" = 3L)
@@ -1245,12 +1254,12 @@ foceiControl <- function(sigdig = 3, #
   # censOption: the censored (M2/M3/M4) inner-Hessian / 2nd-derivative treatment.
   # "gauss" (default) keeps the historic uncensored Gauss-Newton curvature; "laplace"
   # uses the exact censored 2nd derivative (a proper Laplace).  Shared with saem/nlm.
-  if (checkmate::testIntegerish(censOption, len=1, lower=0, upper=1, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(censOption, len = 1, lower = 0, upper = 1, any.missing = FALSE)) {
     censOption <- as.integer(censOption)
   } else {
     censOption <- setNames(c("gauss" = 0L, "laplace" = 1L)[match.arg(censOption)], NULL)
   }
-  if (checkmate::testIntegerish(eventType, len=1, lower=1, upper=3, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(eventType, len = 1, lower = 1, upper = 3, any.missing = FALSE)) {
     eventType <- as.integer(eventType)
   } else {
     .eventTypeIdx <- c("central" = 2L, "forward" = 3L)
@@ -1262,19 +1271,19 @@ foceiControl <- function(sigdig = 3, #
   eventSens <- match.arg(eventSens)
 
   .normTypeIdx <- c("rescale2" = 1L, "rescale" = 2L, "mean" = 3L, "std" = 4L, "len" = 5L, "constant" = 6L)
-  if (checkmate::testIntegerish(normType, len=1, lower=1, upper=6, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(normType, len = 1, lower = 1, upper = 6, any.missing = FALSE)) {
     normType <- as.integer(normType)
   } else {
     normType <- setNames(.normTypeIdx[match.arg(normType)], NULL)
   }
   .methodIdx <- c("forward" = 0L, "central" = 1L, "switch" = 3L)
-  if (checkmate::testIntegerish(derivMethod, len=1, lower=0L, upper=3L, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(derivMethod, len = 1, lower = 0L, upper = 3L, any.missing = FALSE)) {
     derivMethod <- as.integer(derivMethod)
   } else {
     derivMethod <- match.arg(derivMethod)
     derivMethod <- setNames(.methodIdx[derivMethod], NULL)
   }
-  if (checkmate::testIntegerish(covDerivMethod, len=1, lower=0L, upper=3L, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(covDerivMethod, len = 1, lower = 0L, upper = 3L, any.missing = FALSE)) {
     covDerivMethod <- as.integer(covDerivMethod)
   } else {
     covDerivMethod <- match.arg(covDerivMethod)
@@ -1290,7 +1299,7 @@ foceiControl <- function(sigdig = 3, #
   # "sa"/"imp" are foreign to the focei kernel; skip the in-kernel cov step and
   # recompute them post-fit at the converged estimates (see .covRecompute).
   covMethodDeferred <- NA_character_
-  if (checkmate::testIntegerish(covMethod, len=1, lower=0L, upper=3L, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(covMethod, len = 1, lower = 0L, upper = 3L, any.missing = FALSE)) {
     covMethod <- as.integer(covMethod)
     .ct <- list(...)$covType
     if (!is.null(.ct)) covType <- match.arg(.ct, c("analytic", "fd"))
@@ -1315,8 +1324,12 @@ foceiControl <- function(sigdig = 3, #
   if (is.na(covMethodDeferred) && !is.null(list(...)$covMethodDeferred)) {
     covMethodDeferred <- list(...)$covMethodDeferred
   }
-  if (!is.null(covSolveTol)) checkmate::assertNumeric(covSolveTol, len = 1, lower = 0,
-                                                      finite = TRUE, any.missing = FALSE)
+  if (!is.null(covSolveTol)) {
+    checkmate::assertNumeric(covSolveTol,
+      len = 1, lower = 0,
+      finite = TRUE, any.missing = FALSE
+    )
+  }
   checkmate::assertFlag(covFull)
   checkmate::assertFlag(fast)
   priorMethod <- match.arg(priorMethod)
@@ -1325,8 +1338,9 @@ foceiControl <- function(sigdig = 3, #
   .bad <- .bad[!(.bad %in% .foceiControlInternal)]
   if (length(.bad) > 0) {
     stop("unused argument: ", paste
-    (paste0("'", .bad, "'", sep=""), collapse=", "),
-    call.=FALSE)
+    (paste0("'", .bad, "'", sep = ""), collapse = ", "),
+    call. = FALSE
+    )
   }
   .skipCov <- NULL
   if (!is.null(.xtra$skipCov)) {
@@ -1375,7 +1389,7 @@ foceiControl <- function(sigdig = 3, #
       outerOptFun <- .newuoa
       outerOpt <- -1L
     } else {
-      if (checkmate::testIntegerish(outerOpt, lower=0, upper=1, len=1)) {
+      if (checkmate::testIntegerish(outerOpt, lower = 0, upper = 1, len = 1)) {
         outerOpt <- as.integer(outerOpt)
       } else {
         .outerOptIdx <- c("L-BFGS-B" = 0L, "lbfgsb3c" = 1L)
@@ -1394,17 +1408,18 @@ foceiControl <- function(sigdig = 3, #
   # so computing it is wasted work: downgrade to fast=FALSE with a warning.
   if (isTRUE(fast) && .outerOptTxt %in% c("bobyqa", "uobyqa", "newuoa")) {
     warning("outerOpt='", .outerOptTxt,
-            "' is derivative-free; the analytic 'fast' gradient is unused -- reverting to fast=FALSE",
-            call.=FALSE)
+      "' is derivative-free; the analytic 'fast' gradient is unused -- reverting to fast=FALSE",
+      call. = FALSE
+    )
     fast <- FALSE
   }
-  if (checkmate::testIntegerish(innerOpt, lower=1, upper=2, len=1)) {
+  if (checkmate::testIntegerish(innerOpt, lower = 1, upper = 2, len = 1)) {
     innerOpt <- as.integer(innerOpt)
   } else {
     .innerOptFun <- c("n1qn1" = 1L, "BFGS" = 2L)
     innerOpt <- setNames(.innerOptFun[match.arg(innerOpt)], NULL)
   }
-  if (checkmate::testIntegerish(warm, lower=0, upper=1, len=1, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(warm, lower = 0, upper = 1, len = 1, any.missing = FALSE)) {
     warm <- as.integer(warm)
   } else {
     .warmIdx <- c("calc" = 1L, "save" = 0L)
@@ -1413,7 +1428,7 @@ foceiControl <- function(sigdig = 3, #
   if (!is.null(.xtra$resetEtaSize)) {
     .resetEtaSize <- .xtra$resetEtaSize
   } else {
-    checkmate::assertNumeric(resetEtaP, lower=0, upper=1, len=1)
+    checkmate::assertNumeric(resetEtaP, lower = 0, upper = 1, len = 1)
     if (resetEtaP > 0 & resetEtaP < 1) {
       .resetEtaSize <- qnorm(1 - (resetEtaP / 2))
     } else if (resetEtaP <= 0) {
@@ -1425,40 +1440,42 @@ foceiControl <- function(sigdig = 3, #
   if (!is.null(.xtra$resetThetaSize)) {
     .resetThetaSize <- .xtra$resetThetaSize
   } else {
-    checkmate::assertNumeric(resetThetaP, lower=0, upper=1, len=1)
+    checkmate::assertNumeric(resetThetaP, lower = 0, upper = 1, len = 1)
     if (resetThetaP > 0 & resetThetaP < 1) {
       .resetThetaSize <- qnorm(1 - (resetThetaP / 2))
     } else if (resetThetaP <= 0) {
       .resetThetaSize <- Inf
     } else {
-      stop("cannot always reset THETAs", call.=FALSE)
+      stop("cannot always reset THETAs", call. = FALSE)
     }
   }
   if (!is.null(.xtra$resetThetaFinalSize)) {
     .resetThetaFinalSize <- .xtra$resetThetaFinalSize
   } else {
-    checkmate::assertNumeric(resetThetaFinalP, lower=0, upper=1, len=1)
+    checkmate::assertNumeric(resetThetaFinalP, lower = 0, upper = 1, len = 1)
     if (resetThetaFinalP > 0 & resetThetaFinalP < 1) {
       .resetThetaFinalSize <- qnorm(1 - (resetThetaFinalP / 2))
     } else if (resetThetaFinalP <= 0) {
       .resetThetaFinalSize <- Inf
     } else {
-      stop("cannot always reset THETAs", call.=FALSE)
+      stop("cannot always reset THETAs", call. = FALSE)
     }
   }
-  if (checkmate::testIntegerish(addProp, lower=1, upper=1, len=1)) {
+  if (checkmate::testIntegerish(addProp, lower = 1, upper = 1, len = 1)) {
     addProp <- c("combined1", "combined2")[addProp]
   } else {
     addProp <- match.arg(addProp)
   }
-  checkmate::assertLogical(compress, any.missing=FALSE, len=1)
+  checkmate::assertLogical(compress, any.missing = FALSE, len = 1)
   if (!is.null(.xtra$genRxControl)) {
     genRxControl <- .xtra$genRxControl
   } else {
     genRxControl <- FALSE
     if (is.null(rxControl)) {
-      rxControl <- .rxControlScaleSigdig(rxode2::rxControl(sigdig=sigdig,
-                                                           maxsteps=500000L), sigdig)
+      rxControl <- .rxControlScaleSigdig(rxode2::rxControl(
+        sigdig = sigdig,
+        maxsteps = 500000L
+      ), sigdig)
       genRxControl <- TRUE
     } else if (inherits(rxControl, "rxControl")) {
       # a fully-formed rxControl object is the user's explicit solving spec; leave
@@ -1468,88 +1485,89 @@ foceiControl <- function(sigdig = 3, #
     }
     if (!inherits(rxControl, "rxControl")) {
       stop("rxControl needs to be ode solving options from rxode2::rxControl()",
-           call.=FALSE)
+        call. = FALSE
+      )
     }
   }
-  checkmate::assertNumeric(diagOmegaBoundUpper, lower=1, len=1, any.missing=FALSE, finite=TRUE)
-  checkmate::assertNumeric(diagOmegaBoundLower, lower=1, len=1, any.missing=FALSE, finite=TRUE)
+  checkmate::assertNumeric(diagOmegaBoundUpper, lower = 1, len = 1, any.missing = FALSE, finite = TRUE)
+  checkmate::assertNumeric(diagOmegaBoundLower, lower = 1, len = 1, any.missing = FALSE, finite = TRUE)
 
-  if (!checkmate::testIntegerish(cholSEOpt, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(cholSEOpt, any.missing=FALSE, len=1)
+  if (!checkmate::testIntegerish(cholSEOpt, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(cholSEOpt, any.missing = FALSE, len = 1)
   }
   cholSEOpt <- as.integer(cholSEOpt)
 
-  if (!checkmate::testIntegerish(cholSECov, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(cholSECov, any.missing=FALSE, len=1)
+  if (!checkmate::testIntegerish(cholSECov, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(cholSECov, any.missing = FALSE, len = 1)
   }
   cholSECov <- as.integer(cholSECov)
 
-  if (!checkmate::testIntegerish(fo, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(fo, any.missing=FALSE, len=1)
+  if (!checkmate::testIntegerish(fo, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(fo, any.missing = FALSE, len = 1)
   }
   fo <- as.integer(fo)
 
-  if (!checkmate::testIntegerish(resetHessianAndEta, lower=0, upper=1, any.missing=FALSE, len=1)) {
-    checkmate::assertLogical(resetHessianAndEta, any.missing=FALSE, len=1)
+  if (!checkmate::testIntegerish(resetHessianAndEta, lower = 0, upper = 1, any.missing = FALSE, len = 1)) {
+    checkmate::assertLogical(resetHessianAndEta, any.missing = FALSE, len = 1)
   }
   resetHessianAndEta <- as.integer(resetHessianAndEta)
 
   muModel <- match.arg(muModel)
-  checkmate::assertLogical(muRefCovAlg, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(muModelTol, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertIntegerish(muModelMaxCycles, lower=1, len=1, any.missing=FALSE)
+  checkmate::assertLogical(muRefCovAlg, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(muModelTol, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertIntegerish(muModelMaxCycles, lower = 1, len = 1, any.missing = FALSE)
   muModelMaxCycles <- as.integer(muModelMaxCycles)
-  checkmate::assertIntegerish(muModelClampRetries, lower=1, len=1, any.missing=FALSE)
+  checkmate::assertIntegerish(muModelClampRetries, lower = 1, len = 1, any.missing = FALSE)
   muModelClampRetries <- as.integer(muModelClampRetries)
 
-  checkmate::assertNumeric(stateTrim, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(covSmall, lower=0, any.missing=FALSE, finite=TRUE)
-  checkmate::assertLogical(adjLik, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(gradTrim, any.missing=FALSE, len=1)
-  checkmate::assertIntegerish(maxOdeRecalc, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(odeRecalcFactor, len=1, lower=1, any.missing=FALSE)
-  checkmate::assertNumeric(gradCalcCentralSmall, len=1, lower=0, any.missing=FALSE, finite=TRUE)
-  checkmate::assertNumeric(gradCalcCentralLarge, len=1, lower=0, any.missing=FALSE, finite=TRUE)
-  checkmate::assertNumeric(etaNudge, len=1, lower=0, any.missing=FALSE, finite=TRUE)
-  checkmate::assertNumeric(etaNudge2, len=1, lower=0, any.missing=FALSE, finite=TRUE)
-  checkmate::assertIntegerish(nRetries, lower=0, any.missing=FALSE)
+  checkmate::assertNumeric(stateTrim, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(covSmall, lower = 0, any.missing = FALSE, finite = TRUE)
+  checkmate::assertLogical(adjLik, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(gradTrim, any.missing = FALSE, len = 1)
+  checkmate::assertIntegerish(maxOdeRecalc, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(odeRecalcFactor, len = 1, lower = 1, any.missing = FALSE)
+  checkmate::assertNumeric(gradCalcCentralSmall, len = 1, lower = 0, any.missing = FALSE, finite = TRUE)
+  checkmate::assertNumeric(gradCalcCentralLarge, len = 1, lower = 0, any.missing = FALSE, finite = TRUE)
+  checkmate::assertNumeric(etaNudge, len = 1, lower = 0, any.missing = FALSE, finite = TRUE)
+  checkmate::assertNumeric(etaNudge2, len = 1, lower = 0, any.missing = FALSE, finite = TRUE)
+  checkmate::assertIntegerish(nRetries, lower = 0, any.missing = FALSE)
   if (!is.null(seed)) {
-    checkmate::assertIntegerish(seed, any.missing=FALSE, min.len=1)
+    checkmate::assertIntegerish(seed, any.missing = FALSE, min.len = 1)
   }
-  checkmate::assertNumeric(resetThetaCheckPer, lower=0, upper=1, any.missing=FALSE, finite=TRUE)
-  checkmate::assertIntegerish(repeatGillMax, any.missing=FALSE, lower=0, len=1)
-  checkmate::assertIntegerish(stickyRecalcN, any.missing=FALSE, lower=0, len=1)
-  checkmate::assertIntegerish(outerMaxOdeRecalc, any.missing=FALSE, lower=0, len=1)
-  checkmate::assertNumeric(outerOdeRecalcFactor, len=1, lower=1, any.missing=FALSE)
-  checkmate::assertIntegerish(outerStickyRecalcN, any.missing=FALSE, lower=0, len=1)
-  checkmate::assertLogical(indTolRelax, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(gradProgressOfvTime, any.missing=FALSE, lower=0, len=1)
-  checkmate::assertNumeric(badSolveObjfAdj, any.missing=FALSE, len=1)
-  checkmate::assertLogical(fallbackFD, any.missing=FALSE, len=1)
-  checkmate::assertLogical(zeroGradFirstReset, any.missing=TRUE, len=1)
-  checkmate::assertLogical(zeroGradRunReset, any.missing=FALSE, len=1)
-  checkmate::assertLogical(zeroGradBobyqa, any.missing=TRUE, len=1)
+  checkmate::assertNumeric(resetThetaCheckPer, lower = 0, upper = 1, any.missing = FALSE, finite = TRUE)
+  checkmate::assertIntegerish(repeatGillMax, any.missing = FALSE, lower = 0, len = 1)
+  checkmate::assertIntegerish(stickyRecalcN, any.missing = FALSE, lower = 0, len = 1)
+  checkmate::assertIntegerish(outerMaxOdeRecalc, any.missing = FALSE, lower = 0, len = 1)
+  checkmate::assertNumeric(outerOdeRecalcFactor, len = 1, lower = 1, any.missing = FALSE)
+  checkmate::assertIntegerish(outerStickyRecalcN, any.missing = FALSE, lower = 0, len = 1)
+  checkmate::assertLogical(indTolRelax, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(gradProgressOfvTime, any.missing = FALSE, lower = 0, len = 1)
+  checkmate::assertNumeric(badSolveObjfAdj, any.missing = FALSE, len = 1)
+  checkmate::assertLogical(fallbackFD, any.missing = FALSE, len = 1)
+  checkmate::assertLogical(zeroGradFirstReset, any.missing = TRUE, len = 1)
+  checkmate::assertLogical(zeroGradRunReset, any.missing = FALSE, len = 1)
+  checkmate::assertLogical(zeroGradBobyqa, any.missing = TRUE, len = 1)
 
-  checkmate::assertIntegerish(shi21maxOuter, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertIntegerish(shi21maxInner, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertIntegerish(shi21maxInnerCov, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertIntegerish(shi21maxFD, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumber(zeroTheta, lower=0, finite=TRUE)
+  checkmate::assertIntegerish(shi21maxOuter, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertIntegerish(shi21maxInner, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertIntegerish(shi21maxInnerCov, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertIntegerish(shi21maxFD, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumber(zeroTheta, lower = 0, finite = TRUE)
   if (zeroTheta <= 0) {
-    stop("'zeroTheta' must be a positive number", call.=FALSE)
+    stop("'zeroTheta' must be a positive number", call. = FALSE)
   }
-  checkmate::assertNumber(shi21hMin, lower=0, finite=TRUE)
-  checkmate::assertNumber(shi21hMax, lower=0, finite=TRUE)
+  checkmate::assertNumber(shi21hMin, lower = 0, finite = TRUE)
+  checkmate::assertNumber(shi21hMax, lower = 0, finite = TRUE)
   if (shi21hMax <= shi21hMin) {
-    stop("'shi21hMax' must be greater than 'shi21hMin'", call.=FALSE)
+    stop("'shi21hMax' must be greater than 'shi21hMin'", call. = FALSE)
   }
-  checkmate::assertIntegerish(mceta, lower=-2, len=1,any.missing=FALSE)
+  checkmate::assertIntegerish(mceta, lower = -2, len = 1, any.missing = FALSE)
 
-  checkmate::assertNumeric(smatPer, any.missing=FALSE, lower=0, upper=1, len=1)
-  checkmate::assertIntegerish(nAGQ, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(agqHi, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(agqLow, len=1, any.missing=FALSE)
-  checkmate::assertLogical(boundedTransform, len=1, any.missing=FALSE)
+  checkmate::assertNumeric(smatPer, any.missing = FALSE, lower = 0, upper = 1, len = 1)
+  checkmate::assertIntegerish(nAGQ, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(agqHi, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(agqLow, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(boundedTransform, len = 1, any.missing = FALSE)
   .ret <- list(
     maxOuterIterations = as.integer(maxOuterIterations),
     maxInnerIterations = as.integer(maxInnerIterations),
@@ -1591,12 +1609,12 @@ foceiControl <- function(sigdig = 3, #
     iovXform = match.arg(iovXform),
     sumProd = sumProd,
     optExpression = optExpression,
-    literalFix=literalFix,
-    literalFixRes=literalFixRes,
+    literalFix = literalFix,
+    literalFixRes = literalFixRes,
     outerOpt = as.integer(outerOpt),
     ci = as.double(ci),
     sigdig = as.double(sigdig),
-    sigdigTable=sigdigTable,
+    sigdigTable = sigdigTable,
     scaleObjective = as.double(scaleObjective),
     boundTol = as.double(boundTol),
     calcTables = calcTables,
@@ -1608,9 +1626,9 @@ foceiControl <- function(sigdig = 3, #
     foceEbeTol = as.double(foceEbeTol),
     hessEps = as.double(hessEps),
     hessEpsLlik = as.double(hessEpsLlik),
-    optimHessType=optimHessType,
-    optimHessCovType=optimHessCovType,
-    censOption=censOption,
+    optimHessType = optimHessType,
+    optimHessCovType = optimHessCovType,
+    censOption = censOption,
     cholAccept = as.double(cholAccept),
     resetEtaSize = as.double(.resetEtaSize),
     resetThetaSize = as.double(.resetThetaSize),
@@ -1674,7 +1692,7 @@ foceiControl <- function(sigdig = 3, #
     gradCalcCentralSmall = as.double(gradCalcCentralSmall),
     gradCalcCentralLarge = as.double(gradCalcCentralLarge),
     etaNudge = as.double(etaNudge),
-    etaNudge2=as.double(etaNudge2),
+    etaNudge2 = as.double(etaNudge2),
     maxOdeRecalc = as.integer(maxOdeRecalc),
     odeRecalcFactor = as.double(odeRecalcFactor),
     nRetries = nRetries,
@@ -1691,32 +1709,32 @@ foceiControl <- function(sigdig = 3, #
     eventSens = eventSens,
     gradProgressOfvTime = gradProgressOfvTime,
     addProp = addProp,
-    badSolveObjfAdj=badSolveObjfAdj,
-    compress=compress,
-    rxControl=rxControl,
-    genRxControl=genRxControl,
-    skipCov=.skipCov,
-    fallbackFD=fallbackFD,
-    shi21maxOuter=shi21maxOuter,
-    shi21maxInner=shi21maxInner,
-    shi21maxInnerCov=shi21maxInnerCov,
-    shi21maxFD=shi21maxFD,
-    shi21hMax=shi21hMax,
-    shi21hMin=shi21hMin,
-    smatPer=smatPer,
-    sdLowerFact=sdLowerFact,
-    zeroGradFirstReset=zeroGradFirstReset,
-    zeroGradRunReset=zeroGradRunReset,
-    zeroGradBobyqa=zeroGradBobyqa,
-    mceta=as.integer(mceta),
-    warm=warm,
-    nAGQ=as.integer(nAGQ),
-    agqHi=as.double(agqHi),
-    agqLow=as.double(agqLow),
-    sensMethod=sensMethod,
-    linCmtSensCarry=linCmtSensCarry,
-    boundedTransform=boundedTransform,
-    zeroTheta=zeroTheta
+    badSolveObjfAdj = badSolveObjfAdj,
+    compress = compress,
+    rxControl = rxControl,
+    genRxControl = genRxControl,
+    skipCov = .skipCov,
+    fallbackFD = fallbackFD,
+    shi21maxOuter = shi21maxOuter,
+    shi21maxInner = shi21maxInner,
+    shi21maxInnerCov = shi21maxInnerCov,
+    shi21maxFD = shi21maxFD,
+    shi21hMax = shi21hMax,
+    shi21hMin = shi21hMin,
+    smatPer = smatPer,
+    sdLowerFact = sdLowerFact,
+    zeroGradFirstReset = zeroGradFirstReset,
+    zeroGradRunReset = zeroGradRunReset,
+    zeroGradBobyqa = zeroGradBobyqa,
+    mceta = as.integer(mceta),
+    warm = warm,
+    nAGQ = as.integer(nAGQ),
+    agqHi = as.double(agqHi),
+    agqLow = as.double(agqLow),
+    sensMethod = sensMethod,
+    linCmtSensCarry = linCmtSensCarry,
+    boundedTransform = boundedTransform,
+    zeroTheta = zeroTheta
   )
   if (!is.null(.xtra$est)) {
     .ret$est <- .xtra$est
@@ -1732,19 +1750,20 @@ foceiControl <- function(sigdig = 3, #
     if (.doWarn && missing(maxInnerIterations)) {
       warning(sprintf("using 'etaMat' assuming 'maxInnerIterations=%d', set 'maxInnerIterations' explicitly to avoid this warning", maxInnerIterations))
     }
-    checkmate::assertMatrix(etaMat, mode="double", any.missing=FALSE, min.rows=1, min.cols=1)
+    checkmate::assertMatrix(etaMat, mode = "double", any.missing = FALSE, min.rows = 1, min.cols = 1)
     .ret$etaMat <- etaMat
   }
   class(.ret) <- "foceiControl"
   .ret
 }
 
-.rxUiDeparseFoceiControl <- function(object, var, type="foceiControl") {
+.rxUiDeparseFoceiControl <- function(object, var, type = "foceiControl") {
   .ret <- eval(str2lang(paste0(type, "()")))
   .outerOpt <- character(0)
   if (object$outerOpt == -1L && object$outerOptTxt == "custom") {
     warning("functions for `outerOpt` cannot be deparsed, reset to default",
-            call.=FALSE)
+      call. = FALSE
+    )
   } else if (!(object$outerOptTxt %in% c(.ret$outerOptTxt, "stats::optimize"))) {
     .outerOpt <- paste0("outerOpt = ", deparse1(object$outerOptTxt))
   }
@@ -1752,8 +1771,12 @@ foceiControl <- function(sigdig = 3, #
   # covMethod folds the analytic-vs-finite-difference R-matrix choice (carried by the
   # derived internal covType) into a single token; covType is never deparsed on its own.
   .covMethodStr <- function(o) {
-    if (identical(o$covType, "analytic")) return("analytic")
-    if (identical(as.integer(o$covMethod), 0L)) return("")
+    if (identical(o$covType, "analytic")) {
+      return("analytic")
+    }
+    if (identical(as.integer(o$covMethod), 0L)) {
+      return("")
+    }
     .idx <- c("r,s" = 1L, "r" = 2L, "s" = 3L)
     names(.idx)[match(as.integer(o$covMethod), .idx)]
   }
@@ -1806,10 +1829,10 @@ foceiControl <- function(sigdig = 3, #
       paste0(x, " = ", deparse1(object[[x]]))
     }
   }, character(1)), .outerOpt)
-  str2lang(paste(var, " <- ", type, "(", paste(.retD, collapse=", "), ")"))
+  str2lang(paste(var, " <- ", type, "(", paste(.retD, collapse = ", "), ")"))
 }
 
 #' @export
 rxUiDeparse.foceiControl <- function(object, var) {
-  .rxUiDeparseFoceiControl(object, var, type="foceiControl")
+  .rxUiDeparseFoceiControl(object, var, type = "foceiControl")
 }

--- a/R/foceiLinCmtCarry.R
+++ b/R/foceiLinCmtCarry.R
@@ -59,8 +59,10 @@
 #' Render one linCmtB() model-text call for the carry lines
 #' @noRd
 .rxFoceiLinCmtCarryCall <- function(pfx, which1, which2, trans, thetas) {
-  paste0("linCmtB(", pfx, ",", which1, ",", which2, ",", trans, ",",
-         paste(thetas, collapse = ","), ")")
+  paste0(
+    "linCmtB(", pfx, ",", which1, ",", which2, ",", trans, ",",
+    paste(thetas, collapse = ","), ")"
+  )
 }
 # (the per-model context and the final composition live in
 # foceiLinCmtCarryCompose.R)
@@ -98,27 +100,39 @@
       .j <- paste0("rx_lcCarryJ", .p, "r", .r, "_")
       .pv <- paste0("rx_lcCarryP", .p, "r", .r, "_")
       .dloc <- paste0("(", .j, "-", .pv, ")")
-      .l <- c(.l,
-              paste0(.j, "~", .rxFoceiLinCmtCarryCall(cx$pfx, .r, .kcol, cx$trans, .z7)),
-              paste0(.pv, "~", .rxFoceiLinCmtCarryCall(cx$pfx, -6L, .r + cx$m * (cx$nP + .p),
-                                                       cx$trans, .z7)))
+      .l <- c(
+        .l,
+        paste0(.j, "~", .rxFoceiLinCmtCarryCall(cx$pfx, .r, .kcol, cx$trans, .z7)),
+        paste0(.pv, "~", .rxFoceiLinCmtCarryCall(
+          cx$pfx, -6L, .r + cx$m * (cx$nP + .p),
+          cx$trans, .z7
+        ))
+      )
       .terms <- c(.terms, paste0(.g, "*", .dloc))
     }
     if (!is.na(pairs$fD[w])) {
       .terms <- c(.terms, paste0("rx_lcCarryD", .r, "_*", .f))
     }
     if (!is.na(pairs$lagD[w])) {
-      .terms <- c(.terms, paste0("rx_lcCarryKP", .r, "_*", .lg,
-                                 "*(rx_lcCarryDel_-rx_lcCarryDelP_)"))
+      .terms <- c(.terms, paste0(
+        "rx_lcCarryKP", .r, "_*", .lg,
+        "*(rx_lcCarryDel_-rx_lcCarryDelP_)"
+      ))
     }
     .z7[3] <- paste(.terms, collapse = "+") # -7's added value rides in the p2 slot
-    .l <- c(.l, paste0("rx_lcCarryS", .p, "r", .r, "_~",
-                       .rxFoceiLinCmtCarryCall(cx$pfx, -7L, .r + cx$m * .p, cx$trans, .z7)))
+    .l <- c(.l, paste0(
+      "rx_lcCarryS", .p, "r", .r, "_~",
+      .rxFoceiLinCmtCarryCall(cx$pfx, -7L, .r + cx$m * .p, cx$trans, .z7)
+    ))
     if (.hasSlot) {
       .z7[3] <- .dloc
-      .l <- c(.l, paste0("rx_lcCarryU", .p, "r", .r, "_~",
-                         .rxFoceiLinCmtCarryCall(cx$pfx, -7L, .r + cx$m * (cx$nP + .p),
-                                                 cx$trans, .z7)))
+      .l <- c(.l, paste0(
+        "rx_lcCarryU", .p, "r", .r, "_~",
+        .rxFoceiLinCmtCarryCall(
+          cx$pfx, -7L, .r + cx$m * (cx$nP + .p),
+          cx$trans, .z7
+        )
+      ))
     }
   }
   .l

--- a/R/foceiLinCmtCarryCompose.R
+++ b/R/foceiLinCmtCarryCompose.R
@@ -25,20 +25,25 @@
   .anyJump <- any(!is.na(pairs$fD) | !is.na(pairs$lagD))
   .anyLag <- any(!is.na(pairs$lagD))
   .m <- .ncmt + .oral0
-  list(ncmt = .ncmt, oral0 = .oral0, m = .m, central = .oral0,
-       trans = .txt[8], pfx = paste(.txt[1:5], collapse = ","),
-       thetas = .txt[9:15], zero = rep("0", 7), nP = .nP,
-       anyJump = .anyJump, anyLag = .anyLag,
-       aCol = 2L * .nP, lCol = 2L * .nP + 1L,
-       slotExpr = lapply(1:7, function(k) .a[[k + 8L]]),
-       rows = seq_len(.m) - 1L,
-       # an ll() endpoint embeds the concentration call in a larger
-       # expression (#1004): the carry differentiates the concentration,
-       # read back as rx_lcConc_, and symengine supplies the outer chain rule
-       bare = .pc$bare, predSym = .pc$predSym,
-       conc = if (.pc$bare) "rx_pred_" else "rx_lcConc_",
-       concLine = if (.pc$bare) character(0) else
-         paste0("rx_lcConc_~", rxode2::rxFromSE(.callRepr)))
+  list(
+    ncmt = .ncmt, oral0 = .oral0, m = .m, central = .oral0,
+    trans = .txt[8], pfx = paste(.txt[1:5], collapse = ","),
+    thetas = .txt[9:15], zero = rep("0", 7), nP = .nP,
+    anyJump = .anyJump, anyLag = .anyLag,
+    aCol = 2L * .nP, lCol = 2L * .nP + 1L,
+    slotExpr = lapply(1:7, function(k) .a[[k + 8L]]),
+    rows = seq_len(.m) - 1L,
+    # an ll() endpoint embeds the concentration call in a larger
+    # expression (#1004): the carry differentiates the concentration,
+    # read back as rx_lcConc_, and symengine supplies the outer chain rule
+    bare = .pc$bare, predSym = .pc$predSym,
+    conc = if (.pc$bare) "rx_pred_" else "rx_lcConc_",
+    concLine = if (.pc$bare) {
+      character(0)
+    } else {
+      paste0("rx_lcConc_~", rxode2::rxFromSE(.callRepr))
+    }
+  )
 }
 
 #' The pair's final `dfe=` composition: s_central / Vc plus, when the
@@ -50,8 +55,10 @@
 .rxFoceiLinCmtCarryFinal <- function(cx, pairs, w, dfe) {
   .p <- w - 1L
   .sC <- paste0("rx_lcCarryS", .p, "r", cx$central, "_")
-  .vc <- .rxFoceiCarryVc(cx$ncmt, cx$oral0, as.numeric(cx$trans), pairs$slot[w], # nolint: object_usage_linter.
-                         cx$slotExpr)
+  .vc <- .rxFoceiCarryVc(
+    cx$ncmt, cx$oral0, as.numeric(cx$trans), pairs$slot[w], # nolint: object_usage_linter.
+    cx$slotExpr
+  )
   .vcRepr <- paste(.vc$vc)
   .vcTxt <- paste0("(", rxode2::rxFromSE(.vcRepr), ")")
   .conc <- paste0(.sC, "/", .vcTxt)
@@ -62,7 +69,9 @@
     # to "-x", and "-" + "-x" would read as a C decrement
     .conc <- paste0(.conc, "-rx_lcCarryG", .p, "_*(", .dTxt, ")*", cx$conc, "/", .vcTxt)
   }
-  if (cx$bare) return(paste0(dfe, "=", .conc))
+  if (cx$bare) {
+    return(paste0(dfe, "=", .conc))
+  }
   # ll() endpoint: d(pred)/d(eta) = d(pred)/d(conc) * d(conc)/d(eta) plus
   # whatever eta dependence the expression has with the concentration held
   # fixed (symengine sees rx_lcConc_ as a free symbol for that)

--- a/R/foceiLinCmtCarryData.R
+++ b/R/foceiLinCmtCarryData.R
@@ -13,18 +13,24 @@
 .rxFoceiCarryCovVaries <- function(data, cov) {
   .n <- names(data)
   .idCol <- .n[tolower(.n) == "id"]
-  if (length(.idCol) != 1L || !(cov %in% .n)) return(NA)
-  any(vapply(split(data[[cov]], data[[.idCol]]),
-             function(v) {
-               v <- v[!is.na(v)]
-               length(unique(v)) > 1L
-             }, logical(1)))
+  if (length(.idCol) != 1L || !(cov %in% .n)) {
+    return(NA)
+  }
+  any(vapply(
+    split(data[[cov]], data[[.idCol]]),
+    function(v) {
+      v <- v[!is.na(v)]
+      length(unique(v)) > 1L
+    }, logical(1)
+  ))
 }
 
 #' NA without data, else whether any of the covariates varies within a subject
 #' @noRd
 .rxFoceiCarryVarying <- function(covs, data) {
-  if (is.null(data)) return(NA)
+  if (is.null(data)) {
+    return(NA)
+  }
   .v <- vapply(covs, function(cv) .rxFoceiCarryCovVaries(data, cv), logical(1))
   if (all(is.na(.v))) NA else isTRUE(any(.v, na.rm = TRUE))
 }
@@ -32,14 +38,16 @@
 #' Empty carry-eligibility result (fixed column layout)
 #' @noRd
 .rxFoceiCarryEmpty <- function() {
-  data.frame(slot = integer(0), slotName = character(0),
-             eta = character(0), etaName = character(0),
-             covs = character(0), shape = character(0),
-             formula = character(0), dEtaFormula = character(0),
-             varying = logical(0),
-             fD = character(0), fCov = logical(0), fCmt = character(0),
-             lagD = character(0), lagCmt = character(0),
-             stringsAsFactors = FALSE)
+  data.frame(
+    slot = integer(0), slotName = character(0),
+    eta = character(0), etaName = character(0),
+    covs = character(0), shape = character(0),
+    formula = character(0), dEtaFormula = character(0),
+    varying = logical(0),
+    fD = character(0), fCov = logical(0), fCmt = character(0),
+    lagD = character(0), lagCmt = character(0),
+    stringsAsFactors = FALSE
+  )
 }
 
 #' Carry-eligible pairs straight from a model UI (test/entry convenience)
@@ -54,26 +62,35 @@
   # cheap UI-level exits before ui$foceiEtaS builds a full symengine
   # environment (~0.25 s per call): no linCmt() or no covariate means no
   # pair can exist, and the empty result is identical
-  if (rxode2::.rxLinNcmt(.ui)["numLin"] <= 0L) return(.rxFoceiCarryEmpty())
-  if (length(.ui$allCovs) == 0L) return(.rxFoceiCarryEmpty())
+  if (rxode2::.rxLinNcmt(.ui)["numLin"] <= 0L) {
+    return(.rxFoceiCarryEmpty())
+  }
+  if (length(.ui$allCovs) == 0L) {
+    return(.rxFoceiCarryEmpty())
+  }
   interpolation <- match.arg(interpolation)
   # the data-independent candidate result is a pure function of the model
   # digest; skip the foceiEtaS symengine build on a repeat fit of the same
   # model.  Data-dependent checks never reach this memo (data = NULL only).
   .key <- if (is.null(data) && # nolint: object_usage_linter.
-              !identical(Sys.getenv("NLMIXR2EST_CARRY_MEMO"), "off")) {
+    !identical(Sys.getenv("NLMIXR2EST_CARRY_MEMO"), "off")) {
     tryCatch(rxUiGet.foceiModelDigest(list(.ui)), error = function(e) NULL)
   }
   .cached <- .foceiLinCmtCarryMemoGet(.key) # nolint: object_usage_linter.
-  if (!is.null(.cached)) return(.cached)
+  if (!is.null(.cached)) {
+    return(.cached)
+  }
   .s <- .ui$foceiEtaS
   .etaVars <- paste0("ETA_", seq_len(.s$..maxEta), "_")
-  .ret <- .rxFoceiLinCmtCarryEligible(list(.ui), .s, .etaVars, data = data, # nolint: object_usage_linter.
-                                      interpolation = interpolation)
+  .ret <- .rxFoceiLinCmtCarryEligible(list(.ui), .s, .etaVars,
+    data = data, # nolint: object_usage_linter.
+    interpolation = interpolation
+  )
   # the final shape rides with the result so consumers (the fit-time
   # jump-data check) never rebuild the symengine environment for it
   attr(.ret, "oral0") <- tryCatch(.rxFoceiLinCmtCarryShape(.s)$oral0, # nolint: object_usage_linter.
-                                  error = function(e) NULL)
+    error = function(e) NULL
+  )
   .foceiLinCmtCarryMemoPut(.key, .ret) # nolint: object_usage_linter.
   .ret
 }
@@ -85,38 +102,48 @@
 #' @noRd
 .rxFoceiCarryPairRow <- function(eta, etaName, slot, jump, mods, why, varying, render) {
   .txt <- function(x) .rxFoceiCarryTxt(x, render) # nolint: object_usage_linter.
-  data.frame(slot = if (is.null(slot)) NA_integer_ else slot$k,
-             slotName = if (is.null(slot)) NA_character_ else .rxFoceiLinCmtCarrySlotNames[slot$k], # nolint: object_usage_linter.
-             eta = eta,
-             etaName = etaName,
-             covs = paste(why, collapse = ","),
-             shape = if (is.null(slot)) NA_character_ else slot$shape,
-             formula = if (is.null(slot)) NA_character_ else .txt(paste(slot$expr)),
-             dEtaFormula = if (is.null(slot)) NA_character_ else .txt(paste(slot$g)),
-             varying = varying,
-             fD = .txt(jump$fD),
-             fCov = isTRUE(jump$fCov),
-             fCmt = if (is.null(jump$fD)) NA_character_ else mods$f$cmt,
-             lagD = .txt(jump$lagD),
-             lagCmt = if (is.null(jump$lagD)) NA_character_ else mods$lag$cmt,
-             stringsAsFactors = FALSE)
+  data.frame(
+    slot = if (is.null(slot)) NA_integer_ else slot$k,
+    slotName = if (is.null(slot)) NA_character_ else .rxFoceiLinCmtCarrySlotNames[slot$k], # nolint: object_usage_linter.
+    eta = eta,
+    etaName = etaName,
+    covs = paste(why, collapse = ","),
+    shape = if (is.null(slot)) NA_character_ else slot$shape,
+    formula = if (is.null(slot)) NA_character_ else .txt(paste(slot$expr)),
+    dEtaFormula = if (is.null(slot)) NA_character_ else .txt(paste(slot$g)),
+    varying = varying,
+    fD = .txt(jump$fD),
+    fCov = isTRUE(jump$fCov),
+    fCmt = if (is.null(jump$fD)) NA_character_ else mods$f$cmt,
+    lagD = .txt(jump$lagD),
+    lagCmt = if (is.null(jump$lagD)) NA_character_ else mods$lag$cmt,
+    stringsAsFactors = FALSE
+  )
 }
 
 #' Expected data CMT values for a linCmt() compartment name
 #' @noRd
 .rxFoceiCarryCmtValues <- function(cmt, oral0) {
-  if (identical(cmt, "depot")) return(list(num = 1L, chr = "depot"))
-  if (identical(cmt, "central")) return(list(num = oral0 + 1L, chr = "central"))
+  if (identical(cmt, "depot")) {
+    return(list(num = 1L, chr = "depot"))
+  }
+  if (identical(cmt, "central")) {
+    return(list(num = oral0 + 1L, chr = "central"))
+  }
   list(num = NA_integer_, chr = cmt)
 }
 
 #' Do every dose's CMT values point at the modified compartment?
 #' @noRd
 .rxFoceiCarryDoseCmtOk <- function(dose, cmt, oral0) {
-  if (!("CMT" %in% names(dose))) return(TRUE)
+  if (!("CMT" %in% names(dose))) {
+    return(TRUE)
+  }
   .v <- dose[["CMT"]]
   .ok <- .rxFoceiCarryCmtValues(cmt, oral0)
-  if (is.numeric(.v)) return(all(.v == .ok$num))
+  if (is.numeric(.v)) {
+    return(all(.v == .ok$num))
+  }
   all(as.character(.v) == .ok$chr)
 }
 
@@ -135,9 +162,13 @@
 .rxFoceiCarryDoseRows <- function(data) {
   .d <- data
   names(.d) <- toupper(names(.d))
-  if (!("EVID" %in% names(.d))) return(NULL)
+  if (!("EVID" %in% names(.d))) {
+    return(NULL)
+  }
   .dose <- .d[.d[["EVID"]] %in% c(1L, 4L, 101L), , drop = FALSE]
-  if (nrow(.dose) == 0L) return(NULL)
+  if (nrow(.dose) == 0L) {
+    return(NULL)
+  }
   .dose
 }
 
@@ -147,12 +178,18 @@
 #' @noRd
 .rxFoceiCarryJumpDataProblem <- function(pairs, data, oral0) {
   .jump <- pairs[!is.na(pairs$fD) | !is.na(pairs$lagD), , drop = FALSE]
-  if (nrow(.jump) == 0L) return(NULL)
+  if (nrow(.jump) == 0L) {
+    return(NULL)
+  }
   .dose <- .rxFoceiCarryDoseRows(data)
-  if (is.null(.dose)) return(NULL)
+  if (is.null(.dose)) {
+    return(NULL)
+  }
   .cmts <- unique(c(.jump$fCmt, .jump$lagCmt))
   .cmts <- .cmts[!is.na(.cmts)]
-  if (length(.cmts) > 1L) return("f() and alag() on different compartments")
+  if (length(.cmts) > 1L) {
+    return("f() and alag() on different compartments")
+  }
   if (!.rxFoceiCarryDoseCmtOk(.dose, .cmts, oral0)) {
     return("doses outside the f()/alag() compartment")
   }

--- a/R/foceiLinCmtCarryEligible.R
+++ b/R/foceiLinCmtCarryEligible.R
@@ -43,7 +43,8 @@
 #' @noRd
 .rxFoceiCarryFreeSyms <- function(expr) {
   tryCatch(vapply(symengine::free_symbols(expr), as.character, character(1)),
-           error = function(e) character(0))
+    error = function(e) character(0)
+  )
 }
 
 #' Is a symengine expression identically zero?
@@ -77,9 +78,13 @@
   .ui <- x[[1]]
   .empty <- .rxFoceiCarryEmpty() # nolint: object_usage_linter.
   .allCovs <- .ui$allCovs
-  if (length(.allCovs) == 0L) return(.empty)
+  if (length(.allCovs) == 0L) {
+    return(.empty)
+  }
   .predArgs <- .rxFoceiCarryPredArgs(.ui, s) # nolint: object_usage_linter.
-  if (is.null(.predArgs)) return(.empty)
+  if (is.null(.predArgs)) {
+    return(.empty)
+  }
   .iniDf <- .ui$iniDf
   .etaDf <- .iniDf[!is.na(.iniDf$neta1) & .iniDf$neta1 == .iniDf$neta2, , drop = FALSE]
   # per-slot free symbols (slots 9-15 of the linCmtB call are p1..ka)
@@ -88,8 +93,10 @@
   .mods <- .rxFoceiCarryEventMods(.ui, s, etaVars) # nolint: object_usage_linter.
   .ret <- .empty
   for (.e in seq_along(etaVars)) {
-    .row <- .rxFoceiCarryEligibleEta(.e, etaVars, .etaDf, .allCovs, .slotExpr,
-                                      .slotFree, .mods, data, interpolation, render)
+    .row <- .rxFoceiCarryEligibleEta(
+      .e, etaVars, .etaDf, .allCovs, .slotExpr,
+      .slotFree, .mods, data, interpolation, render
+    )
     if (!is.null(.row)) .ret <- rbind(.ret, .row)
   }
   .ret
@@ -101,7 +108,9 @@
 #' @noRd
 .rxFoceiCarryEtaIdOnly <- function(e, etaDf) {
   .wEta <- which(etaDf$neta1 == e)
-  if (length(.wEta) != 1L) return(FALSE)
+  if (length(.wEta) != 1L) {
+    return(FALSE)
+  }
   .cond <- etaDf$condition[.wEta]
   is.na(.cond) || identical(.cond, "id")
 }
@@ -112,34 +121,52 @@
 #' @noRd
 .rxFoceiCarryEtaSlotInfo <- function(eta, etaVars, allCovs, slotExpr, slotFree) {
   .inSlot <- which(vapply(slotFree, function(f) eta %in% f, logical(1)))
-  if (length(.inSlot) == 0L) return(list())
+  if (length(.inSlot) == 0L) {
+    return(list())
+  }
   # eta must live in exactly one slot; multi-slot substitution is unvalidated
-  if (length(.inSlot) != 1L) return(NULL)
+  if (length(.inSlot) != 1L) {
+    return(NULL)
+  }
   .free <- slotFree[[.inSlot]]
   # exactly one eta in that slot, no direct time dependence
-  if (sum(etaVars %in% .free) != 1L || "t" %in% .free) return(NULL)
+  if (sum(etaVars %in% .free) != 1L || "t" %in% .free) {
+    return(NULL)
+  }
   .expr <- slotExpr[[.inSlot]]
   .d <- tryCatch(symengine::D(.expr, symengine::S(eta)), error = function(err) NULL)
-  if (is.null(.d) || .rxFoceiCarryIsZero(.d)) return(NULL)
+  if (is.null(.d) || .rxFoceiCarryIsZero(.d)) {
+    return(NULL)
+  }
   .shape <- .rxFoceiCarryShape(.expr, .d, allCovs, etaVars)
-  if (is.null(.shape)) return(NULL)
-  list(k = .inSlot, g = .d, expr = .expr, shape = .shape,
-       covs = intersect(.free, allCovs))
+  if (is.null(.shape)) {
+    return(NULL)
+  }
+  list(
+    k = .inSlot, g = .d, expr = .expr, shape = .shape,
+    covs = intersect(.free, allCovs)
+  )
 }
 
 #' "mult" / "add" when the eta enters separably, else NULL
 #' @noRd
 .rxFoceiCarryShape <- function(expr, d, allCovs, etaVars) {
-  if (.rxFoceiCarryIsZero(symengine::expand(d - expr))) return("mult")
+  if (.rxFoceiCarryIsZero(symengine::expand(d - expr))) {
+    return("mult")
+  }
   .dFree <- .rxFoceiCarryFreeSyms(d)
-  if (length(intersect(.dFree, c(allCovs, etaVars, "t"))) == 0L) return("add")
+  if (length(intersect(.dFree, c(allCovs, etaVars, "t"))) == 0L) {
+    return("add")
+  }
   NULL
 }
 
 #' Render a symengine repr to model text (or pass it through)
 #' @noRd
 .rxFoceiCarryTxt <- function(repr, render) {
-  if (is.null(repr) || is.na(repr)) return(NA_character_)
+  if (is.null(repr) || is.na(repr)) {
+    return(NA_character_)
+  }
   if (render) rxode2::rxFromSE(repr) else repr
 }
 
@@ -148,23 +175,34 @@
 .rxFoceiCarryEligibleEta <- function(e, etaVars, etaDf, allCovs, slotExpr,
                                      slotFree, mods, data, interpolation, render) {
   .eta <- etaVars[e]
-  if (!.rxFoceiCarryEtaIdOnly(e, etaDf)) return(NULL)
+  if (!.rxFoceiCarryEtaIdOnly(e, etaDf)) {
+    return(NULL)
+  }
   .jump <- .rxFoceiCarryEtaJump(.eta, mods, allCovs) # nolint: object_usage_linter.
-  if (!isTRUE(.jump$ok)) return(NULL)
+  if (!isTRUE(.jump$ok)) {
+    return(NULL)
+  }
   .slot <- .rxFoceiCarryEtaSlotInfo(.eta, etaVars, allCovs, slotExpr, slotFree)
-  if (is.null(.slot)) return(NULL)
+  if (is.null(.slot)) {
+    return(NULL)
+  }
   .hasSlot <- length(.slot) > 0L
   .why <- .rxFoceiCarryWhy(if (.hasSlot) .slot else NULL, .jump, mods, slotFree, allCovs)
-  if (length(.why) == 0L) return(NULL)
+  if (length(.why) == 0L) {
+    return(NULL)
+  }
   .varying <- .rxFoceiCarryVarying(.why, data) # nolint: object_usage_linter.
   if (identical(interpolation, "linear") && isTRUE(.varying)) {
     stop("time-varying covariate '", paste(.why, collapse = "', '"),
-         "' on a linCmt() parameter needs 'locf', 'nocb' or 'midpoint' ",
-         "interpolation; 'linear' cannot be represented by the linCmt() solution",
-         call. = FALSE)
+      "' on a linCmt() parameter needs 'locf', 'nocb' or 'midpoint' ",
+      "interpolation; 'linear' cannot be represented by the linCmt() solution",
+      call. = FALSE
+    )
   }
-  .rxFoceiCarryPairRow(.eta, etaDf$name[which(etaDf$neta1 == e)], # nolint: object_usage_linter.
-                       if (.hasSlot) .slot else NULL, .jump, mods, .why, .varying, render)
+  .rxFoceiCarryPairRow(
+    .eta, etaDf$name[which(etaDf$neta1 == e)], # nolint: object_usage_linter.
+    if (.hasSlot) .slot else NULL, .jump, mods, .why, .varying, render
+  )
 }
 
 #' The covariates that make this eta's gradient history-dependent: those on

--- a/R/foceiLinCmtCarryEmitJump.R
+++ b/R/foceiLinCmtCarryEmitJump.R
@@ -10,62 +10,88 @@
   .l <- character(0)
   if (cx$anyJump) {
     # pin the full -5 advance: a jump contribution does not telescope
-    .l <- c(.l, paste0("rx_lcCarryPin_~",
-                       .rxFoceiLinCmtCarryCall(cx$pfx, -8L, 0L, cx$trans, cx$zero))) # nolint: object_usage_linter.
+    .l <- c(.l, paste0(
+      "rx_lcCarryPin_~",
+      .rxFoceiLinCmtCarryCall(cx$pfx, -8L, 0L, cx$trans, cx$zero)
+    )) # nolint: object_usage_linter.
   }
   # once-per-row advance of every carry column (M depends only on this
   # row's theta, so one call serves every pair AND every tracker)
-  .l <- c(.l, paste0("rx_lcCarryAdv_~",
-                     .rxFoceiLinCmtCarryCall(cx$pfx, -5L, 0L, cx$trans, cx$thetas))) # nolint: object_usage_linter.
-  if (!cx$anyJump) return(.l)
-  for (.r in cx$rows) {
-    .l <- c(.l,
-            # amounts at this row (post-dose) and the advanced amounts
-            # tracker M_r A_{r-1}; their difference is the interval's input
-            paste0("rx_lcCarryA", .r, "_~",
-                   .rxFoceiLinCmtCarryCall(cx$pfx, .r, -2L, cx$trans, cx$zero)), # nolint: object_usage_linter.
-            paste0("rx_lcCarryPA", .r, "_~",
-                   .rxFoceiLinCmtCarryCall(cx$pfx, -6L, .r + cx$m * cx$aCol, cx$trans, cx$zero)), # nolint: object_usage_linter.
-            paste0("rx_lcCarryD", .r, "_~(rx_lcCarryA", .r, "_-rx_lcCarryPA", .r, "_)"))
+  .l <- c(.l, paste0(
+    "rx_lcCarryAdv_~",
+    .rxFoceiLinCmtCarryCall(cx$pfx, -5L, 0L, cx$trans, cx$thetas)
+  )) # nolint: object_usage_linter.
+  if (!cx$anyJump) {
+    return(.l)
   }
-  if (!cx$anyLag) return(.l)
   for (.r in cx$rows) {
-    .l <- c(.l, paste0("rx_lcCarryL", .r, "_~",
-                       .rxFoceiLinCmtCarryCall(cx$pfx, -6L, .r + cx$m * cx$lCol, cx$trans, cx$zero))) # nolint: object_usage_linter.
+    .l <- c(
+      .l,
+      # amounts at this row (post-dose) and the advanced amounts
+      # tracker M_r A_{r-1}; their difference is the interval's input
+      paste0(
+        "rx_lcCarryA", .r, "_~",
+        .rxFoceiLinCmtCarryCall(cx$pfx, .r, -2L, cx$trans, cx$zero)
+      ), # nolint: object_usage_linter.
+      paste0(
+        "rx_lcCarryPA", .r, "_~",
+        .rxFoceiLinCmtCarryCall(cx$pfx, -6L, .r + cx$m * cx$aCol, cx$trans, cx$zero)
+      ), # nolint: object_usage_linter.
+      paste0("rx_lcCarryD", .r, "_~(rx_lcCarryA", .r, "_-rx_lcCarryPA", .r, "_)")
+    )
+  }
+  if (!cx$anyLag) {
+    return(.l)
+  }
+  for (.r in cx$rows) {
+    .l <- c(.l, paste0(
+      "rx_lcCarryL", .r, "_~",
+      .rxFoceiLinCmtCarryCall(cx$pfx, -6L, .r + cx$m * cx$lCol, cx$trans, cx$zero)
+    )) # nolint: object_usage_linter.
   }
   # K_r P_r: the kernel's right-hand side applied to the advanced amounts
-  .kp <- .rxFoceiCarryRhsTxt(cx$ncmt, cx$oral0, as.numeric(cx$trans), cx$slotExpr, # nolint: object_usage_linter.
-                             paste0("rx_lcCarryPA", cx$rows, "_"))
+  .kp <- .rxFoceiCarryRhsTxt(
+    cx$ncmt, cx$oral0, as.numeric(cx$trans), cx$slotExpr, # nolint: object_usage_linter.
+    paste0("rx_lcCarryPA", cx$rows, "_")
+  )
   for (.r in cx$rows) .l <- c(.l, paste0("rx_lcCarryKP", .r, "_~", .kp[.r + 1L]))
   .absD <- paste(paste0("abs(rx_lcCarryD", cx$rows, "_)"), collapse = "+")
   .absL <- paste(paste0("abs(rx_lcCarryL", cx$rows, "_)"), collapse = "+")
   .scale <- paste(paste0("abs(rx_lcCarryA", cx$rows, "_)+abs(rx_lcCarryPA", cx$rows, "_)"),
-                  collapse = "+")
-  c(.l,
+    collapse = "+"
+  )
+  c(
+    .l,
     # did an input enter at this row / at the previous row?  D is a
     # difference of two solves of the same state, so compare it against
     # the amounts' own scale, not against zero
     paste0("rx_lcCarryDel_~ifelse((", .absD, ")>1e-8*(", .scale, ")+1e-300,1,0)"),
-    paste0("rx_lcCarryDelP_~ifelse((", .absL, ")>1e-8*(", .scale, ")+1e-300,1,0)"))
+    paste0("rx_lcCarryDelP_~ifelse((", .absL, ")>1e-8*(", .scale, ")+1e-300,1,0)")
+  )
 }
 
 #' Lines emitted once per row after every pair (with the last pair): keep
 #' the amounts / lag trackers at this row's values
 #' @noRd
 .rxFoceiLinCmtCarryEpilogue <- function(cx) { # nolint: object_usage_linter.
-  if (!cx$anyJump) return(character(0))
+  if (!cx$anyJump) {
+    return(character(0))
+  }
   .l <- character(0)
   for (.r in cx$rows) {
     .z7 <- cx$zero
     .z7[3] <- paste0("rx_lcCarryD", .r, "_")
-    .l <- c(.l, paste0("rx_lcCarryUA", .r, "_~",
-                       .rxFoceiLinCmtCarryCall(cx$pfx, -7L, .r + cx$m * cx$aCol, cx$trans, .z7))) # nolint: object_usage_linter.
+    .l <- c(.l, paste0(
+      "rx_lcCarryUA", .r, "_~",
+      .rxFoceiLinCmtCarryCall(cx$pfx, -7L, .r + cx$m * cx$aCol, cx$trans, .z7)
+    )) # nolint: object_usage_linter.
     if (cx$anyLag) {
       .z7[3] <- paste0("(rx_lcCarryD", .r, "_-rx_lcCarryL", .r, "_)")
-      .l <- c(.l, paste0("rx_lcCarryUL", .r, "_~",
-                         .rxFoceiLinCmtCarryCall(cx$pfx, -7L, .r + cx$m * cx$lCol, cx$trans, .z7))) # nolint: object_usage_linter.
+      .l <- c(.l, paste0(
+        "rx_lcCarryUL", .r, "_~",
+        .rxFoceiLinCmtCarryCall(cx$pfx, -7L, .r + cx$m * cx$lCol, cx$trans, .z7)
+      )) # nolint: object_usage_linter.
     }
   }
   .l
 }
-

--- a/R/foceiLinCmtCarryEvent.R
+++ b/R/foceiLinCmtCarryEvent.R
@@ -38,7 +38,9 @@
   for (.i in 1:7) .args[[.rxFoceiLinCmtCarrySlotNames[.i]]] <- as.name(.rxFoceiCarrySlotPh[.i]) # nolint: object_usage_linter.
   .build <- utils::getFromNamespace(paste0(".linToOdeBuildMicro", ncmt), "rxode2")
   .m <- tryCatch(.build(.args), error = function(e) NULL)
-  if (is.null(.m)) return(NULL)
+  if (is.null(.m)) {
+    return(NULL)
+  }
   .keep <- intersect(c("k", "k12", "k21", "k13", "k31", "v", "ka"), names(.m))
   .ret <- lapply(.keep, function(n) {
     symengine::S(paste(deparse(.m[[n]], width.cutoff = 500L), collapse = ""))
@@ -65,7 +67,9 @@
 #' @noRd
 .rxFoceiCarryVc <- function(ncmt, oral0, trans, slot, slotExpr) {
   .m <- .rxFoceiCarryMicro(ncmt, oral0, trans)
-  if (is.null(.m) || is.null(.m$v)) return(NULL)
+  if (is.null(.m) || is.null(.m$v)) {
+    return(NULL)
+  }
   .vc <- .m$v
   .dvc <- NULL
   if (!is.na(slot)) {
@@ -80,7 +84,9 @@
 #' @noRd
 .rxFoceiCarryRhsTxt <- function(ncmt, oral0, trans, slotExpr, xNames) {
   .m <- .rxFoceiCarryMicro(ncmt, oral0, trans)
-  if (is.null(.m)) return(NULL)
+  if (is.null(.m)) {
+    return(NULL)
+  }
   .S <- symengine::S
   .x <- lapply(xNames, .S)
   .c <- oral0 + 1L # central index (1-based) in the kernel's row order
@@ -114,10 +120,14 @@
 .rxFoceiCarryEventMods <- function(ui, s, etaVars) {
   .lin <- rxode2::.rxLinCmt(ui)
   .lin <- grep("^rx__sens_", .lin, value = TRUE, invert = TRUE)
-  if (length(.lin) == 0L) return(list(f = NULL, lag = NULL))
+  if (length(.lin) == 0L) {
+    return(list(f = NULL, lag = NULL))
+  }
   .one <- function(kind) {
     .rows <- .rxFoceiLinCmtEventRows(s, .lin, kind, etaVars) # nolint: object_usage_linter.
-    if (length(.rows) != 1L) return(NULL)
+    if (length(.rows) != 1L) {
+      return(NULL)
+    }
     list(cmt = names(.rows), sym = .rows[[1]]$sym, drivers = .rows[[1]]$drivers)
   }
   list(f = .one("f"), lag = .one("lag"))

--- a/R/foceiLinCmtCarryGates.R
+++ b/R/foceiLinCmtCarryGates.R
@@ -9,8 +9,10 @@
 #' solve, so nothing may be emitted without this.
 #' @noRd
 .rxFoceiLinCmtCarryCapable <- function() {
-  exists("linCmtCarryLiveTest", envir = asNamespace("rxode2"),
-         inherits = FALSE)
+  exists("linCmtCarryLiveTest",
+    envir = asNamespace("rxode2"),
+    inherits = FALSE
+  )
 }
 
 #' Does the loaded rxode2 have the fast-path pin (which1=-8) an event jump
@@ -18,7 +20,9 @@
 #' @noRd
 .rxFoceiLinCmtCarryJumpCapable <- function() {
   .ns <- asNamespace("rxode2")
-  if (!exists("linCmtCarrySentinelMax", envir = .ns, inherits = FALSE)) return(FALSE)
+  if (!exists("linCmtCarrySentinelMax", envir = .ns, inherits = FALSE)) {
+    return(FALSE)
+  }
   isTRUE(get("linCmtCarrySentinelMax", envir = .ns)() >= 8L)
 }
 
@@ -43,14 +47,22 @@
 #' @return eligibility data.frame (zero rows -> NULL), or NULL
 #' @noRd
 .rxFoceiLinCmtCarryPairsForBuild <- function(x, s, etaVars, extraPred = NULL) {
-  if (!.rxFoceiLinCmtCarryBuildEnabled(x[[1]])) return(NULL)
+  if (!.rxFoceiLinCmtCarryBuildEnabled(x[[1]])) {
+    return(NULL)
+  }
   .pairs <- .rxFoceiLinCmtCarryDetect(x, s, etaVars)
-  if (is.null(.pairs) || nrow(.pairs) == 0L) return(NULL)
-  if (!.rxFoceiLinCmtCarryModelOk(s)) return(NULL)
+  if (is.null(.pairs) || nrow(.pairs) == 0L) {
+    return(NULL)
+  }
+  if (!.rxFoceiLinCmtCarryModelOk(s)) {
+    return(NULL)
+  }
   .jump <- !is.na(.pairs$fD) | !is.na(.pairs$lagD)
   if (any(.jump) && !.rxFoceiLinCmtCarryJumpCapable()) {
     .pairs <- .pairs[!.jump, , drop = FALSE]
-    if (nrow(.pairs) == 0L) return(NULL)
+    if (nrow(.pairs) == 0L) {
+      return(NULL)
+    }
   }
   .rxFoceiLinCmtCarryCheckCap(.pairs)
   .pairs
@@ -59,7 +71,9 @@
 #' Is the carry switched on for this build (capability, control, interpolation)?
 #' @noRd
 .rxFoceiLinCmtCarryBuildEnabled <- function(ui) {
-  if (!.rxFoceiLinCmtCarryCapable()) return(FALSE)
+  if (!.rxFoceiLinCmtCarryCapable()) {
+    return(FALSE)
+  }
   if (identical(rxode2::rxGetControl(ui, "linCmtSensCarry", "auto"), "none")) {
     return(FALSE)
   }
@@ -77,13 +91,18 @@
   # D(rx_pred_, ETA_n_) evaluations (shared-symengine-state corruption);
   # the emission renders in-loop via rxFromSE(S(<repr>)) instead.
   # (nolint: lintr resolves cross-file helpers against the installed package)
-  tryCatch(.rxFoceiLinCmtCarryEligible(x, s, etaVars, data = NULL, # nolint: object_usage_linter.
-                                       render = FALSE),
-           error = function(e) {
-             warning("linCmt() carry detection failed; standard gradient used",
-                     call. = FALSE)
-             NULL
-           })
+  tryCatch(
+    .rxFoceiLinCmtCarryEligible(x, s, etaVars,
+      data = NULL, # nolint: object_usage_linter.
+      render = FALSE
+    ),
+    error = function(e) {
+      warning("linCmt() carry detection failed; standard gradient used",
+        call. = FALSE
+      )
+      NULL
+    }
+  )
 }
 
 #' ncmt / oral0 / trans of the structural linCmtB() call in `rx_pred_`
@@ -99,7 +118,9 @@
 #' @noRd
 .rxFoceiLinCmtCarryModelOk <- function(s) {
   .sh <- .rxFoceiLinCmtCarryShape(s)
-  if (any(is.na(unlist(.sh)))) return(FALSE)
+  if (any(is.na(unlist(.sh)))) {
+    return(FALSE)
+  }
   !is.null(.rxFoceiCarryMicro(.sh$ncmt, .sh$oral0, .sh$trans)) # nolint: object_usage_linter.
 }
 
@@ -113,9 +134,10 @@
     as.integer(any(!is.na(pairs$lagD)))
   if (.need > 8L) {
     stop("the carry-eligible (linCmt parameter, eta) pairs need ", .need,
-         " carry columns (8 available); reduce the model or use ",
-         "foceiControl(linCmtSensCarry=\"none\")",
-         call. = FALSE)
+      " carry columns (8 available); reduce the model or use ",
+      "foceiControl(linCmtSensCarry=\"none\")",
+      call. = FALSE
+    )
   }
   invisible(TRUE)
 }

--- a/R/foceiLinCmtCarryMemo.R
+++ b/R/foceiLinCmtCarryMemo.R
@@ -21,8 +21,10 @@
 #' (tests; a session never needs this itself)
 #' @noRd
 .foceiLinCmtCarryMemoClear <- function(files = TRUE) {
-  .keys <- setdiff(ls(envir = .carryPairsMemo, all.names = FALSE),
-                   c("hits", "misses", "fileHits"))
+  .keys <- setdiff(
+    ls(envir = .carryPairsMemo, all.names = FALSE),
+    c("hits", "misses", "fileHits")
+  )
   rm(list = .keys, envir = .carryPairsMemo)
   if (files) {
     .dir <- tryCatch(rxode2::rxTempDir(), error = function(e) NULL)
@@ -37,9 +39,11 @@
 #' results served from the persistent sidecar in rxode2's cache directory
 #' @noRd
 .foceiLinCmtCarryMemoStats <- function(reset = FALSE) {
-  .st <- c(hits = get0("hits", envir = .carryPairsMemo, ifnotfound = 0L),
-           misses = get0("misses", envir = .carryPairsMemo, ifnotfound = 0L),
-           fileHits = get0("fileHits", envir = .carryPairsMemo, ifnotfound = 0L))
+  .st <- c(
+    hits = get0("hits", envir = .carryPairsMemo, ifnotfound = 0L),
+    misses = get0("misses", envir = .carryPairsMemo, ifnotfound = 0L),
+    fileHits = get0("fileHits", envir = .carryPairsMemo, ifnotfound = 0L)
+  )
   if (reset) {
     assign("hits", 0L, envir = .carryPairsMemo)
     assign("misses", 0L, envir = .carryPairsMemo)
@@ -55,7 +59,8 @@
 #' @noRd
 .foceiLinCmtCarryCacheFile <- function(key) {
   tryCatch(file.path(rxode2::rxTempDir(), paste0("focei-carry-", key, ".rds")),
-           error = function(e) NULL)
+    error = function(e) NULL
+  )
 }
 
 #' Read the sidecar; NULL unless it exists and was written by THIS
@@ -64,9 +69,13 @@
 #' @noRd
 .foceiLinCmtCarryCacheRead <- function(key) {
   .f <- .foceiLinCmtCarryCacheFile(key)
-  if (is.null(.f) || !file.exists(.f)) return(NULL)
+  if (is.null(.f) || !file.exists(.f)) {
+    return(NULL)
+  }
   .x <- tryCatch(readRDS(.f), error = function(e) NULL)
-  if (!is.list(.x) || !identical(.x$md5, nlmixr2.md5)) return(NULL)
+  if (!is.list(.x) || !identical(.x$md5, nlmixr2.md5)) {
+    return(NULL)
+  }
   .x$pairs
 }
 
@@ -74,9 +83,12 @@
 #' @noRd
 .foceiLinCmtCarryCacheWrite <- function(key, pairs) {
   .f <- .foceiLinCmtCarryCacheFile(key)
-  if (is.null(.f)) return(invisible(NULL))
+  if (is.null(.f)) {
+    return(invisible(NULL))
+  }
   tryCatch(saveRDS(list(md5 = nlmixr2.md5, pairs = pairs), .f),
-           error = function(e) NULL)
+    error = function(e) NULL
+  )
   invisible(NULL)
 }
 
@@ -84,7 +96,9 @@
 #' sidecar (hydrating the session env on a file hit); NULL on a miss
 #' @noRd
 .foceiLinCmtCarryMemoGet <- function(key) {
-  if (is.null(key)) return(NULL)
+  if (is.null(key)) {
+    return(NULL)
+  }
   .bump <- function(ctr) {
     assign(ctr, .foceiLinCmtCarryMemoStats()[[ctr]] + 1L, envir = .carryPairsMemo)
   }
@@ -93,7 +107,9 @@
     return(get(key, envir = .carryPairsMemo, inherits = FALSE))
   }
   .cached <- .foceiLinCmtCarryCacheRead(key)
-  if (is.null(.cached)) return(NULL)
+  if (is.null(.cached)) {
+    return(NULL)
+  }
   .bump("fileHits")
   assign(key, .cached, envir = .carryPairsMemo)
   .cached
@@ -102,12 +118,17 @@
 #' Store a computed result in the session env (bounded) and the sidecar
 #' @noRd
 .foceiLinCmtCarryMemoPut <- function(key, pairs) {
-  if (is.null(key)) return(invisible(NULL))
+  if (is.null(key)) {
+    return(invisible(NULL))
+  }
   assign("misses", .foceiLinCmtCarryMemoStats()[["misses"]] + 1L,
-         envir = .carryPairsMemo)
+    envir = .carryPairsMemo
+  )
   # bound the memo (a session rarely fits more than a handful of models)
-  .keys <- setdiff(ls(envir = .carryPairsMemo, all.names = FALSE),
-                   c("hits", "misses", "fileHits"))
+  .keys <- setdiff(
+    ls(envir = .carryPairsMemo, all.names = FALSE),
+    c("hits", "misses", "fileHits")
+  )
   if (length(.keys) >= 64L) {
     rm(list = .keys, envir = .carryPairsMemo)
   }

--- a/R/foceiLinCmtCarryPredCall.R
+++ b/R/foceiLinCmtCarryPredCall.R
@@ -17,7 +17,9 @@
       return(invisible())
     }
     .a <- tryCatch(symengine::get_args(x), error = function(e) NULL)
-    if (is.null(.a)) return(invisible())
+    if (is.null(.a)) {
+      return(invisible())
+    }
     for (.i in seq_along(.a)) .walk(.a[[.i]])
     invisible()
   }
@@ -37,36 +39,55 @@
 #'   call replaced by the symbol `rx_lcConc_`)
 #' @noRd
 .rxFoceiCarryPredCall <- function(s) {
-  if (!exists("rx_pred_", envir = s, inherits = FALSE)) return(NULL)
+  if (!exists("rx_pred_", envir = s, inherits = FALSE)) {
+    return(NULL)
+  }
   .pred <- get("rx_pred_", envir = s, inherits = FALSE)
   .calls <- .rxFoceiCarryFindLinCmtB(.pred)
-  if (length(.calls) == 0L) return(NULL)
+  if (length(.calls) == 0L) {
+    return(NULL)
+  }
   .reprs <- vapply(.calls, paste, character(1))
-  if (length(unique(.reprs)) != 1L) return(NULL)
+  if (length(unique(.reprs)) != 1L) {
+    return(NULL)
+  }
   .call <- .calls[[1L]]
   .args <- symengine::get_args(.call)
-  if (length(.args) != 15L) return(NULL)
+  if (length(.args) != 15L) {
+    return(NULL)
+  }
   # the value form (which1 = -1); a sensitivity read inside rx_pred_ is not
   # something the carry can stand in for
   if (!isTRUE(all.equal(suppressWarnings(as.numeric(paste(.args[[6]]))), -1))) {
     return(NULL)
   }
   .bare <- identical(paste(.pred), .reprs[1L])
-  list(call = .call, args = .args, bare = .bare,
-       predSym = if (.bare) symengine::S("rx_lcConc_") else
-         symengine::subs(.pred, .call, symengine::S("rx_lcConc_")))
+  list(
+    call = .call, args = .args, bare = .bare,
+    predSym = if (.bare) {
+      symengine::S("rx_lcConc_")
+    } else {
+      symengine::subs(.pred, .call, symengine::S("rx_lcConc_"))
+    }
+  )
 }
 
 #' The 15 `linCmtB()` arguments of `rx_pred_`'s structural call, or NULL
 #' when the model is not a pure linCmt() model with one such call
 #' @noRd
 .rxFoceiCarryPredArgs <- function(ui, s) {
-  if (rxode2::.rxLinNcmt(ui)["numLin"] <= 0L) return(NULL)
+  if (rxode2::.rxLinNcmt(ui)["numLin"] <= 0L) {
+    return(NULL)
+  }
   # mixed ODE + linCmt() models evaluate linCmtB() inside the integrator as
   # well as in the lhs pass; the once-per-row carry stepping is only
   # validated for pure linCmt() models
-  if (length(.rxode2stateOdeNoOutput(s)) > 0L) return(NULL)
+  if (length(.rxode2stateOdeNoOutput(s)) > 0L) {
+    return(NULL)
+  }
   .pc <- .rxFoceiCarryPredCall(s)
-  if (is.null(.pc)) return(NULL)
+  if (is.null(.pc)) {
+    return(NULL)
+  }
   .pc$args
 }

--- a/R/foceiLinCmtCarryTheta.R
+++ b/R/foceiLinCmtCarryTheta.R
@@ -32,7 +32,9 @@
 #' @noRd
 .rxCarryFindLinCmtB <- function(expr, acc = list()) {
   .nm <- tryCatch(symengine::get_name(expr), error = function(e) "")
-  if (identical(.nm, "linCmtB")) return(c(acc, list(expr)))
+  if (identical(.nm, "linCmtB")) {
+    return(c(acc, list(expr)))
+  }
   .a <- tryCatch(symengine::get_args(expr), error = function(e) NULL)
   if (!is.null(.a)) {
     for (.i in seq_along(.a)) acc <- .rxCarryFindLinCmtB(.a[[.i]], acc)
@@ -47,15 +49,23 @@
 #'   rx_pred_ does not contain exactly one structural call
 #' @noRd
 .rxCarryFactorPred <- function(s) {
-  if (!exists("rx_pred_", envir = s, inherits = FALSE)) return(NULL)
+  if (!exists("rx_pred_", envir = s, inherits = FALSE)) {
+    return(NULL)
+  }
   .pred <- get("rx_pred_", envir = s, inherits = FALSE)
   .calls <- .rxCarryFindLinCmtB(.pred)
-  if (length(.calls) != 1L) return(NULL)
+  if (length(.calls) != 1L) {
+    return(NULL)
+  }
   .args <- symengine::get_args(.calls[[1]])
-  if (length(.args) != 15L) return(NULL)
+  if (length(.args) != 15L) {
+    return(NULL)
+  }
   # the structural (value) call has which1 = which2 = -1
   .w <- suppressWarnings(as.numeric(c(paste(.args[[6]]), paste(.args[[7]]))))
-  if (any(is.na(.w)) || any(.w != -1)) return(NULL)
+  if (any(is.na(.w)) || any(.w != -1)) {
+    return(NULL)
+  }
   .outer <- symengine::subs(.pred, .calls[[1]], symengine::S("rx_lcConc_"))
   list(call = .calls[[1]], args = .args, outer = .outer)
 }
@@ -78,7 +88,9 @@
   .ui <- x[[1]]
   .empty <- .rxFoceiCarryEmpty() # nolint: object_usage_linter.
   .allCovs <- .ui$allCovs
-  if (length(.allCovs) == 0L) return(.empty)
+  if (length(.allCovs) == 0L) {
+    return(.empty)
+  }
   .slotExpr <- lapply(1:7, function(k) fp$args[[k + 8L]])
   .slotFree <- lapply(.slotExpr, .rxFoceiCarryFreeSyms) # nolint: object_usage_linter.
   .mods <- .rxFoceiCarryEventMods(.ui, s, thetaVars) # nolint: object_usage_linter.
@@ -92,9 +104,11 @@
     .hasSlot <- length(.slot) > 0L
     .why <- .rxFoceiCarryWhy(if (.hasSlot) .slot else NULL, .jump, .mods, .slotFree, .allCovs) # nolint: object_usage_linter.
     if (length(.why) == 0L) next
-    .ret <- rbind(.ret, .rxFoceiCarryPairRow(.th, .rxCarryThetaName(.ui, .k), # nolint: object_usage_linter.
-                                             if (.hasSlot) .slot else NULL,
-                                             .jump, .mods, .why, NA, render))
+    .ret <- rbind(.ret, .rxFoceiCarryPairRow(
+      .th, .rxCarryThetaName(.ui, .k), # nolint: object_usage_linter.
+      if (.hasSlot) .slot else NULL,
+      .jump, .mods, .why, NA, render
+    ))
   }
   .ret
 }
@@ -115,9 +129,13 @@
 #' @noRd
 .rxCarryThetaPairsForBuild <- function(x, s, thetaVars) {
   .fp <- .rxCarryThetaModelOk(x[[1]], s)
-  if (is.null(.fp)) return(NULL)
+  if (is.null(.fp)) {
+    return(NULL)
+  }
   .pairs <- .rxCarryThetaDetect(x, s, thetaVars, .fp)
-  if (is.null(.pairs)) return(NULL)
+  if (is.null(.pairs)) {
+    return(NULL)
+  }
   .rxFoceiLinCmtCarryCheckCap(.pairs) # nolint: object_usage_linter.
   list(pairs = .pairs, fp = .fp)
 }
@@ -125,15 +143,23 @@
 #' The factored call when the model/control can carry at all, else NULL
 #' @noRd
 .rxCarryThetaModelOk <- function(ui, s) {
-  if (!.rxFoceiLinCmtCarryBuildEnabled(ui)) return(NULL) # nolint: object_usage_linter.
-  if (rxode2::.rxLinNcmt(ui)["numLin"] <= 0L) return(NULL)
+  if (!.rxFoceiLinCmtCarryBuildEnabled(ui)) {
+    return(NULL)
+  } # nolint: object_usage_linter.
+  if (rxode2::.rxLinNcmt(ui)["numLin"] <= 0L) {
+    return(NULL)
+  }
   # the once-per-row stepping is only validated for pure linCmt() models
-  if (length(.rxode2stateOdeNoOutput(s)) > 0L) return(NULL)
+  if (length(.rxode2stateOdeNoOutput(s)) > 0L) {
+    return(NULL)
+  }
   .fp <- .rxCarryFactorPred(s)
-  if (is.null(.fp)) return(NULL)
+  if (is.null(.fp)) {
+    return(NULL)
+  }
   .sh <- .rxCarryCallShape(.fp)
   if (any(is.na(unlist(.sh))) ||
-        is.null(.rxFoceiCarryMicro(.sh$ncmt, .sh$oral0, .sh$trans))) { # nolint: object_usage_linter.
+    is.null(.rxFoceiCarryMicro(.sh$ncmt, .sh$oral0, .sh$trans))) { # nolint: object_usage_linter.
     return(NULL)
   }
   .fp
@@ -143,17 +169,23 @@
 #' @noRd
 .rxCarryThetaDetect <- function(x, s, thetaVars, fp) {
   .pairs <- tryCatch(.rxCarryThetaEligible(x, s, thetaVars, fp, render = FALSE),
-                     error = function(e) {
-                       warning("linCmt() theta carry detection failed; standard gradient used",
-                               call. = FALSE)
-                       NULL
-                     })
-  if (is.null(.pairs) || nrow(.pairs) == 0L) return(NULL)
+    error = function(e) {
+      warning("linCmt() theta carry detection failed; standard gradient used",
+        call. = FALSE
+      )
+      NULL
+    }
+  )
+  if (is.null(.pairs) || nrow(.pairs) == 0L) {
+    return(NULL)
+  }
   # slot channels only: a theta on f()/alag() is a dosing parameter the nlm
   # family already routes through its own eventSens machinery
   # (rxUiGet.nlmEnv's eventTheta), and that interaction is unvalidated
   .pairs <- .pairs[is.na(.pairs$fD) & is.na(.pairs$lagD), , drop = FALSE]
-  if (nrow(.pairs) == 0L) return(NULL)
+  if (nrow(.pairs) == 0L) {
+    return(NULL)
+  }
   .pairs
 }
 
@@ -175,8 +207,9 @@
   # `tmp=`; make it an intermediate and point its direct term at the
   # factored concentration rather than at rx_pred_
   .lines[.i] <- gsub("rx_pred_", "rx_lcConc_",
-                     sub(paste0("^", .tmp, "="), paste0(.tmp, "~"), .lines[.i]),
-                     fixed = TRUE)
+    sub(paste0("^", .tmp, "="), paste0(.tmp, "~"), .lines[.i]),
+    fixed = TRUE
+  )
   if (w == 1L) {
     .callRepr <- paste(fp$call)
     .lines <- c(paste0("rx_lcConc_~", rxode2::rxFromSE(.callRepr)), .lines)

--- a/R/nlm.R
+++ b/R/nlm.R
@@ -41,28 +41,27 @@
 #' @export
 #' @author Matthew L. Fidler
 #' @examples
-#'
 #' \donttest{
 #' # A logit regression example with emax model
 #'
-#' dsn <- data.frame(i=1:1000)
+#' dsn <- data.frame(i = 1:1000)
 #' dsn$time <- exp(rnorm(1000))
-#' dsn$DV=rbinom(1000,1,exp(-1+dsn$time)/(1+exp(-1+dsn$time)))
+#' dsn$DV <- rbinom(1000, 1, exp(-1 + dsn$time) / (1 + exp(-1 + dsn$time)))
 #'
 #' mod <- function() {
-#'  ini({
-#'    E0 <- 0.5
-#'    Em <- 0.5
-#'    E50 <- 2
-#'    g <- fix(2)
-#'  })
-#'  model({
-#'    v <- E0+Em*time^g/(E50^g+time^g)
-#'    ll(bin) ~ DV * v - log(1 + exp(v))
-#'  })
+#'   ini({
+#'     E0 <- 0.5
+#'     Em <- 0.5
+#'     E50 <- 2
+#'     g <- fix(2)
+#'   })
+#'   model({
+#'     v <- E0 + Em * time^g / (E50^g + time^g)
+#'     ll(bin) ~ DV * v - log(1 + exp(v))
+#'   })
 #' }
 #'
-#' fit2 <- nlmixr(mod, dsn, est="nlm")
+#' fit2 <- nlmixr(mod, dsn, est = "nlm")
 #'
 #' print(fit2)
 #'
@@ -77,91 +76,82 @@ nlmControl <- function(typsize = NULL,
                        fscale = 1, print.level = 0, ndigit = NULL, gradtol = NULL,
                        stepmax = NULL,
                        steptol = NULL, iterlim = 10000, check.analyticals = FALSE,
-                       returnNlm=FALSE,
-                       solveType=c("hessian", "grad", "fun"),
-
-                       stickyRecalcN=4,
-                       maxOdeRecalc=5,
-                       odeRecalcFactor=10^(0.5),
-                       indTolRelax=TRUE,
-
-                       eventType=c("central", "forward"),
-                       shiErr=(.Machine$double.eps)^(1/3),
-                       shi21maxFD=20L,
-
-                       optimHessType=c("central", "forward"),
-                       hessErr =(.Machine$double.eps)^(1/3),
-                       shi21maxHess=20L,
-
-                       censOption=c("gauss", "laplace"),
-
-                       eventSens=c("jump", "fd"),
-
-                       linCmtSensCarry=c("auto", "none"),
-
-                       sensMethod=c("default", "forward"),
-
+                       returnNlm = FALSE,
+                       solveType = c("hessian", "grad", "fun"),
+                       stickyRecalcN = 4,
+                       maxOdeRecalc = 5,
+                       odeRecalcFactor = 10^(0.5),
+                       indTolRelax = TRUE,
+                       eventType = c("central", "forward"),
+                       shiErr = (.Machine$double.eps)^(1 / 3),
+                       shi21maxFD = 20L,
+                       optimHessType = c("central", "forward"),
+                       hessErr = (.Machine$double.eps)^(1 / 3),
+                       shi21maxHess = 20L,
+                       censOption = c("gauss", "laplace"),
+                       eventSens = c("jump", "fd"),
+                       linCmtSensCarry = c("auto", "none"),
+                       sensMethod = c("default", "forward"),
                        useColor = NULL,
                        printNcol = NULL, #
                        print = 1L, #
-
                        normType = c("rescale2", "mean", "rescale", "std", "len", "constant"), #
                        scaleType = c("nlmixr2", "norm", "mult", "multAdd"), #
                        scaleCmax = 1e5, #
                        scaleCmin = 1e-5, #
-                       scaleC=NULL,
-                       scaleTo=1.0,
-                       gradTo=1.0,
-
-                       rxControl=NULL,
-                       optExpression=TRUE, sumProd=FALSE,
-                       literalFix=TRUE,
-                       literalFixRes=TRUE,
+                       scaleC = NULL,
+                       scaleTo = 1.0,
+                       gradTo = 1.0,
+                       rxControl = NULL,
+                       optExpression = TRUE, sumProd = FALSE,
+                       literalFix = TRUE,
+                       literalFixRes = TRUE,
                        addProp = c("combined2", "combined1"),
-                       calcTables=TRUE, compress=FALSE,
-                       covMethod=c("r", "nlm", ""),
-                       adjObf=TRUE, ci=0.95, sigdig=3, sigdigTable=NULL,
-                       boundedTransform=TRUE, ...) {
-  checkmate::assertNumeric(shiErr, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(hessErr, lower=0, any.missing=FALSE, len=1)
+                       calcTables = TRUE, compress = FALSE,
+                       covMethod = c("r", "nlm", ""),
+                       adjObf = TRUE, ci = 0.95, sigdig = 3, sigdigTable = NULL,
+                       boundedTransform = TRUE, ...) {
+  checkmate::assertNumeric(shiErr, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(hessErr, lower = 0, any.missing = FALSE, len = 1)
 
-  checkmate::assertIntegerish(shi21maxFD, lower=1, any.missing=FALSE, len=1)
-  checkmate::assertIntegerish(shi21maxHess, lower=1, any.missing=FALSE, len=1)
+  checkmate::assertIntegerish(shi21maxFD, lower = 1, any.missing = FALSE, len = 1)
+  checkmate::assertIntegerish(shi21maxHess, lower = 1, any.missing = FALSE, len = 1)
 
-  checkmate::assertLogical(optExpression, len=1, any.missing=FALSE)
-  checkmate::assertLogical(literalFix, len=1, any.missing=FALSE)
-  checkmate::assertLogical(literalFixRes, len=1, any.missing=FALSE)
-  checkmate::assertLogical(sumProd, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(stepmax, lower=0, len=1, null.ok=TRUE, any.missing=FALSE)
-  checkmate::assertIntegerish(print.level, lower=0, upper=2, any.missing=FALSE)
-  checkmate::assertNumeric(ndigit, lower=0, len=1, any.missing=FALSE, null.ok=TRUE)
+  checkmate::assertLogical(optExpression, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(literalFix, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(literalFixRes, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(sumProd, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(stepmax, lower = 0, len = 1, null.ok = TRUE, any.missing = FALSE)
+  checkmate::assertIntegerish(print.level, lower = 0, upper = 2, any.missing = FALSE)
+  checkmate::assertNumeric(ndigit, lower = 0, len = 1, any.missing = FALSE, null.ok = TRUE)
   # nlm gradtol/steptol keyed to the shared sigdig target (10^-sigdig), matching the
   # ODE rtol so nlm converges to the precision the solve supports; a user value wins
   if (is.null(gradtol)) gradtol <- if (!is.null(sigdig)) .sigdigOptTol(sigdig) else 1e-6
   if (is.null(steptol)) steptol <- if (!is.null(sigdig)) .sigdigOptTol(sigdig) else 1e-6
-  checkmate::assertNumeric(gradtol, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(steptol, lower=0, len=1, any.missing=FALSE)
-  checkmate::assertIntegerish(iterlim, lower=1, len=1, any.missing=FALSE)
-  checkmate::assertLogical(check.analyticals, len=1, any.missing=FALSE)
-  checkmate::assertLogical(returnNlm, len=1, any.missing=FALSE)
-  checkmate::assertLogical(calcTables, len=1, any.missing=FALSE)
-  checkmate::assertLogical(compress, len=1, any.missing=TRUE)
-  checkmate::assertLogical(adjObf, len=1, any.missing=TRUE)
-  checkmate::assertLogical(boundedTransform, len=1, any.missing=FALSE)
+  checkmate::assertNumeric(gradtol, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(steptol, lower = 0, len = 1, any.missing = FALSE)
+  checkmate::assertIntegerish(iterlim, lower = 1, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(check.analyticals, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(returnNlm, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(calcTables, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(compress, len = 1, any.missing = TRUE)
+  checkmate::assertLogical(adjObf, len = 1, any.missing = TRUE)
+  checkmate::assertLogical(boundedTransform, len = 1, any.missing = FALSE)
 
   .xtra <- list(...)
   .bad <- names(.xtra)
   .bad <- .bad[!(.bad %in% c("genRxControl", "iterPrintControl"))]
   if (length(.bad) > 0) {
     stop("unused argument: ", paste
-    (paste0("'", .bad, "'", sep=""), collapse=", "),
-    call.=FALSE)
+    (paste0("'", .bad, "'", sep = ""), collapse = ", "),
+    call. = FALSE
+    )
   }
 
-  checkmate::assertIntegerish(stickyRecalcN, any.missing=FALSE, lower=0, len=1)
-  checkmate::assertIntegerish(maxOdeRecalc, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(odeRecalcFactor, len=1, lower=1, any.missing=FALSE)
-  checkmate::assertLogical(indTolRelax, any.missing=FALSE, len=1)
+  checkmate::assertIntegerish(stickyRecalcN, any.missing = FALSE, lower = 0, len = 1)
+  checkmate::assertIntegerish(maxOdeRecalc, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(odeRecalcFactor, len = 1, lower = 1, any.missing = FALSE)
+  checkmate::assertLogical(indTolRelax, any.missing = FALSE, len = 1)
 
   .genRxControl <- FALSE
   if (!is.null(.xtra$genRxControl)) {
@@ -172,19 +162,18 @@ nlmControl <- function(typsize = NULL,
   }
   if (is.null(rxControl)) {
     if (!is.null(sigdig)) {
-      rxControl <- .rxControlScaleSigdig(rxode2::rxControl(sigdig=sigdig), sigdig)
+      rxControl <- .rxControlScaleSigdig(rxode2::rxControl(sigdig = sigdig), sigdig)
     } else {
-      rxControl <- rxode2::rxControl(atol=1e-4, rtol=1e-4)
+      rxControl <- rxode2::rxControl(atol = 1e-4, rtol = 1e-4)
     }
     .genRxControl <- TRUE
-  } else if (inherits(rxControl, "rxControl")) {
-  } else if (is.list(rxControl)) {
+  } else if (inherits(rxControl, "rxControl")) {} else if (is.list(rxControl)) {
     rxControl <- .rxControlScaleSigdig(do.call(rxode2::rxControl, rxControl), sigdig, skip = names(rxControl))
   } else {
-    stop("solving options 'rxControl' needs to be generated from 'rxode2::rxControl'", call=FALSE)
+    stop("solving options 'rxControl' needs to be generated from 'rxode2::rxControl'", call = FALSE)
   }
   if (!is.null(sigdig)) {
-    checkmate::assertNumeric(sigdig, lower=1, finite=TRUE, any.missing=TRUE, len=1)
+    checkmate::assertNumeric(sigdig, lower = 1, finite = TRUE, any.missing = TRUE, len = 1)
     if (is.null(sigdigTable)) {
       sigdigTable <- round(sigdig)
     }
@@ -192,10 +181,10 @@ nlmControl <- function(typsize = NULL,
   if (is.null(sigdigTable)) {
     sigdigTable <- 3
   }
-  checkmate::assertIntegerish(sigdigTable, lower=1, len=1, any.missing=FALSE)
+  checkmate::assertIntegerish(sigdigTable, lower = 1, len = 1, any.missing = FALSE)
 
   .solveTypeIdx <- c("hessian" = 3L, "grad" = 2L, "fun" = 1L)
-  if (checkmate::testIntegerish(solveType, len=1, lower=1, upper=6, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(solveType, len = 1, lower = 1, upper = 6, any.missing = FALSE)) {
     solveType <- as.integer(solveType)
   } else {
     solveType <- setNames(.solveTypeIdx[match.arg(solveType)], NULL)
@@ -206,15 +195,15 @@ nlmControl <- function(typsize = NULL,
     covMethod <- match.arg(covMethod)
   }
 
-  .eventTypeIdx <- c("central" =2L, "forward"=1L)
-  if (checkmate::testIntegerish(eventType, len=1, lower=1, upper=6, any.missing=FALSE)) {
+  .eventTypeIdx <- c("central" = 2L, "forward" = 1L)
+  if (checkmate::testIntegerish(eventType, len = 1, lower = 1, upper = 6, any.missing = FALSE)) {
     eventType <- as.integer(eventType)
   } else {
     eventType <- setNames(.eventTypeIdx[match.arg(eventType)], NULL)
   }
 
-  .optimHessTypeIdx <- c("central" =2L, "forward"=1L)
-  if (checkmate::testIntegerish(optimHessType, len=1, lower=1, upper=6, any.missing=FALSE)) {
+  .optimHessTypeIdx <- c("central" = 2L, "forward" = 1L)
+  if (checkmate::testIntegerish(optimHessType, len = 1, lower = 1, upper = 6, any.missing = FALSE)) {
     optimHessType <- as.integer(optimHessType)
   } else {
     optimHessType <- setNames(.optimHessTypeIdx[match.arg(optimHessType)], NULL)
@@ -222,7 +211,7 @@ nlmControl <- function(typsize = NULL,
   # censOption: FOCEI-family censored (M2/M3/M4) 2nd-derivative treatment -- "gauss" (historic
   # Gauss-Newton, default) or "laplace" (exact).  Accepted for a uniform interface but INERT for
   # NLM (its finite-difference Hessian already reflects censoring exactly); kept for alignment.
-  if (checkmate::testIntegerish(censOption, len=1, lower=0, upper=1, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(censOption, len = 1, lower = 0, upper = 1, any.missing = FALSE)) {
     censOption <- as.integer(censOption)
   } else {
     censOption <- setNames(c("gauss" = 0L, "laplace" = 1L)[match.arg(censOption)], NULL)
@@ -244,11 +233,13 @@ nlmControl <- function(typsize = NULL,
   ## a control so an explicit sensMethod="forward" keeps working.
   sensMethod <- match.arg(sensMethod)
 
-  .iterPrintControl <- .absorbIterPrintControl(print = print,
-                                               printNcol = printNcol,
-                                               useColor = useColor,
-                                               iterPrintControl = .xtra$iterPrintControl)
-  if (checkmate::testIntegerish(scaleType, len=1, lower=1, upper=4, any.missing=FALSE)) {
+  .iterPrintControl <- .absorbIterPrintControl(
+    print = print,
+    printNcol = printNcol,
+    useColor = useColor,
+    iterPrintControl = .xtra$iterPrintControl
+  )
+  if (checkmate::testIntegerish(scaleType, len = 1, lower = 1, upper = 4, any.missing = FALSE)) {
     scaleType <- as.integer(scaleType)
   } else {
     .scaleTypeIdx <- c("norm" = 1L, "nlmixr2" = 2L, "mult" = 3L, "multAdd" = 4L)
@@ -256,67 +247,62 @@ nlmControl <- function(typsize = NULL,
   }
 
   .normTypeIdx <- c("rescale2" = 1L, "rescale" = 2L, "mean" = 3L, "std" = 4L, "len" = 5L, "constant" = 6L)
-  if (checkmate::testIntegerish(normType, len=1, lower=1, upper=6, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(normType, len = 1, lower = 1, upper = 6, any.missing = FALSE)) {
     normType <- as.integer(normType)
   } else {
     normType <- setNames(.normTypeIdx[match.arg(normType)], NULL)
   }
-  checkmate::assertNumeric(scaleCmax, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(scaleCmin, lower=0, any.missing=FALSE, len=1)
+  checkmate::assertNumeric(scaleCmax, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(scaleCmin, lower = 0, any.missing = FALSE, len = 1)
   if (!is.null(scaleC)) {
-    checkmate::assertNumeric(scaleC, lower=0, any.missing=FALSE)
+    checkmate::assertNumeric(scaleC, lower = 0, any.missing = FALSE)
   }
-  checkmate::assertNumeric(scaleTo, len=1, lower=0, any.missing=FALSE)
-  checkmate::assertNumeric(gradTo, len=1, lower=0, any.missing=FALSE)
+  checkmate::assertNumeric(scaleTo, len = 1, lower = 0, any.missing = FALSE)
+  checkmate::assertNumeric(gradTo, len = 1, lower = 0, any.missing = FALSE)
 
-  .ret <- list(covMethod=covMethod,
-               typsize = typsize,
-               fscale = fscale, print.level = print.level, ndigit=ndigit, gradtol = gradtol,
-               stepmax = stepmax,
-               steptol = steptol, iterlim = iterlim,
-               check.analyticals = check.analyticals,
-               optExpression=optExpression,
-               literalFix=literalFix,
-               literalFixRes=literalFixRes,
-               sumProd=sumProd,
-               rxControl=rxControl,
-               returnNlm=returnNlm,
-
-               stickyRecalcN=as.integer(stickyRecalcN),
-               maxOdeRecalc=as.integer(maxOdeRecalc),
-               odeRecalcFactor=odeRecalcFactor,
-               indTolRelax=indTolRelax,
-
-               eventType=eventType,
-               shiErr=shiErr,
-               shi21maxFD=as.integer(shi21maxFD),
-
-               optimHessType=optimHessType,
-               hessErr=hessErr,
-               shi21maxHess=as.integer(shi21maxHess),
-               censOption=censOption,
-
-               eventSens=eventSens,
-               sensMethod=sensMethod,
-
-               iterPrintControl = .iterPrintControl,
-               scaleType=scaleType,
-               normType=normType,
-
-               scaleCmax=scaleCmax,
-               scaleCmin=scaleCmin,
-               scaleC=scaleC,
-               scaleTo=scaleTo,
-               gradTo=gradTo,
-
-               addProp=match.arg(addProp),
-               calcTables=calcTables,
-               compress=compress,
-               solveType=solveType,
-               linCmtSensCarry=match.arg(linCmtSensCarry),
-               ci=ci, sigdig=sigdig, sigdigTable=sigdigTable,
-               genRxControl=.genRxControl,
-               boundedTransform=boundedTransform)
+  .ret <- list(
+    covMethod = covMethod,
+    typsize = typsize,
+    fscale = fscale, print.level = print.level, ndigit = ndigit, gradtol = gradtol,
+    stepmax = stepmax,
+    steptol = steptol, iterlim = iterlim,
+    check.analyticals = check.analyticals,
+    optExpression = optExpression,
+    literalFix = literalFix,
+    literalFixRes = literalFixRes,
+    sumProd = sumProd,
+    rxControl = rxControl,
+    returnNlm = returnNlm,
+    stickyRecalcN = as.integer(stickyRecalcN),
+    maxOdeRecalc = as.integer(maxOdeRecalc),
+    odeRecalcFactor = odeRecalcFactor,
+    indTolRelax = indTolRelax,
+    eventType = eventType,
+    shiErr = shiErr,
+    shi21maxFD = as.integer(shi21maxFD),
+    optimHessType = optimHessType,
+    hessErr = hessErr,
+    shi21maxHess = as.integer(shi21maxHess),
+    censOption = censOption,
+    eventSens = eventSens,
+    sensMethod = sensMethod,
+    iterPrintControl = .iterPrintControl,
+    scaleType = scaleType,
+    normType = normType,
+    scaleCmax = scaleCmax,
+    scaleCmin = scaleCmin,
+    scaleC = scaleC,
+    scaleTo = scaleTo,
+    gradTo = gradTo,
+    addProp = match.arg(addProp),
+    calcTables = calcTables,
+    compress = compress,
+    solveType = solveType,
+    linCmtSensCarry = match.arg(linCmtSensCarry),
+    ci = ci, sigdig = sigdig, sigdigTable = sigdigTable,
+    genRxControl = .genRxControl,
+    boundedTransform = boundedTransform
+  )
   class(.ret) <- "nlmControl"
   .ret
 }
@@ -344,7 +330,7 @@ rxUiDeparse.nlmControl <- function(object, var) {
 #' @rdname nmObjHandleControlObject
 #' @export
 nmObjHandleControlObject.nlmControl <- function(control, env) {
-  assign("nlmControl", control, envir=env)
+  assign("nlmControl", control, envir = env)
 }
 
 #' @rdname nmObjGetControl
@@ -353,13 +339,17 @@ nmObjGetControl.nlm <- function(x, ...) {
   .env <- x[[1]]
   if (exists("nlmControl", .env)) {
     .control <- get("nlmControl", .env)
-    if (inherits(.control, "nlmControl")) return(.control)
+    if (inherits(.control, "nlmControl")) {
+      return(.control)
+    }
   }
   if (exists("control", .env)) {
     .control <- get("control", .env)
-    if (inherits(.control, "nlmControl")) return(.control)
+    if (inherits(.control, "nlmControl")) {
+      return(.control)
+    }
   }
-  stop("cannot find nlm related control object", call.=FALSE)
+  stop("cannot find nlm related control object", call. = FALSE)
 }
 
 #' @rdname getValidNlmixrControl
@@ -399,7 +389,7 @@ getValidNlmixrCtl.nlm <- function(control) {
 .uiGetThetaDropFixed <- function(rxui) {
   .iniDf <- rxui$iniDf
   .w <- which(!is.na(.iniDf$ntheta))
-  .env <- new.env(parent=emptyenv())
+  .env <- new.env(parent = emptyenv())
   .env$t <- 0
   lapply(.w, function(i) {
     if (.iniDf$fix[i]) {
@@ -411,7 +401,7 @@ getValidNlmixrCtl.nlm <- function(control) {
   })
 }
 
-#'@export
+#' @export
 rxUiGet.nlmModel0 <- function(x, ...) {
   .ui <- rxode2::rxUiDecompress(x[[1]])
   # on.exit() registered BEFORE mutating either flag: an interrupt landing
@@ -427,24 +417,28 @@ rxUiGet.nlmModel0 <- function(x, ...) {
   .predDf <- .ui$predDf
   .save <- .predDf
   .predDf[.predDf$distribution == "norm", "distribution"] <- "dnorm"
-  assign(".predDfFocei", .predDf, envir=.ui)
-  #assign("predDf", .predDf, envir=.ui)
-  on.exit(assign("predDf", .save, envir=.ui), add = TRUE)
+  assign(".predDfFocei", .predDf, envir = .ui)
+  # assign("predDf", .predDf, envir=.ui)
+  on.exit(assign("predDf", .save, envir = .ui), add = TRUE)
   # rx_r_/rx_nu_ for the llik-forced norm/dnorm/t/cauchy path are already
   # fixed at the source (.fixCensRNuLine, R/focei.R) -- see #979.
   .errLines <- rxGetDistributionFoceiLines(.ui)
-  .ret <- rxode2::rxCombineErrorLines(.ui, errLines=.errLines,
-                              prefixLines=.uiGetThetaDropFixed(.ui),
-                              paramsLine=NA, #.uiGetThetaEtaParams(.f),
-                              modelVars=TRUE,
-                              cmtLines=FALSE,
-                              dvidLine=FALSE)
+  .ret <- rxode2::rxCombineErrorLines(.ui,
+    errLines = .errLines,
+    prefixLines = .uiGetThetaDropFixed(.ui),
+    paramsLine = NA, # .uiGetThetaEtaParams(.f),
+    modelVars = TRUE,
+    cmtLines = FALSE,
+    dvidLine = FALSE
+  )
   .ret <- .ret[[2]]
-  .ret <- as.call(c(quote(`{`),
-                    lapply(seq_along(.ret)[-1], function(i) {
-                      .ret[[i]]
-                    }),
-                    list(str2lang("rx_pred_ <- -rx_pred_"))))
+  .ret <- as.call(c(
+    quote(`{`),
+    lapply(seq_along(.ret)[-1], function(i) {
+      .ret[[i]]
+    }),
+    list(str2lang("rx_pred_ <- -rx_pred_"))
+  ))
   as.call(c(list(quote(`rxModelVars`)), .ret))
 }
 attr(rxUiGet.nlmModel0, "rstudio") <- quote(rxModelVar({}))
@@ -462,8 +456,10 @@ attr(rxUiGet.nlmModel0, "rstudio") <- quote(rxModelVar({}))
   .env$.if <- NULL
   .env$.def1 <- NULL
   .malert("pruning branches ({.code if}/{.code else}) of population log-likelihood model...")
-  .ret <- rxode2::.rxPrune(.x, envir = .env,
-                           strAssign = rxModelVars(x[[1]])$strAssign)
+  .ret <- rxode2::.rxPrune(.x,
+    envir = .env,
+    strAssign = rxModelVars(x[[1]])$strAssign
+  )
   .mv <- rxode2::rxModelVars(.ret)
   ## Need to convert to a function
   if (rxode2::.rxIsLinCmt() == 1L) {
@@ -486,7 +482,7 @@ rxUiGet.nlmParams <- function(x, ...) {
   .ui <- x[[1]]
   .iniDf <- .ui$iniDf
   .w <- which(!.iniDf$fix)
-  .env <- new.env(parent=emptyenv())
+  .env <- new.env(parent = emptyenv())
   .env$t <- 0
   ## Declare the model covariates (ui$allCovs) explicitly after DV.  Referenced
   ## covariates land here anyway (auto-detected after the thetas), so this only
@@ -496,12 +492,16 @@ rxUiGet.nlmParams <- function(x, ...) {
   ## the solve parameter layout so they retain a stable par_ptr slot.
   .covs <- .ui$allCovs
   if (is.null(.covs)) .covs <- character(0)
-  paste0("params(",
-         paste(c(vapply(.w, function(i) {
-           .env$t <- .env$t + 1
-           paste0("THETA[", .env$t, "]")
-         }, character(1), USE.NAMES = FALSE), "DV", .covs),
-         collapse=","), ")")
+  paste0(
+    "params(",
+    paste(
+      c(vapply(.w, function(i) {
+        .env$t <- .env$t + 1
+        paste0("THETA[", .env$t, "]")
+      }, character(1), USE.NAMES = FALSE), "DV", .covs),
+      collapse = ","
+    ), ")"
+  )
 }
 attr(rxUiGet.nlmParams, "rstudio") <- "params()"
 
@@ -567,8 +567,8 @@ rxUiGet.nlmRxModel <- function(x, ...) {
   # Add rx_pred_f_ and rx_r_ as lhs outputs for censoring support
   .fr <- .nlmGetFRLines(.s)
   .ret <- paste(c(
-    #.s$..stateInfo["state"],
-    #.lhs0,
+    # .s$..stateInfo["state"],
+    # .lhs0,
     .lhs,
     .ddt,
     .lagDefs,
@@ -578,8 +578,8 @@ rxUiGet.nlmRxModel <- function(x, ...) {
     .fr$f_line,
     .fr$r_line,
     .fr$nu_line,
-    #.s$..stateInfo["statef"],
-    #.s$..stateInfo["dvid"],
+    # .s$..stateInfo["statef"],
+    # .s$..stateInfo["dvid"],
     ""
   ), collapse = "\n")
   if (exists("..maxTheta", .s)) {
@@ -608,20 +608,27 @@ rxUiGet.nlmRxModel <- function(x, ...) {
   }
   if (.optExpression) {
     .ret <- rxode2::rxOptExpr(.ret, "population log-likelihood model",
-                              parallel = .optExprCores(x[[1]]))
+      parallel = .optExprCores(x[[1]])
+    )
     .msuccess("done")
   }
-  .cmt <-  rxUiGet.foceiCmtPreModel(x, ...)
+  .cmt <- rxUiGet.foceiCmtPreModel(x, ...)
   .interp <- rxUiGet.interpLinesStr(x, ...)
   if (.interp != "") {
-    .cmt <-paste0(.cmt, "\n", .interp)
+    .cmt <- paste0(.cmt, "\n", .interp)
   }
   ## no splitBolus() here -- this model solves the pre-split events, so
   ## declaring it would split the doses twice (see .foceiPreProcessData())
-  list(predOnly=.nlmixr2estRxode2(paste(c(rxUiGet.nlmParams(x, ...), .cmt,
-                                          .ret, .foceiToCmtLinesAndDvid(x[[1]])), collapse="\n"),
-                                  "rxNlmPredOnly"),
-       eventTheta=.eventTheta)
+  list(
+    predOnly = .nlmixr2estRxode2(
+      paste(c(
+        rxUiGet.nlmParams(x, ...), .cmt,
+        .ret, .foceiToCmtLinesAndDvid(x[[1]])
+      ), collapse = "\n"),
+      "rxNlmPredOnly"
+    ),
+    eventTheta = .eventTheta
+  )
 }
 
 #' @export
@@ -633,7 +640,7 @@ attr(rxUiGet.loadPruneNlmSens, "rstudio") <- emptyenv()
 #' @export
 rxUiGet.nlmThetaS <- function(x, ...) {
   .s <- rxUiGet.loadPruneNlmSens(x, ...)
-  .sensEtaOrTheta(.s, theta=TRUE, rxui = x[[1]], matExpForcing = FALSE)
+  .sensEtaOrTheta(.s, theta = TRUE, rxui = x[[1]], matExpForcing = FALSE)
 }
 attr(rxUiGet.nlmThetaS, "rstudio") <- emptyenv()
 
@@ -645,7 +652,8 @@ rxUiGet.nlmHdTheta <- function(x, ...) {
   .grd <- rxode2::rxExpandFEta_(
     .stateVars, .s$..maxTheta,
     ifelse(.predMinusDv, 1L, 2L),
-    isTheta=TRUE)
+    isTheta = TRUE
+  )
   if (rxode2::.useUtf()) {
     .malert("calculate \u2202(f)/\u2202(\u03B8)")
   } else {
@@ -804,7 +812,8 @@ rxUiGet.nlmEnv <- function(x, ...) {
   .sumProd <- rxode2::rxGetControl(x[[1]], "sumProd", FALSE)
   .optExpression <- rxode2::rxGetControl(x[[1]], "optExpression", TRUE)
   .rxFinalizeNlm(.s, .sumProd, .optExpression, .optExprCores(x[[1]]),
-                 interpLines = rxUiGet.interpLinesStr(x, ...))
+    interpLines = rxUiGet.interpLinesStr(x, ...)
+  )
   .s$..outer <- NULL
   if (exists("..maxTheta", .s)) {
     .eventTheta <- rep(0L, .s$..maxTheta)
@@ -855,27 +864,34 @@ rxUiGet.nlmSensModel <- function(x, ...) {
   ## "jump" attaches rxode2's analytic event (alag/F/rate/dur) sensitivities to
   ## the thetaGrad model; nlm has no FD fallback so under "fd" the gradient simply misses the jump.
   .eventSens <- rxode2::rxGetControl(x[[1]], "eventSens", "jump")
-  list(thetaGrad=.nlmixr2estRxode2(.s$..nlmS, "rxNlmGrad", eventSens=.eventSens),
-       predOnly=.nlmixr2estRxode2(.s$..pred.nolhs, "rxNlmPred"),
-       eventTheta=.s$.eventTheta)
+  list(
+    thetaGrad = .nlmixr2estRxode2(.s$..nlmS, "rxNlmGrad", eventSens = .eventSens),
+    predOnly = .nlmixr2estRxode2(.s$..pred.nolhs, "rxNlmPred"),
+    eventTheta = .s$.eventTheta
+  )
 }
 
 #' @export
 rxUiGet.nlmParNameFun <- function(x, ...) {
   .ui <- x[[1]]
   .iniDf <- .ui$iniDf
-  .env <- new.env(parent=emptyenv())
+  .env <- new.env(parent = emptyenv())
   .env$i <- 1
   .w <- which(!.iniDf$fix)
   eval(str2lang(
-    paste0("function(p) {c(",
-           paste(vapply(.w, function(t) {
-             .ret <- paste0("'THETA[", .env$i, "]'=p[", .env$i, "]")
-             .env$i <- .env$i + 1
-             .ret
-           }, character(1), USE.NAMES=FALSE), collapse=","), ")}")))
+    paste0(
+      "function(p) {c(",
+      paste(vapply(.w, function(t) {
+        .ret <- paste0("'THETA[", .env$i, "]'=p[", .env$i, "]")
+        .env$i <- .env$i + 1
+        .ret
+      }, character(1), USE.NAMES = FALSE), collapse = ","), ")}"
+    )
+  ))
 }
-attr(rxUiGet.nlmParNameFun, "rstudio") <- function(){c(`THETA[1]`=1, `THETA[2]`=2, `THETA[3]`=3)}
+attr(rxUiGet.nlmParNameFun, "rstudio") <- function() {
+  c(`THETA[1]` = 1, `THETA[2]` = 2, `THETA[3]` = 3)
+}
 
 #' @export
 rxUiGet.optimParNameFun <- rxUiGet.nlmParNameFun
@@ -979,37 +995,41 @@ nlmObjectiveSetup <- function(ui, data, control = NULL, gradient = FALSE,
   } else if (length(.typsize) == 1L) {
     .typsize <- rep(.typsize, length(.p))
   } else {
-    stop("'typsize' needs to match the number of estimated parameters (or equal 1)", call.=FALSE)
+    stop("'typsize' needs to match the number of estimated parameters (or equal 1)", call. = FALSE)
   }
   .stepmax <- .ctl$stepmax
   if (is.null(.stepmax)) {
-    .stepmax <- max(1000 * sqrt(sum((.p/.typsize)^2)), 1000)
+    .stepmax <- max(1000 * sqrt(sum((.p / .typsize)^2)), 1000)
   }
   .hessian <- .ctl$covMethod == "nlm"
   if (.ctl$solveType == 1L) {
-    .mi <-  ui$nlmRxModel
+    .mi <- ui$nlmRxModel
   } else {
     .mi <- ui$nlmSensModel
   }
   ## Event ("jump") sensitivities are activated in .nlmSetupEnv and deactivated in .nlmFreeEnv; nothing extra needed here.
   .env <- .nlmSetupEnv(.p, ui, dataSav, .mi, .ctl)
-  on.exit({.nlmFreeEnv()})
+  on.exit({
+    .nlmFreeEnv()
+  })
   .ret <- eval(bquote(stats::nlm(
-    f=.(.nlmixrNlmFunC),
-    p=.(.env$par.ini),
-    hessian=.(.hessian),
-    typsize=.(.typsize),
-    fscale=.(.ctl$fscale),
-    print.level=.(.ctl$print.level),
-    ndigit=.(.ctl$ndigit),
-    gradtol=.(.ctl$gradtol),
-    stepmax=.(.stepmax),
+    f = .(.nlmixrNlmFunC),
+    p = .(.env$par.ini),
+    hessian = .(.hessian),
+    typsize = .(.typsize),
+    fscale = .(.ctl$fscale),
+    print.level = .(.ctl$print.level),
+    ndigit = .(.ctl$ndigit),
+    gradtol = .(.ctl$gradtol),
+    stepmax = .(.stepmax),
     steptol = .(.ctl$steptol),
     iterlim = .(.ctl$iterlim),
     check.analyticals = .(.ctl$check.analyticals)
   )))
-  .nlmFinalizeList(.env, .ret, par="estimate", printLine=TRUE,
-                   hessianCov=TRUE)
+  .nlmFinalizeList(.env, .ret,
+    par = "estimate", printLine = TRUE,
+    hessianCov = TRUE
+  )
 }
 #' Get the full theta for nlm methods
 #'
@@ -1020,38 +1040,44 @@ nlmObjectiveSetup <- function(ui, data, control = NULL, gradient = FALSE,
 #' @noRd
 .nlmGetTheta <- function(nlm, ui) {
   .iniDf <- ui$iniDf
-  setNames(vapply(seq_along(.iniDf$name),
-         function(i) {
-           if (.iniDf$fix[i]) {
-             .iniDf$est[i]
-           } else {
-             nlm$estimate[.iniDf$name[i]]
-           }
-         }, double(1), USE.NAMES=FALSE),
-         .iniDf$name)
+  setNames(
+    vapply(seq_along(.iniDf$name),
+      function(i) {
+        if (.iniDf$fix[i]) {
+          .iniDf$est[i]
+        } else {
+          nlm$estimate[.iniDf$name[i]]
+        }
+      }, double(1),
+      USE.NAMES = FALSE
+    ),
+    .iniDf$name
+  )
 }
 
-.nlmControlToFoceiControl <- function(env, assign=TRUE) {
+.nlmControlToFoceiControl <- function(env, assign = TRUE) {
   .nlmControl <- env$nlmControl
   .ui <- env$ui
-  .foceiControl <- foceiControl(rxControl=env$nlmControl$rxControl,
-                                maxOuterIterations=0L,
-                                maxInnerIterations=0L,
-                                covMethod=0L,
-                                sumProd=.nlmControl$sumProd,
-                                optExpression=.nlmControl$optExpression,
-                                literalFix=.nlmControl$literalFix,
-                                literalFixRes=.nlmControl$literalFixRes,
-                                scaleTo=0,
-                                calcTables=.nlmControl$calcTables,
-                                addProp=.nlmControl$addProp,
-                                #skipCov=.ui$foceiSkipCov,
-                                interaction=0L,
-                                compress=.nlmControl$compress,
-                                ci=.nlmControl$ci,
-                                sigdigTable=.nlmControl$sigdigTable,
-                                indTolRelax=.nlmControl$indTolRelax,
-                                eventSens=.nlmControl$eventSens)
+  .foceiControl <- foceiControl(
+    rxControl = env$nlmControl$rxControl,
+    maxOuterIterations = 0L,
+    maxInnerIterations = 0L,
+    covMethod = 0L,
+    sumProd = .nlmControl$sumProd,
+    optExpression = .nlmControl$optExpression,
+    literalFix = .nlmControl$literalFix,
+    literalFixRes = .nlmControl$literalFixRes,
+    scaleTo = 0,
+    calcTables = .nlmControl$calcTables,
+    addProp = .nlmControl$addProp,
+    # skipCov=.ui$foceiSkipCov,
+    interaction = 0L,
+    compress = .nlmControl$compress,
+    ci = .nlmControl$ci,
+    sigdigTable = .nlmControl$sigdigTable,
+    indTolRelax = .nlmControl$indTolRelax,
+    eventSens = .nlmControl$eventSens
+  )
   if (assign) env$control <- .foceiControl
   .foceiControl
 }
@@ -1070,17 +1096,22 @@ nlmObjectiveSetup <- function(ui, data, control = NULL, gradient = FALSE,
       } else if (.fit$code == 2) {
         "successive iterates within tolerance, current iterate is probably solution"
       } else if (.fit$code == 3) {
-        c("last global step failed to locate a point lower than 'estimate'",
-          "either 'estimate' is an approximate local minimum of the function or 'steptol' is too small")
+        c(
+          "last global step failed to locate a point lower than 'estimate'",
+          "either 'estimate' is an approximate local minimum of the function or 'steptol' is too small"
+        )
       } else if (.fit$code == 4) {
         "iteration limit exceeded"
       } else if (.fit$code == 5) {
-        c("maximum step size 'stepmax' exceeded five consecutive times",
-          "either the function is unbounded below, becomes asymptotic to a finite value from above in some direction or 'stepmax' is too small")
+        c(
+          "maximum step size 'stepmax' exceeded five consecutive times",
+          "either the function is unbounded below, becomes asymptotic to a finite value from above in some direction or 'stepmax' is too small"
+        )
       } else {
         ""
       }
-    })
+    }
+  )
 }
 
 #' @rdname nlmixr2Est
@@ -1088,14 +1119,22 @@ nlmObjectiveSetup <- function(ui, data, control = NULL, gradient = FALSE,
 nlmixr2Est.nlm <- function(env, ...) {
   .ui <- env$ui
   rxode2::assertRxUiPopulationOnly(.ui, " for the estimation routine 'nlm', try 'focei'",
-                                   .var.name=.ui$modelName)
+    .var.name = .ui$modelName
+  )
   rxode2::assertRxUiRandomOnIdOnly(.ui, " for the estimation routine 'nlm'",
-                                   .var.name=.ui$modelName)
+    .var.name = .ui$modelName
+  )
   rxode2::warnRxBounded(.ui, " which are ignored in 'nlm'",
-                        .var.name=.ui$modelName)
+    .var.name = .ui$modelName
+  )
   .nlmFamilyControl(env, ...)
-  on.exit({if (exists("control", envir=.ui)) rm("control", envir=.ui)}, add=TRUE)
-  .nlmFamilyFit(env,  ...)
+  on.exit(
+    {
+      if (exists("control", envir = .ui)) rm("control", envir = .ui)
+    },
+    add = TRUE
+  )
+  .nlmFamilyFit(env, ...)
 }
 attr(nlmixr2Est.nlm, "covPresent") <- TRUE
 attr(nlmixr2Est.nlm, "unbounded") <- TRUE

--- a/R/nls.R
+++ b/R/nls.R
@@ -17,33 +17,32 @@
 #'
 #' one.cmt <- function() {
 #'   ini({
-#'    tka <- 0.45
-#'    tcl <- log(c(0, 2.7, 100))
-#'    tv <- 3.45
-#'    add.sd <- 0.7
-#'  })
-#'  model({
-#'    ka <- exp(tka)
-#'    cl <- exp(tcl)
-#'    v <- exp(tv)
-#'    linCmt() ~ add(add.sd)
-#'  })
+#'     tka <- 0.45
+#'     tcl <- log(c(0, 2.7, 100))
+#'     tv <- 3.45
+#'     add.sd <- 0.7
+#'   })
+#'   model({
+#'     ka <- exp(tka)
+#'     cl <- exp(tcl)
+#'     v <- exp(tv)
+#'     linCmt() ~ add(add.sd)
+#'   })
 #' }
 #'
 #' # Uses nlsLM from minpack.lm if available
 #'
-#' fit1 <- nlmixr(one.cmt, nlmixr2data::theo_sd, est="nls", nlsControl(algorithm="LM"))
+#' fit1 <- nlmixr(one.cmt, nlmixr2data::theo_sd, est = "nls", nlsControl(algorithm = "LM"))
 #'
 #' # Uses port and respect parameter boundaries
-#' fit2 <- nlmixr(one.cmt, nlmixr2data::theo_sd, est="nls", nlsControl(algorithm="port"))
+#' fit2 <- nlmixr(one.cmt, nlmixr2data::theo_sd, est = "nls", nlsControl(algorithm = "port"))
 #'
 #' # You can access the underlying nls object with `$nls`
 #' fit2$nls
-#'
 #' }
-nlsControl <- function(maxiter=10000,
+nlsControl <- function(maxiter = 10000,
                        tol = NULL,
-                       minFactor = 1/1024,
+                       minFactor = 1 / 1024,
                        printEval = FALSE,
                        warnOnly = FALSE,
                        scaleOffset = 0,
@@ -59,58 +58,52 @@ nlsControl <- function(maxiter=10000,
                        factor = 100,
                        maxfev = integer(),
                        nprint = 0,
-
                        #### nlm C++ style style to give gradients
-                       solveType=c("grad", "fun"),
-
-                       stickyRecalcN=4,
-                       maxOdeRecalc=5,
-                       odeRecalcFactor=10^(0.5),
-                       indTolRelax=TRUE,
-
-                       eventType=c("central", "forward"),
-                       shiErr=(.Machine$double.eps)^(1/3),
-                       shi21maxFD=20L,
-
+                       solveType = c("grad", "fun"),
+                       stickyRecalcN = 4,
+                       maxOdeRecalc = 5,
+                       odeRecalcFactor = 10^(0.5),
+                       indTolRelax = TRUE,
+                       eventType = c("central", "forward"),
+                       shiErr = (.Machine$double.eps)^(1 / 3),
+                       shi21maxFD = 20L,
                        useColor = NULL,
                        printNcol = NULL, #
                        print = 1L, #
-
                        normType = c("rescale2", "mean", "rescale", "std", "len", "constant"), #
                        scaleType = c("nlmixr2", "norm", "mult", "multAdd"), #
                        scaleCmax = 1e5, #
                        scaleCmin = 1e-5, #
-                       scaleC=NULL,
-                       scaleTo=1.0,
-                       gradTo=1.0,
-
+                       scaleC = NULL,
+                       scaleTo = 1.0,
+                       gradTo = 1.0,
                        ############################################
-                       trace = FALSE, #nolint
-                       rxControl=NULL,
-                       optExpression=TRUE, sumProd=FALSE,
-                       literalFix=TRUE,
-                       returnNls=FALSE,
+                       trace = FALSE, # nolint
+                       rxControl = NULL,
+                       optExpression = TRUE, sumProd = FALSE,
+                       literalFix = TRUE,
+                       returnNls = FALSE,
                        addProp = c("combined2", "combined1"),
                        eventSens = c("jump", "fd"),
                        linCmtSensCarry = c("auto", "none"),
-                       calcTables=TRUE, compress=TRUE,
-                       adjObf=TRUE, ci=0.95, sigdig=4, sigdigTable=NULL,
-                       boundedTransform=TRUE, ...) {
+                       calcTables = TRUE, compress = TRUE,
+                       adjObf = TRUE, ci = 0.95, sigdig = 4, sigdigTable = NULL,
+                       boundedTransform = TRUE, ...) {
   algorithm <- match.arg(algorithm)
   if (algorithm == "LM" && !requireNamespace("minpack.lm", quietly = TRUE)) {
     .malert("to use the LM algorithm you must have minpack.lm installed")
     .malert("changing to default `nls` method")
     algorithm <- "default"
   }
-  checkmate::assertIntegerish(stickyRecalcN, any.missing=FALSE, lower=0, len=1)
-  checkmate::assertIntegerish(maxOdeRecalc, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(odeRecalcFactor, len=1, lower=1, any.missing=FALSE)
-  checkmate::assertLogical(indTolRelax, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(shiErr, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertIntegerish(shi21maxFD, lower=1, any.missing=FALSE, len=1)
+  checkmate::assertIntegerish(stickyRecalcN, any.missing = FALSE, lower = 0, len = 1)
+  checkmate::assertIntegerish(maxOdeRecalc, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(odeRecalcFactor, len = 1, lower = 1, any.missing = FALSE)
+  checkmate::assertLogical(indTolRelax, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(shiErr, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertIntegerish(shi21maxFD, lower = 1, any.missing = FALSE, len = 1)
 
-  .eventTypeIdx <- c("central" =2L, "forward"=1L)
-  if (checkmate::testIntegerish(eventType, len=1, lower=1, upper=6, any.missing=FALSE)) {
+  .eventTypeIdx <- c("central" = 2L, "forward" = 1L)
+  if (checkmate::testIntegerish(eventType, len = 1, lower = 1, upper = 6, any.missing = FALSE)) {
     eventType <- as.integer(eventType)
   } else {
     eventType <- setNames(.eventTypeIdx[match.arg(eventType)], NULL)
@@ -124,37 +117,38 @@ nlsControl <- function(maxiter=10000,
   # user value wins, sigdig=NULL keeps the historic defaults.
   if (is.null(ftol)) ftol <- if (!is.null(sigdig)) .sigdigScale(sqrt(.Machine$double.eps), sigdig) else sqrt(.Machine$double.eps)
   if (is.null(ptol)) ptol <- if (!is.null(sigdig)) .sigdigScale(sqrt(.Machine$double.eps), sigdig) else sqrt(.Machine$double.eps)
-  checkmate::assertNumeric(ftol, len=1, any.missing=FALSE, lower=0)
-  checkmate::assertNumeric(ptol, len=1, any.missing=FALSE, lower=0)
-  checkmate::assertNumeric(gtol, len=1, any.missing=FALSE, lower=0)
-  checkmate::assertNumeric(epsfcn, len=1, any.missing=FALSE, lower=0)
-  checkmate::assertNumeric(factor, len=1, any.missing=FALSE, lower=1)
-  checkmate::assertIntegerish(maxfev, min.len=0, max.len=1, any.missing=FALSE)
+  checkmate::assertNumeric(ftol, len = 1, any.missing = FALSE, lower = 0)
+  checkmate::assertNumeric(ptol, len = 1, any.missing = FALSE, lower = 0)
+  checkmate::assertNumeric(gtol, len = 1, any.missing = FALSE, lower = 0)
+  checkmate::assertNumeric(epsfcn, len = 1, any.missing = FALSE, lower = 0)
+  checkmate::assertNumeric(factor, len = 1, any.missing = FALSE, lower = 1)
+  checkmate::assertIntegerish(maxfev, min.len = 0, max.len = 1, any.missing = FALSE)
 
-  checkmate::assertLogical(trace, len=1, any.missing=FALSE) # nolint
-  checkmate::assertLogical(nDcentral, len=1, any.missing=FALSE)
-  checkmate::assertNumeric(scaleOffset, any.missing=FALSE, finite=TRUE)
-  checkmate::assertLogical(warnOnly, len=1, any.missing = FALSE)
-  checkmate::assertLogical(printEval, len=1, any.missing=FALSE)
-  checkmate::assertIntegerish(maxiter, len=1, any.missing=FALSE, lower=1)
+  checkmate::assertLogical(trace, len = 1, any.missing = FALSE) # nolint
+  checkmate::assertLogical(nDcentral, len = 1, any.missing = FALSE)
+  checkmate::assertNumeric(scaleOffset, any.missing = FALSE, finite = TRUE)
+  checkmate::assertLogical(warnOnly, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(printEval, len = 1, any.missing = FALSE)
+  checkmate::assertIntegerish(maxiter, len = 1, any.missing = FALSE, lower = 1)
   if (is.null(tol)) tol <- if (!is.null(sigdig)) .sigdigOptTol(sigdig) else 1e-05
-  checkmate::assertNumeric(tol, len=1, any.missing=FALSE, lower=0)
-  checkmate::assertNumeric(minFactor, len=1, any.missing=FALSE, lower=0)
-  checkmate::assertLogical(optExpression, len=1, any.missing=FALSE)
-  checkmate::assertLogical(literalFix, len=1, any.missing=FALSE)
-  checkmate::assertLogical(sumProd, len=1, any.missing=FALSE)
-  checkmate::assertLogical(returnNls, len=1, any.missing=FALSE)
-  checkmate::assertLogical(calcTables, len=1, any.missing=FALSE)
-  checkmate::assertLogical(compress, len=1, any.missing=TRUE)
-  checkmate::assertLogical(adjObf, len=1, any.missing=TRUE)
-  checkmate::assertLogical(boundedTransform, len=1, any.missing=FALSE)
+  checkmate::assertNumeric(tol, len = 1, any.missing = FALSE, lower = 0)
+  checkmate::assertNumeric(minFactor, len = 1, any.missing = FALSE, lower = 0)
+  checkmate::assertLogical(optExpression, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(literalFix, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(sumProd, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(returnNls, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(calcTables, len = 1, any.missing = FALSE)
+  checkmate::assertLogical(compress, len = 1, any.missing = TRUE)
+  checkmate::assertLogical(adjObf, len = 1, any.missing = TRUE)
+  checkmate::assertLogical(boundedTransform, len = 1, any.missing = FALSE)
   .xtra <- list(...)
   .bad <- names(.xtra)
   .bad <- .bad[!(.bad %in% c("genRxControl", "iterPrintControl"))]
   if (length(.bad) > 0) {
     stop("unused argument: ", paste
-    (paste0("'", .bad, "'", sep=""), collapse=", "),
-    call.=FALSE)
+    (paste0("'", .bad, "'", sep = ""), collapse = ", "),
+    call. = FALSE
+    )
   }
 
   .genRxControl <- FALSE
@@ -165,19 +159,18 @@ nlsControl <- function(maxiter=10000,
     if (!is.null(sigdig)) {
       # nls's Levenberg-Marquardt step is sensitive to ODE solver noise, so give it
       # a tighter solve (3 orders below the shared sigdig target) than the optimizer
-      rxControl <- .rxControlScaleSigdig(rxode2::rxControl(sigdig=sigdig), sigdig, tighten = 3)
+      rxControl <- .rxControlScaleSigdig(rxode2::rxControl(sigdig = sigdig), sigdig, tighten = 3)
     } else {
-      rxControl <- rxode2::rxControl(atol=1e-4, rtol=1e-4)
+      rxControl <- rxode2::rxControl(atol = 1e-4, rtol = 1e-4)
     }
     .genRxControl <- TRUE
-  } else if (inherits(rxControl, "rxControl")) {
-  } else if (is.list(rxControl)) {
+  } else if (inherits(rxControl, "rxControl")) {} else if (is.list(rxControl)) {
     rxControl <- .rxControlScaleSigdig(do.call(rxode2::rxControl, rxControl), sigdig, skip = names(rxControl), tighten = 3)
   } else {
-    stop("solving options 'rxControl' needs to be generated from 'rxode2::rxControl'", call=FALSE)
+    stop("solving options 'rxControl' needs to be generated from 'rxode2::rxControl'", call = FALSE)
   }
   if (!is.null(sigdig)) {
-    checkmate::assertNumeric(sigdig, lower=1, finite=TRUE, any.missing=TRUE, len=1)
+    checkmate::assertNumeric(sigdig, lower = 1, finite = TRUE, any.missing = TRUE, len = 1)
     if (is.null(sigdigTable)) {
       sigdigTable <- round(sigdig)
     }
@@ -185,13 +178,15 @@ nlsControl <- function(maxiter=10000,
   if (is.null(sigdigTable)) {
     sigdigTable <- 3
   }
-  checkmate::assertIntegerish(sigdigTable, lower=1, len=1, any.missing=FALSE)
+  checkmate::assertIntegerish(sigdigTable, lower = 1, len = 1, any.missing = FALSE)
 
-  .iterPrintControl <- .absorbIterPrintControl(print = print,
-                                               printNcol = printNcol,
-                                               useColor = useColor,
-                                               iterPrintControl = .xtra$iterPrintControl)
-  if (checkmate::testIntegerish(scaleType, len=1, lower=1, upper=4, any.missing=FALSE)) {
+  .iterPrintControl <- .absorbIterPrintControl(
+    print = print,
+    printNcol = printNcol,
+    useColor = useColor,
+    iterPrintControl = .xtra$iterPrintControl
+  )
+  if (checkmate::testIntegerish(scaleType, len = 1, lower = 1, upper = 4, any.missing = FALSE)) {
     scaleType <- as.integer(scaleType)
   } else {
     .scaleTypeIdx <- c("norm" = 1L, "nlmixr2" = 2L, "mult" = 3L, "multAdd" = 4L)
@@ -199,67 +194,67 @@ nlsControl <- function(maxiter=10000,
   }
 
   .normTypeIdx <- c("rescale2" = 1L, "rescale" = 2L, "mean" = 3L, "std" = 4L, "len" = 5L, "constant" = 6L)
-  if (checkmate::testIntegerish(normType, len=1, lower=1, upper=6, any.missing=FALSE)) {
+  if (checkmate::testIntegerish(normType, len = 1, lower = 1, upper = 6, any.missing = FALSE)) {
     normType <- as.integer(normType)
   } else {
     normType <- setNames(.normTypeIdx[match.arg(normType)], NULL)
   }
-  checkmate::assertNumeric(scaleCmax, lower=0, any.missing=FALSE, len=1)
-  checkmate::assertNumeric(scaleCmin, lower=0, any.missing=FALSE, len=1)
+  checkmate::assertNumeric(scaleCmax, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assertNumeric(scaleCmin, lower = 0, any.missing = FALSE, len = 1)
   if (!is.null(scaleC)) {
-    checkmate::assertNumeric(scaleC, lower=0, any.missing=FALSE)
+    checkmate::assertNumeric(scaleC, lower = 0, any.missing = FALSE)
   }
-  checkmate::assertNumeric(scaleTo, len=1, lower=0, any.missing=FALSE)
-  checkmate::assertNumeric(gradTo, len=1, lower=0, any.missing=FALSE)
+  checkmate::assertNumeric(scaleTo, len = 1, lower = 0, any.missing = FALSE)
+  checkmate::assertNumeric(gradTo, len = 1, lower = 0, any.missing = FALSE)
 
 
-  .ret <- list(algorithm=algorithm, maxiter=maxiter,
-               tol=tol,
-               trace=trace, #nolint
-               minFactor=minFactor,
-               printEval=printEval,
-               warnOnly=warnOnly,
-               scaleOffset=scaleOffset,
-               nDcentral=nDcentral,
-               solveType=solveType,
-               linCmtSensCarry=match.arg(linCmtSensCarry),
-               stickyRecalcN=stickyRecalcN,
-               maxOdeRecalc=maxOdeRecalc,
-               odeRecalcFactor=odeRecalcFactor,
-               indTolRelax=indTolRelax,
-               eventType=eventType,
-               shiErr=shiErr,
-               shi21maxFD=shi21maxFD,
-               ftol = ftol,
-               ptol = ptol,
-               gtol = gtol,
-               diag = diag,
-               epsfcn = epsfcn,
-               factor = factor,
-               maxfev = maxfev,
-               nprint = nprint,
-               iterPrintControl = .iterPrintControl,
-               scaleType=scaleType,
-               normType=normType,
-
-               scaleCmax=scaleCmax,
-               scaleCmin=scaleCmin,
-               scaleC=scaleC,
-               scaleTo=scaleTo,
-               gradTo=gradTo,
-
-               optExpression=optExpression,
-               literalFix=literalFix,
-               sumProd=sumProd,
-               rxControl=rxControl,
-               returnNls=returnNls,
-               addProp=match.arg(addProp),
-               eventSens=match.arg(eventSens),
-               calcTables=calcTables,
-               compress=compress,
-               ci=ci, sigdig=sigdig, sigdigTable=sigdigTable,
-               genRxControl=.genRxControl,
-               boundedTransform=boundedTransform)
+  .ret <- list(
+    algorithm = algorithm, maxiter = maxiter,
+    tol = tol,
+    trace = trace, # nolint
+    minFactor = minFactor,
+    printEval = printEval,
+    warnOnly = warnOnly,
+    scaleOffset = scaleOffset,
+    nDcentral = nDcentral,
+    solveType = solveType,
+    linCmtSensCarry = match.arg(linCmtSensCarry),
+    stickyRecalcN = stickyRecalcN,
+    maxOdeRecalc = maxOdeRecalc,
+    odeRecalcFactor = odeRecalcFactor,
+    indTolRelax = indTolRelax,
+    eventType = eventType,
+    shiErr = shiErr,
+    shi21maxFD = shi21maxFD,
+    ftol = ftol,
+    ptol = ptol,
+    gtol = gtol,
+    diag = diag,
+    epsfcn = epsfcn,
+    factor = factor,
+    maxfev = maxfev,
+    nprint = nprint,
+    iterPrintControl = .iterPrintControl,
+    scaleType = scaleType,
+    normType = normType,
+    scaleCmax = scaleCmax,
+    scaleCmin = scaleCmin,
+    scaleC = scaleC,
+    scaleTo = scaleTo,
+    gradTo = gradTo,
+    optExpression = optExpression,
+    literalFix = literalFix,
+    sumProd = sumProd,
+    rxControl = rxControl,
+    returnNls = returnNls,
+    addProp = match.arg(addProp),
+    eventSens = match.arg(eventSens),
+    calcTables = calcTables,
+    compress = compress,
+    ci = ci, sigdig = sigdig, sigdigTable = sigdigTable,
+    genRxControl = .genRxControl,
+    boundedTransform = boundedTransform
+  )
   class(.ret) <- "nlsControl"
   .ret
 }
@@ -286,7 +281,7 @@ rxUiDeparse.nlsControl <- function(object, var) {
 #' @rdname nmObjHandleControlObject
 #' @export
 nmObjHandleControlObject.nlsControl <- function(control, env) {
-  assign("nlsControl", control, envir=env)
+  assign("nlsControl", control, envir = env)
 }
 
 
@@ -296,13 +291,17 @@ nmObjGetControl.nls <- function(x, ...) {
   .env <- x[[1]]
   if (exists("nlsControl", .env)) {
     .control <- get("nlsControl", .env)
-    if (inherits(.control, "nlsControl")) return(.control)
+    if (inherits(.control, "nlsControl")) {
+      return(.control)
+    }
   }
   if (exists("control", .env)) {
     .control <- get("control", .env)
-    if (inherits(.control, "nlsControl")) return(.control)
+    if (inherits(.control, "nlsControl")) {
+      return(.control)
+    }
   }
-  stop("cannot find nls related control object", call.=FALSE)
+  stop("cannot find nls related control object", call. = FALSE)
 }
 
 #' @rdname getValidNlmixrControl
@@ -332,11 +331,17 @@ getValidNlmixrCtl.nls <- function(control) {
 #' @keywords internal
 #' @export
 .nlmixrNlsFun <- function(DV, ...) {
-  do.call(rxode2::rxSolve,
-          c(list(object=nlmixr2global$nlsEnv$model,
-                 params=nlmixr2global$nlsEnv$parFun(...),
-                 events=nlmixr2global$nlsEnv$data),
-            nlmixr2global$nlsEnv$rxControl))$rx_pred_
+  do.call(
+    rxode2::rxSolve,
+    c(
+      list(
+        object = nlmixr2global$nlsEnv$model,
+        params = nlmixr2global$nlsEnv$parFun(...),
+        events = nlmixr2global$nlsEnv$data
+      ),
+      nlmixr2global$nlsEnv$rxControl
+    )
+  )$rx_pred_
 }
 #' @rdname dot-nlmixrNlsFun
 #' @export
@@ -389,7 +394,8 @@ rxGetDistributionNlsLines.norm <- function(line) {
   pred1 <- line[[2]]
   .errNum <- line[[3]]
   .line <- rxode2::.handleSingleErrTypeNormOrTFoceiBase(env, pred1, .errNum,
-                                                        rxPredLlik=.getRxPredLlikOption())
+    rxPredLlik = .getRxPredLlikOption()
+  )
   .yj <- as.double(pred1$transform) - 1
   if (.yj == 2) {
     .lineExtra <- quote(rx_dv_ ~ DV)
@@ -410,11 +416,15 @@ rxGetDistributionNlsLines.norm <- function(line) {
       #   rx_r_ ~ (rx_pred_f_ * prop.sd)^2
       .f <- pred1$f
       .type <- as.character(pred1$errTypeF)
-      .lineExtra <- c(.lineExtra,
-                      list(switch(.type, untransformed = quote(rx_r_ ~ (rx_pred_f_)^2),
-                                  transformed = quote(rx_r_ ~ (rx_pred_)^2),
-                                  f = bquote(rx_r_ ~ (.(str2lang(.f)))^2),
-                                  none = quote(rx_r_ ~ (rx_pred_f_) ^2))))
+      .lineExtra <- c(
+        .lineExtra,
+        list(switch(.type,
+          untransformed = quote(rx_r_ ~ (rx_pred_f_)^2),
+          transformed = quote(rx_r_ ~ (rx_pred_)^2),
+          f = bquote(rx_r_ ~ (.(str2lang(.f)))^2),
+          none = quote(rx_r_ ~ (rx_pred_f_)^2)
+        ))
+      )
     } else if (.errType == "pow") {
       .cnd <- pred1$cond
       if (!is.na(pred1$c)) {
@@ -424,16 +434,20 @@ rxGetDistributionNlsLines.norm <- function(line) {
         if (length(.w) == 1L) {
           .p2 <- str2lang(env$iniDf$name[.w])
         } else {
-          stop("cannot find exponent of power expression", call.=FALSE)
+          stop("cannot find exponent of power expression", call. = FALSE)
         }
       }
       .f <- pred1$f
       .type <- as.character(pred1$errTypeF)
-      .lineExtra <- c(.lineExtra,
-                      list(switch(.type, untransformed = bquote(rx_r_ ~ (rx_pred_f_)^(2 * .(.p2))),
-                                  transformed = bquote(rx_r_ ~ (rx_pred_)^(2 * .(.p2))),
-                                  f = bquote(rx_r_ ~ (.(str2lang(.f)))^(2 * .(.p2))),
-                                  none = quote(rx_r_ ~ (rx_pred_f_) ^(2 * .(.p2))))))
+      .lineExtra <- c(
+        .lineExtra,
+        list(switch(.type,
+          untransformed = bquote(rx_r_ ~ (rx_pred_f_)^(2 * .(.p2))),
+          transformed = bquote(rx_r_ ~ (rx_pred_)^(2 * .(.p2))),
+          f = bquote(rx_r_ ~ (.(str2lang(.f)))^(2 * .(.p2))),
+          none = quote(rx_r_ ~ (rx_pred_f_)^(2 * .(.p2)))
+        ))
+      )
     }
   }
   c(.line, .lineExtra)
@@ -442,7 +456,7 @@ rxGetDistributionNlsLines.norm <- function(line) {
 #' @rdname rxGetDistributionNlsLines
 #' @export
 rxGetDistributionNlsLines.default <- function(line) {
-  stop("only normally related endoints can be used with 'nls', try 'nlm'", call.=FALSE)
+  stop("only normally related endoints can be used with 'nls', try 'nlm'", call. = FALSE)
 }
 
 #' @export
@@ -464,40 +478,48 @@ rxGetDistributionNlsLines.rxUi <- function(line) {
 #' @noRd
 .uiGetNlsTheta <- function(rxui) {
   .iniDf <- rxui$iniDf
-  #.w <- which(!.ui$iniDf$fix & !(.ui$iniDf$err %in% c("add", "prop", "pow")))
-  .env <- new.env(parent=emptyenv())
+  # .w <- which(!.ui$iniDf$fix & !(.ui$iniDf$err %in% c("add", "prop", "pow")))
+  .env <- new.env(parent = emptyenv())
   .env$i <- 0
   .w <- which(!(rxui$iniDf$err %in% c("add", "prop", "pow")))
   lapply(.w, function(i) {
     if (rxui$iniDf$fix[i]) {
-      return(eval(parse(text=paste0("quote(", .iniDf$name[i], " <- ", rxui$iniDf$est[i],")"))))
+      return(eval(parse(text = paste0("quote(", .iniDf$name[i], " <- ", rxui$iniDf$est[i], ")"))))
     }
     if (rxui$iniDf$err[i] %in% c("add", "prop", "pow")) {
       return(NULL)
     }
     .env$i <- .env$i + 1
-    eval(parse(text=paste0("quote(", .iniDf$name[i], " <- THETA[", .env$i,"])")))
+    eval(parse(text = paste0("quote(", .iniDf$name[i], " <- THETA[", .env$i, "])")))
   })
 }
 
 #' @export
 rxUiGet.nlsModel0 <- function(x, ...) {
   .f <- x[[1]]
-  .ret <- rxode2::rxCombineErrorLines(.f, errLines=rxGetDistributionNlsLines(.f),
-                                      prefixLines=.uiGetNlsTheta(.f),
-                                      paramsLine=NA, #.uiGetThetaEtaParams(.f),
-                                      modelVars=TRUE,
-                                      cmtLines=FALSE,
-                                      dvidLine=FALSE)
+  .ret <- rxode2::rxCombineErrorLines(.f,
+    errLines = rxGetDistributionNlsLines(.f),
+    prefixLines = .uiGetNlsTheta(.f),
+    paramsLine = NA, # .uiGetThetaEtaParams(.f),
+    modelVars = TRUE,
+    cmtLines = FALSE,
+    dvidLine = FALSE
+  )
   ## pred <- (Vm * conc)/(K + conc)
   ## (resp - pred) / sqrt(pred)
   .ret <- .ret[[-1]]
   .w <- seq_along(.ret)
   .w <- .w[-1]
-  as.call(c(list(quote(`rxModelVars`)),
-            as.call(c(list(quote(`{`)),
-                      lapply(.w, function(i){.ret[[i]]}),
-                      list(quote(rx_pred_ <- (rx_dv_ - rx_pred_) / sqrt(rx_r_)))))))
+  as.call(c(
+    list(quote(`rxModelVars`)),
+    as.call(c(
+      list(quote(`{`)),
+      lapply(.w, function(i) {
+        .ret[[i]]
+      }),
+      list(quote(rx_pred_ <- (rx_dv_ - rx_pred_) / sqrt(rx_r_)))
+    ))
+  ))
 }
 attr(rxUiGet.nlsModel0, "rstudio") <- quote(rxModelVars({}))
 
@@ -515,8 +537,10 @@ attr(rxUiGet.nlsModel0, "rstudio") <- quote(rxModelVars({}))
   .env$.if <- NULL
   .env$.def1 <- NULL
   .malert("pruning branches ({.code if}/{.code else}) of nls model...")
-  .ret <- rxode2::.rxPrune(.x, envir = .env,
-                           strAssign=rxode2::rxModelVars(x[[1]])$strAssign)
+  .ret <- rxode2::.rxPrune(.x,
+    envir = .env,
+    strAssign = rxode2::rxModelVars(x[[1]])$strAssign
+  )
   .mv <- rxode2::rxModelVars(.ret)
   ## Need to convert to a function
   if (rxode2::.rxIsLinCmt() == 1L) {
@@ -556,13 +580,13 @@ rxUiGet.nlsRxModel <- function(x, ...) {
     if (is.null(.lhs)) .lhs <- character(0)
   }
   .ret <- paste(c(
-    #.s$..stateInfo["state"],
-    #.lhs0,
+    # .s$..stateInfo["state"],
+    # .lhs0,
     .lhs,
     .ddt,
     .prd,
-    #.s$..stateInfo["statef"],
-    #.s$..stateInfo["dvid"],
+    # .s$..stateInfo["statef"],
+    # .s$..stateInfo["dvid"],
     ""
   ), collapse = "\n")
   if (exists("..maxTheta", .s)) {
@@ -595,17 +619,23 @@ rxUiGet.nlsRxModel <- function(x, ...) {
     .msuccess("done")
   }
 
-  .cmt <-  rxUiGet.foceiCmtPreModel(x, ...)
+  .cmt <- rxUiGet.foceiCmtPreModel(x, ...)
   .interp <- rxUiGet.interpLinesStr(x, ...)
   if (.interp != "") {
-    .cmt <-paste0(.cmt, "\n", .interp)
+    .cmt <- paste0(.cmt, "\n", .interp)
   }
   ## no splitBolus() here -- this model solves the pre-split events, so
   ## declaring it would split the doses twice (see .foceiPreProcessData())
-  list(predOnly =.nlmixr2estRxode2(paste(c(rxUiGet.nlsParams(x, ...), .cmt,
-                                         .ret, .foceiToCmtLinesAndDvid(x[[1]])), collapse="\n"),
-                                   "rxNlsPredOnly"),
-       eventTheta=.eventTheta)
+  list(
+    predOnly = .nlmixr2estRxode2(
+      paste(c(
+        rxUiGet.nlsParams(x, ...), .cmt,
+        .ret, .foceiToCmtLinesAndDvid(x[[1]])
+      ), collapse = "\n"),
+      "rxNlsPredOnly"
+    ),
+    eventTheta = .eventTheta
+  )
 }
 
 #' @export
@@ -617,7 +647,7 @@ attr(rxUiGet.loadPruneNlsSens, "rstudio") <- emptyenv()
 #' @export
 rxUiGet.nlsThetaS <- function(x, ...) {
   .s <- rxUiGet.loadPruneNlsSens(x, ...)
-  .sensEtaOrTheta(.s, theta=TRUE, rxui = x[[1]])
+  .sensEtaOrTheta(.s, theta = TRUE, rxui = x[[1]])
 }
 attr(rxUiGet.nlsThetaS, "rstudio") <- emptyenv()
 
@@ -629,7 +659,8 @@ rxUiGet.nlsHdTheta <- function(x, ...) {
   .grd <- rxode2::rxExpandFEta_(
     .stateVars, .s$..maxTheta,
     ifelse(.predMinusDv, 1L, 2L),
-    isTheta=TRUE)
+    isTheta = TRUE
+  )
   if (rxode2::.useUtf()) {
     .malert("calculate \u2202(f)/\u2202(\u03B8)")
   } else {
@@ -765,7 +796,8 @@ rxUiGet.nlsEnv <- function(x, ...) {
   .sumProd <- rxode2::rxGetControl(x[[1]], "sumProd", FALSE)
   .optExpression <- rxode2::rxGetControl(x[[1]], "optExpression", TRUE)
   .rxFinalizeNls(.s, .sumProd, .optExpression, .optExprCores(x[[1]]),
-                 interpLines = rxUiGet.interpLinesStr(x, ...))
+    interpLines = rxUiGet.interpLinesStr(x, ...)
+  )
   .s$..outer <- NULL
   if (exists("..maxTheta", .s)) {
     .eventTheta <- rep(0L, .s$..maxTheta)
@@ -798,9 +830,11 @@ rxUiGet.nlsSensModel <- function(x, ...) {
   .s <- rxUiGet.nlsEnv(x, ...)
   ## "jump" attaches rxode2's analytic event (alag/F/rate/dur) sensitivities to the residual-Jacobian model instead of using finite differences.
   .eventSens <- rxode2::rxGetControl(x[[1]], "eventSens", "jump")
-  list(thetaGrad=.nlmixr2estRxode2(.s$..nlsS, "rxNlsGrad", eventSens=.eventSens),
-       predOnly=.nlmixr2estRxode2(.s$..pred.nolhs, "rxNlsPred"),
-       eventTheta=.s$.eventTheta)
+  list(
+    thetaGrad = .nlmixr2estRxode2(.s$..nlsS, "rxNlsGrad", eventSens = .eventSens),
+    predOnly = .nlmixr2estRxode2(.s$..pred.nolhs, "rxNlsPred"),
+    eventTheta = .s$.eventTheta
+  )
 }
 
 
@@ -808,29 +842,32 @@ rxUiGet.nlsSensModel <- function(x, ...) {
 rxUiGet.nlsParStart <- function(x, ...) {
   .ui <- x[[1]]
   .w <- which(!.ui$iniDf$fix & !(.ui$iniDf$err %in% c("add", "prop", "pow")))
-  setNames(lapply(.w, function(i){
-    .ui$iniDf$est[i]
-  }),
-  .ui$iniDf$name[.w])
+  setNames(
+    lapply(.w, function(i) {
+      .ui$iniDf$est[i]
+    }),
+    .ui$iniDf$name[.w]
+  )
 }
 
 #' @export
 rxUiGet.nlsParStartTheta <- function(x, ...) {
   .ui <- x[[1]]
   .w <- which(!.ui$iniDf$fix & !(.ui$iniDf$err %in% c("add", "prop", "pow")))
-  setNames(vapply(.w, function(i){
-    .ui$iniDf$est[i]
-  }, double(1), USE.NAMES = FALSE),
-  paste0("THETA[", seq_along(.ui$iniDf$name[.w]), "]")
+  setNames(
+    vapply(.w, function(i) {
+      .ui$iniDf$est[i]
+    }, double(1), USE.NAMES = FALSE),
+    paste0("THETA[", seq_along(.ui$iniDf$name[.w]), "]")
   )
 }
-attr(rxUiGet.nlsParStartTheta, "rstudio") <- c(`THETA[1]`=0.1)
+attr(rxUiGet.nlsParStartTheta, "rstudio") <- c(`THETA[1]` = 0.1)
 
 #' @export
 rxUiGet.nlsParams <- function(x, ...) {
   .ui <- x[[1]]
   .w <- which(!.ui$iniDf$fix & !(.ui$iniDf$err %in% c("add", "prop", "pow")))
-  paste0("params(", paste(c(paste0("THETA[", seq_along(.ui$iniDf$name[.w]), "]"), "DV"), collapse=", "), ")")
+  paste0("params(", paste(c(paste0("THETA[", seq_along(.ui$iniDf$name[.w]), "]"), "DV"), collapse = ", "), ")")
 }
 attr(rxUiGet.nlsParams, "rstudio") <- "params(THETA[1], DV)"
 
@@ -838,51 +875,60 @@ attr(rxUiGet.nlsParams, "rstudio") <- "params(THETA[1], DV)"
 rxUiGet.nlsParLower <- function(x, ...) {
   .ui <- x[[1]]
   .w <- which(!.ui$iniDf$fix & !(.ui$iniDf$err %in% c("add", "prop", "pow")))
-  setNames(vapply(.w, function(i){
-    .ui$iniDf$lower[i]
-  }, double(1), USE.NAMES=FALSE),
-  .ui$iniDf$name[.w])
+  setNames(
+    vapply(.w, function(i) {
+      .ui$iniDf$lower[i]
+    }, double(1), USE.NAMES = FALSE),
+    .ui$iniDf$name[.w]
+  )
 }
-attr(rxUiGet.nlsParLower, "rstudio") <- c(`ka`=0.01)
+attr(rxUiGet.nlsParLower, "rstudio") <- c(`ka` = 0.01)
 
 #' @export
 rxUiGet.nlsParUpper <- function(x, ...) {
   .ui <- x[[1]]
   .w <- which(!.ui$iniDf$fix & !(.ui$iniDf$err %in% c("add", "prop", "pow")))
-  setNames(vapply(.w, function(i){
-    .ui$iniDf$upper[i]
-  }, double(1), USE.NAMES=FALSE),
-  .ui$iniDf$name[.w])
+  setNames(
+    vapply(.w, function(i) {
+      .ui$iniDf$upper[i]
+    }, double(1), USE.NAMES = FALSE),
+    .ui$iniDf$name[.w]
+  )
 }
-attr(rxUiGet.nlsParUpper, "rstudio") <- c(`ka`=1000)
+attr(rxUiGet.nlsParUpper, "rstudio") <- c(`ka` = 1000)
 
 #' @export
 rxUiGet.nlsParNameFun <- function(x, ...) {
   .ui <- x[[1]]
   .iniDf <- .ui$iniDf
   .args <- vapply(seq_along(.iniDf$ntheta),
-                  function(t) {
-                    if (.iniDf$err[t] %in% c("add", "prop", "pow")) {
-                      ""
-                    } else if (.iniDf$fix[t]) {
-                      ""
-                    } else {
-                      .iniDf$name[t]
-                    }
-                  }, character(1), USE.NAMES=FALSE)
+    function(t) {
+      if (.iniDf$err[t] %in% c("add", "prop", "pow")) {
+        ""
+      } else if (.iniDf$fix[t]) {
+        ""
+      } else {
+        .iniDf$name[t]
+      }
+    }, character(1),
+    USE.NAMES = FALSE
+  )
   .args <- .args[.args != ""]
   eval(str2lang(
-    paste0("function(",paste(.args, collapse=", "),
-           ") {c(",
-           paste(vapply(seq_along(.iniDf$ntheta), function(t) {
-             if (.iniDf$err[t] %in% c("add", "prop", "pow")) {
-               paste0("'THETA[", t, "]'=", .iniDf$est[t])
-             } else if (.iniDf$fix[t]) {
-               paste0("'THETA[", t, "]'=", .iniDf$est[t])
-             } else {
-               paste0("'THETA[", t, "]'=", .iniDf$name[t])
-             }
-           }, character(1), USE.NAMES=FALSE), collapse=","), ")}")))
+    paste0(
+      "function(", paste(.args, collapse = ", "),
+      ") {c(",
+      paste(vapply(seq_along(.iniDf$ntheta), function(t) {
+        if (.iniDf$err[t] %in% c("add", "prop", "pow")) {
+          paste0("'THETA[", t, "]'=", .iniDf$est[t])
+        } else if (.iniDf$fix[t]) {
+          paste0("'THETA[", t, "]'=", .iniDf$est[t])
+        } else {
+          paste0("'THETA[", t, "]'=", .iniDf$name[t])
+        }
+      }, character(1), USE.NAMES = FALSE), collapse = ","), ")}"
+    )
+  ))
 }
 attr(rxUiGet.nlsParNameFun, "rstudio") <- function() {}
 
@@ -890,26 +936,30 @@ attr(rxUiGet.nlsParNameFun, "rstudio") <- function() {}
   .ui <- x[[1]]
   .iniDf <- .ui$iniDf
   .args <- vapply(seq_along(.iniDf$ntheta),
-                  function(t) {
-                    if (.iniDf$err[t] %in% c("add", "prop", "pow")) {
-                      ""
-                    } else if (.iniDf$fix[t]) {
-                      ""
-                    } else {
-                      .iniDf$name[t]
-                    }
-                  }, character(1), USE.NAMES=FALSE)
+    function(t) {
+      if (.iniDf$err[t] %in% c("add", "prop", "pow")) {
+        ""
+      } else if (.iniDf$fix[t]) {
+        ""
+      } else {
+        .iniDf$name[t]
+      }
+    }, character(1),
+    USE.NAMES = FALSE
+  )
   c("DV", .args[.args != ""])
 }
 
 #' @export
-rxUiGet.nlsFormula <- function(x, ..., grad=FALSE) {
+rxUiGet.nlsFormula <- function(x, ..., grad = FALSE) {
   .args <- .nlsFormulaArgs(x)
-  str2lang(paste0("~nlmixr2est::.nlmixrNlsFunValGrad(",
-                  paste(.args, collapse=", "),
-                  ")"))
+  str2lang(paste0(
+    "~nlmixr2est::.nlmixrNlsFunValGrad(",
+    paste(.args, collapse = ", "),
+    ")"
+  ))
 }
-attr(rxUiGet.nlsFormula, "rstudio") <- quote(~nlmixr2est::.nlmixrNlsFunValGrad(DV, ka, V, CL))
+attr(rxUiGet.nlsFormula, "rstudio") <- quote(~ nlmixr2est::.nlmixrNlsFunValGrad(DV, ka, V, CL))
 
 .nlsFitModel <- function(ui, dataSav) {
   .ctl <- ui$control
@@ -935,71 +985,81 @@ attr(rxUiGet.nlsFormula, "rstudio") <- quote(~nlmixr2est::.nlmixrNlsFunValGrad(D
   }
   if (length(.cens) == 1L) {
     if (!all(dataSav[.wObs, .cens] == 0)) {
-      stop("'nls' does not work with censored data", call. =FALSE)
+      stop("'nls' does not work with censored data", call. = FALSE)
     }
   }
   if (length(.lim) == 1L) {
     if (any(is.finite(dataSav[.wObs, .lim]))) {
-      stop("'nls' does not work with limit data", call. =FALSE)
+      stop("'nls' does not work with limit data", call. = FALSE)
     }
   }
   .env <- .nlmSetupEnv(.p, ui, dataSav, .mi, .ctl,
-                       lower=ui$nlsParLower, upper=ui$nlsParUpper)
+    lower = ui$nlsParLower, upper = ui$nlsParUpper
+  )
   .env$par.ini.list <- setNames(as.list(.env$par.ini), names(ui$nlsParStart))
 
   if (.ctl$algorithm == "LM") {
-    .nls.control <- minpack.lm::nls.lm.control(ftol = .ctl$ftol, ptol = .ctl$ptol,
-                                               gtol = .ctl$gtol,
-                                               diag = .ctl$diag,
-                                               epsfcn = .ctl$epsfcn,
-                                               factor = .ctl$factor,
-                                               maxfev = .ctl$maxfev,
-                                               maxiter = .ctl$maxiter,
-                                               nprint = .ctl$nprint)
+    .nls.control <- minpack.lm::nls.lm.control(
+      ftol = .ctl$ftol, ptol = .ctl$ptol,
+      gtol = .ctl$gtol,
+      diag = .ctl$diag,
+      epsfcn = .ctl$epsfcn,
+      factor = .ctl$factor,
+      maxfev = .ctl$maxfev,
+      maxiter = .ctl$maxiter,
+      nprint = .ctl$nprint
+    )
     class(.ctl) <- NULL
     if (.ctl$solveType == 11L) {
       .ret <- bquote(minpack.lm::nls.lm(
-        par=.(.env$par.ini),
-        lower=.(.env$lower),
-        upper=.(.env$upper),
-        fn=nlmixr2est::.nlmixrNlsFunVal,
-        control=.(.nls.control)))
+        par = .(.env$par.ini),
+        lower = .(.env$lower),
+        upper = .(.env$upper),
+        fn = nlmixr2est::.nlmixrNlsFunVal,
+        control = .(.nls.control)
+      ))
     } else {
       .ret <- bquote(minpack.lm::nls.lm(
-        par=.(.env$par.ini),
-        lower=.(.env$lower),
-        upper=.(.env$upper),
-        fn=nlmixr2est::.nlmixrNlsFunVal,
-        jac=nlmixr2est::.nlmixrNlsFunGrad,
-        control=.(.nls.control)))
+        par = .(.env$par.ini),
+        lower = .(.env$lower),
+        upper = .(.env$upper),
+        fn = nlmixr2est::.nlmixrNlsFunVal,
+        jac = nlmixr2est::.nlmixrNlsFunGrad,
+        control = .(.nls.control)
+      ))
     }
     .ret <- eval(.ret)
-    .ret <- .nlmFinalizeList(.env, .ret, par="par", printLine=TRUE,
-                             hessianCov=TRUE)
+    .ret <- .nlmFinalizeList(.env, .ret,
+      par = "par", printLine = TRUE,
+      hessianCov = TRUE
+    )
     .ret$sd <- sd(.ret$fvec)
-    .ret$logLik <- sum(stats::dnorm(.ret$fvec, log=TRUE))
+    .ret$logLik <- sum(stats::dnorm(.ret$fvec, log = TRUE))
   } else {
     nlmixr2global$nlsEnv$dataNls <- dataSav[dataSav$EVID == 0, ]
     .nls.control <- stats::nls.control(
       maxiter = .ctl$maxiter, tol = .ctl$tol, minFactor = .ctl$minFactor,
       printEval = .ctl$printEval, warnOnly = .ctl$warnOnly,
       scaleOffset = .ctl$scaleOffset,
-      nDcentral = .ctl$nDcentral)
+      nDcentral = .ctl$nDcentral
+    )
     class(.ctl) <- NULL
     .ret <- bquote(stats::nls(
-      formula= .(ui$nlsFormula),
-      data=nlmixr2est::.nlmixrNlsData(),
-      start=.(.env$par.ini.list),
-      control=.(.nls.control),
-      algorithm=.(.ctl$algorithm),
-      trace=.(.ctl$trace), # nolint
-      model=FALSE,
-      lower=.(.env$lower),
-      upper=.(.env$upper)
+      formula = .(ui$nlsFormula),
+      data = nlmixr2est::.nlmixrNlsData(),
+      start = .(.env$par.ini.list),
+      control = .(.nls.control),
+      algorithm = .(.ctl$algorithm),
+      trace = .(.ctl$trace), # nolint
+      model = FALSE,
+      lower = .(.env$lower),
+      upper = .(.env$upper)
     ))
     .ret <- eval(.ret)
-    .ret <- .nlmFinalizeList(.env, .ret, printLine=TRUE,
-                             hessianCov=FALSE)
+    .ret <- .nlmFinalizeList(.env, .ret,
+      printLine = TRUE,
+      hessianCov = FALSE
+    )
   }
   .ret
 }
@@ -1020,30 +1080,32 @@ attr(rxUiGet.nlsFormula, "rstudio") <- quote(~nlmixr2est::.nlmixrNlsFunValGrad(D
     } else {
       .theta0[.iniDf$name[t]]
     }
-  }, double(1), USE.NAMES=FALSE), .iniDf$name)
+  }, double(1), USE.NAMES = FALSE), .iniDf$name)
 }
 
-.nlsControlToFoceiControl <- function(env, assign=TRUE) {
+.nlsControlToFoceiControl <- function(env, assign = TRUE) {
   .nlsControl <- env$nlsControl
   .ui <- env$ui
-  .foceiControl <- foceiControl(rxControl=env$nlsControl$rxControl,
-                                maxOuterIterations=0L,
-                                maxInnerIterations=0L,
-                                covMethod=0L,
-                                sumProd=.nlsControl$sumProd,
-                                optExpression=.nlsControl$optExpression,
-                                literalFix=.nlsControl$literalFix,
-                                literalFixRes=FALSE,
-                                scaleTo=0,
-                                calcTables=.nlsControl$calcTables,
-                                addProp=.nlsControl$addProp,
-                                #skipCov=.ui$foceiSkipCov,
-                                interaction=0L,
-                                compress=.nlsControl$compress,
-                                ci=.nlsControl$ci,
-                                sigdigTable=.nlsControl$sigdigTable,
-                                indTolRelax=.nlsControl$indTolRelax,
-                                eventSens=.nlsControl$eventSens)
+  .foceiControl <- foceiControl(
+    rxControl = env$nlsControl$rxControl,
+    maxOuterIterations = 0L,
+    maxInnerIterations = 0L,
+    covMethod = 0L,
+    sumProd = .nlsControl$sumProd,
+    optExpression = .nlsControl$optExpression,
+    literalFix = .nlsControl$literalFix,
+    literalFixRes = FALSE,
+    scaleTo = 0,
+    calcTables = .nlsControl$calcTables,
+    addProp = .nlsControl$addProp,
+    # skipCov=.ui$foceiSkipCov,
+    interaction = 0L,
+    compress = .nlsControl$compress,
+    ci = .nlsControl$ci,
+    sigdigTable = .nlsControl$sigdigTable,
+    indTolRelax = .nlsControl$indTolRelax,
+    eventSens = .nlsControl$eventSens
+  )
   if (assign) env$control <- .foceiControl
   .foceiControl
 }
@@ -1072,7 +1134,8 @@ attr(rxUiGet.nlsFormula, "rstudio") <- quote(~nlmixr2est::.nlmixrNlsFunValGrad(D
         .ret$objective <- -2 * as.numeric(stats::logLik(.ret$nls))
       }
       .ret
-    })
+    }
+  )
 }
 
 #' @rdname nlmixr2Est
@@ -1080,21 +1143,31 @@ attr(rxUiGet.nlsFormula, "rstudio") <- quote(~nlmixr2est::.nlmixrNlsFunValGrad(D
 nlmixr2Est.nls <- function(env, ...) {
   .ui <- env$ui
   rxode2::assertRxUiNoAutoregressive(.ui, " for the estimation routine 'nls', try 'focei'",
-                                     .var.name=.ui$modelName)
+    .var.name = .ui$modelName
+  )
   rxode2::assertRxUiPopulationOnly(.ui, " for the estimation routine 'nls', try 'focei'",
-                                   .var.name=.ui$modelName)
+    .var.name = .ui$modelName
+  )
   rxode2::assertRxUiRandomOnIdOnly(.ui, " for the estimation routine 'nls'",
-                                   .var.name=.ui$modelName)
+    .var.name = .ui$modelName
+  )
   rxode2::assertRxUiSingleEndpoint(.ui, " for the estimation routine 'nls'",
-                                   .var.name=.ui$modelName)
+    .var.name = .ui$modelName
+  )
   rxode2::assertRxUiEstimatedResiduals(.ui, " for the estimation routine 'nls'",
-                                       .var.name=.ui$modelName)
-  rxode2::warnRxBounded(.ui, " which are ignored in 'nls'", .var.name=.ui$modelName)
+    .var.name = .ui$modelName
+  )
+  rxode2::warnRxBounded(.ui, " which are ignored in 'nls'", .var.name = .ui$modelName)
   # No add+prop or add+pow
   # Single endpoint
   .nlsFamilyControl(env, ...)
-  on.exit({if (exists("control", envir=.ui)) rm("control", envir=.ui)}, add=TRUE)
-  .nlsFamilyFit(env,  ...)
+  on.exit(
+    {
+      if (exists("control", envir = .ui)) rm("control", envir = .ui)
+    },
+    add = TRUE
+  )
+  .nlsFamilyFit(env, ...)
 }
 attr(nlmixr2Est.nls, "covPresent") <- TRUE
 attr(nlmixr2Est.nls, "unbounded") <- TRUE

--- a/R/nmObjGet.R
+++ b/R/nmObjGet.R
@@ -11,13 +11,14 @@
 #' @export
 nmObjGet <- function(x, ...) {
   if (!inherits(x, "nmObjGet")) {
-    stop("'", as.character(substitute(x)), "' is wrong type for 'nmObjGet'", call.=FALSE)
+    stop("'", as.character(substitute(x)), "' is wrong type for 'nmObjGet'", call. = FALSE)
   }
   .arg <- class(x)[1]
   if (any(.arg == c(
     "logLik", "value", "obf", "ofv",
     "objf", "OBJF", "objective", "AIC",
-    "BIC"))) {
+    "BIC"
+  ))) {
     .nmObjEnsureObjective(x[[1]])
   }
   if (.rstudioComplete()) {
@@ -43,8 +44,10 @@ nmObjGet <- function(x, ...) {
 #' @export
 nmObjGet.iniUi <- function(x, ...) {
   .env <- x[[1]]
-  .iniDf0 <- get("iniDf0", envir=.env)
-  if (is.null(.iniDf0)) return(NULL)
+  .iniDf0 <- get("iniDf0", envir = .env)
+  if (is.null(.iniDf0)) {
+    return(NULL)
+  }
   ## When the estimation method changes the model STRUCTURE (e.g. est="vae"
   ## covariate selection), the original model is stashed as a full ui in iniDf0;
   ## return it directly. Otherwise iniDf0 is the original iniDf data.frame -- swap
@@ -54,7 +57,7 @@ nmObjGet.iniUi <- function(x, ...) {
     return(if (nlmixr2global$finalUiCompressed) rxode2::rxUiCompress(.ui) else .ui)
   }
   .ui <- .cloneEnv(rxode2::rxUiDecompress(get("ui", .env)))
-  assign("iniDf", .iniDf0, envir=.ui)
+  assign("iniDf", .iniDf0, envir = .ui)
   rxode2::rxUiCompress(.ui)
 }
 attr(nmObjGet.iniUi, "desc") <- "The initial ui used to run the model"
@@ -66,10 +69,14 @@ nmObjGet.uiIni <- nmObjGet.iniUi
 #' @export
 nmObjGet.iniDf0 <- function(x, ...) {
   .env <- x[[1]]
-  .iniDf0 <- get("iniDf0", envir=.env)
-  if (is.null(.iniDf0)) return(NULL)
+  .iniDf0 <- get("iniDf0", envir = .env)
+  if (is.null(.iniDf0)) {
+    return(NULL)
+  }
   ## a ui (structure changed) -> the original model's iniDf; else the data.frame
-  if (!is.data.frame(.iniDf0)) return(rxode2::rxUiDecompress(.iniDf0)$iniDf)
+  if (!is.data.frame(.iniDf0)) {
+    return(rxode2::rxUiDecompress(.iniDf0)$iniDf)
+  }
   .iniDf0
 }
 attr(nmObjGet.iniDf0, "desc") <- "The initial estimate data frame of the original model"
@@ -89,7 +96,7 @@ attr(nmObjGet.iniDf0, "rstudio") <- emptyenv()
 #' nmObjUiSetCompressed(TRUE) # now the $ui will return a compressed value
 #'
 nmObjUiSetCompressed <- function(type) {
-  checkmate::assertLogical(type,len=1, any.missing=FALSE)
+  checkmate::assertLogical(type, len = 1, any.missing = FALSE)
   nlmixr2global$finalUiCompressed <- type
   invisible(type)
 }
@@ -131,7 +138,7 @@ nmObjGet.ui <- nmObjGet.finalUi
 nmObjGetData <- function(x, ...) {
   # need to assign environment correctly for UDF
   if (!inherits(x, "nmObjGetData")) {
-    stop("'x' is wrong type for 'nmObjGetData'", call.=FALSE)
+    stop("'x' is wrong type for 'nmObjGetData'", call. = FALSE)
   }
   if (.rstudioComplete()) {
     # During Rstudio completion, return a dummy/rstudio value instead of computing the real one.
@@ -157,10 +164,16 @@ nmObjGetData <- function(x, ...) {
 nmObjGetData.dataLloq <- function(x, ...) {
   .fit <- x[[1]]
   .df <- as.data.frame(.fit)
-  if (!any(names(.df) == "CENS")) return(NULL)
-  if (!any(names(.df) == "upperLim")) return(NULL)
+  if (!any(names(.df) == "CENS")) {
+    return(NULL)
+  }
+  if (!any(names(.df) == "upperLim")) {
+    return(NULL)
+  }
   .w <- which(.df$CENS == 1)
-  if (length(.w) == 0) return(NULL)
+  if (length(.w) == 0) {
+    return(NULL)
+  }
   mean(.df$upperLim[.w])
 }
 
@@ -168,10 +181,16 @@ nmObjGetData.dataLloq <- function(x, ...) {
 nmObjGetData.dataUloq <- function(x, ...) {
   .fit <- x[[1]]
   .df <- as.data.frame(.fit)
-  if (!any(names(.df) == "CENS")) return(NULL)
-  if (!any(names(.df) == "lowerLim")) return(NULL)
+  if (!any(names(.df) == "CENS")) {
+    return(NULL)
+  }
+  if (!any(names(.df) == "lowerLim")) {
+    return(NULL)
+  }
   .w <- which(.df$CENS == -1)
-  if (length(.w) == 0) return(NULL)
+  if (length(.w) == 0) {
+    return(NULL)
+  }
   mean(.df$lowerLim[.w])
 }
 
@@ -180,22 +199,26 @@ nmObjGet.dataNormInfo <- function(x, ...) {
   .fit <- x[[1]]
   .ui <- .fit$ui
   .datSav <- .fit$dataSav
-  .predDf <-.ui$predDf
-  if (all(.predDf$dist %in% c("norm", "dnorm","t", "cauchy"))) {
-    return(list(filter=rep(TRUE, length(.datSav[,1])),
-                 nnorm=length(.datSav[,1]),
-                 nlik=0,
-                 nother=0,
-                 nlmixrRowNums=.datSav$nlmixrRowNums))
+  .predDf <- .ui$predDf
+  if (all(.predDf$dist %in% c("norm", "dnorm", "t", "cauchy"))) {
+    return(list(
+      filter = rep(TRUE, length(.datSav[, 1])),
+      nnorm = length(.datSav[, 1]),
+      nlik = 0,
+      nother = 0,
+      nlmixrRowNums = .datSav$nlmixrRowNums
+    ))
   }
-  .ret <- .Call(`_nlmixr2est_filterNormalLikeAndDoses`,
-                .datSav$CMT, .predDf$distribution, .predDf$cmt)
+  .ret <- .Call(
+    `_nlmixr2est_filterNormalLikeAndDoses`,
+    .datSav$CMT, .predDf$distribution, .predDf$cmt
+  )
   .ret$nlmixrRowNums <- .datSav[.ret$filter, "nlmixrRowNums"]
   .ret
 }
 
 #' @export
-nmObjGet.warnings <-function(x, ...) {
+nmObjGet.warnings <- function(x, ...) {
   get("runInfo", x[[1]])
 }
 attr(nmObjGet.warnings, "desc") <- "Warnings from the nlmixr2 run"
@@ -215,33 +238,34 @@ nmObjGet.default <- function(x, ...) {
     .ret <- get(.arg, envir = .env)
     if (inherits(.ret, "raw")) {
       .type <- rxode2::rxGetSerialType_(.ret)
-      .ret <- try(.deserializeRaw(.ret, .type), silent=TRUE)
+      .ret <- try(.deserializeRaw(.ret, .type), silent = TRUE)
       if (inherits(.ret, "try-error")) {
         warning("cannot deserialize object '", .arg, "' (", .type, ")",
-                call.=FALSE)
+          call. = FALSE
+        )
         .ret <- NULL
       }
     }
     return(.ret)
   }
   # Now get the ui, install the control object temporarily and use `rxUiGet`
-  .ui <- get("ui", envir=.env)
+  .ui <- get("ui", envir = .env)
   .ui <- rxode2::rxUiDecompress(.ui)
   on.exit({
-    assign("ui", rxode2::rxUiCompress(.ui), envir=.env)
+    assign("ui", rxode2::rxUiCompress(.ui), envir = .env)
   })
   .ctl <- nmObjGetControl(.createEstObject(x[[1]]), ...)
   if (!is.null(.ctl)) {
-    assign("control", .ctl, envir=.ui)
+    assign("control", .ctl, envir = .ui)
   }
-  on.exit(suppressWarnings(try(rm(list="control", envir=.ui), silent=TRUE)))
+  on.exit(suppressWarnings(try(rm(list = "control", envir = .ui), silent = TRUE)))
   .lst <- list(.ui, x[[2]])
   class(.lst) <- c(.arg, "rxUiGet")
   .ret <- rxUiGet(.lst)
   .ret
 }
 
-#'@rdname nmObjGet
+#' @rdname nmObjGet
 #' @export
 nmObjGet.modelName <- function(x, ...) {
   .obj <- x[[1]]
@@ -263,7 +287,7 @@ nmObjGet.cor <- function(x, ...) {
   .cor
 }
 attr(nmObjGet.cor, "desc") <- "correlation matrix of theta, calculated from covariance of theta"
-attr(nmObjGet.cor, "rstudio") <- lotri::lotri(a+b~c(1, 0.1, 1))
+attr(nmObjGet.cor, "rstudio") <- lotri::lotri(a + b ~ c(1, 0.1, 1))
 
 .omegaR <- function(.cov) {
   .sd2 <- sqrt(diag(.cov))
@@ -286,12 +310,16 @@ attr(nmObjGet.cor, "rstudio") <- lotri::lotri(a+b~c(1, 0.1, 1))
 nmObjGet.omegaR <- function(x, ...) {
   .obj <- x[[1]]
   .cov <- .obj$omega
-  if (is.null(.cov)) return(NULL)
+  if (is.null(.cov)) {
+    return(NULL)
+  }
   if (is.list(.cov)) {
     .n <- names(.cov)
     .ret <- lapply(seq_along(.cov), function(i) {
       .covi <- .cov[[i]]
-      if (is.null(.covi)) return(NULL)
+      if (is.null(.covi)) {
+        return(NULL)
+      }
       .omegaR(.covi)
     })
     names(.ret) <- .n
@@ -301,7 +329,7 @@ nmObjGet.omegaR <- function(x, ...) {
   }
 }
 attr(nmObjGet.omegaR, "desc") <- "correlation matrix of omega"
-attr(nmObjGet.omegaR, "rstudio") <- lotri::lotri(a+b~c(1, 0.1, 1))
+attr(nmObjGet.omegaR, "rstudio") <- lotri::lotri(a + b ~ c(1, 0.1, 1))
 
 #' @rdname nmObjGet
 #' @export
@@ -309,7 +337,7 @@ nmObjGet.phiR <- function(x, ...) {
   .obj <- x[[1]]
   .phi <- .obj$phiC
   if (is.null(.phi)) {
-    if (any(names(x[[1]]) !="CWRES")) warning("this requires 'CWRES' in fit (use `addCwres()`)", call.=FALSE)
+    if (any(names(x[[1]]) != "CWRES")) warning("this requires 'CWRES' in fit (use `addCwres()`)", call. = FALSE)
     return(NULL)
   }
   .ret <- lapply(seq_along(.phi), function(i) {
@@ -317,7 +345,7 @@ nmObjGet.phiR <- function(x, ...) {
     .d <- diag(.cov)
     if (any(.d == 0) || any(!is.finite(.d))) {
       .d1 <- length(.d)
-      return(matrix(rep(NA, .d1*.d1), .d1, .d1))
+      return(matrix(rep(NA, .d1 * .d1), .d1, .d1))
     }
     .sd2 <- sqrt(diag(.cov))
     .cor <- stats::cov2cor(.cov)
@@ -336,14 +364,14 @@ nmObjGet.phiSE <- function(x, ...) {
   .obj <- x[[1]]
   .phi <- .obj$phiC
   if (is.null(.phi)) {
-    if (any(names(x[[1]]) !="CWRES")) warning("this requires 'CWRES' in fit (use `addCwres()`)", call.=FALSE)
+    if (any(names(x[[1]]) != "CWRES")) warning("this requires 'CWRES' in fit (use `addCwres()`)", call. = FALSE)
     return(NULL)
   }
   .d1 <- dim(.phi[[1]])[1]
   .ret <- vapply(seq_along(.phi), function(i) {
     .cov <- .phi[[i]]
     suppressWarnings(sqrt(diag(.cov)))
-  }, double(.d1), USE.NAMES=FALSE)
+  }, double(.d1), USE.NAMES = FALSE)
   dim(.ret) <- c(.d1, length(.phi))
   dimnames(.ret) <- list(paste0("se(", colnames(.phi[[1]]), ")"), names(.phi))
   .ret <- as.data.frame(t(.ret))
@@ -351,7 +379,7 @@ nmObjGet.phiSE <- function(x, ...) {
   if (!is.null(names(.phi))) {
     .id <- names(.phi)
   }
-  cbind(data.frame(ID=.id), .ret)
+  cbind(data.frame(ID = .id), .ret)
 }
 attr(nmObjGet.phiSE, "desc") <- "standard error of each individual's eta (if present)"
 
@@ -360,16 +388,16 @@ attr(nmObjGet.phiSE, "desc") <- "standard error of each individual's eta (if pre
 nmObjGet.phiRSE <- function(x, ...) {
   .obj <- x[[1]]
   .phi <- .obj$phiC
-  .eta <- .obj$eta[,-1, drop=FALSE]
-  if (is.null(.phi)){
-    if (any(names(x[[1]]) !="CWRES")) warning("this requires 'CWRES' in fit (use `addCwres()`)", call.=FALSE)
+  .eta <- .obj$eta[, -1, drop = FALSE]
+  if (is.null(.phi)) {
+    if (any(names(x[[1]]) != "CWRES")) warning("this requires 'CWRES' in fit (use `addCwres()`)", call. = FALSE)
     return(NULL)
   }
-  .d1 <-dim(.phi[[1]])[1]
-  .ret <-vapply(seq_along(.phi), function(i) {
+  .d1 <- dim(.phi[[1]])[1]
+  .ret <- vapply(seq_along(.phi), function(i) {
     .cov <- .phi[[i]]
-    suppressWarnings(sqrt(diag(.cov))/unlist(.eta[i,, drop=FALSE])*100)
-  }, double(.d1), USE.NAMES=FALSE)
+    suppressWarnings(sqrt(diag(.cov)) / unlist(.eta[i, , drop = FALSE]) * 100)
+  }, double(.d1), USE.NAMES = FALSE)
   dim(.ret) <- c(.d1, length(.phi))
   dimnames(.ret) <- list(paste0("rse(", colnames(.phi[[1]]), ")%"), names(.phi))
   .ret <- as.data.frame(t(.ret))
@@ -377,7 +405,7 @@ nmObjGet.phiRSE <- function(x, ...) {
   if (!is.null(names(.phi))) {
     .id <- names(.phi)
   }
-  cbind(data.frame(ID=.id), .ret)
+  cbind(data.frame(ID = .id), .ret)
 }
 attr(nmObjGet.phiRSE, "desc") <- "relative standard error of each individual's eta (if present)"
 
@@ -387,24 +415,26 @@ nmObjGet.phiCI <- function(x, ...) {
   .obj <- x[[1]]
   .phi <- .obj$phiC
   if (is.null(.phi)) {
-    if (any(names(x[[1]]) !="CWRES")) warning("this requires 'CWRES' in fit (use `addCwres()`)", call.=FALSE)
+    if (any(names(x[[1]]) != "CWRES")) warning("this requires 'CWRES' in fit (use `addCwres()`)", call. = FALSE)
     return(NULL)
   }
   .ci <- rxode2::rxGetControl(.obj$ui, "ci", 0.95)
   .qn <- stats::qnorm(1 - (1 - .ci) / 2)
   .etaNames <- colnames(.phi[[1]])
-  .eta <- .obj$eta[, .etaNames, drop=FALSE]
+  .eta <- .obj$eta[, .etaNames, drop = FALSE]
   .low <- (1 - .ci) / 2
   .hi <- 1 - .low
-  .lowLab <- paste0(format(100 * .low, trim=TRUE, digits=3), "%")
-  .hiLab <- paste0(format(100 * .hi, trim=TRUE, digits=3), "%")
+  .lowLab <- paste0(format(100 * .low, trim = TRUE, digits = 3), "%")
+  .hiLab <- paste0(format(100 * .hi, trim = TRUE, digits = 3), "%")
   .ret <- lapply(seq_along(.phi), function(i) {
     .cov <- .phi[[i]]
     .se <- suppressWarnings(sqrt(diag(.cov)))
-    .est <- unlist(.eta[i, , drop=FALSE])
+    .est <- unlist(.eta[i, , drop = FALSE])
     .row <- data.frame(t(as.vector(rbind(.est - .qn * .se, .est + .qn * .se))))
-    names(.row) <- as.vector(rbind(paste0(.etaNames, " (", .lowLab, ")"),
-                                   paste0(.etaNames, " (", .hiLab, ")")))
+    names(.row) <- as.vector(rbind(
+      paste0(.etaNames, " (", .lowLab, ")"),
+      paste0(.etaNames, " (", .hiLab, ")")
+    ))
     .row
   })
   .ret <- do.call(rbind, .ret)
@@ -412,10 +442,9 @@ nmObjGet.phiCI <- function(x, ...) {
   if (!is.null(names(.phi))) {
     .id <- names(.phi)
   }
-  cbind(data.frame(ID=.id), .ret)
+  cbind(data.frame(ID = .id), .ret)
 }
 attr(nmObjGet.phiCI, "desc") <- "confidence interval of each individual's eta (if present)"
-
 
 
 #' @rdname nmObjGet
@@ -423,13 +452,15 @@ attr(nmObjGet.phiCI, "desc") <- "confidence interval of each individual's eta (i
 nmObjGet.dataSav <- function(x, ...) {
   .obj <- x[[1]]
   .objEnv <- .obj$env
-  if (exists("dataSav", .objEnv)) return(get("dataSav", envir=.objEnv))
+  if (exists("dataSav", .objEnv)) {
+    return(get("dataSav", envir = .objEnv))
+  }
   .data <- .obj$origData
   .env <- new.env(emptyenv())
   .foceiPreProcessData(.data, .env, .obj$ui, .obj$control$rxControl)
   .env$dataSav
 }
-#attr(nmObjGet.dataSav, "desc") <- "data that focei sees for optimization"
+# attr(nmObjGet.dataSav, "desc") <- "data that focei sees for optimization"
 
 #' @export
 nmObjGet.foceiControl <- function(x, ...) {
@@ -439,10 +470,12 @@ attr(nmObjGet.foceiControl, "desc") <- "Get the focei control required for creat
 
 #' @rdname nmObjGet
 #' @export
-nmObjGet.idLvl <- function(x, ...){
+nmObjGet.idLvl <- function(x, ...) {
   .obj <- x[[1]]
   .objEnv <- .obj$env
-  if (exists("idLvl", .objEnv)) return(get("idLvl", envir=.objEnv))
+  if (exists("idLvl", .objEnv)) {
+    return(get("idLvl", envir = .objEnv))
+  }
   .data <- .obj$origData
   .env <- new.env(emptyenv())
   .foceiPreProcessData(.data, .env, .obj$ui, .obj$control$rxControl)
@@ -454,16 +487,18 @@ nmObjGet.idLvl <- function(x, ...){
 nmObjGet.covLvl <- function(x, ...) {
   .obj <- x[[1]]
   .objEnv <- .obj$env
-  if (exists("covLvl", .objEnv)) return(get("covLvl", envir=.objEnv))
+  if (exists("covLvl", .objEnv)) {
+    return(get("covLvl", envir = .objEnv))
+  }
   .data <- .obj$origData
   .env <- new.env(emptyenv())
   .foceiPreProcessData(.data, .env, .obj$ui, .obj$control$rxControl)
   .env$covLvl
 }
-#attr(nmObjGet.dataSav, "desc") <- "data that focei sees for optimization"
+# attr(nmObjGet.dataSav, "desc") <- "data that focei sees for optimization"
 
-.dataMergeStub <- function(obj, preferFit=TRUE) {
-  .env      <- obj$env
+.dataMergeStub <- function(obj, preferFit = TRUE) {
+  .env <- obj$env
   .origData <- obj$origData
   .origData$nlmixrRowNums <- seq_len(nrow(.origData))
   # add llikObs
@@ -475,29 +510,31 @@ nmObjGet.covLvl <- function(x, ...) {
     } else {
       .dataSav <- obj$dataSav
       if (length(.dataSav$nlmixrRowNums) == length(obj$env$llikObs)) {
-        .llik0 <- data.frame(nlmixrRowNums=.dataSav$nlmixrRowNums, nlmixrLlikObs=obj$env$llikObs)
-        .llik0 <- .llik0[.llik0$nlmixrRowNums != 0,]
-        .origData <- merge(.origData, .llik0, by="nlmixrRowNums", all.x=TRUE)
-        .origData <- .origData[order(.origData$nlmixrRowNums),]
+        .llik0 <- data.frame(nlmixrRowNums = .dataSav$nlmixrRowNums, nlmixrLlikObs = obj$env$llikObs)
+        .llik0 <- .llik0[.llik0$nlmixrRowNums != 0, ]
+        .origData <- merge(.origData, .llik0, by = "nlmixrRowNums", all.x = TRUE)
+        .origData <- .origData[order(.origData$nlmixrRowNums), ]
       } else {
-        .nlmixrRowNums <- .dataSav[.dataSav$EVID == 0 | .dataSav$EVID == 2 |
-                                     (.dataSav$EVID >= 9 & .dataSav$EVID <= 99),
-                                   "nlmixrRowNums"]
+        .nlmixrRowNums <- .dataSav[
+          .dataSav$EVID == 0 | .dataSav$EVID == 2 |
+            (.dataSav$EVID >= 9 & .dataSav$EVID <= 99),
+          "nlmixrRowNums"
+        ]
         .llikObs <- obj$env$llikObs[!is.na(obj$env$llikObs)]
         if (length(.nlmixrRowNums) == length(.llikObs)) {
-          .llik0 <- data.frame(nlmixrRowNums=.nlmixrRowNums, nlmixrLlikObs=.llikObs)
-          .llik0 <- .llik0[.llik0$nlmixrRowNums != 0,]
-          .origData <- merge(.origData, .llik0, by="nlmixrRowNums", all.x=TRUE)
-          .origData <- .origData[order(.origData$nlmixrRowNums),]
+          .llik0 <- data.frame(nlmixrRowNums = .nlmixrRowNums, nlmixrLlikObs = .llikObs)
+          .llik0 <- .llik0[.llik0$nlmixrRowNums != 0, ]
+          .origData <- merge(.origData, .llik0, by = "nlmixrRowNums", all.x = TRUE)
+          .origData <- .origData[order(.origData$nlmixrRowNums), ]
         } else {
-          warning("'nlmixrLlikObs' not added to dataset", call.=FALSE)
+          warning("'nlmixrLlikObs' not added to dataset", call. = FALSE)
         }
       }
     }
   }
   .fitData <- as.data.frame(obj)
   if (is.null(.fitData$EVID)) .fitData$EVID <- 0
-  if (is.null(.fitData$AMT))  .fitData$AMT  <- 0
+  if (is.null(.fitData$AMT)) .fitData$AMT <- 0
   .names <- tolower(names(.origData))
   .wid <- which(.names == "id")
   names(.origData)[.wid] <- "ID"
@@ -518,110 +555,126 @@ nmObjGet.covLvl <- function(x, ...) {
 #' @export
 nmObjGetData.dataMergeLeft <- function(x, ...) {
   .obj <- x[[1]]
-  .lst <- .dataMergeStub(.obj, preferFit=FALSE)
-  .ret <- merge(.lst[[1]], .lst[[2]], by=c("ID", "nlmixrRowNums"), all.x=TRUE)
+  .lst <- .dataMergeStub(.obj, preferFit = FALSE)
+  .ret <- merge(.lst[[1]], .lst[[2]], by = c("ID", "nlmixrRowNums"), all.x = TRUE)
   .ret <- .ret[, names(.ret) != "nlmixrRowNums"]
   .ret
 }
 attr(nmObjGetData.dataMergeLeft, "desc") <- "left join between original and fit dataset (prefer columns in original dataset)"
-attr(nmObjGetData.dataMergeLeft, "rstudio") <- data.frame(data="prefer original",
-                                                          left="original", right="fit")
+attr(nmObjGetData.dataMergeLeft, "rstudio") <- data.frame(
+  data = "prefer original",
+  left = "original", right = "fit"
+)
 
 #' @rdname nmObjGetData
 #' @export
 nmObjGetData.dataMergeRight <- function(x, ...) {
   .obj <- x[[1]]
-  .lst <- .dataMergeStub(.obj, preferFit=FALSE)
-  .ret <- merge(.lst[[1]], .lst[[2]], by=c("ID", "nlmixrRowNums"), all.y=TRUE)
+  .lst <- .dataMergeStub(.obj, preferFit = FALSE)
+  .ret <- merge(.lst[[1]], .lst[[2]], by = c("ID", "nlmixrRowNums"), all.y = TRUE)
   .ret <- .ret[, names(.ret) != "nlmixrRowNums"]
   .ret
 }
 attr(nmObjGetData.dataMergeRight, "desc") <- "right join between original and fit dataset (prefer columns in original dataset)"
-attr(nmObjGetData.dataMergeRight, "rstudio") <- data.frame(data="prefer original",
-                                                          left="original", right="fit")
+attr(nmObjGetData.dataMergeRight, "rstudio") <- data.frame(
+  data = "prefer original",
+  left = "original", right = "fit"
+)
 
 #' @rdname nmObjGetData
 #' @export
 nmObjGetData.dataMergeInner <- function(x, ...) {
   .obj <- x[[1]]
-  .lst <- .dataMergeStub(.obj, preferFit=FALSE)
-  .ret <- merge(.lst[[1]], .lst[[2]], by=c("ID", "nlmixrRowNums"))
+  .lst <- .dataMergeStub(.obj, preferFit = FALSE)
+  .ret <- merge(.lst[[1]], .lst[[2]], by = c("ID", "nlmixrRowNums"))
   .ret <- .ret[, names(.ret) != "nlmixrRowNums"]
   .ret
 }
 attr(nmObjGetData.dataMergeInner, "desc") <- "inner join between original and fit dataset (prefer columns in original dataset)"
-attr(nmObjGetData.dataMergeInner, "rstudio") <- data.frame(data="prefer original",
-                                                           left="original", right="fit")
+attr(nmObjGetData.dataMergeInner, "rstudio") <- data.frame(
+  data = "prefer original",
+  left = "original", right = "fit"
+)
 
 
 #' @rdname nmObjGetData
 #' @export
 nmObjGetData.dataMergeFull <- function(x, ...) {
   .obj <- x[[1]]
-  .lst <- .dataMergeStub(.obj, preferFit=FALSE)
-  .ret <- merge(.lst[[1]], .lst[[2]], by=c("ID", "nlmixrRowNums"), all.x=TRUE, all.y=TRUE)
+  .lst <- .dataMergeStub(.obj, preferFit = FALSE)
+  .ret <- merge(.lst[[1]], .lst[[2]], by = c("ID", "nlmixrRowNums"), all.x = TRUE, all.y = TRUE)
   .ret <- .ret[, names(.ret) != "nlmixrRowNums"]
   .ret
 }
 attr(nmObjGetData.dataMergeFull, "desc") <- "full join between original and fit dataset (prefer columns in fit dataset)"
-attr(nmObjGetData.dataMergeFull, "rstudio") <- data.frame(data="prefer data",
-                                                           left="original", right="fit")
+attr(nmObjGetData.dataMergeFull, "rstudio") <- data.frame(
+  data = "prefer data",
+  left = "original", right = "fit"
+)
 
 
 #' @rdname nmObjGetData
 #' @export
 nmObjGetData.fitMergeLeft <- function(x, ...) {
   .obj <- x[[1]]
-  .lst <- .dataMergeStub(.obj, preferFit=FALSE)
-  .ret <- merge(.lst[[1]], .lst[[2]], by=c("ID", "nlmixrRowNums"), all.x=TRUE)
+  .lst <- .dataMergeStub(.obj, preferFit = FALSE)
+  .ret <- merge(.lst[[1]], .lst[[2]], by = c("ID", "nlmixrRowNums"), all.x = TRUE)
   .ret <- .ret[, names(.ret) != "nlmixrRowNums"]
   .ret
 }
 attr(nmObjGetData.fitMergeLeft, "desc") <- "left join between original and fit dataset (prefer columns in fit dataset)"
-attr(nmObjGetData.fitMergeLeft, "rstudio") <- data.frame(data="prefer fit",
-                                                           left="original", right="fit")
+attr(nmObjGetData.fitMergeLeft, "rstudio") <- data.frame(
+  data = "prefer fit",
+  left = "original", right = "fit"
+)
 
 
 #' @rdname nmObjGetData
 #' @export
 nmObjGetData.fitMergeRight <- function(x, ...) {
   .obj <- x[[1]]
-  .lst <- .dataMergeStub(.obj, preferFit=TRUE)
-  .ret <- merge(.lst[[1]], .lst[[2]], by=c("ID", "nlmixrRowNums"), all.y=TRUE)
+  .lst <- .dataMergeStub(.obj, preferFit = TRUE)
+  .ret <- merge(.lst[[1]], .lst[[2]], by = c("ID", "nlmixrRowNums"), all.y = TRUE)
   .ret <- .ret[, names(.ret) != "nlmixrRowNums"]
   .ret
 }
 attr(nmObjGetData.fitMergeRight, "desc") <- "right join between original and fit dataset (prefer columns in fit dataset)"
-attr(nmObjGetData.fitMergeRight, "rstudio") <- data.frame(data="prefer fit",
-                                                        left="original", right="fit")
+attr(nmObjGetData.fitMergeRight, "rstudio") <- data.frame(
+  data = "prefer fit",
+  left = "original", right = "fit"
+)
 
 
 #' @rdname nmObjGetData
 #' @export
 nmObjGetData.fitMergeInner <- function(x, ...) {
   .obj <- x[[1]]
-  .lst <- .dataMergeStub(.obj, preferFit=TRUE)
-  .ret <- merge(.lst[[1]], .lst[[2]], by=c("ID", "nlmixrRowNums"))
+  .lst <- .dataMergeStub(.obj, preferFit = TRUE)
+  .ret <- merge(.lst[[1]], .lst[[2]], by = c("ID", "nlmixrRowNums"))
   .ret <- .ret[, names(.ret) != "nlmixrRowNums"]
   .ret
 }
 attr(nmObjGetData.fitMergeInner, "desc") <- "inner join between original and fit dataset (prefer columns in fit dataset)"
-attr(nmObjGetData.fitMergeInner, "rstudio") <- data.frame(data="prefer fit",
-                                                          left="original", right="fit")
+attr(nmObjGetData.fitMergeInner, "rstudio") <- data.frame(
+  data = "prefer fit",
+  left = "original", right = "fit"
+)
 
 
 #' @rdname nmObjGetData
 #' @export
 nmObjGetData.fitMergeFull <- function(x, ...) {
   .obj <- x[[1]]
-  .lst <- .dataMergeStub(.obj, preferFit=TRUE)
-  .ret <- merge(.lst[[1]], .lst[[2]], by=c("ID", "nlmixrRowNums"), all.x=TRUE, all.y=TRUE)
+  .lst <- .dataMergeStub(.obj, preferFit = TRUE)
+  .ret <- merge(.lst[[1]], .lst[[2]], by = c("ID", "nlmixrRowNums"), all.x = TRUE, all.y = TRUE)
   .ret <- .ret[, names(.ret) != "nlmixrRowNums"]
   .ret
 }
 attr(nmObjGetData.fitMergeFull, "desc") <- "full join between original and fit dataset (prefer columns in fit dataset)"
-attr(nmObjGetData.fitMergeFull, "rstudio") <- data.frame(data="prefer fit",
-                                                          left="original", right="fit")
+attr(nmObjGetData.fitMergeFull, "rstudio") <- data.frame(
+  data = "prefer fit",
+  left = "original", right = "fit"
+)
 
 
 #' @rdname nmObjGet
@@ -629,7 +682,7 @@ attr(nmObjGetData.fitMergeFull, "rstudio") <- data.frame(data="prefer fit",
 nmObjGet.parHist <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("parHistData", envir=.env)) {
+  if (exists("parHistData", envir = .env)) {
     return(.parHistCalc(.env))
   }
   NULL
@@ -641,12 +694,14 @@ attr(nmObjGet.parHist, "desc") <- "Parameter History"
 nmObjGet.parHistStacked <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("parHistData", envir=.env)) {
+  if (exists("parHistData", envir = .env)) {
     .parHist <- .parHistCalc(.env)
     .iter <- .parHist$iter
-    .ret <- data.frame(iter=.iter, stack(.parHist[, -1]))
-    names(.ret) <- sub("values", "val",
-                       sub("ind", "par", names(.ret)))
+    .ret <- data.frame(iter = .iter, stack(.parHist[, -1]))
+    names(.ret) <- sub(
+      "values", "val",
+      sub("ind", "par", names(.ret))
+    )
     return(.ret)
   }
   NULL
@@ -677,8 +732,10 @@ attr(nmObjGet.sigma, "rstudio") <- numeric(0)
 #' @rdname nmObjGet
 #' @export
 nmObjGet.coefficients <- function(x, ...) {
-  list(fixed = fixef(x[[1]]),
-       random = ranef(x[[1]]))
+  list(
+    fixed = fixef(x[[1]]),
+    random = ranef(x[[1]])
+  )
 }
 
 #' @rdname nmObjGet
@@ -732,12 +789,14 @@ nmObjGet.saemCfg <- function(x, ...) {
 nmObjGet.saemNmc <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("saemControl", envir=.env)) {
-    .saemControl <- get("saemControl", envir=.env)
+  if (exists("saemControl", envir = .env)) {
+    .saemControl <- get("saemControl", envir = .env)
     return(.saemControl$mcmc$nmc)
-  } else if (exists("control", envir=.env)) {
-    .saemControl <- get("control", envir=.env)
-    if (any(names(.saemControl) == "mcmc")) return(.saemControl$mcmc$nmc)
+  } else if (exists("control", envir = .env)) {
+    .saemControl <- get("control", envir = .env)
+    if (any(names(.saemControl) == "mcmc")) {
+      return(.saemControl$mcmc$nmc)
+    }
   }
   NA_integer_
 }
@@ -753,36 +812,38 @@ nmObjGet.saemEvtDf <- function(x, ...) {
   # the fit; a no-op unless the subject has overlapping-time reset episodes.
   .saemMonotonicResetTime(.evt)
 }
-#attr(nmObjGet.saemEvtDf, "desc") <- "event data frame as seen by saem"
+# attr(nmObjGet.saemEvtDf, "desc") <- "event data frame as seen by saem"
 
 #' @export
 nmObjGet.saemEvt <- function(x, ...) {
   as.matrix(nmObjGet.saemEvtDf(x, ...))
 }
-#attr(nmObjGet.saemEvtDf, "desc") <- "event matrix as seen by saem; stored in saem.cfg"
+# attr(nmObjGet.saemEvtDf, "desc") <- "event matrix as seen by saem; stored in saem.cfg"
 
 #' @export
 nmObjGet.saemEvtMDf <- function(x, ...) {
   .nmc <- nmObjGet.saemNmc(x, ...)
-  if (is.na(.nmc)) stop("cannot figure out the number of mcmc simulations", call.=FALSE)
+  if (is.na(.nmc)) stop("cannot figure out the number of mcmc simulations", call. = FALSE)
   .evt <- nmObjGet.saemEvtDf(x, ...)
   .evtM <- .evt[rep(seq_len(dim(.evt)[1]), .nmc), ]
   .evtM$ID <- cumsum(c(FALSE, diff(.evtM$ID) != 0))
   .evtM
 }
-#attr(nmObjGet.saemEvtDf, "desc") <- "saem event data frame evtM for mcmc"
+# attr(nmObjGet.saemEvtDf, "desc") <- "saem event data frame evtM for mcmc"
 
 #' @export
 nmObjGet.saemEvtM <- function(x, ...) {
   as.matrix(nmObjGet.saemEvtMDf(x, ...))
 }
-#attr(nmObjGet.saemEvtM, "desc") <- "saem event matrix evtM for mcmc; stored in saem.cfg"
-attr(nmObjGet.saemEvtM, "rstudio") <- lotri::lotri(a+b~c(1, 0.1, 1))
+# attr(nmObjGet.saemEvtM, "desc") <- "saem event matrix evtM for mcmc; stored in saem.cfg"
+attr(nmObjGet.saemEvtM, "rstudio") <- lotri::lotri(a + b ~ c(1, 0.1, 1))
 
 #' @export
 nmObjGet.saem <- function(x, ...) {
   .obj <- x[[1]]
-  if (!exists("saem0", .obj)) return(NULL)
+  if (!exists("saem0", .obj)) {
+    return(NULL)
+  }
   .saem <- .obj$saem0
   .saemCfg <- attr(.saem, "saem.cfg")
   .saemCfg$evt <- .obj$saemEvt
@@ -794,10 +855,10 @@ nmObjGet.saem <- function(x, ...) {
 nmObjGet.innerModel <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("foceiModel", envir=.env)) {
-    .model <- get("foceiModel", envir=.env)
-  } else if (exists("model", envir=.env)) {
-    .model <- get("model", envir=.env)
+  if (exists("foceiModel", envir = .env)) {
+    .model <- get("foceiModel", envir = .env)
+  } else if (exists("model", envir = .env)) {
+    .model <- get("model", envir = .env)
   } else {
     return(NULL)
   }
@@ -859,12 +920,12 @@ nmObjGetPredOnly <- function(x) {
 nmObjGetPredOnly.saem <- function(x) {
   .env <- x[[1]]
   .model <- NULL
-  if (exists("saemModel", envir=.env)) {
-    .model <- get("saemModel", envir=.env)
-  } else if (exists("model", envir=.env)) {
-    .model <- get("model", envir=.env)
+  if (exists("saemModel", envir = .env)) {
+    .model <- get("saemModel", envir = .env)
+  } else if (exists("model", envir = .env)) {
+    .model <- get("model", envir = .env)
   } else {
-    stop("cannot find saem model components", call.=FALSE)
+    stop("cannot find saem model components", call. = FALSE)
   }
   .model$predOnly
 }
@@ -874,10 +935,10 @@ nmObjGetPredOnly.saem <- function(x) {
 nmObjGetPredOnly.default <- function(x) {
   .env <- x[[1]]
   .model <- NULL
-  if (exists("foceiModel", envir=.env)) {
-    .model <- get("foceiModel", envir=.env)
-  } else if (exists("model", envir=.env)) {
-    .model <- get("model", envir=.env)
+  if (exists("foceiModel", envir = .env)) {
+    .model <- get("foceiModel", envir = .env)
+  } else if (exists("model", envir = .env)) {
+    .model <- get("model", envir = .env)
   }
   .model$predOnly
 }
@@ -901,12 +962,12 @@ nmObjGetIpredModel <- function(x) {
 nmObjGetIpredModel.saem <- function(x) {
   .env <- x[[1]]
   .model <- NULL
-  if (exists("saemModel", envir=.env)) {
-    .model <- get("saemModel", envir=.env)
-  } else if (exists("model", envir=.env)) {
-    .model <- get("model", envir=.env)
+  if (exists("saemModel", envir = .env)) {
+    .model <- get("saemModel", envir = .env)
+  } else if (exists("model", envir = .env)) {
+    .model <- get("model", envir = .env)
   } else {
-    stop("cannot find saem model components", call.=FALSE)
+    stop("cannot find saem model components", call. = FALSE)
   }
   .model$predOnly
 }
@@ -916,13 +977,15 @@ nmObjGetIpredModel.saem <- function(x) {
 nmObjGetIpredModel.default <- function(x) {
   .env <- x[[1]]
   .model <- NULL
-  if (exists("foceiModel", envir=.env)) {
-    .model <- get("foceiModel", envir=.env)
-  } else if (exists("model", envir=.env)) {
-    .model <- get("model", envir=.env)
+  if (exists("foceiModel", envir = .env)) {
+    .model <- get("foceiModel", envir = .env)
+  } else if (exists("model", envir = .env)) {
+    .model <- get("model", envir = .env)
   }
   .inner <- .model$inner
-  if (is.null(.inner)) return(.model$predOnly)
+  if (is.null(.inner)) {
+    return(.model$predOnly)
+  }
   .inner
 }
 
@@ -964,13 +1027,15 @@ nmObjGetEstimationModel.saem <- function(x) {
 nmObjGetEstimationModel.default <- function(x) {
   .env <- x[[1]]
   .model <- NULL
-  if (exists("foceiModel", envir=.env)) {
-    .model <- get("foceiModel", envir=.env)
-  } else if (exists("model", envir=.env)) {
-    .model <- get("model", envir=.env)
+  if (exists("foceiModel", envir = .env)) {
+    .model <- get("foceiModel", envir = .env)
+  } else if (exists("model", envir = .env)) {
+    .model <- get("model", envir = .env)
   }
   .inner <- .model$inner
-  if (is.null(.inner)) return(.model$predOnly)
+  if (is.null(.inner)) {
+    return(.model$predOnly)
+  }
   .inner
 }
 #' Create an estimation object
@@ -985,13 +1050,13 @@ nmObjGetEstimationModel.default <- function(x) {
   } else {
     .env <- x
   }
-  if (exists("est", envir=.env)) {
-    .est <- get("est", envir=.env)
+  if (exists("est", envir = .env)) {
+    .est <- get("est", envir = .env)
     .ret <- list(.env)
     class(.ret) <- .est
     return(.ret)
   } else {
-    stop("Cannot figure out the estimation method", call.=FALSE)
+    stop("Cannot figure out the estimation method", call. = FALSE)
   }
 }
 
@@ -1082,9 +1147,13 @@ nmObjGetRxSolve <- function(x, what) {
 nmObjGetRxSolve.default <- function(x, what) {
   .env <- x[[1]]
   .control <- nmObjGetControl(x)
-  if (!any(names(.control) == "rxControl")) return(NULL)
+  if (!any(names(.control) == "rxControl")) {
+    return(NULL)
+  }
   .lst <- .control$rxControl
-  if (is.null(what)) return(.lst)
+  if (is.null(what)) {
+    return(.lst)
+  }
   .lst[[what]]
 }
 
@@ -1098,7 +1167,9 @@ nmObjGet.simulationModel <- function(x, ...) {
   .key <- .simModelCacheKey(.env)
   if (!is.null(.key)) {
     .cached <- .simModelCacheGet(.key)
-    if (!is.null(.cached)) return(.cached)
+    if (!is.null(.cached)) {
+      return(.cached)
+    }
   }
   .ret <- eval(rxode2::getBaseSimModel(.env))
   if (!is.null(.key)) {
@@ -1118,35 +1189,44 @@ nmObjGet.rxControl <- function(x, ...) {
 nmObjGet.mixList <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("mixList", envir=.env)) return(get("mixList", envir=.env))
+  if (exists("mixList", envir = .env)) {
+    return(get("mixList", envir = .env))
+  }
   NULL
 }
 attr(nmObjGet.mixList, "desc") <- "List of ETAs and posterior probabilities for each mixture component"
-attr(nmObjGet.mixList, "rstudio") <- list(mix1=data.frame(ID=1L, prob=0.8))
+attr(nmObjGet.mixList, "rstudio") <- list(mix1 = data.frame(ID = 1L, prob = 0.8))
 
 #' @rdname nmObjGet
 #' @export
 nmObjGet.mixNum <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("mixNum", envir=.env)) return(get("mixNum", envir=.env))
+  if (exists("mixNum", envir = .env)) {
+    return(get("mixNum", envir = .env))
+  }
   NULL
 }
 attr(nmObjGet.mixNum, "desc") <- "Data frame with ID and most likely mixture number per subject"
-attr(nmObjGet.mixNum, "rstudio") <- data.frame(ID=1L, mixnum=1L)
+attr(nmObjGet.mixNum, "rstudio") <- data.frame(ID = 1L, mixnum = 1L)
 
 #' @rdname nmObjGet
 #' @export
 nmObjGet.ranef <- function(x, ...) {
   .env <- x[[1]]
-  if (!exists("ranef", envir=.env)) return(NULL)
-  .ret <- get("ranef", envir=.env)
-  if (is.null(.ret)) return(NULL)
-  if (exists("mixNum", envir=.env)) {
-    .mn <- get("mixNum", envir=.env)
+  if (!exists("ranef", envir = .env)) {
+    return(NULL)
+  }
+  .ret <- get("ranef", envir = .env)
+  if (is.null(.ret)) {
+    return(NULL)
+  }
+  if (exists("mixNum", envir = .env)) {
+    .mn <- get("mixNum", envir = .env)
     if (!is.null(.mn) && "mixnum" %in% names(.mn)) {
-      .ret <- merge(.ret, .mn[, c("ID", "mixnum"), drop=FALSE],
-                    by="ID", all.x=TRUE, sort=FALSE)
+      .ret <- merge(.ret, .mn[, c("ID", "mixnum"), drop = FALSE],
+        by = "ID", all.x = TRUE, sort = FALSE
+      )
     }
   }
   .ret

--- a/R/nmObjGet.R
+++ b/R/nmObjGet.R
@@ -1091,7 +1091,20 @@ nmObjGetRxSolve.default <- function(x, what) {
 #' @rdname nmObjGet
 #' @export
 nmObjGet.simulationModel <- function(x, ...) {
-  eval(rxode2::getBaseSimModel(x[[1]]))
+  .env <- x[[1]]
+  ## lowering the fit is a pure function of its model, but it is not cheap,
+  ## and `rxode2::rxSolve()` on a fit asks for it on every single call
+  ## (nlmixr2/rxode2#1289) -- see R/simModelCache.R
+  .key <- .simModelCacheKey(.env)
+  if (!is.null(.key)) {
+    .cached <- .simModelCacheGet(.key)
+    if (!is.null(.cached)) return(.cached)
+  }
+  .ret <- eval(rxode2::getBaseSimModel(.env))
+  if (!is.null(.key)) {
+    .simModelCacheSet(.key, .ret)
+  }
+  .ret
 }
 
 #' @rdname nmObjGet

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -268,8 +268,8 @@ attr(nlmixr2Est.predict, "random") <- TRUE
 #'     ka <- exp(tka + eta.ka)
 #'     cl <- exp(tcl + eta.cl)
 #'     v <- exp(tv + eta.v)
-#'     d / dt(depot) <- -ka * depot
-#'     d / dt(center) <- ka * depot - cl / v * center
+#'     d/dt(depot) <- -ka * depot
+#'     d/dt(center) <- ka * depot - cl / v * center
 #'     cp <- center / v
 #'     cp ~ add(add.sd)
 #'   })

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -8,9 +8,9 @@
 #' @return A list of control settings for `rxSolve`.
 #' @noRd
 .rxSolveGetControlForNlmixr <- function(env) {
-  .ui <- get("ui", envir=env)
-  if (exists("control", envir=env)) {
-    .rxControl <- get("control", envir=env)
+  .ui <- get("ui", envir = env)
+  if (exists("control", envir = env)) {
+    .rxControl <- get("control", envir = env)
   }
   if (!inherits(.rxControl, "rxControl")) {
     .rxControl <- try(.rxControl$rxControl)
@@ -43,13 +43,17 @@
       .rxControl$thetaMat <- .thetaMat
     }
     if (.rxControl$dfObs == 0L & !.isPred) {
-      .minfo(paste0("using `dfObs=", nlmixr2global$nlmixr2SimInfo$dfObs,
-             "` from the number of observations in fitted model"))
+      .minfo(paste0(
+        "using `dfObs=", nlmixr2global$nlmixr2SimInfo$dfObs,
+        "` from the number of observations in fitted model"
+      ))
       .rxControl$dfObs <- nlmixr2global$nlmixr2SimInfo$dfObs
     }
     if (.rxControl$dfSub == 0L & !.isPred) {
-      .minfo(paste0("using `dfSub=", nlmixr2global$nlmixr2SimInfo$dfSub,
-             "` from the number of subjects in fitted model"))
+      .minfo(paste0(
+        "using `dfSub=", nlmixr2global$nlmixr2SimInfo$dfSub,
+        "` from the number of subjects in fitted model"
+      ))
       .rxControl$dfSub <- nlmixr2global$nlmixr2SimInfo$dfSub
     }
 
@@ -58,29 +62,29 @@
       .rxControl$sigma <- nlmixr2global$nlmixr2SimInfo$sigma
     }
   }
-  if (exists("table", envir=env) &&
-        !is.null(env$table)) {
+  if (exists("table", envir = env) &&
+    !is.null(env$table)) {
     .table <- env$table
-    if (checkmate::testLogical(.table$covariates, any.missing=FALSE, len=1) &&
-          !.table$covariates && .rxControl$addCov) {
+    if (checkmate::testLogical(.table$covariates, any.missing = FALSE, len = 1) &&
+      !.table$covariates && .rxControl$addCov) {
       .rxControl$addCov <- FALSE
     }
-    if (checkmate::testLogical(.table$addDosing, any.missing=FALSE, len=1) &&
-        .table$addDosing && !.rxControl$addDosing) {
+    if (checkmate::testLogical(.table$addDosing, any.missing = FALSE, len = 1) &&
+      .table$addDosing && !.rxControl$addDosing) {
       .rxControl$addDosing <- TRUE
     }
-    if (checkmate::testLogical(.table$subsetNonmem, any.missing=FALSE, len=1) &&
-          !.table$subsetNonmem && .rxControl$subsetNonmem) {
+    if (checkmate::testLogical(.table$subsetNonmem, any.missing = FALSE, len = 1) &&
+      !.table$subsetNonmem && .rxControl$subsetNonmem) {
       .rxControl$subsetNonmem <- FALSE
     }
-    if (checkmate::testIntegerish(.table$cores, len=1, lower=1, any.missing=FALSE)) {
-      .rxControl$cores <-.table$cores
+    if (checkmate::testIntegerish(.table$cores, len = 1, lower = 1, any.missing = FALSE)) {
+      .rxControl$cores <- .table$cores
     }
-    if (checkmate::testCharacter(.table$keep, any.missing=FALSE)) {
+    if (checkmate::testCharacter(.table$keep, any.missing = FALSE)) {
       .keep <- unique(c(.table$keep, .rxControl$keep))
       .rxControl$keep <- .keep
     }
-    if (checkmate::testCharacter(.table$drop, any.missing=FALSE)) {
+    if (checkmate::testCharacter(.table$drop, any.missing = FALSE)) {
       .drop <- unique(c(.table$drop, .rxControl$drop))
       .rxControl$drop <- .drop
     }
@@ -103,53 +107,62 @@ nmObjGet.rxControlWithVar <- function(x, ...) {
     .oldControl <- get("control", .env)
     on.exit({
       nlmixr2global$nlmixr2SimInfo <- NULL
-      assign("control", .oldControl, envir=.env)})
+      assign("control", .oldControl, envir = .env)
+    })
     if (!inherits(.oldControl, "rxControl")) {
       .rxControl <- nmObjGet.rxControl(x, ...)
     } else {
       .rxControl <- .oldControl
     }
-    assign("control", .rxControl, envir=.env)
+    assign("control", .rxControl, envir = .env)
   } else {
     .rxControl <- nmObjGet.rxControl(x, ...)
-    assign("control", .rxControl, envir=.env)
+    assign("control", .rxControl, envir = .env)
     on.exit({
       nlmixr2global$nlmixr2SimInfo <- NULL
-      if (exists("control", envir=.env)) {
-        rm(list="control", envir=.env)
+      if (exists("control", envir = .env)) {
+        rm(list = "control", envir = .env)
       }
     })
   }
   .rxSolveGetControlForNlmixr(.env)
 }
 
-#'@rdname nlmixr2Est
-#'@export
+#' @rdname nlmixr2Est
+#' @export
 nlmixr2Est.rxSolve <- function(env, ...) {
-  .events <- get("data", envir=env)
-  do.call(rxode2::rxSolve, c(list(object = get("ui", envir=env), params = NULL,
-                                  events = .events, inits = NULL), .rxSolveGetControlForNlmixr(env),
-                             list(theta = NULL, eta = NULL)))
+  .events <- get("data", envir = env)
+  do.call(rxode2::rxSolve, c(
+    list(
+      object = get("ui", envir = env), params = NULL,
+      events = .events, inits = NULL
+    ), .rxSolveGetControlForNlmixr(env),
+    list(theta = NULL, eta = NULL)
+  ))
 }
 attr(nlmixr2Est.rxSolve, "covPresent") <- TRUE
 attr(nlmixr2Est.rxSolve, "unbounded") <- FALSE
 attr(nlmixr2Est.rxSolve, "random") <- TRUE
 
-#'@rdname nlmixr2Est
-#'@export
+#' @rdname nlmixr2Est
+#' @export
 nlmixr2Est.simulate <- function(env, ...) {
   .rxControl <- .rxSolveGetControlForNlmixr(env)
-  .events <- get("data", envir=env)
-  do.call(rxode2::rxSolve, c(list(object = get("ui", envir=env), params = NULL,
-                                  events = .events, inits = NULL), .rxSolveGetControlForNlmixr(env),
-                             list(theta = NULL, eta = NULL)))
+  .events <- get("data", envir = env)
+  do.call(rxode2::rxSolve, c(
+    list(
+      object = get("ui", envir = env), params = NULL,
+      events = .events, inits = NULL
+    ), .rxSolveGetControlForNlmixr(env),
+    list(theta = NULL, eta = NULL)
+  ))
 }
 attr(nlmixr2Est.simulate, "covPresent") <- TRUE
 attr(nlmixr2Est.simulate, "unbounded") <- FALSE
 attr(nlmixr2Est.simulate, "random") <- TRUE
 
-#'@rdname nlmixr2Est
-#'@export
+#' @rdname nlmixr2Est
+#' @export
 nlmixr2Est.simulation <- function(env, ...) {
   .nlmixr2clearPipe()
   nlmixr2global$nlmixr2SimInfo <- NULL
@@ -159,18 +172,22 @@ nlmixr2Est.simulation <- function(env, ...) {
   })
   .rxControl <- .rxSolveGetControlForNlmixr(env)
   env$control <- .rxControl
-  .events <- get("data", envir=env)
-  do.call(rxode2::rxSolve, c(list(object = get("ui", envir=env), params = NULL,
-                                  events = .events, inits = NULL), .rxControl,
-                             list(theta = NULL, eta = NULL)))
+  .events <- get("data", envir = env)
+  do.call(rxode2::rxSolve, c(
+    list(
+      object = get("ui", envir = env), params = NULL,
+      events = .events, inits = NULL
+    ), .rxControl,
+    list(theta = NULL, eta = NULL)
+  ))
 }
 attr(nlmixr2Est.simulation, "covPresent") <- TRUE
 attr(nlmixr2Est.simulation, "unbounded") <- FALSE
 attr(nlmixr2Est.simulation, "random") <- TRUE
 
 
-#'@rdname nlmixr2Est
-#'@export
+#' @rdname nlmixr2Est
+#' @export
 nlmixr2Est.predict <- function(env, ...) {
   .nlmixr2clearPipe()
   nlmixr2global$nlmixr2SimInfo <- NULL
@@ -181,12 +198,14 @@ nlmixr2Est.predict <- function(env, ...) {
   .rxControl <- .rxSolveGetControlForNlmixr(env)
   .rxControl$omega <- NA
   .rxControl$sigma <- NA
-  .events <- get("data", envir=env)
+  .events <- get("data", envir = env)
   if (is.na(.rxControl$simVariability)) {
     .rxControl$simVariability <- FALSE
   }
-  nlmixr2(object=get("ui", envir=env), data=.events,
-          est="rxSolve", control=.rxControl)
+  nlmixr2(
+    object = get("ui", envir = env), data = .events,
+    est = "rxSolve", control = .rxControl
+  )
 }
 attr(nlmixr2Est.predict, "covPresent") <- TRUE
 attr(nlmixr2Est.predict, "unbounded") <- FALSE
@@ -203,9 +222,11 @@ attr(nlmixr2Est.predict, "random") <- TRUE
   .both <- both
   if (!any(names(.both$rest) == "newdata")) {
     .w <- which(vapply(seq_along(.both$rest),
-                       function(i) {
-                         inherits(.both$rest[[i]], "data.frame")
-                       }, logical(1), USE.NAMES=FALSE))
+      function(i) {
+        inherits(.both$rest[[i]], "data.frame")
+      }, logical(1),
+      USE.NAMES = FALSE
+    ))
     if (length(.w) == 1L) {
       names(.both$rest)[1] <- "newdata"
     }
@@ -231,53 +252,55 @@ attr(nlmixr2Est.predict, "random") <- TRUE
 #' @export
 #'
 #' @examples
-#'
 #' \donttest{
 #'
 #' one.compartment <- function() {
-#'  ini({
-#'   tka <- log(1)
-#'   tcl <- log(10)
-#'   tv <- log(35)
-#'   eta.ka ~ 0.1
-#'   eta.cl ~ 0.1
-#'   eta.v ~ 0.1
-#'   add.sd <- 0.1
-#'  })
-#'  model({
-#'   ka <- exp(tka + eta.ka)
-#'   cl <- exp(tcl + eta.cl)
-#'   v <- exp(tv + eta.v)
-#'   d/dt(depot) = -ka * depot
-#'   d/dt(center) = ka * depot - cl / v * center
-#'   cp = center / v
-#'   cp ~ add(add.sd)
-#'  })
+#'   ini({
+#'     tka <- log(1)
+#'     tcl <- log(10)
+#'     tv <- log(35)
+#'     eta.ka ~ 0.1
+#'     eta.cl ~ 0.1
+#'     eta.v ~ 0.1
+#'     add.sd <- 0.1
+#'   })
+#'   model({
+#'     ka <- exp(tka + eta.ka)
+#'     cl <- exp(tcl + eta.cl)
+#'     v <- exp(tv + eta.v)
+#'     d / dt(depot) <- -ka * depot
+#'     d / dt(center) <- ka * depot - cl / v * center
+#'     cp <- center / v
+#'     cp ~ add(add.sd)
+#'   })
 #' }
 #'
 #' # The fit is performed by the function nlmixr/nlmix2 specifying
 #' # the model, data and estimate
-#' fit <- nlmixr2(one.compartment, theo_sd, est = "focei",
-#'                foceiControl(maxOuterIterations = 0L))
+#' fit <- nlmixr2(one.compartment, theo_sd,
+#'   est = "focei",
+#'   foceiControl(maxOuterIterations = 0L)
+#' )
 #'
 #' # Population predictions
-#' ppred <- predict(fit, theo_sd, level="population")
+#' ppred <- predict(fit, theo_sd, level = "population")
 #'
 #' # Individual predictions
-#' ipred <- predict(fit, theo_sd, level="individual")
-#'
+#' ipred <- predict(fit, theo_sd, level = "individual")
 #' }
 #'
 predict.nlmixr2FitCore <- function(object, ...,
                                    level = c("population", "individual")) {
-  if (checkmate::testNumeric(level, len=1)) {
+  if (checkmate::testNumeric(level, len = 1)) {
     level <- switch(as.character(level),
-                    "0" = "population",
-                    "1" = "individual",
-                    "bad")
+      "0" = "population",
+      "1" = "individual",
+      "bad"
+    )
     if (identical(level, "bad")) {
       stop("level numeric must be 0 (population) or 1 (individual)",
-           call.=FALSE)
+        call. = FALSE
+      )
     }
   }
   if (identical(level, "ipred")) {
@@ -304,7 +327,7 @@ predict.nlmixr2FitCore <- function(object, ...,
     .minfo("population predictions requested (`level=\"population\"`)")
   }
 
-  .both <- .getNewData(.getControlFromDots(rxode2::rxControl(envir=.env), ...))
+  .both <- .getNewData(.getControlFromDots(rxode2::rxControl(envir = .env), ...))
   if (.est != "ipred") {
     .both$ctl$omega <- NA
     .both$ctl$sigma <- NA
@@ -323,11 +346,15 @@ predict.nlmixr2FitCore <- function(object, ...,
   }
   if (.est == "ipred") {
     .params <- .nlmixrGetIpredParams(object)
-    do.call(rxode2::rxSolve,
-            c(list(object, .params, .data), .rxControl))
+    do.call(
+      rxode2::rxSolve,
+      c(list(object, .params, .data), .rxControl)
+    )
   } else {
-    nlmixr2(object=object, data=.data,
-            est=.est, control=.rxControl)
+    nlmixr2(
+      object = object, data = .data,
+      est = .est, control = .rxControl
+    )
   }
 }
 
@@ -343,13 +370,15 @@ simulate.nlmixr2FitCore <- function(object, ...) {
   if (!is.environment(.env)) {
     .env <- parent.frame(1)
   }
-  .both <- .getNewData(.getControlFromDots(rxode2::rxControl(envir=.env), ...))
+  .both <- .getNewData(.getControlFromDots(rxode2::rxControl(envir = .env), ...))
   .rxControl <- do.call(rxode2::rxControl, .both$ctl)
   .rxControl$envir <- .env
   if (inherits(.both$rest$newdata, "data.frame")) {
-    nlmixr2(object=object, data=.both$rest$newdata,
-            est="rxSolve", control=.rxControl)
+    nlmixr2(
+      object = object, data = .both$rest$newdata,
+      est = "rxSolve", control = .rxControl
+    )
   } else {
-    nlmixr2(object=object, est="rxSolve", control=.rxControl)
+    nlmixr2(object = object, est = "rxSolve", control = .rxControl)
   }
 }

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -32,7 +32,11 @@
       .isPred <- TRUE
     }
   }
-  if (!is.null(nlmixr2global$nlmixr2SimInfo)) {
+  ## every use below is conditional on `!.isPred`, so ask for the simulation
+  ## information only when it can actually be used -- on the `rxSolve()` path
+  ## it is a promise, and forcing it re-derives the model from the fit
+  ## (nlmixr2/rxode2#1289)
+  if (!.isPred && !is.null(nlmixr2global$nlmixr2SimInfo)) {
     .thetaMat <- nlmixr2global$nlmixr2SimInfo$thetaMat
     if (is.null(.rxControl$thetaMat) & !.isPred) {
       .minfo("using population uncertainty from fitted model (`thetaMat`)")
@@ -88,7 +92,12 @@
 ##' @export
 nmObjGet.rxControlWithVar <- function(x, ...) {
   .tmp <- x[[1]]
-  nlmixr2global$nlmixr2SimInfo <- .tmp$simInfo
+  ## `$simInfo` re-runs the pre-process hooks and re-derives the simulation
+  ## model from the fit, which is the bulk of the cost of solving a fit and
+  ## grows process memory that is never returned (nlmixr2/rxode2#1289).  Only
+  ## simulations that use the model's uncertainty read it, so hand
+  ## `.rxSolveGetControlForNlmixr()` a promise and let it decide.
+  delayedAssign("nlmixr2SimInfo", .tmp$simInfo, assign.env = nlmixr2global)
   .env <- .tmp$env
   if (exists("control", .env)) {
     .oldControl <- get("control", .env)

--- a/R/simModelCache.R
+++ b/R/simModelCache.R
@@ -31,15 +31,23 @@
 #' @return the fit's `ui` object, or `NULL` when the value should not be cached
 #' @noRd
 .simModelCacheKey <- function(env) {
-  if (!isTRUE(getOption("nlmixr2.simModelCache", TRUE))) return(NULL)
-  if (!is.environment(env)) return(NULL)
-  if (!exists("ui", envir = env, inherits = FALSE)) return(NULL)
+  if (!isTRUE(getOption("nlmixr2.simModelCache", TRUE))) {
+    return(NULL)
+  }
+  if (!is.environment(env)) {
+    return(NULL)
+  }
+  if (!exists("ui", envir = env, inherits = FALSE)) {
+    return(NULL)
+  }
   .ui <- get("ui", envir = env, inherits = FALSE)
   ## a fit holds a compressed ui, which has value semantics: replacing the
   ## model replaces the object, and that is what invalidates the entry.  An
   ## uncompressed ui is an environment, which could be edited in place behind
   ## the cache's back, so it is not a key that can be trusted.
-  if (is.environment(.ui)) return(NULL)
+  if (is.environment(.ui)) {
+    return(NULL)
+  }
   .ui
 }
 
@@ -71,8 +79,10 @@
 .simModelCacheSet <- function(ui, model) {
   .entries <- .simModelCache$entries
   .keep <- vapply(seq_along(.entries),
-                  function(i) !identical(.entries[[i]]$ui, ui),
-                  logical(1), USE.NAMES = FALSE)
+    function(i) !identical(.entries[[i]]$ui, ui),
+    logical(1),
+    USE.NAMES = FALSE
+  )
   .entries <- c(list(list(ui = ui, model = model)), .entries[.keep])
   if (length(.entries) > .simModelCacheMax) {
     .entries <- .entries[seq_len(.simModelCacheMax)]

--- a/R/simModelCache.R
+++ b/R/simModelCache.R
@@ -1,0 +1,94 @@
+## Cache of lowered simulation models, keyed on the fitted model
+##
+## `rxode2::rxSolve()` on a fit asks the fit for `$simulationModel` on every
+## call, and lowering the fit to an rxode2 model is neither cheap nor free of
+## side effects: for an ODE model it is ~50 ms and a couple of MB of process
+## memory per call, and the memory is not given back by `gc()`,
+## `rxode2::rxUnloadAll()` or `rxode2::rxClean()`.  Simulating from a fit in a
+## loop therefore grew without bound (nlmixr2/rxode2#1289).
+##
+## The cache is keyed on the `ui` object held in the fit environment, and an
+## entry holds that `ui` -- never the fit -- so a cached entry cannot keep a
+## fit (and its data) alive.  The key is the entire model, structure *and*
+## final estimates, so two fits that share a key lower to the same simulation
+## model and can safely share the entry.  The lowered model is a pure function
+## of the `ui`, and piping/updating a fit builds a new `ui`, which is what
+## invalidates the entry.
+.simModelCache <- new.env(parent = emptyenv())
+.simModelCache$entries <- list()
+
+## Number of lowered models kept.  Each entry is only as large as the model
+## itself (a couple hundred KB for a typical PK model), and simulation loops
+## work on one fit at a time, so a small cache is enough to remove the
+## repeated lowering while bounding what the package holds onto.
+.simModelCacheMax <- 5L
+
+#' Key used to cache the lowered simulation model of a fit
+#'
+#' @param env object handed to `nmObjGet.simulationModel()`, that is the
+#'   environment of a nlmixr2 fit.  Anything else (including a bare `rxUi`,
+#'   which is an environment without a `ui` binding) is not cached.
+#' @return the fit's `ui` object, or `NULL` when the value should not be cached
+#' @noRd
+.simModelCacheKey <- function(env) {
+  if (!isTRUE(getOption("nlmixr2.simModelCache", TRUE))) return(NULL)
+  if (!is.environment(env)) return(NULL)
+  if (!exists("ui", envir = env, inherits = FALSE)) return(NULL)
+  .ui <- get("ui", envir = env, inherits = FALSE)
+  ## a fit holds a compressed ui, which has value semantics: replacing the
+  ## model replaces the object, and that is what invalidates the entry.  An
+  ## uncompressed ui is an environment, which could be edited in place behind
+  ## the cache's back, so it is not a key that can be trusted.
+  if (is.environment(.ui)) return(NULL)
+  .ui
+}
+
+#' Get a cached lowered simulation model
+#'
+#' @param ui key from [.simModelCacheKey()]
+#' @return the cached model, or `NULL` when this model has not been lowered yet
+#' @noRd
+.simModelCacheGet <- function(ui) {
+  .entries <- .simModelCache$entries
+  for (.i in seq_along(.entries)) {
+    if (identical(.entries[[.i]]$ui, ui)) {
+      if (.i != 1L) {
+        # most recently used first, so the least recently used falls off the end
+        .simModelCache$entries <- c(.entries[.i], .entries[-.i])
+      }
+      return(.entries[[.i]]$model)
+    }
+  }
+  NULL
+}
+
+#' Cache a lowered simulation model
+#'
+#' @param ui key from [.simModelCacheKey()]
+#' @param model lowered rxode2 simulation model
+#' @return `model`, invisibly
+#' @noRd
+.simModelCacheSet <- function(ui, model) {
+  .entries <- .simModelCache$entries
+  .keep <- vapply(seq_along(.entries),
+                  function(i) !identical(.entries[[i]]$ui, ui),
+                  logical(1), USE.NAMES = FALSE)
+  .entries <- c(list(list(ui = ui, model = model)), .entries[.keep])
+  if (length(.entries) > .simModelCacheMax) {
+    .entries <- .entries[seq_len(.simModelCacheMax)]
+  }
+  .simModelCache$entries <- .entries
+  invisible(model)
+}
+
+#' Empty the lowered simulation model cache
+#'
+#' Only needed when measuring the cache itself; the cache is keyed on the
+#' fitted model, so a stale entry cannot be returned for a changed model.
+#'
+#' @return nothing, called for the side effect
+#' @noRd
+.simModelCacheReset <- function() {
+  .simModelCache$entries <- list()
+  invisible()
+}

--- a/bench/lincmt_setup_floor_profile.R
+++ b/bench/lincmt_setup_floor_profile.R
@@ -28,31 +28,43 @@ set.seed(1002003)
 simTimes <- c(0.25, 0.75, 1.5, 3, 5.5, 8, 12.5, 17, 24, 32)
 nSub <- 40L
 eta <- matrix(rnorm(nSub * 3L, 0, 0.3), nSub, 3L,
-              dimnames = list(NULL, c("ka", "cl", "v")))
+  dimnames = list(NULL, c("ka", "cl", "v"))
+)
 simMod <- rxode2::rxode2(
-  "cp = central/v; d/dt(depot) = -ka*depot; d/dt(central) = ka*depot - cl/v*central")
-pars <- data.frame(ka = 1.2 * exp(eta[, "ka"]), cl = 4 * exp(eta[, "cl"]),
-                   v = 30 * exp(eta[, "v"]))
+  "cp = central/v; d/dt(depot) = -ka*depot; d/dt(central) = ka*depot - cl/v*central"
+)
+pars <- data.frame(
+  ka = 1.2 * exp(eta[, "ka"]), cl = 4 * exp(eta[, "cl"]),
+  v = 30 * exp(eta[, "v"])
+)
 ev <- rxode2::et(amt = 100, cmt = "depot") |> rxode2::et(simTimes)
 sim <- rxode2::rxSolve(simMod, pars, ev, cores = 1L, addDosing = FALSE)
 set.seed(2003004)
-simDat <- data.frame(ID = rep(seq_len(nSub), each = length(simTimes)),
-                     TIME = sim$time,
-                     DV = sim$cp * (1 + rnorm(nrow(sim), 0, 0.15)),
-                     AMT = 0, EVID = 0, CMT = "central")
-doseRows <- data.frame(ID = seq_len(nSub), TIME = 0, DV = NA_real_,
-                       AMT = 100, EVID = 1, CMT = "depot")
+simDat <- data.frame(
+  ID = rep(seq_len(nSub), each = length(simTimes)),
+  TIME = sim$time,
+  DV = sim$cp * (1 + rnorm(nrow(sim), 0, 0.15)),
+  AMT = 0, EVID = 0, CMT = "central"
+)
+doseRows <- data.frame(
+  ID = seq_len(nSub), TIME = 0, DV = NA_real_,
+  AMT = 100, EVID = 1, CMT = "depot"
+)
 dat <- rbind(doseRows, simDat)
 dat <- dat[order(dat$ID, dat$TIME, -dat$EVID), ]
 if (useCov) {
-  dat$wt <- 60 + 20 * (dat$ID %% 3L) / 2  # constant within subject
+  dat$wt <- 60 + 20 * (dat$ID %% 3L) / 2 # constant within subject
 }
 
 # nolint start: object_usage_linter. (rxode2 ini/model DSL assignments)
 uiLin <- function() {
   ini({
-    lka <- log(1.44); lcl <- log(4.8); lv <- log(36)
-    eta.ka ~ 0.1; eta.cl ~ 0.1; eta.v ~ 0.1
+    lka <- log(1.44)
+    lcl <- log(4.8)
+    lv <- log(36)
+    eta.ka ~ 0.1
+    eta.cl ~ 0.1
+    eta.v ~ 0.1
     prop.sd <- 0.2
   })
   model({
@@ -65,8 +77,12 @@ uiLin <- function() {
 }
 uiLinCov <- function() {
   ini({
-    lka <- log(1.44); lcl <- log(4.8); lv <- log(36)
-    eta.ka ~ 0.1; eta.cl ~ 0.1; eta.v ~ 0.1
+    lka <- log(1.44)
+    lcl <- log(4.8)
+    lv <- log(36)
+    eta.ka ~ 0.1
+    eta.cl ~ 0.1
+    eta.v ~ 0.1
     prop.sd <- 0.2
   })
   model({
@@ -85,21 +101,25 @@ if (useCov) {
 
 ctlPost <- nlmixr2est::foceiControl(
   calcTables = FALSE, print = 0L, covMethod = "", maxOuterIterations = 0L,
-  rxControl = rxode2::rxControl(cores = 1L, linCmtSensType = "AD"))
+  rxControl = rxode2::rxControl(cores = 1L, linCmtSensType = "AD")
+)
 
 fitOnce <- function() {
   t0 <- proc.time()[["elapsed"]]
   suppressWarnings(suppressMessages(
-    nlmixr2est::nlmixr2(uiLin, dat, est = "focei", control = ctlPost)))
+    nlmixr2est::nlmixr2(uiLin, dat, est = "focei", control = ctlPost)
+  ))
   c(sec = proc.time()[["elapsed"]] - t0)
 }
 
 ## ---- cold vs warm wall times --------------------------------------------
 secs <- numeric(0)
-for (r in seq_len(nRep + 1L)) secs[r] <- fitOnce()  # rep 1 = cold (compiles)
-cat(sprintf("cold (rep1, incl. compile): %.3f s\nwarm reps: %s (median %.3f s)\n",
-            secs[1], paste(sprintf("%.3f", secs[-1]), collapse = ", "),
-            stats::median(secs[-1])))
+for (r in seq_len(nRep + 1L)) secs[r] <- fitOnce() # rep 1 = cold (compiles)
+cat(sprintf(
+  "cold (rep1, incl. compile): %.3f s\nwarm reps: %s (median %.3f s)\n",
+  secs[1], paste(sprintf("%.3f", secs[-1]), collapse = ", "),
+  stats::median(secs[-1])
+))
 
 ## ---- Rprof one warm repeat ----------------------------------------------
 prof <- tempfile(fileext = ".out")
@@ -122,14 +142,19 @@ anchor <- c(
   etTransData  = "etTrans",
   foceiSetup   = "foceiSetup",
   innerEval    = "foceiInner|\\.Call.*Inner|foceiOuterF",
-  tableTear    = "focei\\.theta|nlmixr2CreateOutputFromUi|\\.foceiFitInternal")
+  tableTear    = "focei\\.theta|nlmixr2CreateOutputFromUi|\\.foceiFitInternal"
+)
 cat("\n-- anchor by.total seconds (overlapping; interpret with the tables above) --\n")
 rn <- rownames(s$by.total)
 for (a in names(anchor)) {
   hit <- grepl(anchor[[a]], rn)
   if (any(hit)) {
-    cat(sprintf("%-14s max(by.total)=%6.3f s  fns: %s\n", a,
-                max(s$by.total$total.time[hit]),
-                paste(utils::head(gsub("\"", "", rn[hit]), 3), collapse = ", ")))
-  } else cat(sprintf("%-14s (no samples)\n", a))
+    cat(sprintf(
+      "%-14s max(by.total)=%6.3f s  fns: %s\n", a,
+      max(s$by.total$total.time[hit]),
+      paste(utils::head(gsub("\"", "", rn[hit]), 3), collapse = ", ")
+    ))
+  } else {
+    cat(sprintf("%-14s (no samples)\n", a))
+  }
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -29,7 +29,7 @@ if (isTRUE(as.logical(Sys.getenv("NLMIXR2EST_TEST_CRAN_ONLY", "false")))) {
 }
 
 .onCran <- !identical(Sys.getenv("NOT_CRAN"), "true")
-.onCI   <- isTRUE(as.logical(Sys.getenv("CI", "false")))
+.onCI <- isTRUE(as.logical(Sys.getenv("CI", "false")))
 
 if (.onCI || .onCran) {
   options(Ncpus = 1L)
@@ -63,18 +63,24 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
 # under an hour; the slow-tests workflow runs them one at a time.
 .slowBatches <- list(
   # batch 1
-  c("focei-wang2007-boxcox", "focei-wang2007-combined", "vpcSim",
-    "qrpem-slow", "focei-foce-plus"),
+  c(
+    "focei-wang2007-boxcox", "focei-wang2007-combined", "vpcSim",
+    "qrpem-slow", "focei-foce-plus"
+  ),
   # batch 2
-  c("focei-wang2007-lognormal", "cov-analytic", "focei-wang2007-power",
-    "cov-condition", "agq-cov", "cov-decouple-saimp"),
+  c(
+    "focei-wang2007-lognormal", "cov-analytic", "focei-wang2007-power",
+    "cov-condition", "agq-cov", "cov-decouple-saimp"
+  ),
   # batch 3
-  c("focei-wang2007-boxcox-half", "nlm-cens", "focei-cens-t-fit",
+  c(
+    "focei-wang2007-boxcox-half", "nlm-cens", "focei-cens-t-fit",
     "issue-429", "issue-470",
     "focei-wang2007-bounded", "saem-loglik", "mu-timevarying", "saem-nearpd",
     "saem-nonmutheta", "focei-theta-reset-bounds",
     "saem-cov-analytic", "focei-shi21-bounds", "splitbolus-interp",
-    "optexpression-saem-nlme", "saem-cov-multi-endpoint-904"),
+    "optexpression-saem-nlme", "saem-cov-multi-endpoint-904"
+  ),
 
   # batches 4-7 -- the former batches 4 (13 files) and 5 (15 files), each split
   # in two.  Both TIMED OUT on the weekly runner (run 30688874991, 2026-08-01):
@@ -85,38 +91,52 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   # focei-wang2007-* file is kept in a separate batch -- one is ~10 error models
   # x 6 fits (ODE and solved-form) and dominates whatever batch it lands in.
   # batch 4
-  c("impmap", "matexp", "mfocei", "focei-wang2007-yeojohnson",
+  c(
+    "impmap", "matexp", "mfocei", "focei-wang2007-yeojohnson",
     "nlme", "focei-fast-grad", "lincmt-ode-fit", "focei-lincmt-carry-fit",
     "focei-lincmt-carry-fit-fallback", "focei-lincmt-carry-jump-fit",
     "focei-lincmt-carry-ll-fit",
-    "focei-lincmt-carry-theta-fit"),
+    "focei-lincmt-carry-theta-fit"
+  ),
   # batch 5
-  c("focei-wang2007-boxcox-lnorm", "nlme-cov", "agq-fast-grad",
+  c(
+    "focei-wang2007-boxcox-lnorm", "nlme-cov", "agq-fast-grad",
     "focei-ll-fast-grad-fit", "focei-fast-methods-fit", "odeswap-fit",
-    "focei-factr-fit"),
+    "focei-factr-fit"
+  ),
   # batch 6
-  c("focei-llik", "iov", "iov-zero-eta", "saem-mix", "saem-mix-regress",
-    "posthoc", "ar-est", "mu-family", "uninformative-etas-revisit"),
+  c(
+    "focei-llik", "iov", "iov-zero-eta", "saem-mix", "saem-mix-regress",
+    "posthoc", "ar-est", "mu-family", "uninformative-etas-revisit"
+  ),
   # batch 7
-  c("mu-plain-fit", "vae-fit", "focei-wang2007-basic", "vae-neonatal",
-    "vae-errmodel", "table-cmt", "vae-covariate-selection"),
+  c(
+    "mu-plain-fit", "vae-fit", "focei-wang2007-basic", "vae-neonatal",
+    "vae-errmodel", "table-cmt", "vae-covariate-selection"
+  ),
   # batch 8 -- heaviest remaining files on the single-worker CI runner
   # (VAE internals + a few slow structural tests), moved out of the essential
   # push/PR subset to trim its wall time / reclamation exposure.
-  c("vae-encoder", "vae-train", "vae-decoder", "vae-elbo", "vae-inner",
+  c(
+    "vae-encoder", "vae-train", "vae-decoder", "vae-elbo", "vae-inner",
     "vae-fixbounds", "vae-parhist", "vae-iov", "vae-grad-fit", "vae-ll-grad-fit",
-    "vae-l0learn-fit", "vae-hockey-fit", "split", "unary-mu", "timing", "bounded-transform"),
+    "vae-l0learn-fit", "vae-hockey-fit", "split", "unary-mu", "timing", "bounded-transform"
+  ),
   # batch 9 -- emvi/fbvi (variational inference) multi-iteration fits, plus the
   # cross-method omega off-diagonal fit checks (vae/emvi/npag/npb)
-  c("vi-repro", "vi-focei-agreement", "vi-neonatal", "vi-fullrank",
-    "vi-fullbayes", "vi-stan", "omega-offdiag", "augpred", "vae-residopt"),
+  c(
+    "vi-repro", "vi-focei-agreement", "vi-neonatal", "vi-fullrank",
+    "vi-fullbayes", "vi-stan", "omega-offdiag", "augpred", "vae-residopt"
+  ),
   # batch 10 -- nonparametric (npag/npb) fit-based validation.  These set up the
   # FOCEi inner problem and run full NPAG cycles / independent solves, so they are
   # much slower than the essential npag unit tests (dispatch/ipm/grid, which stay
   # in the push/PR subset) and run weekly only.
-  c("npag-psi", "npag-cycle", "npag-fit", "npb-fit", "npag-bimodal", "npag-fixed",
+  c(
+    "npag-psi", "npag-cycle", "npag-fit", "npb-fit", "npag-bimodal", "npag-fixed",
     "npag-error-models", "npag-mixture", "npag-general-lik", "npag-muexpand",
-    "npag-golden", "lik-contrib-methods", "npag-npb-cens-978")
+    "npag-golden", "lik-contrib-methods", "npag-npb-cens-978"
+  )
 )
 .slowAll <- unlist(.slowBatches)
 
@@ -127,12 +147,14 @@ if (nzchar(.batch)) {
   # Slow-batch mode: run ONLY this batch's slow files.
   .b <- suppressWarnings(as.integer(.batch))
   if (is.na(.b) || .b < 1L || .b > length(.slowBatches)) {
-    stop(sprintf("NLMIXR2EST_TEST_BATCH=%s out of range (1..%d)",
-                 .batch, length(.slowBatches)))
+    stop(sprintf(
+      "NLMIXR2EST_TEST_BATCH=%s out of range (1..%d)",
+      .batch, length(.slowBatches)
+    ))
   }
   .files <- .slowBatches[[.b]]
   if (length(.files) == 0L) {
-    .filter <- "^$"  # empty batch: match nothing
+    .filter <- "^$" # empty batch: match nothing
   } else {
     .filter <- paste0("^(", paste(.files, collapse = "|"), ")$")
   }
@@ -148,14 +170,17 @@ if (nzchar(.batch)) {
   .shard <- Sys.getenv("NLMIXR2EST_TEST_SHARD")
   if (nzchar(.shard)) {
     .p <- strsplit(.shard, "/", fixed = TRUE)[[1]]
-    .i <- suppressWarnings(as.integer(.p[1])); .n <- suppressWarnings(as.integer(.p[2]))
+    .i <- suppressWarnings(as.integer(.p[1]))
+    .n <- suppressWarnings(as.integer(.p[2]))
     if (length(.p) != 2L || is.na(.i) || is.na(.n) || .n < 1L || .i < 1L || .i > .n) {
       stop(sprintf("NLMIXR2EST_TEST_SHARD=%s must be \"i/n\" with 1 <= i <= n", .shard))
     }
     # Deal the files out round-robin over a SORTED list so the split is stable
     # across jobs and platforms, and every file lands in exactly one shard.
-    .all <- sort(sub("^test-", "", sub("\\.R$", "",
-                                       basename(Sys.glob(file.path("testthat", "test-*.R"))))))
+    .all <- sort(sub("^test-", "", sub(
+      "\\.R$", "",
+      basename(Sys.glob(file.path("testthat", "test-*.R")))
+    )))
     .ess <- setdiff(.all, .slowAll)
     # An empty list would make every shard match nothing and report a green run
     # having tested nothing at all -- fail loudly instead.
@@ -163,8 +188,11 @@ if (nzchar(.batch)) {
       stop("NLMIXR2EST_TEST_SHARD set but no test files found in ./testthat")
     }
     .mine <- .ess[seq_along(.ess) %% .n == (.i %% .n)]
-    .filter <- if (length(.mine) == 0L) "^$" else
+    .filter <- if (length(.mine) == 0L) {
+      "^$"
+    } else {
       paste0("^(", paste(.mine, collapse = "|"), ")$")
+    }
   } else {
     .filter <- paste0("^(?!(", paste(.slowAll, collapse = "|"), ")$)")
   }

--- a/tests/testthat/helper-lincmt-carry-ll.R
+++ b/tests/testthat/helper-lincmt-carry-ll.R
@@ -96,5 +96,7 @@
   ev
 }
 
-.carryLlPars <- c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
-                  `ETA[1]` = 0.3)
+.carryLlPars <- c(
+  `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
+  `ETA[1]` = 0.3
+)

--- a/tests/testthat/helper-lincmt-carry.R
+++ b/tests/testthat/helper-lincmt-carry.R
@@ -112,11 +112,13 @@
 # Non-uniform dose/observation spacing with a within-subject wt change
 # (uniform spacing has hidden real pairing bugs in this effort before).
 .carryEv <- function() {
-  .ev <- data.frame(id = 1,
-                    time = c(0, 3, 7, 15, 24, 30, 41, 50),
-                    amt = c(100, 0, 100, 0, 100, 0, 100, 0),
-                    evid = c(1, 0, 1, 0, 1, 0, 1, 0),
-                    cmt = 1)
+  .ev <- data.frame(
+    id = 1,
+    time = c(0, 3, 7, 15, 24, 30, 41, 50),
+    amt = c(100, 0, 100, 0, 100, 0, 100, 0),
+    evid = c(1, 0, 1, 0, 1, 0, 1, 0),
+    cmt = 1
+  )
   .ev$wt <- ifelse(.ev$time < 20, 70, ifelse(.ev$time < 40, 85, 100))
   .ev
 }
@@ -125,9 +127,11 @@
 .carryFitDat <- function(nid = 6L) {
   do.call(rbind, lapply(seq_len(nid), function(i) {
     tim <- c(0, 3, 7, 15, 24, 30, 41, 50) + (i - 1) * 0.5
-    d <- data.frame(id = i, time = tim,
-                    amt = c(100, 0, 100, 0, 100, 0, 100, 0),
-                    evid = c(1, 0, 1, 0, 1, 0, 1, 0), cmt = 1)
+    d <- data.frame(
+      id = i, time = tim,
+      amt = c(100, 0, 100, 0, 100, 0, 100, 0),
+      evid = c(1, 0, 1, 0, 1, 0, 1, 0), cmt = 1
+    )
     w0 <- 60 + 5 * i
     d$wt <- ifelse(d$time < 20, w0, ifelse(d$time < 40, w0 + 15, w0 + 30))
     d
@@ -135,18 +139,22 @@
 }
 
 .carryFitCtl <- function(carry, maxOut = 0L) {
-  nlmixr2est::foceiControl(print = 0, maxOuterIterations = maxOut,
-                           covMethod = "", calcTables = FALSE,
-                           sigdig = 8, etaNudge = 0, etaNudge2 = 0,
-                           rxControl = rxode2::rxControl(covsInterpolation = "nocb"),
-                           linCmtSensCarry = carry)
+  nlmixr2est::foceiControl(
+    print = 0, maxOuterIterations = maxOut,
+    covMethod = "", calcTables = FALSE,
+    sigdig = 8, etaNudge = 0, etaNudge2 = 0,
+    rxControl = rxode2::rxControl(covsInterpolation = "nocb"),
+    linCmtSensCarry = carry
+  )
 }
 
 # Jump-channel fixtures shared by test-focei-lincmt-carry-jump.R and
 # test-focei-lincmt-carry-trans.R
-.carryJumpPars <- c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1.2),
-                    `THETA[4]` = -0.5, `THETA[5]` = log(0.5), `THETA[6]` = 0.5,
-                    `ETA[1]` = 0.3, `ETA[2]` = -0.2, `ETA[3]` = 0.1)
+.carryJumpPars <- c(
+  `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1.2),
+  `THETA[4]` = -0.5, `THETA[5]` = log(0.5), `THETA[6]` = 0.5,
+  `ETA[1]` = 0.3, `ETA[2]` = -0.2, `ETA[3]` = 0.1
+)
 
 # max relative error of every eta's substituted gradient vs central FD
 .carryJumpFd <- function(mod, pars, ev, carry = "auto", interp = "nocb") { # nolint: object_usage_linter.
@@ -156,16 +164,20 @@
   txt <- suppressMessages(u$foceiEnv)$..inner
   m <- suppressWarnings(rxode2::rxode2(txt))
   slv <- function(q) {
-    rxode2::rxSolve(m, params = q, events = ev, returnType = "data.frame",
-                    covsInterpolation = interp)
+    rxode2::rxSolve(m,
+      params = q, events = ev, returnType = "data.frame",
+      covsInterpolation = interp
+    )
   }
   r0 <- slv(pars)
   h <- 1e-5
   neta <- sum(grepl("^ETA", names(pars)))
   err <- vapply(seq_len(neta), function(k) {
     en <- paste0("ETA[", k, "]")
-    a <- pars; a[en] <- a[en] + h
-    b <- pars; b[en] <- b[en] - h
+    a <- pars
+    a[en] <- a[en] + h
+    b <- pars
+    b[en] <- b[en] - h
     fd <- (slv(a)$rx_pred_ - slv(b)$rx_pred_) / (2 * h)
     got <- r0[[paste0("rx__sens_rx_pred__BY_ETA_", k, "___")]]
     max(abs(got - fd) / (abs(fd) + 1e-8))

--- a/tests/testthat/test-cov-focei.R
+++ b/tests/testthat/test-cov-focei.R
@@ -30,13 +30,13 @@ nmTest({
         ktr <- 6 / mtt
 
         ## ODE example
-        d / dt(depot) <- -ktr * depot
-        d / dt(central) <- ktr * trans5 - (cl / v) * central
-        d / dt(trans1) <- ktr * depot - ktr * trans1
-        d / dt(trans2) <- ktr * trans1 - ktr * trans2
-        d / dt(trans3) <- ktr * trans2 - ktr * trans3
-        d / dt(trans4) <- ktr * trans3 - ktr * trans4
-        d / dt(trans5) <- ktr * trans4 - ktr * trans5
+        d/dt(depot) <- -ktr * depot
+        d/dt(central) <- ktr * trans5 - (cl / v) * central
+        d/dt(trans1) <- ktr * depot - ktr * trans1
+        d/dt(trans2) <- ktr * trans1 - ktr * trans2
+        d/dt(trans3) <- ktr * trans2 - ktr * trans3
+        d/dt(trans4) <- ktr * trans3 - ktr * trans4
+        d/dt(trans5) <- ktr * trans4 - ktr * trans5
 
         ## Concentration is calculated
         cp <- central / v

--- a/tests/testthat/test-fix-cov.R
+++ b/tests/testthat/test-fix-cov.R
@@ -16,8 +16,8 @@ nmTest({
       ka <- exp(tka + eta.ka)
       cl <- exp(tcl + eta.cl + wt.cl*logWt70 + sexf.cl*sexf)
       v <- exp(tv + eta.v + wt.v2*logWt70)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       ipre <- center / v
       ipre ~ add(add.sd)
     })
@@ -55,8 +55,8 @@ nmTest({
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl + eta.cl + wt.cl*logWt70 + sexf.cl*sexf)
         v <- exp(tv + eta.v + wt.v2*logWt70)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         ipre <- center / v
         ipre ~ add(add.sd)
       })
@@ -96,8 +96,8 @@ nmTest({
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl + eta.cl + wt.cl*logWt70 + sexf.cl*sexf)
         v <- exp(tv + eta.v + wt.v2*logWt70)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         ipre <- center / v
         ipre ~ add(add.sd)
       })
@@ -144,8 +144,8 @@ nmTest({
           ka <- exp(tka + eta.ka)
           cl <- exp(tcl + eta.cl + wt.cl*logWt70 + sexf.cl*sexf)
           v <- exp(tv + eta.v + wt.v2*logWt70)
-          d / dt(depot) <- -ka * depot
-          d / dt(center) <- ka * depot - cl / v * center
+          d/dt(depot) <- -ka * depot
+          d/dt(center) <- ka * depot - cl / v * center
           ipre <- center / v
           ipre ~ add(add.sd)
         })

--- a/tests/testthat/test-focei-cores-fresh-rx.R
+++ b/tests/testthat/test-focei-cores-fresh-rx.R
@@ -44,8 +44,8 @@ nmTest({
             ka <- exp(tka + eta.ka)
             cl <- exp(tcl + eta.cl)
             v <- exp(tv + eta.v)
-            d / dt(depot) <- -ka * depot
-            d / dt(center) <- ka * depot - cl / v * center
+            d/dt(depot) <- -ka * depot
+            d/dt(center) <- ka * depot - cl / v * center
             cp <- center / v
             cp ~ add(add.sd)
           })

--- a/tests/testthat/test-focei-lincmt-adr-default.R
+++ b/tests/testthat/test-focei-lincmt-adr-default.R
@@ -6,13 +6,19 @@
 # must still reach the fit.
 test_that("a linCmt() FOCEi fit uses rxode2's forward-mode AD default", {
   skip_on_cran()
-  skip_if_not(exists("linCmtBSensTypesSeen", envir = asNamespace("rxode2")),
-              "rxode2 without linCmtBSensTypesSeen()")
+  skip_if_not(
+    exists("linCmtBSensTypesSeen", envir = asNamespace("rxode2")),
+    "rxode2 without linCmtBSensTypesSeen()"
+  )
   seen <- function() utils::getFromNamespace("linCmtBSensTypesSeen", "rxode2")(TRUE)
   one.cmt <- function() {
     ini({
-      tka <- 0.45; tcl <- log(c(0, 2.7, 100)); tv <- 3.45
-      eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+      tka <- 0.45
+      tcl <- log(c(0, 2.7, 100))
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
       add.sd <- 0.7
     })
     model({
@@ -23,13 +29,16 @@ test_that("a linCmt() FOCEi fit uses rxode2's forward-mode AD default", {
     })
   }
   ctl <- function(st) {
-    foceiControl(print = 0, maxOuterIterations = 0L, covMethod = "",
-                 calcTables = FALSE, rxControl = rxode2::rxControl(linCmtSensType = st))
+    foceiControl(
+      print = 0, maxOuterIterations = 0L, covMethod = "",
+      calcTables = FALSE, rxControl = rxode2::rxControl(linCmtSensType = st)
+    )
   }
   fit <- function(st) {
     invisible(seen())
     f <- suppressWarnings(suppressMessages(
-      nlmixr2(one.cmt, nlmixr2data::theo_sd, est = "focei", control = ctl(st))))
+      nlmixr2(one.cmt, nlmixr2data::theo_sd, est = "focei", control = ctl(st))
+    ))
     list(objf = f$objf, seen = seen())
   }
   auto <- fit("auto")

--- a/tests/testthat/test-focei-lincmt-carry-eligible-gates.R
+++ b/tests/testthat/test-focei-lincmt-carry-eligible-gates.R
@@ -70,7 +70,7 @@ test_that("a mixed ODE + linCmt() model is never carry-eligible", {
       v <- exp(tv)
       kin <- exp(tkin) * exp(eta.kin)
       cp <- linCmt()
-      d / dt(eff) <- kin * cp - 0.5 * eff
+      d/dt(eff) <- kin * cp - 0.5 * eff
       cp ~ add(add.sd)
     })
   }

--- a/tests/testthat/test-focei-lincmt-carry-eligible-gates.R
+++ b/tests/testthat/test-focei-lincmt-carry-eligible-gates.R
@@ -19,12 +19,14 @@ test_that("data confirms or refutes a candidate; linear interpolation errors onl
       cp ~ add(add.sd)
     })
   }
-  .datVary <- data.frame(id = rep(1:2, each = 4),
-                         time = rep(c(0, 12, 24, 36), 2),
-                         amt = rep(c(100, 0, 0, 0), 2),
-                         evid = rep(c(1, 0, 0, 0), 2),
-                         dv = rep(c(0, 1, 2, 1), 2),
-                         wt = rep(c(70, 70, 90, 90), 2))
+  .datVary <- data.frame(
+    id = rep(1:2, each = 4),
+    time = rep(c(0, 12, 24, 36), 2),
+    amt = rep(c(100, 0, 0, 0), 2),
+    evid = rep(c(1, 0, 0, 0), 2),
+    dv = rep(c(0, 1, 2, 1), 2),
+    wt = rep(c(70, 70, 90, 90), 2)
+  )
   .datConst <- .datVary
   .datConst$wt <- 70
 
@@ -39,12 +41,18 @@ test_that("data confirms or refutes a candidate; linear interpolation errors onl
   expect_false(.p$varying)
 
   # linear interpolation: error only when confirmed varying
-  expect_error(suppressMessages(
-    .foceiLinCmtCarryPairs(.mult, data = .datVary, interpolation = "linear")),
-    "linear")
-  expect_error(suppressMessages(
-    .foceiLinCmtCarryPairs(.mult, data = .datConst, interpolation = "linear")),
-    NA)
+  expect_error(
+    suppressMessages(
+      .foceiLinCmtCarryPairs(.mult, data = .datVary, interpolation = "linear")
+    ),
+    "linear"
+  )
+  expect_error(
+    suppressMessages(
+      .foceiLinCmtCarryPairs(.mult, data = .datConst, interpolation = "linear")
+    ),
+    NA
+  )
 })
 
 test_that("a mixed ODE + linCmt() model is never carry-eligible", {
@@ -62,7 +70,7 @@ test_that("a mixed ODE + linCmt() model is never carry-eligible", {
       v <- exp(tv)
       kin <- exp(tkin) * exp(eta.kin)
       cp <- linCmt()
-      d/dt(eff) <- kin * cp - 0.5 * eff
+      d / dt(eff) <- kin * cp - 0.5 * eff
       cp ~ add(add.sd)
     })
   }
@@ -109,8 +117,10 @@ test_that("a prediction wrapping the linCmt() value is carried through the outer
   ui <- nlmixr2est::nlmixr2(scaled)
   expect_equal(nrow(.foceiLinCmtCarryPairs(ui)), 1L)
   skip_if_not(.rxFoceiLinCmtCarryCapable())
-  pars <- c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
-            `ETA[1]` = 0.3)
+  pars <- c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
+    `ETA[1]` = 0.3
+  )
   r <- suppressWarnings(.carryJumpFd(scaled, pars, .carryEv(), "auto"))
   expect_lt(r$err, 1e-6)
   expect_true(grepl("rx_lcConc_~linCmtB(", r$txt, fixed = TRUE))
@@ -136,17 +146,21 @@ test_that("data-independent candidate pairs are memoized by the model digest", {
   expect_equal(.st3[["misses"]], 2L)
   expect_false(identical(.p1, .p3))
   # a data-dependent call bypasses the memo entirely (no counter movement)
-  .dat <- data.frame(id = rep(1:2, each = 3), time = rep(c(0, 12, 24), 2),
-                     amt = rep(c(100, 0, 0), 2), evid = rep(c(1, 0, 0), 2),
-                     dv = rep(c(0, 1, 2), 2), wt = rep(c(70, 90, 90), 2))
+  .dat <- data.frame(
+    id = rep(1:2, each = 3), time = rep(c(0, 12, 24), 2),
+    amt = rep(c(100, 0, 0), 2), evid = rep(c(1, 0, 0), 2),
+    dv = rep(c(0, 1, 2), 2), wt = rep(c(70, 90, 90), 2)
+  )
   .p4 <- .foceiLinCmtCarryPairs(.ui, data = .dat)
   .st4 <- .foceiLinCmtCarryMemoStats()
   expect_equal(.st4, .st3)
   expect_true(isTRUE(.p4$varying[1]))
   # a control that keys the digest (covsInterpolation) invalidates the entry
   .ui2 <- .carryUiCov()
-  rxode2::rxAssignControlValue(.ui2, "rxControl",
-                               rxode2::rxControl(covsInterpolation = "nocb"))
+  rxode2::rxAssignControlValue(
+    .ui2, "rxControl",
+    rxode2::rxControl(covsInterpolation = "nocb")
+  )
   .foceiLinCmtCarryPairs(.ui2)
   .st5 <- .foceiLinCmtCarryMemoStats()
   expect_equal(.st5[["misses"]], 3L)
@@ -156,7 +170,7 @@ test_that("candidate pairs persist through the rxode2 cache-directory sidecar", 
   .foceiLinCmtCarryMemoClear()
   .foceiLinCmtCarryMemoStats(reset = TRUE)
   .ui <- .carryUiCov()
-  .p1 <- .foceiLinCmtCarryPairs(.ui)          # compute + write the sidecar
+  .p1 <- .foceiLinCmtCarryPairs(.ui) # compute + write the sidecar
   .key <- rxUiGet.foceiModelDigest(list(rxode2::assertRxUi(.ui)))
   .f <- .foceiLinCmtCarryCacheFile(.key)
   expect_true(file.exists(.f))

--- a/tests/testthat/test-focei-lincmt-carry-emit-fd.R
+++ b/tests/testthat/test-focei-lincmt-carry-emit-fd.R
@@ -21,8 +21,10 @@
 test_that("substituted gradient matches FD-on-eta; naive build shows the bug", {
   skip_if_not(.rxFoceiLinCmtCarryCapable())
   .ev <- .carryEv()
-  .pars <- c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
-             `ETA[1]` = 0.3)
+  .pars <- c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
+    `ETA[1]` = 0.3
+  )
   .sC <- .carrySetControl(.carryUiCov(), "auto")$foceiEnv
   .sN <- .carrySetControl(.carryUiCov(), "none")$foceiEnv
   .mC <- suppressWarnings(rxode2::rxode2(.sC$..inner))
@@ -31,7 +33,7 @@ test_that("substituted gradient matches FD-on-eta; naive build shows the bug", {
   .solveN <- .carrySolveInner(.mN, .pars, .ev)
   .h <- 1e-5
   .fd <- (.solveC(`ETA[1]` = 0.3 + .h)$rx_pred_ -
-            .solveC(`ETA[1]` = 0.3 - .h)$rx_pred_) / (2 * .h)
+    .solveC(`ETA[1]` = 0.3 - .h)$rx_pred_) / (2 * .h)
   .r0 <- .solveC()
   .rn <- .solveN()
   # predictions themselves agree between the two builds
@@ -44,16 +46,18 @@ test_that("substituted gradient matches FD-on-eta; naive build shows the bug", {
 test_that("two simultaneous pairs (cl and v slots) both match FD", {
   skip_if_not(.rxFoceiLinCmtCarryCapable())
   .ev <- .carryEv()
-  .pars <- c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
-             `ETA[1]` = 0.3, `ETA[2]` = -0.2)
+  .pars <- c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
+    `ETA[1]` = 0.3, `ETA[2]` = -0.2
+  )
   .m <- suppressWarnings(rxode2::rxode2(.carryUiTwoPair()$foceiEnv$..inner))
   .solve <- .carrySolveInner(.m, .pars, .ev)
   .h <- 1e-5
   .r0 <- .solve()
   .fd1 <- (.solve(`ETA[1]` = 0.3 + .h)$rx_pred_ -
-             .solve(`ETA[1]` = 0.3 - .h)$rx_pred_) / (2 * .h)
+    .solve(`ETA[1]` = 0.3 - .h)$rx_pred_) / (2 * .h)
   .fd2 <- (.solve(`ETA[2]` = -0.2 + .h)$rx_pred_ -
-             .solve(`ETA[2]` = -0.2 - .h)$rx_pred_) / (2 * .h)
+    .solve(`ETA[2]` = -0.2 - .h)$rx_pred_) / (2 * .h)
   expect_lt(.carryRelErr(.r0$rx__sens_rx_pred__BY_ETA_1___, .fd1), 1e-6)
   # eta.v needs the row-local direct term on top of the amounts carry
   expect_lt(.carryRelErr(.r0$rx__sens_rx_pred__BY_ETA_2___, .fd2), 1e-6)
@@ -63,16 +67,20 @@ test_that("proportional error chains d(rx_r_)/d(eta) through the carried sensiti
   skip_if_not(.rxFoceiLinCmtCarryCapable())
   .s <- nlmixr2est::nlmixr2(.carryModProp)$foceiEnv
   .inner <- .s$..inner
-  expect_true(grepl("rx__sens_rx_r__BY_ETA_1___=.*rx__sens_rx_pred__BY_ETA_1___",
-                    .inner))
+  expect_true(grepl(
+    "rx__sens_rx_r__BY_ETA_1___=.*rx__sens_rx_pred__BY_ETA_1___",
+    .inner
+  ))
   .ev <- .carryEv()
-  .pars <- c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.1,
-             `ETA[1]` = 0.3)
+  .pars <- c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.1,
+    `ETA[1]` = 0.3
+  )
   .m <- suppressWarnings(rxode2::rxode2(.inner))
   .solve <- .carrySolveInner(.m, .pars, .ev)
   .h <- 1e-5
   .r0 <- .solve()
   .fdR <- (.solve(`ETA[1]` = 0.3 + .h)$rx_r_ -
-             .solve(`ETA[1]` = 0.3 - .h)$rx_r_) / (2 * .h)
+    .solve(`ETA[1]` = 0.3 - .h)$rx_r_) / (2 * .h)
   expect_lt(.carryRelErr(.r0$rx__sens_rx_r__BY_ETA_1___, .fdR), 1e-6)
 })

--- a/tests/testthat/test-focei-lincmt-carry-emit.R
+++ b/tests/testthat/test-focei-lincmt-carry-emit.R
@@ -50,12 +50,15 @@ test_that("the model cache digest keys covsInterpolation (linear skips the carry
   .mk <- function(interp) {
     .ui <- rxode2::.copyUi(.carryUiCov())
     .ctl <- nlmixr2est::foceiControl(
-      rxControl = rxode2::rxControl(covsInterpolation = interp))
+      rxControl = rxode2::rxControl(covsInterpolation = interp)
+    )
     assign("control", .ctl, envir = .ui)
     .ui
   }
-  expect_false(identical(.mk("locf")$foceiModelDigest,
-                         .mk("linear")$foceiModelDigest))
+  expect_false(identical(
+    .mk("locf")$foceiModelDigest,
+    .mk("linear")$foceiModelDigest
+  ))
   expect_identical(.mk("locf")$foceiModelDigest, .mk("locf")$foceiModelDigest)
 })
 
@@ -63,9 +66,18 @@ test_that("more than four carry-eligible pairs fails loudly at model build", {
   skip_if_not(.rxFoceiLinCmtCarryCapable())
   five <- function() {
     ini({
-      tcl <- log(2); tv <- log(20); tq <- log(1); tv2 <- log(30)
-      tq2 <- log(0.5); tv3 <- log(40); tka <- log(1)
-      eta.cl ~ 0.1; eta.v ~ 0.1; eta.q ~ 0.1; eta.v2 ~ 0.1; eta.ka ~ 0.1
+      tcl <- log(2)
+      tv <- log(20)
+      tq <- log(1)
+      tv2 <- log(30)
+      tq2 <- log(0.5)
+      tv3 <- log(40)
+      tka <- log(1)
+      eta.cl ~ 0.1
+      eta.v ~ 0.1
+      eta.q ~ 0.1
+      eta.v2 ~ 0.1
+      eta.ka ~ 0.1
       add.sd <- 0.5
     })
     model({
@@ -84,7 +96,8 @@ test_that("more than four carry-eligible pairs fails loudly at model build", {
   expect_equal(nrow(.foceiLinCmtCarryPairs(ui)), 5L)
   s <- ui$foceiEtaS
   expect_error(.rxFoceiLinCmtCarryPairsForBuild(
-    list(ui), s, paste0("ETA_", seq_len(s$..maxEta), "_")), "carry columns")
+    list(ui), s, paste0("ETA_", seq_len(s$..maxEta), "_")
+  ), "carry columns")
   # (inside the HdEta build the error is re-raised by the progress abort as
   # "Aborted calculation", which escapes expect_error -- the direct call
   # above is what pins the message)
@@ -94,8 +107,12 @@ test_that("an eta that also drives a modeled alag() is carried with a lag channe
   skip_if_not(.rxFoceiLinCmtCarryCapable() && .rxFoceiLinCmtCarryJumpCapable())
   lagged <- function() {
     ini({
-      tka <- log(1); tcl <- log(2); tv <- log(20); tlag <- log(0.2)
-      eta.cl ~ 0.1; eta.v ~ 0.1
+      tka <- log(1)
+      tcl <- log(2)
+      tv <- log(20)
+      tlag <- log(0.2)
+      eta.cl ~ 0.1
+      eta.v ~ 0.1
       add.sd <- 0.5
     })
     model({

--- a/tests/testthat/test-focei-lincmt-carry-fit-fallback.R
+++ b/tests/testthat/test-focei-lincmt-carry-fit-fallback.R
@@ -15,15 +15,20 @@
 test_that("ss dose rows fall back to the standard gradient with a runInfo note", {
   skip_on_cran()
   skip_if_not(.rxFoceiLinCmtCarryCapable())
-  d <- data.frame(id = 1, time = c(0, 3, 7, 15, 24, 30),
-                  amt = c(100, 0, 100, 0, 100, 0),
-                  evid = c(1, 0, 1, 0, 1, 0), cmt = 1,
-                  ss = c(1, 0, 0, 0, 0, 0), ii = c(12, 0, 0, 0, 0, 0))
+  d <- data.frame(
+    id = 1, time = c(0, 3, 7, 15, 24, 30),
+    amt = c(100, 0, 100, 0, 100, 0),
+    evid = c(1, 0, 1, 0, 1, 0), cmt = 1,
+    ss = c(1, 0, 0, 0, 0, 0), ii = c(12, 0, 0, 0, 0, 0)
+  )
   d$wt <- ifelse(d$time < 20, 70, 85)
   d$dv <- c(0, 3.2, 0, 2.5, 0, 2.2)
   fit <- suppressWarnings(suppressMessages(
-    nlmixr2est::nlmixr2(.carryModCov, d, est = "focei",
-                        control = .carryFitCtl("auto"))))
+    nlmixr2est::nlmixr2(.carryModCov, d,
+      est = "focei",
+      control = .carryFitCtl("auto")
+    )
+  ))
   expect_identical(fit$foceiControl$linCmtSensCarry, "none")
   expect_true(any(grepl("carry gradient off", unlist(fit$runInfo))))
 })
@@ -31,14 +36,19 @@ test_that("ss dose rows fall back to the standard gradient with a runInfo note",
 test_that("evid=2 rows fall back to the standard gradient with a runInfo note", {
   skip_on_cran()
   skip_if_not(.rxFoceiLinCmtCarryCapable())
-  d <- data.frame(id = 1, time = c(0, 3, 5, 7, 15, 24, 30),
-                  amt = c(100, 0, 0, 100, 0, 100, 0),
-                  evid = c(1, 0, 2, 1, 0, 1, 0), cmt = 1)
+  d <- data.frame(
+    id = 1, time = c(0, 3, 5, 7, 15, 24, 30),
+    amt = c(100, 0, 0, 100, 0, 100, 0),
+    evid = c(1, 0, 2, 1, 0, 1, 0), cmt = 1
+  )
   d$wt <- ifelse(d$time < 20, 70, 85)
   d$dv <- c(0, 3.2, 0, 0, 2.5, 0, 2.2)
   fit <- suppressWarnings(suppressMessages(
-    nlmixr2est::nlmixr2(.carryModCov, d, est = "focei",
-                        control = .carryFitCtl("auto"))))
+    nlmixr2est::nlmixr2(.carryModCov, d,
+      est = "focei",
+      control = .carryFitCtl("auto")
+    )
+  ))
   expect_identical(fit$foceiControl$linCmtSensCarry, "none")
   expect_true(any(grepl("carry gradient off", unlist(fit$runInfo))))
   expect_false(grepl("rx_lcCarry", .carryInnerTxt(fit)))
@@ -51,15 +61,20 @@ test_that("linear covariate interpolation on a varying eligible covariate is an 
   d$dv <- ifelse(d$evid == 0, 3, 0)
   ctlLin <- nlmixr2est::foceiControl(
     print = 0, maxOuterIterations = 0L, covMethod = "", calcTables = FALSE,
-    rxControl = rxode2::rxControl(covsInterpolation = "linear"))
-  expect_error(suppressWarnings(suppressMessages(
-    nlmixr2est::nlmixr2(.carryModCov, d, est = "focei", control = ctlLin))),
-    "linear")
+    rxControl = rxode2::rxControl(covsInterpolation = "linear")
+  )
+  expect_error(
+    suppressWarnings(suppressMessages(
+      nlmixr2est::nlmixr2(.carryModCov, d, est = "focei", control = ctlLin)
+    )),
+    "linear"
+  )
   # a covariate that is constant within every subject is fine under linear
   dc <- d
   dc$wt <- 70
   fit <- suppressWarnings(suppressMessages(
-    nlmixr2est::nlmixr2(.carryModCov, dc, est = "focei", control = ctlLin)))
+    nlmixr2est::nlmixr2(.carryModCov, dc, est = "focei", control = ctlLin)
+  ))
   expect_true(inherits(fit, "nlmixr2FitCore"))
   expect_false(grepl("rx_lcCarry", .carryInnerTxt(fit)))
 })
@@ -67,8 +82,10 @@ test_that("linear covariate interpolation on a varying eligible covariate is an 
 test_that("runtime constant-theta fast path engages per subject and is equivalent", {
   skip_on_cran()
   skip_if_not(.rxFoceiLinCmtCarryCapable())
-  skip_if_not(exists("linCmtCarryFastStats", envir = asNamespace("rxode2"),
-                     inherits = FALSE))
+  skip_if_not(exists("linCmtCarryFastStats",
+    envir = asNamespace("rxode2"),
+    inherits = FALSE
+  ))
   .stats <- function(reset = FALSE) utils::getFromNamespace("linCmtCarryFastStats", "rxode2")(reset)
   .setFast <- function(x) utils::getFromNamespace("linCmtCarrySetFast", "rxode2")(x)
   on.exit(.setFast(TRUE), add = TRUE)
@@ -77,8 +94,10 @@ test_that("runtime constant-theta fast path engages per subject and is equivalen
   s <- suppressMessages(u$foceiEnv)
   expect_true(grepl("rx_lcCarryAdv_", s$..inner))
   m <- suppressWarnings(rxode2::rxode2(s$..inner))
-  pars <- c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
-            `ETA[1]` = 0.3)
+  pars <- c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
+    `ETA[1]` = 0.3
+  )
   evConst <- .carryEv()
   evConst$wt <- 70
   evVary <- .carryEv()
@@ -87,8 +106,10 @@ test_that("runtime constant-theta fast path engages per subject and is equivalen
   runOne <- function(ev, fastOn) {
     .setFast(fastOn)
     invisible(.stats(TRUE))
-    r <- rxode2::rxSolve(m, params = pars, events = ev,
-                         returnType = "data.frame")
+    r <- rxode2::rxSolve(m,
+      params = pars, events = ev,
+      returnType = "data.frame"
+    )
     list(r = r, s = .stats(FALSE))
   }
   # constant-covariate subject: every advance skips; results identical to slow
@@ -115,13 +136,16 @@ test_that("CWRES consumes the carried gradient through the shared inner env", {
   d$dv[obs] <- 2 + 0.1 * seq_len(sum(obs))
   # calcTables on (default) so CWRES is computed through the shared inner env
   fitOne <- function(carry) {
-    ctl <- nlmixr2est::foceiControl(print = 0, maxOuterIterations = 0L,
-                                    covMethod = "", sigdig = 8,
-                                    etaNudge = 0, etaNudge2 = 0,
-                                    rxControl = rxode2::rxControl(covsInterpolation = "nocb"),
-                                    linCmtSensCarry = carry)
+    ctl <- nlmixr2est::foceiControl(
+      print = 0, maxOuterIterations = 0L,
+      covMethod = "", sigdig = 8,
+      etaNudge = 0, etaNudge2 = 0,
+      rxControl = rxode2::rxControl(covsInterpolation = "nocb"),
+      linCmtSensCarry = carry
+    )
     suppressWarnings(suppressMessages(
-      nlmixr2est::nlmixr2(.carryModCov, d, est = "focei", control = ctl)))
+      nlmixr2est::nlmixr2(.carryModCov, d, est = "focei", control = ctl)
+    ))
   }
   fC <- fitOne("auto")
   fN <- fitOne("none")
@@ -140,11 +164,14 @@ test_that("a carry-eligible fit survives foceiControl(fast=TRUE)", {
   skip_if_not(.rxFoceiLinCmtCarryCapable())
   d <- .carryFitDat(2L)
   d$dv <- ifelse(d$evid == 0, 3, 0)
-  ctl <- nlmixr2est::foceiControl(print = 0, maxOuterIterations = 2L,
-                                  covMethod = "", calcTables = FALSE, fast = TRUE,
-                                  rxControl = rxode2::rxControl(covsInterpolation = "nocb"))
+  ctl <- nlmixr2est::foceiControl(
+    print = 0, maxOuterIterations = 2L,
+    covMethod = "", calcTables = FALSE, fast = TRUE,
+    rxControl = rxode2::rxControl(covsInterpolation = "nocb")
+  )
   fit <- suppressWarnings(suppressMessages(
-    nlmixr2est::nlmixr2(.carryModCov, d, est = "focei", control = ctl)))
+    nlmixr2est::nlmixr2(.carryModCov, d, est = "focei", control = ctl)
+  ))
   expect_true(inherits(fit, "nlmixr2FitCore"))
   expect_true(is.finite(fit$objf))
   expect_true(grepl("rx_lcCarry", .carryInnerTxt(fit)))

--- a/tests/testthat/test-focei-lincmt-carry-fit.R
+++ b/tests/testthat/test-focei-lincmt-carry-fit.R
@@ -36,10 +36,14 @@ cp = central/v")
   set.seed(17)
   etaTrue <- rnorm(6, 0, 0.3)
   dv <- unlist(lapply(1:6, function(i) {
-    rxode2::rxSolve(m, params = c(tcl = log(2), tv = log(20),
-                                  eta_cl = etaTrue[i]),
-                    events = dat[dat$id == i, ], returnType = "data.frame",
-                    covsInterpolation = "nocb", useLinCmt = FALSE)$cp
+    rxode2::rxSolve(m,
+      params = c(
+        tcl = log(2), tv = log(20),
+        eta_cl = etaTrue[i]
+      ),
+      events = dat[dat$id == i, ], returnType = "data.frame",
+      covsInterpolation = "nocb", useLinCmt = FALSE
+    )$cp
   }))
   obs <- dat$evid == 0
   dat$dv <- 0
@@ -47,8 +51,11 @@ cp = central/v")
   dat$dv[obs] <- dv + rnorm(sum(obs), 0, 0.3)
   fit <- function(ui, carry, maxOut = 0L) {
     suppressWarnings(suppressMessages(
-      nlmixr2est::nlmixr2(ui, dat, est = "focei",
-                          control = .carryFitCtl(carry, maxOut))))
+      nlmixr2est::nlmixr2(ui, dat,
+        est = "focei",
+        control = .carryFitCtl(carry, maxOut)
+      )
+    ))
   }
   # posthoc (fixed thetas): the pure inner-problem comparison
   fO <- fit(uiO, "none")
@@ -85,7 +92,8 @@ test_that("carry gradient matches FD across compartment configs; naive fails all
       assign("control", ctl, envir = u)
       suppressMessages(u$foceiEnv)
     }
-    sA <- mkS("auto"); sN <- mkS("none")
+    sA <- mkS("auto")
+    sN <- mkS("none")
     expect_true(grepl("rx_lcCarryAdv_", sA$..inner))
     mA <- suppressWarnings(rxode2::rxode2(sA$..inner))
     mN <- suppressWarnings(rxode2::rxode2(sN$..inner))
@@ -106,43 +114,77 @@ test_that("carry gradient matches FD across compartment configs; naive fails all
   }
   # 2-cmt IV (m=2 row stride)
   runCfg(function() {
-    ini({tcl <- log(2); tv <- log(20); tq <- log(1); tvp <- log(30)
-         eta.cl ~ 0.1; add.sd <- 0.5})
+    ini({
+      tcl <- log(2)
+      tv <- log(20)
+      tq <- log(1)
+      tvp <- log(30)
+      eta.cl ~ 0.1
+      add.sd <- 0.5
+    })
     model({
-      cl <- exp(tcl) * (wt/70)^0.75 * exp(eta.cl)
-      v <- exp(tv); q <- exp(tq); vp <- exp(tvp)
+      cl <- exp(tcl) * (wt / 70)^0.75 * exp(eta.cl)
+      v <- exp(tv)
+      q <- exp(tq)
+      vp <- exp(tvp)
       cp <- linCmt()
       cp ~ add(add.sd)
     })
-  }, c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1),
-       `THETA[4]` = log(30), `THETA[5]` = 0.5, `ETA[1]` = 0.3), mkEv())
+  }, c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1),
+    `THETA[4]` = log(30), `THETA[5]` = 0.5, `ETA[1]` = 0.3
+  ), mkEv())
   # 1-cmt oral, eta+covariate on ka (slot 7, depot row)
   runCfg(function() {
-    ini({tcl <- log(2); tv <- log(20); tka <- log(1.2)
-         eta.ka ~ 0.1; add.sd <- 0.5})
+    ini({
+      tcl <- log(2)
+      tv <- log(20)
+      tka <- log(1.2)
+      eta.ka ~ 0.1
+      add.sd <- 0.5
+    })
     model({
-      cl <- exp(tcl); v <- exp(tv)
-      ka <- exp(tka) * (wt/70)^0.5 * exp(eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      ka <- exp(tka) * (wt / 70)^0.5 * exp(eta.ka)
       cp <- linCmt()
       cp ~ add(add.sd)
     })
-  }, c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1.2),
-       `THETA[4]` = 0.5, `ETA[1]` = 0.3), mkEv())
+  }, c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1.2),
+    `THETA[4]` = 0.5, `ETA[1]` = 0.3
+  ), mkEv())
   # 1-cmt IV infusion (rate history through the carry advance)
-  runCfg(.carryModCov,
-         c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
-           `ETA[1]` = 0.3), mkEv(dur = 2))
+  runCfg(
+    .carryModCov,
+    c(
+      `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
+      `ETA[1]` = 0.3
+    ), mkEv(dur = 2)
+  )
   # 2-cmt oral (m=3)
   runCfg(function() {
-    ini({tcl <- log(2); tv <- log(20); tq <- log(1); tvp <- log(30)
-         tka <- log(1.2); eta.cl ~ 0.1; add.sd <- 0.5})
+    ini({
+      tcl <- log(2)
+      tv <- log(20)
+      tq <- log(1)
+      tvp <- log(30)
+      tka <- log(1.2)
+      eta.cl ~ 0.1
+      add.sd <- 0.5
+    })
     model({
-      cl <- exp(tcl) * (wt/70)^0.75 * exp(eta.cl)
-      v <- exp(tv); q <- exp(tq); vp <- exp(tvp); ka <- exp(tka)
+      cl <- exp(tcl) * (wt / 70)^0.75 * exp(eta.cl)
+      v <- exp(tv)
+      q <- exp(tq)
+      vp <- exp(tvp)
+      ka <- exp(tka)
       cp <- linCmt()
       cp ~ add(add.sd)
     })
-  }, c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1),
-       `THETA[4]` = log(30), `THETA[5]` = log(1.2), `THETA[6]` = 0.5,
-       `ETA[1]` = 0.3), mkEv())
+  }, c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1),
+    `THETA[4]` = log(30), `THETA[5]` = log(1.2), `THETA[6]` = 0.5,
+    `ETA[1]` = 0.3
+  ), mkEv())
 })

--- a/tests/testthat/test-focei-lincmt-carry-jump-fit.R
+++ b/tests/testthat/test-focei-lincmt-carry-jump-fit.R
@@ -16,17 +16,22 @@
 
 .carryJumpFit <- function(ui, dat, carry, maxOut = 0L) {
   suppressWarnings(suppressMessages(
-    nlmixr2est::nlmixr2(ui, dat, est = "focei",
-                        control = .carryFitCtl(carry, maxOut)))) # nolint: object_usage_linter.
+    nlmixr2est::nlmixr2(ui, dat,
+      est = "focei",
+      control = .carryFitCtl(carry, maxOut)
+    )
+  )) # nolint: object_usage_linter.
 }
 
 # simulate DV from an explicitly integrated ODE truth under nocb
 .carryJumpSimDv <- function(odeTxt, params, dat, nid, sd = 0.3) {
   m <- rxode2::rxode2(odeTxt)
   dv <- unlist(lapply(seq_len(nid), function(i) {
-    rxode2::rxSolve(m, params = params(i), events = dat[dat$id == i, ],
-                    returnType = "data.frame", covsInterpolation = "nocb",
-                    useLinCmt = FALSE, atol = 1e-10, rtol = 1e-10)$cp
+    rxode2::rxSolve(m,
+      params = params(i), events = dat[dat$id == i, ],
+      returnType = "data.frame", covsInterpolation = "nocb",
+      useLinCmt = FALSE, atol = 1e-10, rtol = 1e-10
+    )$cp
   }))
   obs <- dat$evid == 0
   dat$dv <- 0
@@ -51,8 +56,10 @@ alag(depot) = exp(tlag + eta_lag)
 d/dt(depot) = -ka*depot
 d/dt(central) = ka*depot - (cl/v)*central
 cp = central/v", function(i) {
-    c(tcl = log(2), tv = log(20), tka = log(1.2), tf = -0.5, tlag = log(0.5),
-      eta_cl = et[i, 1], eta_f = et[i, 2], eta_lag = et[i, 3])
+    c(
+      tcl = log(2), tv = log(20), tka = log(1.2), tf = -0.5, tlag = log(0.5),
+      eta_cl = et[i, 1], eta_f = et[i, 2], eta_lag = et[i, 3]
+    )
   }, dat, 6L)
   uiO <- rxode2::linToOde(rxode2::rxode2(.carryModJump))
   fO <- .carryJumpFit(uiO, dat, "none")
@@ -87,9 +94,11 @@ cp = central/v", function(i) {
       covMethod = "", calcTables = FALSE, sigdig = 8,
       etaNudge = 0, etaNudge2 = 0, etaMat = .em,
       rxControl = rxode2::rxControl(covsInterpolation = "nocb"),
-      linCmtSensCarry = carry)
+      linCmtSensCarry = carry
+    )
     suppressWarnings(suppressMessages(
-      nlmixr2est::nlmixr2(ui, dat, est = "focei", control = .ctl)))$objective
+      nlmixr2est::nlmixr2(ui, dat, est = "focei", control = .ctl)
+    ))$objective
   }
   oC <- .fixedObj(fC$finalUi, "auto")
   oN <- .fixedObj(fC$finalUi, "none")
@@ -104,10 +113,18 @@ test_that("a 2-cmt A/B/alpha/beta model with a covariate on B fits like its ODE"
   skip_on_cran()
   skip_if_not(.rxFoceiLinCmtCarryCapable())
   mod <- function() {
-    ini({ta <- log(0.5); tb <- log(0.02); tA <- log(0.04); tB <- log(0.01)
-         eta.B ~ 0.1; add.sd <- 0.3})
+    ini({
+      ta <- log(0.5)
+      tb <- log(0.02)
+      tA <- log(0.04)
+      tB <- log(0.01)
+      eta.B ~ 0.1
+      add.sd <- 0.3
+    })
     model({
-      alpha <- exp(ta); beta <- exp(tb); A <- exp(tA)
+      alpha <- exp(ta)
+      beta <- exp(tb)
+      A <- exp(tA)
       B <- exp(tB) * (wt / 70)^-1 * exp(eta.B)
       cp <- linCmt()
       cp ~ add(add.sd)

--- a/tests/testthat/test-focei-lincmt-carry-jump.R
+++ b/tests/testthat/test-focei-lincmt-carry-jump.R
@@ -31,7 +31,8 @@ test_that("a multiplicative f() with a covariate is exact without the carry", {
     ini({tcl <- log(2); tv <- log(20); tka <- log(1.2); tf <- -0.5
          eta.f ~ 0.1; add.sd <- 0.5})
     model({
-      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+      cl <- exp(tcl); v <- exp(tv)
+      ka <- exp(tka)
       f(depot) <- exp(tf + eta.f) * (wt / 70)
       cp <- linCmt()
       cp ~ add(add.sd)
@@ -47,7 +48,8 @@ test_that("a lag on a constant kernel keeps the #920 term (no pair)", {
     ini({tcl <- log(2); tv <- log(20); tka <- log(1.2); tlag <- log(0.5)
          eta.lag ~ 0.1; add.sd <- 0.5})
     model({
-      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+      cl <- exp(tcl); v <- exp(tv)
+      ka <- exp(tka)
       alag(depot) <- exp(tlag + eta.lag)
       cp <- linCmt()
       cp ~ add(add.sd)
@@ -60,11 +62,19 @@ test_that("a lag on a constant kernel keeps the #920 term (no pair)", {
 test_that("a covariate-driven alag() is rejected (bias to the status quo)", {
   skip_if_not(.carryJumpCapable())
   mod <- function() {
-    ini({tcl <- log(2); tv <- log(20); tka <- log(1.2); tlag <- log(0.5)
-         eta.cl ~ 0.1; eta.lag ~ 0.1; add.sd <- 0.5})
+    ini({
+        tcl <- log(2)
+        tv <- log(20)
+        tka <- log(1.2)
+        tlag <- log(0.5)
+        eta.cl ~ 0.1
+        eta.lag ~ 0.1
+        add.sd <- 0.5
+      })
     model({
       cl <- exp(tcl) * (wt / 70)^0.75 * exp(eta.cl)
-      v <- exp(tv); ka <- exp(tka)
+      v <- exp(tv)
+      ka <- exp(tka)
       alag(depot) <- exp(tlag + eta.lag) * (wt / 70)
       cp <- linCmt()
       cp ~ add(add.sd)
@@ -113,10 +123,17 @@ test_that("f()+alag()+covariate gradients match FD for every eta; naive fails cl
 test_that("an additive f() shape with a covariate needs the carry and matches FD", {
   skip_if_not(.carryJumpCapable())
   mod <- function() {
-    ini({tcl <- log(2); tv <- log(20); tka <- log(1.2); tf <- 0
-         eta.f ~ 0.1; add.sd <- 0.5})
+    ini({
+        tcl <- log(2)
+        tv <- log(20)
+        tka <- log(1.2)
+        tf <- 0
+        eta.f ~ 0.1
+        add.sd <- 0.5
+      })
     model({
-      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+      cl <- exp(tcl); v <- exp(tv)
+      ka <- exp(tka)
       f(depot) <- expit(tf + eta.f + (wt - 70) / 70)
       cp <- linCmt()
       cp ~ add(add.sd)

--- a/tests/testthat/test-focei-lincmt-carry-jump.R
+++ b/tests/testthat/test-focei-lincmt-carry-jump.R
@@ -28,10 +28,17 @@ test_that("a multiplicative f() with a covariate is exact without the carry", {
   # F = h(wt) exp(eta): every input scales with exp(eta), so pred * dlnF
   # is exact across the covariate change; no pair is made for eta.f
   mod <- function() {
-    ini({tcl <- log(2); tv <- log(20); tka <- log(1.2); tf <- -0.5
-         eta.f ~ 0.1; add.sd <- 0.5})
+    ini({
+      tcl <- log(2)
+      tv <- log(20)
+      tka <- log(1.2)
+      tf <- -0.5
+      eta.f ~ 0.1
+      add.sd <- 0.5
+    })
     model({
-      cl <- exp(tcl); v <- exp(tv)
+      cl <- exp(tcl)
+      v <- exp(tv)
       ka <- exp(tka)
       f(depot) <- exp(tf + eta.f) * (wt / 70)
       cp <- linCmt()
@@ -45,10 +52,17 @@ test_that("a multiplicative f() with a covariate is exact without the carry", {
 test_that("a lag on a constant kernel keeps the #920 term (no pair)", {
   skip_if_not(.carryJumpCapable())
   mod <- function() {
-    ini({tcl <- log(2); tv <- log(20); tka <- log(1.2); tlag <- log(0.5)
-         eta.lag ~ 0.1; add.sd <- 0.5})
+    ini({
+      tcl <- log(2)
+      tv <- log(20)
+      tka <- log(1.2)
+      tlag <- log(0.5)
+      eta.lag ~ 0.1
+      add.sd <- 0.5
+    })
     model({
-      cl <- exp(tcl); v <- exp(tv)
+      cl <- exp(tcl)
+      v <- exp(tv)
       ka <- exp(tka)
       alag(depot) <- exp(tlag + eta.lag)
       cp <- linCmt()
@@ -63,14 +77,14 @@ test_that("a covariate-driven alag() is rejected (bias to the status quo)", {
   skip_if_not(.carryJumpCapable())
   mod <- function() {
     ini({
-        tcl <- log(2)
-        tv <- log(20)
-        tka <- log(1.2)
-        tlag <- log(0.5)
-        eta.cl ~ 0.1
-        eta.lag ~ 0.1
-        add.sd <- 0.5
-      })
+      tcl <- log(2)
+      tv <- log(20)
+      tka <- log(1.2)
+      tlag <- log(0.5)
+      eta.cl ~ 0.1
+      eta.lag ~ 0.1
+      add.sd <- 0.5
+    })
     model({
       cl <- exp(tcl) * (wt / 70)^0.75 * exp(eta.cl)
       v <- exp(tv)
@@ -124,15 +138,16 @@ test_that("an additive f() shape with a covariate needs the carry and matches FD
   skip_if_not(.carryJumpCapable())
   mod <- function() {
     ini({
-        tcl <- log(2)
-        tv <- log(20)
-        tka <- log(1.2)
-        tf <- 0
-        eta.f ~ 0.1
-        add.sd <- 0.5
-      })
+      tcl <- log(2)
+      tv <- log(20)
+      tka <- log(1.2)
+      tf <- 0
+      eta.f ~ 0.1
+      add.sd <- 0.5
+    })
     model({
-      cl <- exp(tcl); v <- exp(tv)
+      cl <- exp(tcl)
+      v <- exp(tv)
       ka <- exp(tka)
       f(depot) <- expit(tf + eta.f + (wt - 70) / 70)
       cp <- linCmt()
@@ -141,8 +156,10 @@ test_that("an additive f() shape with a covariate needs the carry and matches FD
   }
   ev <- .carryEv()
   ev$cmt <- 1
-  pars <- c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1.2),
-            `THETA[4]` = 0, `THETA[5]` = 0.5, `ETA[1]` = 0.3)
+  pars <- c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1.2),
+    `THETA[4]` = 0, `THETA[5]` = 0.5, `ETA[1]` = 0.3
+  )
   p <- .foceiLinCmtCarryPairs(suppressMessages(nlmixr2est::nlmixr2(mod)))
   expect_equal(nrow(p), 1L)
   expect_true(isTRUE(p$fCov))

--- a/tests/testthat/test-focei-lincmt-carry-ll-fit.R
+++ b/tests/testthat/test-focei-lincmt-carry-ll-fit.R
@@ -19,10 +19,14 @@ cp = central/v")
   set.seed(17)
   etaTrue <- rnorm(6, 0, 0.3)
   dv <- unlist(lapply(1:6, function(i) {
-    rxode2::rxSolve(m, params = c(tcl = log(2), tv = log(20),
-                                  eta_cl = etaTrue[i]),
-                    events = dat[dat$id == i, ], returnType = "data.frame",
-                    covsInterpolation = "nocb", useLinCmt = FALSE)$cp
+    rxode2::rxSolve(m,
+      params = c(
+        tcl = log(2), tv = log(20),
+        eta_cl = etaTrue[i]
+      ),
+      events = dat[dat$id == i, ], returnType = "data.frame",
+      covsInterpolation = "nocb", useLinCmt = FALSE
+    )$cp
   }))
   obs <- dat$evid == 0
   dat$dv <- 0
@@ -30,14 +34,19 @@ cp = central/v")
   dat$dv[obs] <- dv + rnorm(sum(obs), 0, 0.3)
   fit <- function(ui, carry, maxOut = 0L) {
     suppressWarnings(suppressMessages(
-      nlmixr2est::nlmixr2(ui, dat, est = "focei",
-                          control = .carryFitCtl(carry, maxOut))))
+      nlmixr2est::nlmixr2(ui, dat,
+        est = "focei",
+        control = .carryFitCtl(carry, maxOut)
+      )
+    ))
   }
   fO <- fit(uiO, "none")
   fC <- fit(uiL, "auto")
   fN <- fit(uiL, "none")
-  expect_true(grepl("rx_lcConc_",
-                    paste(rxode2::rxNorm(fC$env$innerModel), collapse = "\n")))
+  expect_true(grepl(
+    "rx_lcConc_",
+    paste(rxode2::rxNorm(fC$env$innerModel), collapse = "\n")
+  ))
   gapC <- abs(fC$objective - fO$objective)
   gapN <- abs(fN$objective - fO$objective)
   expect_lt(gapC, 0.01)

--- a/tests/testthat/test-focei-lincmt-carry-ll-fit.R
+++ b/tests/testthat/test-focei-lincmt-carry-ll-fit.R
@@ -1,4 +1,4 @@
-# #1004, fit level: an ll() linCmt() endpoint under a time-varying covariate
+# issue 1004, fit level: an ll() linCmt() endpoint under a time-varying covariate
 # against the same ll() endpoint on the linToOde() ODE equivalent,
 # integrated with useLinCmt=FALSE (genuine sensitivities).  Slow batch -- see
 # .slowBatches in tests/testthat.R; shared fixtures in helper-lincmt-carry.R.
@@ -43,8 +43,8 @@ cp = central/v")
   expect_lt(gapC, 0.01)
   expect_gt(gapN, 0.05)
   expect_lt(max(abs(fC$eta$eta.cl - fO$eta$eta.cl)), 1e-3)
-  FO <- fit(uiO, "none", 200L)
-  FC <- fit(uiL, "auto", 200L)
+  fo <- fit(uiO, "none", 200L)
+  fc <- fit(uiL, "auto", 200L)
   expect_lt(abs(FC$objective - FO$objective), 0.01)
   expect_lt(max(abs(FC$theta - FO$theta)), 5e-3)
 })

--- a/tests/testthat/test-focei-lincmt-carry-ll.R
+++ b/tests/testthat/test-focei-lincmt-carry-ll.R
@@ -1,4 +1,4 @@
-# #1004: the linCmt() sensitivity carry for generalized-likelihood ll()
+# issue 1004: the linCmt() sensitivity carry for generalized-likelihood ll()
 # endpoints.  rx_pred_ is then the log-likelihood with the linCmtB() value
 # call embedded in it; the carry factors the call out as rx_lcConc_,
 # supplies d(rx_lcConc_)/d(eta) exactly as for a bare prediction and lets
@@ -75,7 +75,7 @@ test_that("an ll() model without a time-varying covariate generates identical te
 test_that("the structural call must be unique and in value form", {
   mk <- function(txt) {
     s <- new.env()
-    assign("rx_pred_", symengine::S(txt), envir = s)
+    assign("rx_pred_", symengine::S(txt), envir = s) # nolint: object_name_linter.
     s
   }
   one <- "linCmtB(rx__PTR__, t, 1.0, 1.0, 0.0, -1.0, -1.0, 1.0, a, b, 0.0, 0.0, 0.0, 0.0, 0.0)"

--- a/tests/testthat/test-focei-lincmt-carry-ll.R
+++ b/tests/testthat/test-focei-lincmt-carry-ll.R
@@ -38,8 +38,10 @@ test_that("a Poisson endpoint with a direct eta term outside the concentration i
   skip_if_not(.rxFoceiLinCmtCarryCapable())
   ev <- .carryLlEv()
   ev$dv[ev$evid == 0] <- c(4, 3, 2, 1)
-  pars <- c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
-            `THETA[4]` = 0.3, `ETA[1]` = 0.3, `ETA[2]` = -0.2)
+  pars <- c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
+    `THETA[4]` = 0.3, `ETA[1]` = 0.3, `ETA[2]` = -0.2
+  )
   r <- suppressWarnings(.carryJumpFd(.carryModLlPois, pars, ev, "auto"))
   rn <- suppressWarnings(.carryJumpFd(.carryModLlPois, pars, ev, "none"))
   # eta.cl (ETA_1_) is carried; eta.b (ETA_2_) only enters outside the
@@ -56,8 +58,10 @@ test_that("an eta both in the kernel and outside the concentration gets both ter
   skip_if_not(.rxFoceiLinCmtCarryCapable())
   ev <- .carryLlEv()
   ev$dv[ev$evid == 0] <- c(4, 3, 2, 1)
-  pars <- c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
-            `THETA[4]` = 0.3, `ETA[1]` = 0.3)
+  pars <- c(
+    `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = 0.5,
+    `THETA[4]` = 0.3, `ETA[1]` = 0.3
+  )
   r <- suppressWarnings(.carryJumpFd(.carryModLlPoisShared, pars, ev, "auto"))
   expect_lt(r$err, 1e-6)
   l <- strsplit(r$txt, "\n")[[1]]
@@ -94,7 +98,8 @@ test_that("a carried ll() model keeps the finite-difference inner Hessian under 
   skip_if_not(.rxFoceiLinCmtCarryCapable())
   ui <- rxode2::.copyUi(suppressMessages(nlmixr2est::nlmixr2(.carryModLlNorm)))
   assign("control", nlmixr2est::foceiControl(fast = TRUE, linCmtSensCarry = "auto"),
-         envir = ui)
+    envir = ui
+  )
   s <- suppressWarnings(suppressMessages(ui$foceEnv))
   expect_false(is.null(s$..linCmtCarryPairs))
   expect_null(s$..HdEta2)

--- a/tests/testthat/test-focei-lincmt-carry-theta-fit.R
+++ b/tests/testthat/test-focei-lincmt-carry-theta-fit.R
@@ -20,14 +20,18 @@ test_that("theta-side carry through a real est='nlm' fit (#1003)", {
   ui0 <- suppressMessages(nlmixr2est::nlmixr2(modTheta))
   sim <- rxode2::rxSolve(ui0, d, returnType = "data.frame", covsInterpolation = "nocb")
   d$dv <- ifelse(d$evid == 0,
-                 sim$cp[match(paste(d$id, d$time), paste(sim$id, sim$time))] +
-                   rnorm(nrow(d), 0, 0.3), 0)
+    sim$cp[match(paste(d$id, d$time), paste(sim$id, sim$time))] +
+      rnorm(nrow(d), 0, 0.3), 0
+  )
   fitWith <- function(carry) {
     u <- rxode2::.copyUi(ui0)
     assign("control",
-           nlmixr2est::nlmControl(print = 0, linCmtSensCarry = carry,
-                                  rxControl = rxode2::rxControl(covsInterpolation = "nocb")),
-           envir = u)
+      nlmixr2est::nlmControl(
+        print = 0, linCmtSensCarry = carry,
+        rxControl = rxode2::rxControl(covsInterpolation = "nocb")
+      ),
+      envir = u
+    )
     suppressMessages(nlmixr2est::nlmixr2(u, d, est = "nlm"))
   }
   fitC <- fitWith("auto")
@@ -44,9 +48,11 @@ test_that("theta-side carry through a real est='nlm' fit (#1003)", {
   obs <- d[d$evid == 0, ]
   surf <- function(ui, useLin) {
     p <- c(tcl = th[["tcl"]], tv = th[["tv"]])
-    s <- rxode2::rxSolve(ui, params = p, events = d, returnType = "data.frame",
-                         covsInterpolation = "nocb", useLinCmt = useLin,
-                         atol = 1e-10, rtol = 1e-10)
+    s <- rxode2::rxSolve(ui,
+      params = p, events = d, returnType = "data.frame",
+      covsInterpolation = "nocb", useLinCmt = useLin,
+      atol = 1e-10, rtol = 1e-10
+    )
     f <- s$cp[match(paste(obs$id, obs$time), paste(s$id, s$time))]
     -2 * sum(dnorm(obs$dv, f, abs(th[["add.sd"]]), log = TRUE))
   }
@@ -55,9 +61,12 @@ test_that("theta-side carry through a real est='nlm' fit (#1003)", {
   # mechanism at the fit's own control: the built gradient model carries
   u <- rxode2::.copyUi(ui0)
   assign("control",
-         nlmixr2est::nlmControl(print = 0, linCmtSensCarry = "auto",
-                                rxControl = rxode2::rxControl(covsInterpolation = "nocb")),
-         envir = u)
+    nlmixr2est::nlmControl(
+      print = 0, linCmtSensCarry = "auto",
+      rxControl = rxode2::rxControl(covsInterpolation = "nocb")
+    ),
+    envir = u
+  )
   e <- suppressMessages(u$nlmEnv)
   expect_true(any(grepl("rx_lcConc_~linCmtB", strsplit(e$..nlmS, "\n")[[1]])))
 
@@ -66,15 +75,20 @@ test_that("theta-side carry through a real est='nlm' fit (#1003)", {
   scoreErr <- function(carry) {
     u2 <- rxode2::.copyUi(ui0)
     assign("control",
-           nlmixr2est::nlmControl(print = 0, linCmtSensCarry = carry,
-                                  rxControl = rxode2::rxControl(covsInterpolation = "nocb")),
-           envir = u2)
+      nlmixr2est::nlmControl(
+        print = 0, linCmtSensCarry = carry,
+        rxControl = rxode2::rxControl(covsInterpolation = "nocb")
+      ),
+      envir = u2
+    )
     e2 <- suppressMessages(u2$nlmEnv)
     m <- suppressWarnings(rxode2::rxode2(e2$..nlmS))
     pars <- c(`THETA[1]` = th[["tcl"]], `THETA[2]` = th[["tv"]], `THETA[3]` = th[["add.sd"]])
     slv <- function(q) {
-      rxode2::rxSolve(m, params = q, events = d, returnType = "data.frame",
-                      covsInterpolation = "nocb")
+      rxode2::rxSolve(m,
+        params = q, events = d, returnType = "data.frame",
+        covsInterpolation = "nocb"
+      )
     }
     r0 <- slv(pars)
     h <- 1e-5

--- a/tests/testthat/test-focei-lincmt-carry-theta.R
+++ b/tests/testthat/test-focei-lincmt-carry-theta.R
@@ -59,14 +59,18 @@ test_that("theta-side carry: eligibility, emission and FD (#1003)", {
   fdErr <- function(txt) {
     m <- suppressWarnings(rxode2::rxode2(txt))
     slv <- function(q) {
-      rxode2::rxSolve(m, params = q, events = ev, returnType = "data.frame",
-                      covsInterpolation = "nocb")
+      rxode2::rxSolve(m,
+        params = q, events = ev, returnType = "data.frame",
+        covsInterpolation = "nocb"
+      )
     }
     r0 <- slv(pars)
     h <- 1e-5
     vapply(1:3, function(k) {
       got <- r0[[paste0("rx__sens_rx_pred__BY_THETA_", k, "___")]]
-      if (is.null(got)) return(0) # nls carries no residual-sd column
+      if (is.null(got)) {
+        return(0)
+      } # nls carries no residual-sd column
       tn <- paste0("THETA[", k, "]")
       a <- pars
       a[tn] <- a[tn] + h

--- a/tests/testthat/test-focei-lincmt-carry-trans.R
+++ b/tests/testthat/test-focei-lincmt-carry-trans.R
@@ -9,60 +9,158 @@ test_that("the other parameterizations carry exactly (eta+covariate on each slot
   skip_if_not(.rxFoceiLinCmtCarryCapable())
   ev <- .carryEv()
   cases <- list(
-    list(name = "1-cmt k/v", mod = function() {
-      ini({tk <- log(0.1); tv <- log(20); eta.k ~ 0.1; add.sd <- 0.5})
-      model({k <- exp(tk) * (wt / 70)^0.75 * exp(eta.k); v <- exp(tv)
-             cp <- linCmt(); cp ~ add(add.sd)})
+    list(name = "1-cmt k/v", mod = function() { # nolint: indentation_linter.
+      ini({
+        tk <- log(0.1)
+        tv <- log(20)
+        eta.k ~ 0.1
+        add.sd <- 0.5
+      })
+      model({
+        k <- exp(tk) * (wt / 70)^0.75 * exp(eta.k)
+        v <- exp(tv)
+        cp <- linCmt()
+        cp ~ add(add.sd)
+      })
     }, pars = c(`THETA[1]` = log(0.1), `THETA[2]` = log(20), `THETA[3]` = 0.5, `ETA[1]` = 0.3)),
     list(name = "2-cmt k/k12/k21", mod = function() {
-      ini({tk <- log(0.1); tv <- log(20); tk12 <- log(0.05); tk21 <- log(0.03)
-           eta.k12 ~ 0.1; add.sd <- 0.5})
-      model({k <- exp(tk); v <- exp(tv); k12 <- exp(tk12) * (wt / 70) * exp(eta.k12)
-             k21 <- exp(tk21); cp <- linCmt(); cp ~ add(add.sd)})
+      ini({
+        tk <- log(0.1)
+        tv <- log(20)
+        tk12 <- log(0.05)
+        tk21 <- log(0.03)
+        eta.k12 ~ 0.1
+        add.sd <- 0.5
+      })
+      model({
+        k <- exp(tk)
+        v <- exp(tv)
+        k12 <- exp(tk12) * (wt / 70) * exp(eta.k12)
+        k21 <- exp(tk21)
+        cp <- linCmt()
+        cp ~ add(add.sd)
+      })
     }, pars = c(`THETA[1]` = log(0.1), `THETA[2]` = log(20), `THETA[3]` = log(0.05),
                 `THETA[4]` = log(0.03), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
-    list(name = "2-cmt cl/v/q/vss", mod = function() {
-      ini({tcl <- log(2); tv <- log(20); tq <- log(1); tvss <- log(60)
-           eta.vss ~ 0.1; add.sd <- 0.5})
-      model({cl <- exp(tcl); v <- exp(tv); q <- exp(tq)
-             vss <- exp(tvss) * (wt / 70) * exp(eta.vss)
-             cp <- linCmt(); cp ~ add(add.sd)})
+    list(name = "2-cmt cl/v/q/vss", mod = function() { # nolint: indentation_linter.
+      ini({
+        tcl <- log(2)
+        tv <- log(20)
+        tq <- log(1)
+        tvss <- log(60)
+        eta.vss ~ 0.1
+        add.sd <- 0.5
+      })
+      model({
+        cl <- exp(tcl)
+        v <- exp(tv)
+        q <- exp(tq)
+        vss <- exp(tvss) * (wt / 70) * exp(eta.vss)
+        cp <- linCmt()
+        cp ~ add(add.sd)
+      })
     }, pars = c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1),
                 `THETA[4]` = log(60), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
-    list(name = "2-cmt alpha/beta/k21", mod = function() {
-      ini({ta <- log(0.5); tb <- log(0.02); tk21 <- log(0.05); tv <- log(20)
-           eta.b ~ 0.1; add.sd <- 0.5})
-      model({alpha <- exp(ta); beta <- exp(tb) * (wt / 70)^0.5 * exp(eta.b)
-             k21 <- exp(tk21); v <- exp(tv); cp <- linCmt(); cp ~ add(add.sd)})
+    list(name = "2-cmt alpha/beta/k21", mod = function() { # nolint: indentation_linter.
+      ini({
+        ta <- log(0.5)
+        tb <- log(0.02)
+        tk21 <- log(0.05)
+        tv <- log(20)
+        eta.b ~ 0.1
+        add.sd <- 0.5
+      })
+      model({
+        alpha <- exp(ta)
+        beta <- exp(tb) * (wt / 70)^0.5 * exp(eta.b)
+        k21 <- exp(tk21)
+        v <- exp(tv)
+        cp <- linCmt()
+        cp ~ add(add.sd)
+      })
     }, pars = c(`THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(0.05),
                 `THETA[4]` = log(20), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
-    list(name = "2-cmt alpha/beta/aob", mod = function() {
-      ini({ta <- log(0.5); tb <- log(0.02); taob <- log(2); tv <- log(20)
-           eta.aob ~ 0.1; add.sd <- 0.5})
-      model({alpha <- exp(ta); beta <- exp(tb); aob <- exp(taob) * (wt / 70) * exp(eta.aob)
-             v <- exp(tv); cp <- linCmt(); cp ~ add(add.sd)})
+    list(name = "2-cmt alpha/beta/aob", mod = function() { # nolint: indentation_linter.
+      ini({
+        ta <- log(0.5)
+        tb <- log(0.02)
+        taob <- log(2)
+        tv <- log(20)
+        eta.aob ~ 0.1
+        add.sd <- 0.5
+      })
+      model({
+        alpha <- exp(ta)
+        beta <- exp(tb)
+        aob <- exp(taob) * (wt / 70) * exp(eta.aob)
+        v <- exp(tv)
+        cp <- linCmt()
+        cp ~ add(add.sd)
+      })
     }, pars = c(`THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(2),
                 `THETA[4]` = log(20), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
-    list(name = "2-cmt A/B/alpha/beta (B in Vc)", mod = function() {
-      ini({ta <- log(0.5); tb <- log(0.02); tA <- log(0.04); tB <- log(0.01)
-           eta.B ~ 0.1; add.sd <- 0.5})
-      model({alpha <- exp(ta); beta <- exp(tb); A <- exp(tA)
-             B <- exp(tB) * (wt / 70)^-1 * exp(eta.B); cp <- linCmt(); cp ~ add(add.sd)})
+    list( # nolint: indentation_linter.
+      name = "2-cmt A/B/alpha/beta (B in Vc)", mod = function() { # nolint: indentation_linter.
+      ini({ # nolint: indentation_linter.
+        ta <- log(0.5)
+        tb <- log(0.02)
+        tA <- log(0.04)
+        tB <- log(0.01)
+        eta.bVar ~ 0.1
+        add.sd <- 0.5
+      })
+      model({
+        alpha <- exp(ta)
+        beta <- exp(tb)
+        aVar <- exp(tA)
+        bVar <- exp(tB) * (wt / 70)^-1 * exp(eta.bVar)
+        cp <- linCmt()
+        cp ~ add(add.sd)
+      })
     }, pars = c(`THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(0.04),
                 `THETA[4]` = log(0.01), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
-    list(name = "2-cmt v/B/alpha/beta (v in Vc)", mod = function() {
-      ini({ta <- log(0.5); tb <- log(0.02); tv <- log(25); tB <- log(0.01)
-           eta.v ~ 0.1; add.sd <- 0.5})
-      model({alpha <- exp(ta); beta <- exp(tb); v <- exp(tv) * (wt / 70) * exp(eta.v)
-             B <- exp(tB); cp <- linCmt(); cp ~ add(add.sd)})
+    list( # nolint: indentation_linter.
+      name = "2-cmt v/B/alpha/beta (v in Vc)", mod = function() { # nolint: indentation_linter.
+      ini({ # nolint: indentation_linter.
+        ta <- log(0.5)
+        tb <- log(0.02)
+        tv <- log(25)
+        tB <- log(0.01)
+        eta.v ~ 0.1
+        add.sd <- 0.5
+      })
+      model({
+        alpha <- exp(ta)
+        beta <- exp(tb)
+        v <- exp(tv) * (wt / 70) * exp(eta.v)
+        bVar <- exp(tB)
+        cp <- linCmt()
+        cp ~ add(add.sd)
+      })
     }, pars = c(`THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(25),
                 `THETA[4]` = log(0.01), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
-    list(name = "3-cmt v/B/C/alpha/beta/gamma (C in Vc)", mod = function() {
-      ini({ta <- log(1); tb <- log(0.1); tg <- log(0.01); tv <- log(25)
-           tB <- log(0.01); tC <- log(0.005); eta.C ~ 0.1; add.sd <- 0.5})
-      model({alpha <- exp(ta); beta <- exp(tb); gamma <- exp(tg); v <- exp(tv)
-             B <- exp(tB); C <- exp(tC) * (wt / 70)^-1 * exp(eta.C)
-             cp <- linCmt(); cp ~ add(add.sd)})
+    list( # nolint: indentation_linter.
+      name = "3-cmt v/B/C/alpha/beta/gamma (C in Vc)", mod = function() { # nolint: indentation_linter.
+      ini({ # nolint: indentation_linter.
+        ta <- log(1)
+        tb <- log(0.1)
+        tg <- log(0.01)
+        tv <- log(25)
+        tB <- log(0.01)
+        tC <- log(0.005)
+        eta.cVar ~ 0.1
+        add.sd <- 0.5
+      })
+      model({
+        alpha <- exp(ta)
+        beta <- exp(tb)
+        gamma <- exp(tg)
+        v <- exp(tv)
+        bVar <- exp(tB)
+        cVar <- exp(tC) * (wt / 70)^-1 * exp(eta.cVar)
+        cp <- linCmt()
+        cp ~ add(add.sd)
+      })
     }, pars = c(`THETA[1]` = log(1), `THETA[2]` = log(0.1), `THETA[3]` = log(0.01),
                 `THETA[4]` = log(25), `THETA[5]` = log(0.01), `THETA[6]` = log(0.005),
                 `THETA[7]` = 0.5, `ETA[1]` = 0.3)))

--- a/tests/testthat/test-focei-lincmt-carry-trans.R
+++ b/tests/testthat/test-focei-lincmt-carry-trans.R
@@ -40,8 +40,10 @@ test_that("the other parameterizations carry exactly (eta+covariate on each slot
         cp <- linCmt()
         cp ~ add(add.sd)
       })
-    }, pars = c(`THETA[1]` = log(0.1), `THETA[2]` = log(20), `THETA[3]` = log(0.05),
-                `THETA[4]` = log(0.03), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
+    }, pars = c(
+      `THETA[1]` = log(0.1), `THETA[2]` = log(20), `THETA[3]` = log(0.05),
+      `THETA[4]` = log(0.03), `THETA[5]` = 0.5, `ETA[1]` = 0.3
+    )),
     list(name = "2-cmt cl/v/q/vss", mod = function() { # nolint: indentation_linter.
       ini({
         tcl <- log(2)
@@ -59,8 +61,10 @@ test_that("the other parameterizations carry exactly (eta+covariate on each slot
         cp <- linCmt()
         cp ~ add(add.sd)
       })
-    }, pars = c(`THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1),
-                `THETA[4]` = log(60), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
+    }, pars = c(
+      `THETA[1]` = log(2), `THETA[2]` = log(20), `THETA[3]` = log(1),
+      `THETA[4]` = log(60), `THETA[5]` = 0.5, `ETA[1]` = 0.3
+    )),
     list(name = "2-cmt alpha/beta/k21", mod = function() { # nolint: indentation_linter.
       ini({
         ta <- log(0.5)
@@ -78,8 +82,10 @@ test_that("the other parameterizations carry exactly (eta+covariate on each slot
         cp <- linCmt()
         cp ~ add(add.sd)
       })
-    }, pars = c(`THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(0.05),
-                `THETA[4]` = log(20), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
+    }, pars = c(
+      `THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(0.05),
+      `THETA[4]` = log(20), `THETA[5]` = 0.5, `ETA[1]` = 0.3
+    )),
     list(name = "2-cmt alpha/beta/aob", mod = function() { # nolint: indentation_linter.
       ini({
         ta <- log(0.5)
@@ -97,73 +103,85 @@ test_that("the other parameterizations carry exactly (eta+covariate on each slot
         cp <- linCmt()
         cp ~ add(add.sd)
       })
-    }, pars = c(`THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(2),
-                `THETA[4]` = log(20), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
+    }, pars = c(
+      `THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(2),
+      `THETA[4]` = log(20), `THETA[5]` = 0.5, `ETA[1]` = 0.3
+    )),
     list( # nolint: indentation_linter.
       name = "2-cmt A/B/alpha/beta (B in Vc)", mod = function() { # nolint: indentation_linter.
-      ini({ # nolint: indentation_linter.
-        ta <- log(0.5)
-        tb <- log(0.02)
-        tA <- log(0.04)
-        tB <- log(0.01)
-        eta.bVar ~ 0.1
-        add.sd <- 0.5
-      })
-      model({
-        alpha <- exp(ta)
-        beta <- exp(tb)
-        aVar <- exp(tA)
-        bVar <- exp(tB) * (wt / 70)^-1 * exp(eta.bVar)
-        cp <- linCmt()
-        cp ~ add(add.sd)
-      })
-    }, pars = c(`THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(0.04),
-                `THETA[4]` = log(0.01), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
+        ini({ # nolint: indentation_linter.
+          ta <- log(0.5)
+          tb <- log(0.02)
+          tA <- log(0.04)
+          tB <- log(0.01)
+          eta.bVar ~ 0.1
+          add.sd <- 0.5
+        })
+        model({
+          alpha <- exp(ta)
+          beta <- exp(tb)
+          aVar <- exp(tA)
+          bVar <- exp(tB) * (wt / 70)^-1 * exp(eta.bVar)
+          cp <- linCmt()
+          cp ~ add(add.sd)
+        })
+      }, pars = c(
+        `THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(0.04),
+        `THETA[4]` = log(0.01), `THETA[5]` = 0.5, `ETA[1]` = 0.3
+      )
+    ),
     list( # nolint: indentation_linter.
       name = "2-cmt v/B/alpha/beta (v in Vc)", mod = function() { # nolint: indentation_linter.
-      ini({ # nolint: indentation_linter.
-        ta <- log(0.5)
-        tb <- log(0.02)
-        tv <- log(25)
-        tB <- log(0.01)
-        eta.v ~ 0.1
-        add.sd <- 0.5
-      })
-      model({
-        alpha <- exp(ta)
-        beta <- exp(tb)
-        v <- exp(tv) * (wt / 70) * exp(eta.v)
-        bVar <- exp(tB)
-        cp <- linCmt()
-        cp ~ add(add.sd)
-      })
-    }, pars = c(`THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(25),
-                `THETA[4]` = log(0.01), `THETA[5]` = 0.5, `ETA[1]` = 0.3)),
+        ini({ # nolint: indentation_linter.
+          ta <- log(0.5)
+          tb <- log(0.02)
+          tv <- log(25)
+          tB <- log(0.01)
+          eta.v ~ 0.1
+          add.sd <- 0.5
+        })
+        model({
+          alpha <- exp(ta)
+          beta <- exp(tb)
+          v <- exp(tv) * (wt / 70) * exp(eta.v)
+          bVar <- exp(tB)
+          cp <- linCmt()
+          cp ~ add(add.sd)
+        })
+      }, pars = c(
+        `THETA[1]` = log(0.5), `THETA[2]` = log(0.02), `THETA[3]` = log(25),
+        `THETA[4]` = log(0.01), `THETA[5]` = 0.5, `ETA[1]` = 0.3
+      )
+    ),
     list( # nolint: indentation_linter.
       name = "3-cmt v/B/C/alpha/beta/gamma (C in Vc)", mod = function() { # nolint: indentation_linter.
-      ini({ # nolint: indentation_linter.
-        ta <- log(1)
-        tb <- log(0.1)
-        tg <- log(0.01)
-        tv <- log(25)
-        tB <- log(0.01)
-        tC <- log(0.005)
-        eta.cVar ~ 0.1
-        add.sd <- 0.5
-      })
-      model({
-        alpha <- exp(ta)
-        beta <- exp(tb)
-        gamma <- exp(tg)
-        v <- exp(tv)
-        bVar <- exp(tB)
-        cVar <- exp(tC) * (wt / 70)^-1 * exp(eta.cVar)
-        cp <- linCmt()
-        cp ~ add(add.sd)
-      })
-    }, pars = c(`THETA[1]` = log(1), `THETA[2]` = log(0.1), `THETA[3]` = log(0.01),
-                `THETA[4]` = log(25), `THETA[5]` = log(0.01), `THETA[6]` = log(0.005),
-                `THETA[7]` = 0.5, `ETA[1]` = 0.3)))
+        ini({ # nolint: indentation_linter.
+          ta <- log(1)
+          tb <- log(0.1)
+          tg <- log(0.01)
+          tv <- log(25)
+          tB <- log(0.01)
+          tC <- log(0.005)
+          eta.cVar ~ 0.1
+          add.sd <- 0.5
+        })
+        model({
+          alpha <- exp(ta)
+          beta <- exp(tb)
+          gamma <- exp(tg)
+          v <- exp(tv)
+          bVar <- exp(tB)
+          cVar <- exp(tC) * (wt / 70)^-1 * exp(eta.cVar)
+          cp <- linCmt()
+          cp ~ add(add.sd)
+        })
+      }, pars = c(
+        `THETA[1]` = log(1), `THETA[2]` = log(0.1), `THETA[3]` = log(0.01),
+        `THETA[4]` = log(25), `THETA[5]` = log(0.01), `THETA[6]` = log(0.005),
+        `THETA[7]` = 0.5, `ETA[1]` = 0.3
+      )
+    )
+  )
   for (cs in cases) {
     rC <- .carryJumpFd(cs$mod, cs$pars, ev)
     expect_true(grepl("rx_lcCarryAdv_", rC$txt, fixed = TRUE), label = cs$name)

--- a/tests/testthat/test-focei-lincmt-phi-engage.R
+++ b/tests/testthat/test-focei-lincmt-phi-engage.R
@@ -65,9 +65,9 @@
   .dat <- .phiDat(times)
   invisible(.phiStats(TRUE))
   .rx <- rxode2::rxControl(cores = 1L, linCmtSensType = "AD",
-    linCmtSensPhi = phi)
+                           linCmtSensPhi = phi)
   .ctl <- nlmixr2est::foceiControl(maxOuterIterations = 0L, print = 0L,
-    calcTables = FALSE, covMethod = "", rxControl = .rx)
+                                   calcTables = FALSE, covMethod = "", rxControl = .rx)
   .f <- suppressMessages(nlmixr2est::nlmixr2(.phiMod, .dat, "focei", .ctl))
   list(stats = .phiStats(TRUE), objf = .f$objf)
 }

--- a/tests/testthat/test-focei-lincmt-phi-engage.R
+++ b/tests/testthat/test-focei-lincmt-phi-engage.R
@@ -39,9 +39,13 @@
 # Does the loaded rxode2 have the transition-matrix path and its counters?
 .phiFitCapable <- function() {
   .ns <- asNamespace("rxode2")
-  if (!exists("linCmtSeqStats", envir = .ns, inherits = FALSE)) return(FALSE)
+  if (!exists("linCmtSeqStats", envir = .ns, inherits = FALSE)) {
+    return(FALSE)
+  }
   # rxControl() takes ..., so the argument is declared on rxSolve().
-  if (!("linCmtSensPhi" %in% names(formals(rxode2::rxSolve)))) return(FALSE)
+  if (!("linCmtSensPhi" %in% names(formals(rxode2::rxSolve)))) {
+    return(FALSE)
+  }
   "phiBuild" %in% names(utils::getFromNamespace("linCmtSeqStats", "rxode2")(FALSE))
 }
 
@@ -54,9 +58,13 @@
 .phiDat <- function(times, nid = 4L) {
   do.call(rbind, lapply(seq_len(nid), function(i) {
     cp <- 100 / 30 * (exp(-0.13 * times) - exp(-1.2 * times)) * (1 + 0.05 * i)
-    rbind(data.frame(id = i, time = 0, amt = 100, evid = 1, dv = NA_real_),
-          data.frame(id = i, time = times, amt = 0, evid = 0,
-                     dv = cp * (1 + 0.1 * sin(seq_along(times)))))
+    rbind(
+      data.frame(id = i, time = 0, amt = 100, evid = 1, dv = NA_real_),
+      data.frame(
+        id = i, time = times, amt = 0, evid = 0,
+        dv = cp * (1 + 0.1 * sin(seq_along(times)))
+      )
+    )
   }))
 }
 
@@ -64,10 +72,14 @@
 .phiFit <- function(times, phi = TRUE) {
   .dat <- .phiDat(times)
   invisible(.phiStats(TRUE))
-  .rx <- rxode2::rxControl(cores = 1L, linCmtSensType = "AD",
-                           linCmtSensPhi = phi)
-  .ctl <- nlmixr2est::foceiControl(maxOuterIterations = 0L, print = 0L,
-                                   calcTables = FALSE, covMethod = "", rxControl = .rx)
+  .rx <- rxode2::rxControl(
+    cores = 1L, linCmtSensType = "AD",
+    linCmtSensPhi = phi
+  )
+  .ctl <- nlmixr2est::foceiControl(
+    maxOuterIterations = 0L, print = 0L,
+    calcTables = FALSE, covMethod = "", rxControl = .rx
+  )
   .f <- suppressMessages(nlmixr2est::nlmixr2(.phiMod, .dat, "focei", .ctl))
   list(stats = .phiStats(TRUE), objf = .f$objf)
 }

--- a/tests/testthat/test-focei-outer-fd-fallback.R
+++ b/tests/testthat/test-focei-outer-fd-fallback.R
@@ -232,8 +232,8 @@ nmTest({
       ini({ tka <- 0.45; tcl <- 1; tv <- c(2, 3.45, 5); add.sd <- c(0, 0.7, 5)
         eta.ka ~ 0.6; eta.cl ~ 0.3 })
       model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd) })
     }

--- a/tests/testthat/test-focei-prior.R
+++ b/tests/testthat/test-focei-prior.R
@@ -76,8 +76,8 @@ nmTest({
       ka <- exp(tka + eta.ka)
       cl <- exp(tcl + eta.cl)
       v <- exp(tv + eta.v)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.sd)
     })
@@ -97,8 +97,8 @@ nmTest({
       ka <- exp(tka + eta.ka)
       cl <- exp(tcl + eta.cl)
       v <- exp(tv + eta.v)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.sd)
     })

--- a/tests/testthat/test-focei-ptrs.R
+++ b/tests/testthat/test-focei-ptrs.R
@@ -334,7 +334,7 @@ test_that("dose-handling theta sensitivities carry the event jump (#946)", {
     model({
       cl <- exp(tcl + eta.cl)
       v <- exp(tv)
-      d / dt(central) <- -cl / v * central
+      d/dt(central) <- -cl / v * central
       alag(central) <- exp(tlag)
       cp <- central / v
       cp ~ add(add.sd)
@@ -393,7 +393,7 @@ test_that("an eta entering dose handling gets its jump in the eta gradient (#946
     model({
       cl <- exp(tcl + eta.cl)
       v <- exp(tv)
-      d / dt(central) <- -cl / v * central
+      d/dt(central) <- -cl / v * central
       alag(central) <- exp(tlag + eta.lag)
       cp <- central / v
       cp ~ add(add.sd)

--- a/tests/testthat/test-issue-281.R
+++ b/tests/testthat/test-issue-281.R
@@ -34,9 +34,9 @@ nmTest({
         Stim2 <- emaxD * (CONC^GAM) / (CONC^GAM + ec50^GAM)
         Stim <- Stim1 * (1 + TRX * Stim2)
         Delta <- 1 / (1 + exp(-20 * (time - delay)))
-        d / dt(depot) <- -KA * depot
-        d / dt(centr) <- KA * depot - CL * C2
-        d / dt(Resp) <- kin * (1 + Delta * slope) - kout * (1 + Stim) * Resp
+        d/dt(depot) <- -KA * depot
+        d/dt(centr) <- KA * depot - CL * C2
+        d/dt(Resp) <- kin * (1 + Delta * slope) - kout * (1 + Stim) * Resp
         Resp ~ add(add.err)
       })
     }
@@ -95,9 +95,9 @@ nmTest({
         Stim2 <- emaxD * (CONC^GAM) / (CONC^GAM + ec50^GAM)
         Stim <- Stim1 * (1 + TRX * Stim2)
         Delta <- 1 / (1 + exp(-20 * (time - delay)))
-        d / dt(depot) <- -KA * depot
-        d / dt(centr) <- KA * depot - CL * C2
-        d / dt(Resp) <- kin * (1 + Delta * slope) - kout * (1 + Stim) * Resp
+        d/dt(depot) <- -KA * depot
+        d/dt(centr) <- KA * depot - CL * C2
+        d/dt(Resp) <- kin * (1 + Delta * slope) - kout * (1 + Stim) * Resp
         Resp ~ add(add.err)
       })
     }

--- a/tests/testthat/test-omega-boundary.R
+++ b/tests/testthat/test-omega-boundary.R
@@ -2,14 +2,10 @@ nmTest({
   test_that("omega boundary", {
     one.compartment.IV.MM.model <- function(){
       ini({
-        lVM <- 7
-        label("log Vmax (mg/hr)")
-        lKM <- 5.7
-        label("log KM (mg/L)")
-        lVc <- 4.5
-        label("log Vc (L)")
-        prop.err <- 0.3
-        label("Proportional error")
+        lVM <- 7; label("log Vmax (mg/hr)")
+        lKM <- 5.7; label("log KM (mg/L)")
+        lVc <- 4.5; label("log Vc (L)")
+        prop.err <- 0.3; label("Proportional error")
         eta.Vc ~ 0.15
         label("IIV Vc")
         eta.VM ~ 0.15

--- a/tests/testthat/test-priors-output.R
+++ b/tests/testthat/test-priors-output.R
@@ -34,8 +34,8 @@ nmTest({
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl)
         v <- exp(tv)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd)
       })
@@ -69,8 +69,8 @@ nmTest({
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl)
         v <- exp(tv)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd)
       })
@@ -102,8 +102,8 @@ nmTest({
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl)
         v <- exp(tv)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd)
       })
@@ -132,8 +132,8 @@ nmTest({
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl)
         v <- exp(tv)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd)
       })

--- a/tests/testthat/test-rxsolve.R
+++ b/tests/testthat/test-rxsolve.R
@@ -8,7 +8,8 @@ nmTest({
         tcl <- log(c(0, 2.7, 100)) # Log Cl
         ## This works with interactive models
         ## You may also label the preceding line with label("label text")
-        tv <- 3.45; label("log V")
+        tv <- 3.45
+        label("log V")
         ## the label("Label name") works with all models
         eta.ka ~ 0.6
         eta.cl ~ 0.3
@@ -38,7 +39,8 @@ nmTest({
         tcl <- log(c(0, 2.7, 100)) # Log Cl
         ## This works with interactive models
         ## You may also label the preceding line with label("label text")
-        tv <- 3.45; label("log V")
+        tv <- 3.45
+        label("log V")
         ## the label("Label name") works with all models
         eta.ka ~ 0.6
         eta.cl ~ 0.3
@@ -66,11 +68,16 @@ nmTest({
     mod <- function() {
       # Parameters
       ini({
-        tka <- 0.45; label("Ka (first order absorption)")
-        trate <- 0.4 ; label("Zero order rate")
-        tcl <- 1; label("Cl")
-        tv <- 3.45; label("V")
-        fDepot <- logit(0.5) ; label("amount of dose in first order absorption")
+        tka <- 0.45
+        label("Ka (first order absorption)")
+        trate <- 0.4
+        label("Zero order rate")
+        tcl <- 1
+        label("Cl")
+        tv <- 3.45
+        label("V")
+        fDepot <- logit(0.5)
+        label("amount of dose in first order absorption")
         eta.ka ~ 0.6
         eta.cl ~ 0.3
         eta.v ~ 0.1
@@ -106,7 +113,7 @@ nmTest({
 
 nmTest({
 
-  # nlmixr2/rxode2#1289: `$simInfo` re-runs the pre-process hooks and re-derives
+  # nlmixr2/rxode2 issue 1289: `$simInfo` re-runs the pre-process hooks and re-derives
   # the simulation model, which dominated the cost of solving a fit and grew
   # process memory that was never returned -- and a plain `rxSolve(fit, ...)`
   # never reads any of it.

--- a/tests/testthat/test-rxsolve.R
+++ b/tests/testthat/test-rxsolve.R
@@ -7,8 +7,7 @@ nmTest({
         tcl <- log(c(0, 2.7, 100)) # Log Cl
         ## This works with interactive models
         ## You may also label the preceding line with label("label text")
-        tv <- 3.45
-        label("log V")
+        tv <- 3.45; label("log V")
         ## the label("Label name") works with all models
         eta.ka ~ 0.6
         eta.cl ~ 0.3
@@ -38,8 +37,7 @@ nmTest({
         tcl <- log(c(0, 2.7, 100)) # Log Cl
         ## This works with interactive models
         ## You may also label the preceding line with label("label text")
-        tv <- 3.45
-        label("log V")
+        tv <- 3.45; label("log V")
         ## the label("Label name") works with all models
         eta.ka ~ 0.6
         eta.cl ~ 0.3
@@ -67,16 +65,11 @@ nmTest({
     mod <- function() {
       # Parameters
       ini({
-        tka <- 0.45
-        label("Ka (first order absorption)")
-        trate <- 0.4
-        label("Zero order rate")
-        tcl <- 1
-        label("Cl")
-        tv <- 3.45
-        label("V")
-        fDepot <- logit(0.5)
-        label("amount of dose in first order absorption")
+        tka <- 0.45; label("Ka (first order absorption)")
+        trate <- 0.4; label("Zero order rate")
+        tcl <- 1; label("Cl")
+        tv <- 3.45; label("V")
+        fDepot <- logit(0.5); label("amount of dose in first order absorption")
         eta.ka ~ 0.6
         eta.cl ~ 0.3
         eta.v ~ 0.1
@@ -87,8 +80,8 @@ nmTest({
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl + eta.cl)
         v <- exp(tv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
 
         f(depot) <- expit(fDepot)
         f(center) <- 1 - expit(fDepot)

--- a/tests/testthat/test-rxsolve.R
+++ b/tests/testthat/test-rxsolve.R
@@ -1,6 +1,5 @@
 nmTest({
   test_that("nlmixr interface for solving works", {
-
     one.cmt <- function() {
       ini({
         ## You may label each parameter with a comment
@@ -28,7 +27,7 @@ nmTest({
 
     expect_s3_class(f, "rxSolve")
 
-    f2 <- .nlmixr(one.cmt, nlmixr2data::theo_sd, "rxSolve", rxControl(returnType="data.frame"))
+    f2 <- .nlmixr(one.cmt, nlmixr2data::theo_sd, "rxSolve", rxControl(returnType = "data.frame"))
 
     expect_s3_class(f, "data.frame")
 
@@ -61,7 +60,7 @@ nmTest({
 
   test_that("rxSolve will warn when necessary", {
     library(rxode2)
-    eventTable <- et(amt=320, evid=1, cmt=20, time = 0) |> # nolint: object_name_linter.
+    eventTable <- et(amt = 320, evid = 1, cmt = 20, time = 0) |> # nolint: object_name_linter.
       et(2, 4)
 
     # Now define the nlmixr2/rxode2 model used for both estimation and simulation
@@ -88,14 +87,14 @@ nmTest({
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl + eta.cl)
         v <- exp(tv + eta.v)
-        d/dt(depot) = -ka * depot
-        d/dt(center) = ka * depot - cl / v * center
+        d / dt(depot) <- -ka * depot
+        d / dt(center) <- ka * depot - cl / v * center
 
         f(depot) <- expit(fDepot)
-        f(center) <- 1-expit(fDepot)
+        f(center) <- 1 - expit(fDepot)
         rate(center) <- exp(trate)
 
-        cp = center / v
+        cp <- center / v
         cp ~ add(add.sd)
       })
     }
@@ -108,11 +107,9 @@ nmTest({
       )
     )
   })
-
 })
 
 nmTest({
-
   # nlmixr2/rxode2 issue 1289: `$simInfo` re-runs the pre-process hooks and re-derives
   # the simulation model, which dominated the cost of solving a fit and grew
   # process memory that was never returned -- and a plain `rxSolve(fit, ...)`
@@ -148,5 +145,4 @@ nmTest({
     expect_true(any(grepl("from the number of subjects", .acc$msg, fixed = TRUE)))
     expect_equal(length(unique(.sim$sim.id)), 2L)
   })
-
 })

--- a/tests/testthat/test-rxsolve.R
+++ b/tests/testthat/test-rxsolve.R
@@ -103,3 +103,43 @@ nmTest({
   })
 
 })
+
+nmTest({
+
+  # nlmixr2/rxode2#1289: `$simInfo` re-runs the pre-process hooks and re-derives
+  # the simulation model, which dominated the cost of solving a fit and grew
+  # process memory that was never returned -- and a plain `rxSolve(fit, ...)`
+  # never reads any of it.
+
+  .simInfoEv <- function() {
+    rxode2::et(rxode2::et(amt = 320, cmt = "depot"), seq(0, 24, by = 4))
+  }
+
+  test_that("solving a fit skips simulation information it cannot use", {
+    skip_if(is.null(one.compartment.fit.saem))
+    local_mocked_bindings(
+      .simInfo = function(object) stop("simulation information was derived")
+    )
+    expect_no_error(
+      suppressMessages(rxode2::rxSolve(one.compartment.fit.saem, .simInfoEv()))
+    )
+  })
+
+  test_that("solving a fit with uncertainty still uses its simulation information", {
+    skip_if(is.null(one.compartment.fit.saem))
+    .acc <- new.env(parent = emptyenv())
+    .acc$msg <- character(0)
+    withCallingHandlers(
+      .sim <- rxode2::rxSolve(one.compartment.fit.saem, .simInfoEv(), nStud = 2),
+      message = function(m) {
+        .acc$msg <- c(.acc$msg, conditionMessage(m))
+        invokeRestart("muffleMessage")
+      }
+    )
+    expect_true(any(grepl("population uncertainty", .acc$msg, fixed = TRUE)))
+    expect_true(any(grepl("from the number of observations", .acc$msg, fixed = TRUE)))
+    expect_true(any(grepl("from the number of subjects", .acc$msg, fixed = TRUE)))
+    expect_equal(length(unique(.sim$sim.id)), 2L)
+  })
+
+})

--- a/tests/testthat/test-saem-loglik.R
+++ b/tests/testthat/test-saem-loglik.R
@@ -104,8 +104,8 @@ nmTest({
       })
       model({
         ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         sd <- exp(lsd)
         ll(err) ~ -lsd - 0.5 * log(2 * pi) - 0.5 * ((DV - cp) / sd)^2

--- a/tests/testthat/test-saem-odeswap-regression.R
+++ b/tests/testthat/test-saem-odeswap-regression.R
@@ -20,8 +20,8 @@ nmTest({
       })
       model({
         ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd)
       })
@@ -60,8 +60,8 @@ nmTest({
       model({
         ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
         alag(depot) <- exp(talag)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd)
       })
@@ -79,8 +79,8 @@ nmTest({
       })
       model({
         ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         sd <- exp(lsd)
         ll(err) ~ -lsd - 0.5 * log(2 * pi) - 0.5 * ((DV - cp) / sd)^2

--- a/tests/testthat/test-saem-phi1-inner.R
+++ b/tests/testthat/test-saem-phi1-inner.R
@@ -20,8 +20,8 @@ nmTest({
     })
     model({
       ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       sd <- exp(lsd)
       ll(err) ~ -lsd - 0.5 * log(2 * pi) - 0.5 * ((DV - cp) / sd)^2
@@ -37,8 +37,8 @@ nmTest({
       })
       model({
         ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd)
       })
@@ -127,8 +127,8 @@ nmTest({
       })
       model({
         ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd) + dt(nu)
       })
@@ -164,8 +164,8 @@ nmTest({
       model({
         ka <- exp(tka + tka.wt * WT + eta.ka)
         cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         sd <- exp(lsd)
         ll(err) ~ -lsd - 0.5 * log(2 * pi) - 0.5 * ((DV - cp) / sd)^2

--- a/tests/testthat/test-saem-theo_sd.R
+++ b/tests/testthat/test-saem-theo_sd.R
@@ -18,8 +18,8 @@ if (FALSE) {
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl + eta.cl)
         v <- exp(tv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         ipre <- center / v
         ipre ~ add(add.sd)
       })
@@ -39,8 +39,8 @@ if (FALSE) {
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl + eta.cl)
         v <- exp(tv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         ipre <- log(center / v)
         ipre ~ add(lnorm.sd)
       })

--- a/tests/testthat/test-sens-fd.R
+++ b/tests/testthat/test-sens-fd.R
@@ -10,7 +10,7 @@ nmTest({
     })
     model({
       ke <- popKe * exp(etaKe)
-      d / dt(ipre) <- -ke * ipre
+      d/dt(ipre) <- -ke * ipre
       f(ipre) <- fp * exp(etaF)
       ipre ~ prop(prop.sd)
     })

--- a/tests/testthat/test-simModelCache.R
+++ b/tests/testthat/test-simModelCache.R
@@ -1,0 +1,121 @@
+test_that(".simModelCacheKey() only keys off a fit environment", {
+  expect_null(.simModelCacheKey(NULL))
+  expect_null(.simModelCacheKey(list(ui = "model")))
+  .env <- new.env(parent = emptyenv())
+  # an environment that holds no model is not a fit environment
+  expect_null(.simModelCacheKey(.env))
+  assign("ui", "model", envir = .env)
+  expect_identical(.simModelCacheKey(.env), "model")
+  # an uncompressed (environment) model can be edited in place, so it is not
+  # a key the cache can trust
+  assign("ui", new.env(parent = emptyenv()), envir = .env)
+  expect_null(.simModelCacheKey(.env))
+  assign("ui", "model", envir = .env)
+  # a rxUi is an environment too, and it must not pick up a `ui` from a parent
+  expect_null(.simModelCacheKey(new.env(parent = .env)))
+  withr::with_options(list(nlmixr2.simModelCache = FALSE), {
+    expect_null(.simModelCacheKey(.env))
+  })
+})
+
+test_that("the simulation model cache round trips, replaces and evicts", {
+  .simModelCacheReset()
+  on.exit(.simModelCacheReset())
+
+  expect_null(.simModelCacheGet("a"))
+  .simModelCacheSet("a", "modelA")
+  expect_identical(.simModelCacheGet("a"), "modelA")
+  # keys are compared by value, so an equal key hits the same entry
+  expect_identical(.simModelCacheGet(paste0("", "a")), "modelA")
+
+  # re-setting a key replaces its entry rather than adding a second one
+  .simModelCacheSet("a", "modelA2")
+  expect_identical(.simModelCacheGet("a"), "modelA2")
+  expect_equal(length(.simModelCache$entries), 1L)
+
+  # filling the cache drops the least recently used entry ("a")
+  for (.i in seq_len(.simModelCacheMax)) {
+    .simModelCacheSet(paste0("k", .i), paste0("m", .i))
+  }
+  expect_equal(length(.simModelCache$entries), .simModelCacheMax)
+  expect_null(.simModelCacheGet("a"))
+  # reading "k1" makes it the most recently used, so the next insert keeps it
+  expect_identical(.simModelCacheGet("k1"), "m1")
+  .simModelCacheSet("k99", "m99")
+  expect_equal(length(.simModelCache$entries), .simModelCacheMax)
+  expect_identical(.simModelCacheGet("k1"), "m1")
+  expect_null(.simModelCacheGet("k2"))
+
+  .simModelCacheReset()
+  expect_equal(length(.simModelCache$entries), 0L)
+  expect_null(.simModelCacheGet("k1"))
+})
+
+nmTest({
+  test_that("a fit lowers to one shared simulation model (nlmixr2/rxode2#1289)", {
+    skip_if(is.null(one.compartment.fit.saem))
+    skip_if(is.null(one.compartment.fit.focei))
+    .fit <- one.compartment.fit.saem
+    .simModelCacheReset()
+    on.exit(.simModelCacheReset())
+
+    .mod <- .fit$simulationModel
+    expect_true(is.environment(.mod))
+    # the same object, not merely an equal one: nothing is lowered twice
+    expect_identical(.fit$simulationModel, .mod)
+    expect_equal(length(.simModelCache$entries), 1L)
+
+    # solving the fit reuses that same model instead of lowering per call
+    .ev <- rxode2::et(amt = 320, cmt = "depot")
+    .ev <- rxode2::et(.ev, seq(0, 24, by = 4))
+    suppressMessages(rxode2::rxSolve(.fit, .ev))
+    expect_equal(length(.simModelCache$entries), 1L)
+    expect_identical(.fit$simulationModel, .mod)
+
+    # a different fitted model is a different key, so it gets its own entry
+    expect_false(identical(one.compartment.fit.focei$simulationModel, .mod))
+    expect_equal(length(.simModelCache$entries), 2L)
+
+    # and the cache can be turned off, which restores the per-call lowering
+    withr::with_options(list(nlmixr2.simModelCache = FALSE), {
+      expect_false(identical(.fit$simulationModel, .fit$simulationModel))
+    })
+  })
+
+  test_that("the cached model solves the same as a freshly lowered one", {
+    skip_if(is.null(one.compartment.fit.saem))
+    .fit <- one.compartment.fit.saem
+    .ev <- rxode2::et(amt = 320, cmt = "depot")
+    .ev <- rxode2::et(.ev, seq(0, 24, by = 4))
+    .simModelCacheReset()
+    on.exit(.simModelCacheReset())
+
+    withr::with_options(list(nlmixr2.simModelCache = FALSE), {
+      set.seed(42)
+      .uncached <- suppressMessages(rxode2::rxSolve(.fit, .ev))
+    })
+    set.seed(42)
+    .cached <- suppressMessages(rxode2::rxSolve(.fit, .ev))
+    set.seed(42)
+    .cachedAgain <- suppressMessages(rxode2::rxSolve(.fit, .ev))
+
+    expect_equal(as.data.frame(.cached), as.data.frame(.uncached))
+    # a shared model must not accumulate state between solves either
+    expect_equal(as.data.frame(.cachedAgain), as.data.frame(.uncached))
+  })
+
+  test_that("a cached model still solves after its dll is unloaded", {
+    skip_if(is.null(one.compartment.fit.saem))
+    .fit <- one.compartment.fit.saem
+    .ev <- rxode2::et(amt = 320, cmt = "depot")
+    .ev <- rxode2::et(.ev, seq(0, 24, by = 4))
+    .simModelCacheReset()
+    on.exit(.simModelCacheReset())
+
+    suppressMessages(rxode2::rxSolve(.fit, .ev))
+    rxode2::rxUnloadAll()
+    # the cached model outlives the unload, so it has to reload itself rather
+    # than solve against a dll that is gone
+    expect_no_error(suppressMessages(rxode2::rxSolve(.fit, .ev)))
+  })
+})

--- a/tests/testthat/test-update-estimates.R
+++ b/tests/testthat/test-update-estimates.R
@@ -15,8 +15,8 @@ nmTest({
         ka <- exp(tka + eta.ka)
         cl <- exp(tcl + eta.cl)
         v <- exp(tv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd)
       })

--- a/tests/testthat/test-vae-dataprep.R
+++ b/tests/testthat/test-vae-dataprep.R
@@ -41,8 +41,8 @@ nmTest({
     ini({ lka <- 0.4; lcl <- -0.9; lb <- log(3); lsd <- log(1.2); eta.b ~ 0.1 })
     model({
       ka <- exp(lka); cl <- exp(lcl)
-      d / dt(depot) <- -ka * depot
-      d / dt(central) <- ka * depot - cl * central
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl * central
       mu <- exp(lb + eta.b) * central
       sd <- exp(lsd)
       ll(cp) ~ -0.5 * log(2 * pi) - log(sd) - 0.5 * ((DV - mu) / sd)^2
@@ -52,8 +52,8 @@ nmTest({
     ini({ tka <- 0.45; tcl <- 1; tv <- c(2, 3.45, 5); add.sd <- c(0, 0.7, 5)
       eta.ka ~ 0.6; eta.cl ~ 0.3 })
     model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.sd) })
   }
@@ -74,7 +74,7 @@ nmTest({
       model({
         k <- exp(lk); v <- exp(lv)
         conc <- central / v
-        d / dt(central) <- -k * conc + eta.b * 0
+        d/dt(central) <- -k * conc + eta.b * 0
         sd <- exp(lsd)
         ll(conc) ~ -log(sd) - 0.5 * ((DV - conc) / sd)^2
       })
@@ -93,7 +93,7 @@ nmTest({
       model({
         cl <- exp(lcl)
         central_0 <- exp(linit)          # rxode2's other spelling of central(0)
-        d / dt(central) <- -cl * central
+        d/dt(central) <- -cl * central
         sd <- exp(lsd)
         ll(cp) ~ -log(sd) - 0.5 * ((DV - central * exp(eta.b)) / sd)^2
       })
@@ -107,7 +107,7 @@ nmTest({
       ini({ lcl <- -1; lsd <- 0; eta.b ~ 0.1 })
       model({
         if (TIME > 0) { cl <- exp(lcl) } else { cl <- exp(lcl) }
-        d / dt(central) <- -cl * central
+        d/dt(central) <- -cl * central
         sd <- exp(lsd)
         ll(cp) ~ -log(sd) - 0.5 * ((DV - central * exp(eta.b)) / sd)^2
       })
@@ -123,8 +123,8 @@ nmTest({
       model({
         k <- exp(lk); v <- exp(lv)
         conc ~ central / v
-        d / dt(central) <- -k * central
-        d / dt(effect) <- 1 - conc * effect
+        d/dt(central) <- -k * central
+        d/dt(effect) <- 1 - conc * effect
         sd <- exp(lsd)
         ll(conc) ~ -log(sd) - 0.5 * ((DV - conc * exp(eta.b)) / sd)^2
       })
@@ -145,7 +145,7 @@ nmTest({
         cl <- exp(tcl); v <- exp(tv)
         cp <- linCmt()
         e0 <- exp(te0 + eta.e0); kout <- exp(tkout); kin <- e0 * kout
-        d / dt(pd) <- kin - kout * pd
+        d/dt(pd) <- kin - kout * pd
         pd ~ prop(prop.err)
       })
     }))
@@ -186,8 +186,8 @@ nmTest({
         eta.b ~ 0.1 })
       model({
         ka <- exp(lka); cl <- exp(lcl)
-        d / dt(depot) <- -ka * depot
-        d / dt(central) <- ka * depot - cl * central
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - cl * central
         cp <- central
         cp ~ add(add.sd)
         mu <- exp(lb + eta.b) * central

--- a/tests/testthat/test-vae-grad-fit.R
+++ b/tests/testthat/test-vae-grad-fit.R
@@ -21,8 +21,8 @@ nmTest({
     ini({ tka <- 0.45; tcl <- 1; tv <- c(2, 3.45, 5); add.sd <- c(0, 0.7, 5)
       eta.ka ~ 0.6; eta.cl ~ 0.3 })
     model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.sd) })
   }
@@ -87,8 +87,8 @@ nmTest({
       ini({ tka <- 0.45; tcl <- 1; tv <- c(2, 3.45, 5); add.sd <- c(0, 3.0, 10)
         eta.ka ~ 0.6; eta.cl ~ 0.3 })
       model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd) })
     }

--- a/tests/testthat/test-vae-ll-grad-fit.R
+++ b/tests/testthat/test-vae-ll-grad-fit.R
@@ -19,8 +19,8 @@ nmTest({
     ini({ lka <- 0.4; lcl <- -0.9; lb <- log(3); lsd <- log(1.2); eta.b ~ 0.1 })
     model({
       ka <- exp(lka); cl <- exp(lcl)
-      d / dt(depot) <- -ka * depot
-      d / dt(central) <- ka * depot - cl * central
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl * central
       mu <- exp(lb + eta.b) * central
       sd <- exp(lsd)
       ll(cp) ~ -0.5 * log(2 * pi) - log(sd) - 0.5 * ((DV - mu) / sd)^2
@@ -102,8 +102,8 @@ nmTest({
       ini({ tka <- 0.45; tcl <- 1; tv <- c(2, 3.45, 5); add.sd <- c(0, 0.7, 5)
         eta.ka ~ 0.6; eta.cl ~ 0.3 })
       model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ add(add.sd) })
     }

--- a/tests/testthat/test-vae-nonmutheta-grad.R
+++ b/tests/testthat/test-vae-nonmutheta-grad.R
@@ -11,8 +11,8 @@ nmTest({
     ini({ tka <- 0.45; tcl <- 1; tv <- c(2, 3.45, 5); add.sd <- c(0, 0.7, 5)
       eta.ka ~ 0.6; eta.cl ~ 0.3 })
     model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.sd) })
   }
@@ -22,8 +22,8 @@ nmTest({
     ini({ lka <- 0.4; lcl <- -0.9; lb <- log(3); lsd <- log(1.2); eta.b ~ 0.1 })
     model({
       ka <- exp(lka); cl <- exp(lcl)
-      d / dt(depot) <- -ka * depot
-      d / dt(central) <- ka * depot - cl * central
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl * central
       mu <- exp(lb + eta.b) * central
       sd <- exp(lsd)
       ll(cp) ~ -0.5 * log(2 * pi) - log(sd) - 0.5 * ((DV - mu) / sd)^2
@@ -149,8 +149,8 @@ nmTest({
     ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- 0.7
       eta.ka ~ 0.6; eta.cl ~ 0.3 })
     model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.sd) })
   }
@@ -200,8 +200,8 @@ nmTest({
       ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- 0.7
         eta.ka ~ 0.6; eta.cl ~ 0.3 })
       model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v
         cp ~ lnorm(add.sd) })
     }

--- a/tests/testthat/test-vae-residopt.R
+++ b/tests/testthat/test-vae-residopt.R
@@ -14,8 +14,8 @@ nmTest({
     ini({ lka <- 0.45; lcl <- 1; lv <- 3.45; eta.ka ~ 0.6; eta.cl ~ 0.3
       prop.err <- 0.3; pw <- 0.8 })
     model({ ka <- exp(lka + eta.ka); cl <- exp(lcl + eta.cl); v <- exp(lv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ pow(prop.err, pw) })
   }
@@ -23,8 +23,8 @@ nmTest({
     ini({ lka <- 0.45; lcl <- 1; lv <- 3.45; eta.ka ~ 0.6; eta.cl ~ 0.3
       add.err <- 0.5 })
     model({ ka <- exp(lka + eta.ka); cl <- exp(lcl + eta.cl); v <- exp(lv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ lnorm(add.err) })
   }
@@ -32,8 +32,8 @@ nmTest({
     ini({ lka <- 0.45; lcl <- 1; lv <- 3.45; eta.ka ~ 0.6; eta.cl ~ 0.3
       add.err <- 0.7; prop.err <- 0.1 })
     model({ ka <- exp(lka + eta.ka); cl <- exp(lcl + eta.cl); v <- exp(lv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.err) + prop(prop.err) })
   }
@@ -92,8 +92,8 @@ nmTest({
     ini({ lka <- 0.45; lcl <- 1; lv <- 3.45; eta.ka ~ 0.6; eta.cl ~ 0.3
       add.err <- 0.7; lam <- 1 })
     model({ ka <- exp(lka + eta.ka); cl <- exp(lcl + eta.cl); v <- exp(lv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.err) + boxCox(lam) })
   }
@@ -101,8 +101,8 @@ nmTest({
     ini({ lka <- 0.45; lcl <- 1; lv <- 3.45; eta.ka ~ 0.6; eta.cl ~ 0.3
       add.err <- 0.7; lam <- 1 })
     model({ ka <- exp(lka + eta.ka); cl <- exp(lcl + eta.cl); v <- exp(lv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.err) + yeoJohnson(lam) })
   }
@@ -172,8 +172,8 @@ nmTest({
   .sweep[[1]]$mod <- .addOnlyMod <- function() {
     ini({ lka <- 0.45; lcl <- 1; lv <- 3.45; eta.ka ~ 0.6; eta.cl ~ 0.3; add.err <- 0.7 })
     model({ ka <- exp(lka + eta.ka); cl <- exp(lcl + eta.cl); v <- exp(lv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v; cp ~ add(add.err) })
   }
   .sweep[[2]]$mod <- .combMod
@@ -219,8 +219,8 @@ nmTest({
         eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
         add.err <- 0.7 })
       model({ ka <- exp(lka + eta.ka); cl <- exp(lcl + eta.cl); v <- exp(lv + eta.v)
-        d / dt(depot) <- -ka * depot
-        d / dt(center) <- ka * depot - cl / v * center
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
         cp <- center / v; cp ~ add(add.err) })
     }
     ui <- rxode2::assertRxUi(mod())

--- a/tests/testthat/test-vae-rvar.R
+++ b/tests/testthat/test-vae-rvar.R
@@ -11,16 +11,16 @@ nmTest({
   .addMod <- function() {
     ini({ lka <- 0.45; lcl <- 1; lv <- 3.45; eta.ka ~ 0.6; add.err <- 0.7 })
     model({ ka <- exp(lka + eta.ka); cl <- exp(lcl); v <- exp(lv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.err) })
   }
   .propMod <- function() {
     ini({ lka <- 0.45; lcl <- 1; lv <- 3.45; eta.ka ~ 0.6; prop.err <- 0.15 })
     model({ ka <- exp(lka + eta.ka); cl <- exp(lcl); v <- exp(lv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ prop(prop.err) })
   }
@@ -28,8 +28,8 @@ nmTest({
     ini({ lka <- 0.45; lcl <- 1; lv <- 3.45; eta.ka ~ 0.6
       add.err <- 0.7; prop.err <- 0.15 })
     model({ ka <- exp(lka + eta.ka); cl <- exp(lcl); v <- exp(lv)
-      d / dt(depot) <- -ka * depot
-      d / dt(center) <- ka * depot - cl / v * center
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
       cp <- center / v
       cp ~ add(add.err) + prop(prop.err) })
   }


### PR DESCRIPTION
**Title**

fix(rxSolve): stop re-deriving the model from a fit on every solve (rxode2 1289)

**Body**

Fixes nlmixr2/rxode2#1289.

`rxode2::rxSolve()` on a fit re-derived, on **every call**, everything it needed
from the fit:

* `rxode2:::.rxSolveFromUi()` asks the fit for `$simulationModel`, and
  `nmObjGet.simulationModel()` lowered the fit to an rxode2 model each time; and
* `nmObjGet.rxControlWithVar()` asks for `$simInfo`, which re-runs the
  pre-process hooks and lowers the model again.

On the reporter's reprex (one-compartment ODE fit of `theo_sd`) those two were
0.096 s of the 0.106 s each `rxSolve(fit, ev)` cost, and together they grew
process memory by ~2 MB per call that `gc()`, `rxUnloadAll()` and `rxClean()`
could not give back. A simulation loop over a fit therefore grew without
bound — the report is a `targets` pipeline that died after ~15,600 solves
(~47 GB).

### What this does

**Cache the lowered simulation model** (`R/simModelCache.R`). The lowered model
is a pure function of the fitted model, so it is cached keyed on the `ui` object
the fit environment holds:

* an entry holds that `ui` and **never the fit**, so a cached entry cannot keep
  a fit (or its data) alive, and nothing is added to what `saveRDS(fit)` writes;
* the cache keeps the five most recently used models;
* two fits that share a key lower to the same model, so sharing an entry between
  them is correct; piping or refitting builds a new `ui`, which is what
  invalidates an entry;
* a fit holds a *compressed* `ui`, which has value semantics — an uncompressed
  (environment) `ui` could be edited in place behind the cache's back, so it is
  not used as a key;
* `options(nlmixr2.simModelCache = FALSE)` turns it off.

**Do not derive `$simInfo` when the solve cannot use it** (`R/rxsolve.R`).
`$simInfo` is not cached — it mixes model-derived and fit-derived values — and
it does not need to be: every use of it in `.rxSolveGetControlForNlmixr()`
(`thetaMat`, `dfObs`, `dfSub`, `sigma`) is already conditional on the solve
carrying uncertainty, and a plain `rxSolve(fit, events)` does not. It is now
passed as a promise and that condition is hoisted, so the common path never
derives it at all.

### Result

Same reprex, R 4.6.1 on Linux, 40 solves per measurement:

| | s/call | RSS growth/call |
| --- | --- | --- |
| before | 0.1060 | +2.04 MB |
| lazy `$simInfo` only | 0.0580 | +0.08 MB |
| both | **0.0082** | **+0.00 MB** |

Behavior is unchanged: `rxSolve(fit, ev)` and `rxSolve(fit, ev, nStud = 2)`
return bit-identical results for the same seed as before the change, and the
`nStud = 2` path still reports and uses the fit's `thetaMat`, `dfObs` and
`dfSub`. `$simInfo`, `nlmixr2(fit, est = "simulate")`, `vpcSim()`, `augPred()`
and `ini()`-piping a fit all still work.

### Tests

* `tests/testthat/test-simModelCache.R` — the key rules (fit environment only,
  no uncompressed `ui`, option honoured), cache round trip, replace-not-duplicate,
  LRU eviction; and on real fits: one shared model per fit, solving does not
  lower again, a different fit gets its own entry, the cache can be turned off,
  and a cached model solves identically to a freshly lowered one (twice, so a
  shared model cannot accumulate state).
* `tests/testthat/test-rxsolve.R` — a plain solve never computes `$simInfo`
  (mocked to error), and an `nStud = 2` solve still reports and uses it.

### Not fixed here (filed separately against rxode2)

The per-lowering cost this avoids is itself two leaks in rxode2, which are worth
fixing on their own since any repeated lowering hits them:

* `rxNorm()` (and so `rxode2()`) leaks ~0.4 MB of process memory per call, even
  for a model that is already compiled;
* `getBaseSimModel()` retains ~25 KB of R language objects per call that `gc()`
  never reclaims.