### PR TITLE
refactor(fitSim): drop the focei simulation model that was built and thrown away

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@
 
 ## Internal
 
+- `getBaseSimModelFit()` for the focei family (`focei`, `foce`, `focep`, `fo`,
+  `foi`, `posthoc`) no longer does three times the work for the same answer.
+  The method built a `predOnly`-based simulation model expression and then
+  discarded it, and called `getBaseSimModelFit.default()` twice -- once with
+  the result thrown away -- so lowering a focei fit to a simulation model
+  lowered it three times, one of those through a `rxNorm()` of the focei
+  `predOnly` model.  These methods are now aliases of the default, which is
+  what they already amounted to.
+
 - A covariate whose value is carried on the model in `rxode2::rxForcedPars()` is
   no longer required to be a column of the data.  Such a covariate is supplied
   by the model itself, so demanding it from the data rejected a well-specified

--- a/R/fitSim.R
+++ b/R/fitSim.R
@@ -9,93 +9,6 @@ getBaseSimModelFit <- function(x) {
   UseMethod("getBaseSimModelFit")
 }
 
-.isAssignExpr <- function(x) {
-  length(x) == 3L &&
-    (identical(x[[1]],quote(`=`)) ||
-       identical(x[[1]],quote(`<-`)))
-}
-
-.replaceThetaEtaWithNamed <- function(x, iniDf) {
-  if (is.call(x)) {
-    if (length(x) == 3L &&
-          is.numeric(x[[3]]) &&
-          identical(x[[1]], quote(`[`))) {
-      if (identical(x[[2]], quote(`THETA`))) {
-        return(str2lang(iniDf[which(iniDf$ntheta== x[[3]]), "name"]))
-      }
-      if (identical(x[[2]], quote(`ETA`))) {
-        return(str2lang(iniDf[which(iniDf$neta1 == x[[3]] & iniDf$neta2 == x[[3]]),
-                              "name"]))
-      }
-    }
-    return(as.call(lapply(x, .replaceThetaEtaWithNamed, iniDf)))
-  }
-  x
-}
-
-#' @rdname getBaseSimModelFit
-#' @export
-getBaseSimModelFit.focei <- function(x) {
-  obj <- x[[1]]
-    getBaseSimModelFit.default(x) # fall back to basic with new method
-  if (all(obj$ui$predDf$distribution == "norm")) {
-    .expr <- eval(parse(text=paste0("quote(rxode2({",
-                                    rxode2::rxNorm(obj$foceiModel$predOnly),
-                                    "}))")))
-    .e2 <- .expr[[2]]
-    .e2 <- lapply(seq_along(.e2), function(i) {
-      .cur <- .e2[[i]]
-      .replaceThetaEtaWithNamed(.cur, obj$ui$iniDf)
-    })
-    .w <- vapply(seq_along(.e2), function(i) {
-      .cur <- .e2[[i]]
-      if (.isAssignExpr(.cur) &&
-            identical(.cur[[2]], .cur[[3]])) {
-        return(FALSE)
-      }
-      return(TRUE)
-    }, logical(1), USE.NAMES=FALSE)
-    .e2 <- .e2[.w]
-    .w <- which(vapply(seq_along(.e2), function(i) {
-      .cur <- .e2[[i]]
-      if (.isAssignExpr(.cur) &&
-            identical(.cur[[2]], quote(`rx_r_`))) return(TRUE)
-      FALSE
-    }, logical(1), USE.NAMES=TRUE))
-    .w <- seq(1, .w)
-    .e21 <- .e2[.w]
-    .e22 <- .e2[-.w]
-    .e2 <- as.call(c(.e21,
-      list(quote(ipredSim <- rxTBSi(rx_pred_, rx_lambda_, rx_yj_, rx_low_, rx_hi_)),
-           eval(parse(text=paste0("quote(sim <- rxTBSi(rx_pred_ + sqrt(rx_r_) *(",
-                                  paste(paste0("error.", obj$predDf$var, "*(CMT==", obj$predDf$cmt, ")"),
-                                        collapse = "+"),
-                                  "), rx_lambda_, rx_yj_, rx_low_, rx_hi_))")))),
-      .e22))
-    .expr[[2]] <- .e2
-  }
-  getBaseSimModelFit.default(x)
-}
-
-#' @rdname getBaseSimModelFit
-#' @export
-getBaseSimModelFit.foce <- getBaseSimModelFit.focei
-
-#' @rdname getBaseSimModelFit
-#' @export
-getBaseSimModelFit.focep <- getBaseSimModelFit.focei
-
-#' @rdname getBaseSimModelFit
-#' @export
-getBaseSimModelFit.fo <- getBaseSimModelFit.focei
-#' @rdname getBaseSimModelFit
-#' @export
-getBaseSimModelFit.foi <- getBaseSimModelFit.focei
-
-#' @rdname getBaseSimModelFit
-#' @export
-getBaseSimModelFit.posthoc <- getBaseSimModelFit.focei
-
 #' @rdname getBaseSimModelFit
 #' @export
 getBaseSimModelFit.default <- function(x) {
@@ -103,6 +16,36 @@ getBaseSimModelFit.default <- function(x) {
   .ui <- .obj$ui
   rxode2::getBaseSimModel(.ui)
 }
+
+## The focei-family methods used to build a `predOnly`-based simulation model
+## and then throw it away, and to call the default method twice -- once with
+## its result discarded.  They were therefore already identical to the default
+## in behavior, at about three times the cost (two extra lowerings of the fit
+## per call, one of them a `rxNorm()` of the focei `predOnly` model).  They are
+## kept as aliases so dispatch, and the exported methods, stay as they were.
+#' @rdname getBaseSimModelFit
+#' @export
+getBaseSimModelFit.focei <- getBaseSimModelFit.default
+
+#' @rdname getBaseSimModelFit
+#' @export
+getBaseSimModelFit.foce <- getBaseSimModelFit.default
+
+#' @rdname getBaseSimModelFit
+#' @export
+getBaseSimModelFit.focep <- getBaseSimModelFit.default
+
+#' @rdname getBaseSimModelFit
+#' @export
+getBaseSimModelFit.fo <- getBaseSimModelFit.default
+
+#' @rdname getBaseSimModelFit
+#' @export
+getBaseSimModelFit.foi <- getBaseSimModelFit.default
+
+#' @rdname getBaseSimModelFit
+#' @export
+getBaseSimModelFit.posthoc <- getBaseSimModelFit.default
 
 getBaseSimModel.nlmixr2FitCoreSilent <- function(obj) {
   .est <- obj$est

--- a/tests/testthat/test-fitSim.R
+++ b/tests/testthat/test-fitSim.R
@@ -1,0 +1,40 @@
+test_that("the focei-family simulation models are the default method", {
+  # they used to build a `predOnly`-based model and discard it, and to call the
+  # default method twice -- identical output, three times the work.  Aliases,
+  # not copies, so this fails the moment a body grows back.
+  for (.m in c("focei", "foce", "focep", "fo", "foi", "posthoc")) {
+    expect_identical(get(paste0("getBaseSimModelFit.", .m)),
+                     getBaseSimModelFit.default,
+                     info = .m)
+  }
+})
+
+test_that("getBaseSimModelFit() lowers the fit's model", {
+  # a fit-shaped stand-in: the method only ever reads `$ui`
+  .mod <- function() {
+    ini({
+      tka <- 0.5
+      addSd <- 0.7
+    })
+    model({
+      ka <- exp(tka)
+      d/dt(depot) <- -ka * depot
+      cp <- depot
+      cp ~ add(addSd)
+    })
+  }
+  .ui <- rxode2::rxode2(.mod)
+  .obj <- list(ui = .ui)
+  .lst <- list(.obj)
+  class(.lst) <- c("focei", "getBaseSimModelFit")
+  expect_equal(getBaseSimModelFit(.lst), rxode2::getBaseSimModel(.ui))
+})
+
+nmTest({
+  test_that("a focei fit lowers to the same simulation model as any other fit", {
+    skip_if(is.null(one.compartment.fit.focei))
+    .fit <- one.compartment.fit.focei
+    expect_equal(rxode2::rxNorm(.fit$simulationModel),
+                 rxode2::rxNorm(eval(rxode2::getBaseSimModel(.fit$ui))))
+  })
+})


### PR DESCRIPTION
`getBaseSimModelFit.focei()` — shared by `foce`, `focep`, `fo`, `foi` and
`posthoc` — was behaviorally identical to `getBaseSimModelFit.default()` at
about three times the cost:

```r
getBaseSimModelFit.focei <- function(x) {
  obj <- x[[1]]
    getBaseSimModelFit.default(x) # fall back to basic with new method   # <- result dropped
  if (all(obj$ui$predDf$distribution == "norm")) {
    .expr <- eval(parse(text = paste0("quote(rxode2({",
                                      rxode2::rxNorm(obj$foceiModel$predOnly),
                                      "}))")))
    ...                                                                   # ~35 lines building .e2
    .expr[[2]] <- .e2                                                     # <- .expr never used again
  }
  getBaseSimModelFit.default(x)
}
```

Two things were dead: the `getBaseSimModelFit.default(x)` on the second line
(its value discarded, and the same call made again at the end), and the whole
`if` block — `.expr` is built, including a `rxNorm()` of the focei `predOnly`
model, and then goes out of scope unused.

So lowering a focei fit to a simulation model lowered it three times. That ran
on every `rxSolve(fit, ...)` call before nlmixr2/rxode2#1289 was fixed, and
each of those lowerings also leaked (nlmixr2/rxode2#1289 and the rxode2
`fix/model-lowering-leaks` branch).

### What this does

Makes the focei-family methods aliases of the default, which is what they
already amounted to, and drops `.isAssignExpr()` and
`.replaceThetaEtaWithNamed()`, whose only caller was the dead block. The
methods are kept rather than deleted, so dispatch and the exported method list
are unchanged.

The discarded expression is preserved in history if the unfinished feature it
sketches — a focei-specific simulation model built from `predOnly` with
per-endpoint `error.<var>*(CMT==n)` terms — is ever wanted. If it is not, the
methods can go away entirely and dispatch will land on the default.

### Tests

`tests/testthat/test-fitSim.R`:

* the focei-family methods **are** the default method (`expect_identical`, so a
  body growing back fails);
* the default lowers the fit's own `$ui` (fit-shaped stand-in, no fitting);
* a focei fit's `$simulationModel` is unchanged by this (fixture fit).

15/15 pass in `test-fitSim|simulation|nmobj|rxsolve`.