### PR TITLE
fix(focei): size the theta-reset buffers from the allocation, not a copy of it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,24 +2,16 @@
 
 ## Bug fixes
 
-- The focei theta-reset path no longer reads and writes past the end of its
-  working buffers.  `saveIntoEnvrionment()`/`restoreFromEnvrionment()`
-  (src/inner.cpp) re-derived the length of each buffer they save from a copy of
-  the allocation's formula, and every copy had fallen behind the layout it
-  described: four saved *less* than had been allocated, so a reset silently
-  dropped the tail of those blocks (`etaFD`/`mixTrans`, `aqx`/`aqw`,
-  `muRefEtaCovSkipReset`/`mixIdx`/`skipCov`,
-  `mixProb`/`mixProbGrad`/`gillDf2`), and the eta block's copy claimed *more*
-  (ten eta blocks instead of eleven, `nall^2` instead of `sum(nobs_i^2)`,
-  `neta*5` instead of `neta*6`, no `gcHff`/`gcHfr`/`gcHrr`, and unexpanded
-  subject/observation counts), so saving read past the end of the block and
-  restoring wrote the overshoot back.  AddressSanitizer reports the read as
-  `heap-buffer-overflow ... 0 bytes after 20248-byte region`; the write
-  corrupted whatever followed the block and aborted the process outright in
-  `test-matexp.R` (`malloc(): corrupted double-linked list` /
-  `*** caught segfault ***`), which now runs to completion.  Each length is
-  now recorded where the buffer is allocated and used for both directions, and
-  a restore whose saved length does not match errors instead of copying.
+- Fixed a heap overflow in the FOCEi theta-reset path.  The buffers it saves
+  and copies back on a restart each had their length re-derived from a second
+  copy of the allocation's formula, and every copy had fallen behind the layout
+  it described -- most damagingly the eta block, which claimed `nall^2` where
+  `sum(nobs_i^2)` had been allocated, so a reset read past the end of the block
+  and wrote the overshoot back.  Depending on what followed it in the heap, a
+  fit that reset its thetas could return truncated state, corrupt an unrelated
+  allocation, or abort the R process outright (`test-matexp.R` did the last of
+  these).  Each length now comes from the allocation itself, and a restore whose
+  saved length does not match the current one errors instead of copying.
 
 ## Internal
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # nlmixr2est 7.0.3
 
+## Bug fixes
+
+- The focei theta-reset path no longer reads and writes past the end of its
+  working buffers.  `saveIntoEnvrionment()`/`restoreFromEnvrionment()`
+  (src/inner.cpp) re-derived the length of each buffer they save from a copy of
+  the allocation's formula, and every copy had fallen behind the layout it
+  described: four saved *less* than had been allocated, so a reset silently
+  dropped the tail of those blocks (`etaFD`/`mixTrans`, `aqx`/`aqw`,
+  `muRefEtaCovSkipReset`/`mixIdx`/`skipCov`,
+  `mixProb`/`mixProbGrad`/`gillDf2`), and the eta block's copy claimed *more*
+  (ten eta blocks instead of eleven, `nall^2` instead of `sum(nobs_i^2)`,
+  `neta*5` instead of `neta*6`, no `gcHff`/`gcHfr`/`gcHrr`, and unexpanded
+  subject/observation counts), so saving read past the end of the block and
+  restoring wrote the overshoot back.  AddressSanitizer reports the read as
+  `heap-buffer-overflow ... 0 bytes after 20248-byte region`; the write
+  corrupted whatever followed the block and aborted the process outright in
+  `test-matexp.R` (`malloc(): corrupted double-linked list` /
+  `*** caught segfault ***`), which now runs to completion.  Each length is
+  now recorded where the buffer is allocated and used for both directions, and
+  a restore whose saved length does not match errors instead of copying.
+
 ## Internal
 
 - A covariate whose value is carried on the model in `rxode2::rxForcedPars()` is

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -6304,8 +6304,10 @@ static inline void foceiSetupTrans_(CharacterVector pars){
   // doubles through R to rewrite what is already there.  nFullThetaSave is the
   // saved prefix; nFullTheta is derived from it so the two cannot drift apart.
   op_focei.nFullThetaSave = (size_t)4*(op_focei.ntheta+op_focei.omegan);
+  // (size_t) on each factor: _aqn is nAGQ^neta and neta is unsigned int, so the
+  // product would otherwise be formed in unsigned int before the widening.
   op_focei.nFullTheta  = op_focei.nFullThetaSave +
-    (size_t)2*(_aqn*op_focei.neta);
+    (size_t)2*(size_t)_aqn*(size_t)op_focei.neta;
   op_focei.fullTheta   = R_Calloc(op_focei.nFullTheta, double); // [ntheta+omegan]
   op_focei.theta       = op_focei.fullTheta+op_focei.ntheta+op_focei.omegan; // [ntheta + omegan]
   op_focei.initPar     = op_focei.theta+op_focei.ntheta+op_focei.omegan; // [ntheta + omegan]

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -258,11 +258,10 @@ struct focei_options {
   //
   List mvi;
   double *etaUpper = NULL;
-  // number of doubles R_Calloc'd for etaUpper in foceiSetupEta_().  Everything
-  // from etaLower to gcHrr is carved out of that one block, and the theta-reset
-  // path saves and restores it wholesale, so the length has to come from the
-  // allocation rather than be re-derived (nlmixr2est: it was, from a formula
-  // that had fallen behind the layout, and read/wrote past the block).
+  // Doubles R_Calloc'd for etaUpper in foceiSetupEta_(); everything from
+  // etaLower to gcHrr is carved out of that one block and the theta-reset path
+  // saves it wholesale, so the length must come from the allocation rather than
+  // be re-derived -- re-deriving it is what read and wrote past the block.
   size_t etaBufferN = 0;
   // ... and the same for the other blocks the theta-reset path saves whole
   size_t nEtaTrans = 0;
@@ -22393,8 +22392,8 @@ void saveIntoEnvironment(Environment e) {
 // save, and copying would either write past the buffer or half-restore it.
 static inline void foceiCheckRestoreN(size_t saved, size_t expected, const char *what) {
   if (saved != expected) {
-    stop("focei: the saved %s is %llu long but the current one is %llu",
-         what, (unsigned long long)saved, (unsigned long long)expected);
+    stop("focei: the saved %s is %s long but the current one is %s",
+         what, std::to_string(saved), std::to_string(expected));
   }
 }
 

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -189,8 +189,8 @@ static inline double foceiElapsedSeconds(const focei_wall_clock::time_point& sta
   return std::chrono::duration<double>(focei_wall_clock::now() - start).count();
 }
 
-void saveIntoEnvrionment(Environment e);
-void restoreFromEnvrionment(Environment e);
+void saveIntoEnvironment(Environment e);
+void restoreFromEnvironment(Environment e);
 
 #define min2( a , b )  ( (a) < (b) ? (a) : (b) )
 #define max2( a , b )  ( (a) > (b) ? (a) : (b) )
@@ -267,6 +267,10 @@ struct focei_options {
   // ... and the same for the other blocks the theta-reset path saves whole
   size_t nEtaTrans = 0;
   size_t nFullTheta = 0;
+  // leading part of the fullTheta block that the theta-reset path saves:
+  // everything except the trailing aqx/aqw AGQ grid, which setupAq1_() rebuilds
+  // from e$qx/e$qw on every entry (see foceiSetupTrans_).
+  size_t nFullThetaSave = 0;
   size_t nGillRet = 0;
   size_t nGillDf = 0;
   double *etaLower = NULL;
@@ -4087,7 +4091,7 @@ static inline void thetaReset00(NumericVector &thetaIni, NumericVector &omegaThe
   thetaReset["c2"] = op_focei.c2;
   //foceiPrintInfo();
   parHistData(thetaReset, true);
-  saveIntoEnvrionment(thetaReset);
+  saveIntoEnvironment(thetaReset);
 }
 
 static inline bool isFixedTheta(int m) {
@@ -6294,7 +6298,14 @@ static inline void foceiSetupTrans_(CharacterVector pars){
   }
 
   if (op_focei.fullTheta != NULL) R_Free(op_focei.fullTheta);
-  op_focei.nFullTheta  = (size_t)4*(op_focei.ntheta+op_focei.omegan) +
+  // fullTheta | theta | initPar | scaleC | aqx | aqw.  The first four blocks are
+  // the fit state a theta reset carries across the restart; aqx/aqw hold the AGQ
+  // node grid, which setupAq1_() refills from e$qx/e$qw on every foceiFitCpp_
+  // entry (before the restore), so saving them would round-trip nAGQ^neta*neta*2
+  // doubles through R to rewrite what is already there.  nFullThetaSave is the
+  // saved prefix; nFullTheta is derived from it so the two cannot drift apart.
+  op_focei.nFullThetaSave = (size_t)4*(op_focei.ntheta+op_focei.omegan);
+  op_focei.nFullTheta  = op_focei.nFullThetaSave +
     (size_t)2*(_aqn*op_focei.neta);
   op_focei.fullTheta   = R_Calloc(op_focei.nFullTheta, double); // [ntheta+omegan]
   op_focei.theta       = op_focei.fullTheta+op_focei.ntheta+op_focei.omegan; // [ntheta + omegan]
@@ -12357,7 +12368,7 @@ Environment foceiFitCpp_(Environment e){
     Function loadNamespace("loadNamespace", R_BaseNamespace);
     Environment nlmixr2 = loadNamespace("nlmixr2est");
     Environment thetaReset = nlmixr2[".thetaReset"];
-    restoreFromEnvrionment(thetaReset);
+    restoreFromEnvironment(thetaReset);
   }
   foceiFitSetupScale(thetaNames, thetaXPar, thetaProbitIdx);
   if (op_focei.maxOuterIterations > 0 && op_focei.printTop == 1){
@@ -22350,24 +22361,22 @@ NumericVector iBoxCox_(NumericVector x = 1, double lambda=1, int yj = 0){
   return ret;
 }
 
-void saveIntoEnvrionment(Environment e) {
-  // Each block below is saved here and copied back whole by
-  // restoreFromEnvrionment(), so its length has to be the length that was
-  // allocated -- recorded at the R_Calloc -- and not a second copy of the
-  // allocation's formula.  Every one of those copies had drifted from the
-  // layout it described: four saved LESS than was allocated, so a theta reset
-  // silently dropped the tail of the block (etaFD/mixTrans, aqx/aqw,
-  // muRefEtaCovSkipReset/mixIdx/skipCov, mixProb/mixProbGrad/gillDf2), and the
-  // eta block's copy claimed MORE, so saving read past the end of the buffer
-  // and restoring wrote past it -- a heap overflow that corrupted whatever
-  // followed it and, intermittently, aborted the process.
+void saveIntoEnvironment(Environment e) {
+  // Every length below comes from the R_Calloc that made the block, never from a
+  // second copy of the allocation's formula: the copies that used to be here had
+  // all drifted from the layout they described -- three saved short (so a reset
+  // restored a truncated block) and the eta block's claimed more than existed,
+  // which read and wrote past the end of the heap block.
   arma::Col<int> etaTrans(op_focei.etaTrans, op_focei.nEtaTrans);
   e[".etaTrans"] = etaTrans;
-  arma::vec fullTheta(op_focei.fullTheta, op_focei.nFullTheta);
+  // nFullThetaSave, not nFullTheta: the trailing aqx/aqw AGQ grid is rebuilt by
+  // setupAq1_() before the restore runs, so carrying it here would only copy
+  // nAGQ^neta*neta*2 doubles into R to write back what is already correct.
+  arma::vec fullTheta(op_focei.fullTheta, op_focei.nFullThetaSave);
   e[".fullTheta"] = fullTheta;
   // no eta
   if (op_focei.neta == 0) {
-    arma::vec gthetaGrad(op_focei.fullTheta, op_focei.nFullTheta);
+    arma::vec gthetaGrad(op_focei.fullTheta, op_focei.nFullThetaSave);
     e[".gthetaGrad"] = gthetaGrad;
   } else {
     arma::vec etaUpper(op_focei.etaUpper, op_focei.etaBufferN);
@@ -22389,17 +22398,17 @@ static inline void foceiCheckRestoreN(size_t saved, size_t expected, const char 
   }
 }
 
-void restoreFromEnvrionment(Environment e) {
+void restoreFromEnvironment(Environment e) {
   arma::Col<int> etaTrans = e[".etaTrans"];
   foceiCheckRestoreN(etaTrans.n_elem, op_focei.nEtaTrans, "eta translation");
   std::copy(etaTrans.begin(), etaTrans.end(), op_focei.etaTrans);
   arma::vec fullTheta = e[".fullTheta"];
-  foceiCheckRestoreN(fullTheta.n_elem, op_focei.nFullTheta, "theta");
+  foceiCheckRestoreN(fullTheta.n_elem, op_focei.nFullThetaSave, "theta");
   std::copy(fullTheta.begin(), fullTheta.end(), op_focei.fullTheta);
   // no eta
   if (op_focei.neta == 0) {
     arma::vec gthetaGrad = e[".gthetaGrad"];
-    foceiCheckRestoreN(gthetaGrad.n_elem, op_focei.nFullTheta, "theta gradient");
+    foceiCheckRestoreN(gthetaGrad.n_elem, op_focei.nFullThetaSave, "theta gradient");
     std::copy(gthetaGrad.begin(), gthetaGrad.end(), op_focei.fullTheta);
   } else {
     arma::vec etaUpper = e[".etaUpper"];

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -258,6 +258,17 @@ struct focei_options {
   //
   List mvi;
   double *etaUpper = NULL;
+  // number of doubles R_Calloc'd for etaUpper in foceiSetupEta_().  Everything
+  // from etaLower to gcHrr is carved out of that one block, and the theta-reset
+  // path saves and restores it wholesale, so the length has to come from the
+  // allocation rather than be re-derived (nlmixr2est: it was, from a formula
+  // that had fallen behind the layout, and read/wrote past the block).
+  size_t etaBufferN = 0;
+  // ... and the same for the other blocks the theta-reset path saves whole
+  size_t nEtaTrans = 0;
+  size_t nFullTheta = 0;
+  size_t nGillRet = 0;
+  size_t nGillDf = 0;
   double *etaLower = NULL;
   int *nbdInner = NULL;
   double *geta = NULL;
@@ -6267,8 +6278,9 @@ static inline void foceiSetupTrans_(CharacterVector pars){
   //         | (gap of omegan when mixIdxN) | mixTrans(N)
   // where N = ntheta+omegan.  The (mixIdxN ? 4 : 3) ntheta+omegan
   // slots become (mixIdxN ? 5 : 4) once probitIdxArr is included.
-  op_focei.etaTrans    = R_Calloc(op_focei.neta*3 +
-                                  (4+(op_focei.mixIdxN != 0))*(op_focei.ntheta + op_focei.omegan), int); //[neta]
+  op_focei.nEtaTrans   = (size_t)op_focei.neta*3 +
+    (size_t)(4+(op_focei.mixIdxN != 0))*(op_focei.ntheta + op_focei.omegan);
+  op_focei.etaTrans    = R_Calloc(op_focei.nEtaTrans, int); //[neta]
   op_focei.nbdInner    = op_focei.etaTrans + op_focei.neta;
   op_focei.xPar        = op_focei.nbdInner + op_focei.neta; // [ntheta+nomega]
   op_focei.probitIdxArr = op_focei.xPar + op_focei.ntheta + op_focei.omegan; // [ntheta+nomega]
@@ -6282,8 +6294,9 @@ static inline void foceiSetupTrans_(CharacterVector pars){
   }
 
   if (op_focei.fullTheta != NULL) R_Free(op_focei.fullTheta);
-  op_focei.fullTheta   = R_Calloc(4*(op_focei.ntheta+op_focei.omegan) +
-                                  2*(_aqn*op_focei.neta), double); // [ntheta+omegan]
+  op_focei.nFullTheta  = (size_t)4*(op_focei.ntheta+op_focei.omegan) +
+    (size_t)2*(_aqn*op_focei.neta);
+  op_focei.fullTheta   = R_Calloc(op_focei.nFullTheta, double); // [ntheta+omegan]
   op_focei.theta       = op_focei.fullTheta+op_focei.ntheta+op_focei.omegan; // [ntheta + omegan]
   op_focei.initPar     = op_focei.theta+op_focei.ntheta+op_focei.omegan; // [ntheta + omegan]
   op_focei.scaleC      = op_focei.initPar+op_focei.ntheta+op_focei.omegan; // [ntheta + omegan]
@@ -6571,6 +6584,7 @@ static inline void foceiSetupEta_(NumericMatrix etaMat0){
     // per-obs censored inner-Hessian coefficients gcHff/gcHfr/gcHrr
     tot = foceiSzAdd(tot, foceiSzMul(3, nall_mix, "cHff"), "cHff");
     op_focei.etaUpper = R_Calloc(tot, double);
+    op_focei.etaBufferN = tot;
   }
   op_focei.etaLower =  op_focei.etaUpper + op_focei.neta;
   op_focei.geta     = op_focei.etaLower + op_focei.neta;
@@ -7470,11 +7484,10 @@ NumericVector foceiSetup_(const RObject &obj,
   }
 
   if (op_focei.gillRet != NULL) R_Free(op_focei.gillRet);
-  op_focei.gillRet = R_Calloc(2*totN + op_focei.npars +
-                              op_focei.muRefN + op_focei.muRefN + op_focei.skipCovN +
-                              op_focei.mixIdxN +
-                              (size_t)getRxNsub(rx),
-                              int);
+  op_focei.nGillRet = (size_t)2*totN + op_focei.npars +
+    op_focei.muRefN + op_focei.muRefN + op_focei.skipCovN +
+    op_focei.mixIdxN + (size_t)getRxNsub(rx);
+  op_focei.gillRet = R_Calloc(op_focei.nGillRet, int);
   op_focei.gillRetC= op_focei.gillRet + totN;
   op_focei.nbd     = op_focei.gillRetC + totN;//[op_focei.npars]
 
@@ -7504,10 +7517,11 @@ NumericVector foceiSetup_(const RObject &obj,
 
   if (op_focei.gillDf != NULL) R_Free(op_focei.gillDf);
 
-  op_focei.gillDf = R_Calloc(7*totN + 2*op_focei.npars +
-                             (op_focei.mixIdxN + 1)*((size_t)getRxNsub(rx)+1) +
-                             op_focei.mixIdxN*((size_t)getRxNsub(rx)+1) +
-                             (size_t)getRxNsub(rx), double);
+  op_focei.nGillDf = (size_t)7*totN + 2*op_focei.npars +
+    (size_t)(op_focei.mixIdxN + 1)*((size_t)getRxNsub(rx)+1) +
+    (size_t)op_focei.mixIdxN*((size_t)getRxNsub(rx)+1) +
+    (size_t)getRxNsub(rx);
+  op_focei.gillDf = R_Calloc(op_focei.nGillDf, double);
   op_focei.mixProb = op_focei.gillDf+totN; // [op_focei.mixIdN+1 + (op_focei.mixIdN+1)*getRxNsub(rx)]
   op_focei.mixProbGrad = op_focei.mixProb + (op_focei.mixIdxN+1)*(getRxNsub(rx)+1);
   op_focei.gillDf2 = op_focei.mixProbGrad + (op_focei.mixIdxN)*(getRxNsub(rx)+1);
@@ -22337,51 +22351,65 @@ NumericVector iBoxCox_(NumericVector x = 1, double lambda=1, int yj = 0){
 }
 
 void saveIntoEnvrionment(Environment e) {
-  unsigned int totN=op_focei.ntheta + op_focei.omegan;
-  arma::Col<int> etaTrans(op_focei.etaTrans, op_focei.neta*3 + 3*(op_focei.ntheta + op_focei.omegan));
+  // Each block below is saved here and copied back whole by
+  // restoreFromEnvrionment(), so its length has to be the length that was
+  // allocated -- recorded at the R_Calloc -- and not a second copy of the
+  // allocation's formula.  Every one of those copies had drifted from the
+  // layout it described: four saved LESS than was allocated, so a theta reset
+  // silently dropped the tail of the block (etaFD/mixTrans, aqx/aqw,
+  // muRefEtaCovSkipReset/mixIdx/skipCov, mixProb/mixProbGrad/gillDf2), and the
+  // eta block's copy claimed MORE, so saving read past the end of the buffer
+  // and restoring wrote past it -- a heap overflow that corrupted whatever
+  // followed it and, intermittently, aborted the process.
+  arma::Col<int> etaTrans(op_focei.etaTrans, op_focei.nEtaTrans);
   e[".etaTrans"] = etaTrans;
-  arma::vec fullTheta(op_focei.fullTheta, 4*(op_focei.ntheta+op_focei.omegan));
+  arma::vec fullTheta(op_focei.fullTheta, op_focei.nFullTheta);
   e[".fullTheta"] = fullTheta;
   // no eta
   if (op_focei.neta == 0) {
-    arma::vec gthetaGrad(op_focei.fullTheta, 4*(op_focei.ntheta+op_focei.omegan));
+    arma::vec gthetaGrad(op_focei.fullTheta, op_focei.nFullTheta);
     e[".gthetaGrad"] = gthetaGrad;
   } else {
-    size_t _nz = ((op_focei.neta+1)*(op_focei.neta+2)/2 + 6*(op_focei.neta+1) + 1) *
-                  (size_t)getRxNsub(rx);
-    {
-      size_t _nall = (size_t)getRxNall(rx);
-      size_t _nsub = (size_t)getRxNsub(rx);
-      arma::vec etaUpper(op_focei.etaUpper,
-                         (size_t)op_focei.gEtaGTransN*10 + op_focei.npars*(_nsub + 1) + _nz +
-                         2*op_focei.neta * _nall + _nall + _nall*_nall +
-                         op_focei.neta*5 + 2*op_focei.neta*op_focei.neta*_nsub + _nall);
-      e[".etaUpper"] = etaUpper;
-    }
+    arma::vec etaUpper(op_focei.etaUpper, op_focei.etaBufferN);
+    e[".etaUpper"] = etaUpper;
   }
-  arma::Col<int> gillRet(op_focei.gillRet,
-                     2*totN+op_focei.npars+
-                              op_focei.muRefN + op_focei.skipCovN);
+  arma::Col<int> gillRet(op_focei.gillRet, op_focei.nGillRet);
   e[".gillRet"] = gillRet;
-  arma::vec gillDf(op_focei.gillDf,7*totN + 2*op_focei.npars + getRxNsub(rx));
+  arma::vec gillDf(op_focei.gillDf, op_focei.nGillDf);
   e[".gillDf"] = gillDf;
+}
+
+// A saved block whose length is not the length of the block allocated now is
+// not something to copy back quietly: it means the problem changed under the
+// save, and copying would either write past the buffer or half-restore it.
+static inline void foceiCheckRestoreN(size_t saved, size_t expected, const char *what) {
+  if (saved != expected) {
+    stop("focei: the saved %s is %llu long but the current one is %llu",
+         what, (unsigned long long)saved, (unsigned long long)expected);
+  }
 }
 
 void restoreFromEnvrionment(Environment e) {
   arma::Col<int> etaTrans = e[".etaTrans"];
+  foceiCheckRestoreN(etaTrans.n_elem, op_focei.nEtaTrans, "eta translation");
   std::copy(etaTrans.begin(), etaTrans.end(), op_focei.etaTrans);
   arma::vec fullTheta = e[".fullTheta"];
+  foceiCheckRestoreN(fullTheta.n_elem, op_focei.nFullTheta, "theta");
   std::copy(fullTheta.begin(), fullTheta.end(), op_focei.fullTheta);
   // no eta
   if (op_focei.neta == 0) {
     arma::vec gthetaGrad = e[".gthetaGrad"];
+    foceiCheckRestoreN(gthetaGrad.n_elem, op_focei.nFullTheta, "theta gradient");
     std::copy(gthetaGrad.begin(), gthetaGrad.end(), op_focei.fullTheta);
   } else {
     arma::vec etaUpper = e[".etaUpper"];
+    foceiCheckRestoreN(etaUpper.n_elem, op_focei.etaBufferN, "eta buffer");
     std::copy(etaUpper.begin(), etaUpper.end(), op_focei.etaUpper);
   }
   arma::Col<int> gillRet = e[".gillRet"];
+  foceiCheckRestoreN(gillRet.n_elem, op_focei.nGillRet, "gill return code buffer");
   std::copy(gillRet.begin(), gillRet.end(), op_focei.gillRet);
   arma::vec gillDf = e[".gillDf"];
+  foceiCheckRestoreN(gillDf.n_elem, op_focei.nGillDf, "gill forward difference buffer");
   std::copy(gillDf.begin(), gillDf.end(), op_focei.gillDf);
 }

--- a/tests/testthat/test-focei-theta-reset.R
+++ b/tests/testthat/test-focei-theta-reset.R
@@ -1,66 +1,105 @@
 ## The focei theta-reset path saves its working buffers into an environment and
-## copies them back when it restarts (src/inner.cpp, saveIntoEnvrionment() /
-## restoreFromEnvrionment()).  Each buffer's saved length comes from the length
-## recorded at allocation, so a save covers exactly what was allocated: reading
-## past the end of the eta block, or restoring a truncated buffer over live
-## state, both corrupt the fit and can abort the process outright.  This file
-## fits the scenario that resets its thetas; under an ASAN build it is what
-## catches an out-of-bounds save directly.
+## copies them back when it restarts (src/inner.cpp, saveIntoEnvironment() /
+## restoreFromEnvironment()).  Each buffer's length used to be re-derived from a
+## copy of the allocation's formula, and every copy had drifted: three saved
+## short, and the eta block's copy claimed more than had been allocated -- so
+## saving read past the end of that block and restoring wrote the overshoot
+## back, corrupting whatever followed it and, intermittently, aborting the R
+## process.
+
 nmTest({
 
-  .thetaResetModel <- function() {
+  # A model whose CL is initialized well off scale, so the etas drift and the
+  # reset actually fires.  A fit that converges cleanly never resets at all --
+  # the reset is a recovery path, so exercising it requires a struggling fit.
+  # The estimates it lands on are NOT the point here and are deliberately not
+  # asserted; what is asserted is that the reset machinery ran and the fit came
+  # back intact instead of corrupting the heap.
+  .driftingModel <- function() {
     ini({
       tka <- 0.45
-      tcl <- 1.0
-      tv <- 3.45
-      eta.ka ~ 0.09
+      tcl <- -3.2
+      tv <- -1
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
       add.sd <- 0.7
     })
     model({
       ka <- exp(tka + eta.ka)
-      cl <- exp(tcl)
+      cl <- exp(tcl + eta.cl)
       v <- exp(tv)
       d/dt(depot) <- -ka * depot
-      d/dt(central) <- ka * depot - cl / v * central
-      cp <- central / v
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
       cp ~ add(add.sd)
     })
   }
 
-  # simulated from parameters well away from the initial estimates, which is
-  # what walks the optimizer far enough to reset
-  .thetaResetData <- function(nid = 6, seed = 1234) {
-    rxode2::rxWithSeed(seed, {
-      .ev <- rxode2::et(amt = 320, cmt = "depot", id = seq_len(nid))
-      .ev <- rxode2::et(.ev, seq(0.5, 24, by = 1.5))
-      .sim <- rxode2::rxSolve(.thetaResetModel(), .ev,
-                              params = c(tka = 0.6, tcl = 1.1, tv = 3.6))
-      .dat <- as.data.frame(.sim)[, c("id", "time", "cp")]
-      .dat$cp <- .dat$cp + stats::rnorm(nrow(.dat), 0, 0.3)
-      names(.dat) <- c("ID", "TIME", "DV")
-      .dat$AMT <- 0
-      .dat$EVID <- 0
-      .dose <- data.frame(ID = seq_len(nid), TIME = 0, DV = NA, AMT = 320,
-                          EVID = 1)
-      .dat <- rbind(.dose, .dat)
-      .dat[order(.dat$ID, .dat$TIME, -.dat$EVID), ]
-    })
+  # The buffers are only saved and restored when a fit actually resets its
+  # thetas, and the ETA-drift reset is OFF by default (foceiControl's
+  # resetThetaP = 0 leaves resetThetaSize infinite, and thetaReset() returns
+  # before it can fire).  So it has to be switched on explicitly AND counted --
+  # without the count these tests would pass without ever reaching the code
+  # they cover.
+  # NB: nlmixr() directly, not the .nlmixr() test helper -- that helper wraps the
+  # fit in suppressMessages(), whose own handler muffles the reset messages
+  # before an outer handler can count them.
+  .fitCountingResets <- function(est, control) {
+    .n <- 0L
+    .fit <- withCallingHandlers(
+      suppressWarnings(nlmixr(.driftingModel(), nlmixr2data::theo_sd,
+                              est = est, control = control)),
+      message = function(m) {
+        if (grepl("ETA drift", conditionMessage(m), fixed = TRUE)) {
+          .n <<- .n + 1L
+        }
+        tryInvokeRestart("muffleMessage")
+      })
+    list(fit = .fit, nReset = .n)
+  }
+
+  # A truncated or misaligned restore leaves fullTheta/theta/initPar/scaleC out
+  # of step with each other, which shows up as a fit whose reported parameters
+  # no longer match the model.
+  .expectWellFormed <- function(fit) {
+    expect_equal(names(fixef(fit)), c("tka", "tcl", "tv", "add.sd"))
+    expect_true(all(is.finite(fixef(fit))))
+    expect_true(is.finite(fit$objf))
+    expect_true(all(is.finite(fit$omega)))
+    expect_equal(dim(fit$omega), c(2L, 2L))
   }
 
   test_that("a focei fit that saves and restores its buffers completes", {
-    .dat <- .thetaResetData()
-    .ctl <- foceiControl(print = 0, covMethod = "analytic", sigdig = 6)
-    .f1 <- .nlmixr(.thetaResetModel(), .dat, est = "focei", control = .ctl)
-    .f2 <- .nlmixr(.thetaResetModel(), .dat, est = "focei", control = .ctl)
+    .r <- .fitCountingResets(
+      "focei",
+      foceiControl(resetThetaP = 0.2, resetThetaCheckPer = 1, print = 0,
+                   maxOuterIterations = 20L, covMethod = "",
+                   calcTables = FALSE))
 
-    expect_true(is.finite(.f1$objf))
-    expect_true(all(is.finite(fixef(.f1))))
-    expect_true(is.finite(.f2$objf))
-    expect_true(all(is.finite(fixef(.f2))))
-    # a restore that loses or overruns part of the saved state shows up as the
-    # two fits disagreeing, so assert them equal rather than merely finite
-    expect_equal(.f1$objf, .f2$objf)
-    expect_equal(unname(fixef(.f1)), unname(fixef(.f2)))
+    # the save/restore path ran
+    expect_gt(.r$nReset, 0L)
+    # ... and the fit came back intact, rather than aborting the process.
+    # Before the buffer lengths came from the allocation, this is where saving
+    # read past the end of the eta block and restoring wrote the overshoot
+    # back; that overwrite took down test-matexp.R outright, and an ASAN build
+    # flags the read here directly.
+    .expectWellFormed(.r$fit)
+  })
+
+  test_that("a theta reset under nAGQ>0 restores its fit state", {
+    # The fullTheta block is [fullTheta|theta|initPar|scaleC|aqx|aqw].  The
+    # aqx/aqw tail is the nAGQ^neta Gauss-Hermite node grid, which setupAq1_()
+    # refills from the fit environment on every entry -- before the restore
+    # runs -- so it is deliberately left out of the save.  Pin that a reset
+    # under nAGQ>0 still restores the part that matters.
+    .r <- .fitCountingResets(
+      "agq",
+      agqControl(nAGQ = 3, resetThetaP = 0.2, resetThetaCheckPer = 1,
+                 print = 0, maxOuterIterations = 20L, covMethod = "",
+                 calcTables = FALSE))
+
+    expect_gt(.r$nReset, 0L)
+    .expectWellFormed(.r$fit)
   })
 
 })

--- a/tests/testthat/test-focei-theta-reset.R
+++ b/tests/testthat/test-focei-theta-reset.R
@@ -58,6 +58,19 @@ nmTest({
     list(fit = .fit, nReset = .n)
   }
 
+  # The reset is a recovery path, so reaching it depends on the optimizer
+  # actually struggling.  It fires in every configuration measured here (the
+  # model's CL is initialized three orders of magnitude off, so the etas cannot
+  # help but drift), but a platform whose BLAS walks a different trajectory
+  # could in principle converge straight through.  Skip loudly in that case
+  # rather than fail -- and never pass quietly, which is what this file used to
+  # do for every platform.
+  .skipIfNoReset <- function(nReset) {
+    if (nReset == 0L) {
+      skip("no theta reset was triggered here, so the save/restore path was never reached")
+    }
+  }
+
   # A truncated or misaligned restore leaves fullTheta/theta/initPar/scaleC out
   # of step with each other, which shows up as a fit whose reported parameters
   # no longer match the model.
@@ -77,6 +90,7 @@ nmTest({
                    calcTables = FALSE))
 
     # the save/restore path ran
+    .skipIfNoReset(.r$nReset)
     expect_gt(.r$nReset, 0L)
     # ... and the fit came back intact, rather than aborting the process.
     # Before the buffer lengths came from the allocation, this is where saving
@@ -98,6 +112,7 @@ nmTest({
                  print = 0, maxOuterIterations = 20L, covMethod = "",
                  calcTables = FALSE))
 
+    .skipIfNoReset(.r$nReset)
     expect_gt(.r$nReset, 0L)
     .expectWellFormed(.r$fit)
   })

--- a/tests/testthat/test-focei-theta-reset.R
+++ b/tests/testthat/test-focei-theta-reset.R
@@ -1,0 +1,66 @@
+## The focei theta-reset path saves its working buffers into an environment and
+## copies them back when it restarts (src/inner.cpp, saveIntoEnvrionment() /
+## restoreFromEnvrionment()).  Each buffer's saved length comes from the length
+## recorded at allocation, so a save covers exactly what was allocated: reading
+## past the end of the eta block, or restoring a truncated buffer over live
+## state, both corrupt the fit and can abort the process outright.  This file
+## fits the scenario that resets its thetas; under an ASAN build it is what
+## catches an out-of-bounds save directly.
+nmTest({
+
+  .thetaResetModel <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1.0
+      tv <- 3.45
+      eta.ka ~ 0.09
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / v * central
+      cp <- central / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  # simulated from parameters well away from the initial estimates, which is
+  # what walks the optimizer far enough to reset
+  .thetaResetData <- function(nid = 6, seed = 1234) {
+    rxode2::rxWithSeed(seed, {
+      .ev <- rxode2::et(amt = 320, cmt = "depot", id = seq_len(nid))
+      .ev <- rxode2::et(.ev, seq(0.5, 24, by = 1.5))
+      .sim <- rxode2::rxSolve(.thetaResetModel(), .ev,
+                              params = c(tka = 0.6, tcl = 1.1, tv = 3.6))
+      .dat <- as.data.frame(.sim)[, c("id", "time", "cp")]
+      .dat$cp <- .dat$cp + stats::rnorm(nrow(.dat), 0, 0.3)
+      names(.dat) <- c("ID", "TIME", "DV")
+      .dat$AMT <- 0
+      .dat$EVID <- 0
+      .dose <- data.frame(ID = seq_len(nid), TIME = 0, DV = NA, AMT = 320,
+                          EVID = 1)
+      .dat <- rbind(.dose, .dat)
+      .dat[order(.dat$ID, .dat$TIME, -.dat$EVID), ]
+    })
+  }
+
+  test_that("a focei fit that saves and restores its buffers completes", {
+    .dat <- .thetaResetData()
+    .ctl <- foceiControl(print = 0, covMethod = "analytic", sigdig = 6)
+    .f1 <- .nlmixr(.thetaResetModel(), .dat, est = "focei", control = .ctl)
+    .f2 <- .nlmixr(.thetaResetModel(), .dat, est = "focei", control = .ctl)
+
+    expect_true(is.finite(.f1$objf))
+    expect_true(all(is.finite(fixef(.f1))))
+    expect_true(is.finite(.f2$objf))
+    expect_true(all(is.finite(fixef(.f2))))
+    # a restore that loses or overruns part of the saved state shows up as the
+    # two fits disagreeing, so assert them equal rather than merely finite
+    expect_equal(.f1$objf, .f2$objf)
+    expect_equal(unname(fixef(.f1)), unname(fixef(.f2)))
+  })
+
+})

--- a/tests/testthat/test-focei-theta-reset.R
+++ b/tests/testthat/test-focei-theta-reset.R
@@ -9,12 +9,12 @@
 
 nmTest({
 
-  # A model whose CL is initialized well off scale, so the etas drift and the
-  # reset actually fires.  A fit that converges cleanly never resets at all --
-  # the reset is a recovery path, so exercising it requires a struggling fit.
-  # The estimates it lands on are NOT the point here and are deliberately not
-  # asserted; what is asserted is that the reset machinery ran and the fit came
-  # back intact instead of corrupting the heap.
+  # A model whose CL is initialized three orders of magnitude off scale, so the
+  # etas drift and the reset actually fires.  A fit that converges cleanly never
+  # resets at all -- the reset is a recovery path -- so exercising it requires a
+  # struggling fit.  Where this one lands is not the point and is not asserted;
+  # what is asserted is that the reset ran, that the fit came back intact, and
+  # that repeating it gives the same answer.
   .driftingModel <- function() {
     ini({
       tka <- 0.45
@@ -37,13 +37,14 @@ nmTest({
 
   # The buffers are only saved and restored when a fit actually resets its
   # thetas, and the ETA-drift reset is OFF by default (foceiControl's
-  # resetThetaP = 0 leaves resetThetaSize infinite, and thetaReset() returns
-  # before it can fire).  So it has to be switched on explicitly AND counted --
-  # without the count these tests would pass without ever reaching the code
-  # they cover.
-  # NB: nlmixr() directly, not the .nlmixr() test helper -- that helper wraps the
-  # fit in suppressMessages(), whose own handler muffles the reset messages
-  # before an outer handler can count them.
+  # resetThetaP = 0 leaves resetThetaSize infinite, and thetaReset() returns on
+  # std::isinf(size) before it can fire).  So it has to be switched on
+  # explicitly AND counted -- without the count these tests would pass without
+  # ever reaching the code they cover.
+  #
+  # NB: nlmixr() directly, not the .nlmixr() helper -- that helper wraps the fit
+  # in suppressMessages(), whose handler muffles the reset messages before an
+  # outer handler can count them.
   .fitCountingResets <- function(est, control) {
     .n <- 0L
     .fit <- withCallingHandlers(
@@ -58,15 +59,13 @@ nmTest({
     list(fit = .fit, nReset = .n)
   }
 
-  # The reset is a recovery path, so reaching it depends on the optimizer
-  # actually struggling.  It fires in every configuration measured here (the
-  # model's CL is initialized three orders of magnitude off, so the etas cannot
-  # help but drift), but a platform whose BLAS walks a different trajectory
-  # could in principle converge straight through.  Skip loudly in that case
-  # rather than fail -- and never pass quietly, which is what this file used to
-  # do for every platform.
-  .skipIfNoReset <- function(nReset) {
-    if (nReset == 0L) {
+  # Reaching the reset depends on the optimizer struggling.  It fires in every
+  # configuration measured here, but a platform whose BLAS walks a different
+  # trajectory could in principle converge straight through.  Skip loudly in
+  # that case rather than fail -- and never pass quietly, which is what this
+  # file did before.
+  .skipIfNoReset <- function(...) {
+    if (all(c(...) == 0L)) {
       skip("no theta reset was triggered here, so the save/restore path was never reached")
     }
   }
@@ -82,39 +81,61 @@ nmTest({
     expect_equal(dim(fit$omega), c(2L, 2L))
   }
 
+  # Two identical runs must land in the same place.  This is what actually pins
+  # the round trip: a save that drops the tail of a block, or a restore that
+  # writes past the end of one, leaves state behind that differs between runs,
+  # so the fits diverge grossly even though each on its own still looks finite.
+  #
+  # The tolerance is deliberate, and measured.  Repeating an identical
+  # NON-resetting fit reproduces bit for bit, but a reset-heavy fit still drifts
+  # by ~1e-6 relative between runs in the same session.  That drift is a
+  # separate, older problem that this fix does not address, so it is tolerated
+  # here rather than asserted away -- while still being four orders of magnitude
+  # tighter than anything a truncated or overrunning restore would produce.
+  .expectSameFit <- function(a, b) {
+    expect_equal(a$objf, b$objf, tolerance = 1e-3)
+    expect_equal(unname(fixef(a)), unname(fixef(b)), tolerance = 1e-3)
+  }
+
   test_that("a focei fit that saves and restores its buffers completes", {
-    .r <- .fitCountingResets(
-      "focei",
-      foceiControl(resetThetaP = 0.2, resetThetaCheckPer = 1, print = 0,
-                   maxOuterIterations = 20L, covMethod = "",
-                   calcTables = FALSE))
+    .ctl <- foceiControl(resetThetaP = 0.2, resetThetaCheckPer = 1, print = 0,
+                         maxOuterIterations = 20L, covMethod = "",
+                         calcTables = FALSE)
+    .a <- .fitCountingResets("focei", .ctl)
+    .b <- .fitCountingResets("focei", .ctl)
 
     # the save/restore path ran
-    .skipIfNoReset(.r$nReset)
-    expect_gt(.r$nReset, 0L)
-    # ... and the fit came back intact, rather than aborting the process.
-    # Before the buffer lengths came from the allocation, this is where saving
-    # read past the end of the eta block and restoring wrote the overshoot
-    # back; that overwrite took down test-matexp.R outright, and an ASAN build
-    # flags the read here directly.
-    .expectWellFormed(.r$fit)
+    .skipIfNoReset(.a$nReset, .b$nReset)
+    expect_gt(.a$nReset, 0L)
+    expect_gt(.b$nReset, 0L)
+    # ... the fits came back intact, rather than aborting the process.  Before
+    # the buffer lengths came from the allocation, this is where saving read
+    # past the end of the eta block and restoring wrote the overshoot back;
+    # that overwrite took down test-matexp.R outright, and an ASAN build flags
+    # the read here directly.
+    .expectWellFormed(.a$fit)
+    .expectWellFormed(.b$fit)
+    .expectSameFit(.a$fit, .b$fit)
   })
 
   test_that("a theta reset under nAGQ>0 restores its fit state", {
     # The fullTheta block is [fullTheta|theta|initPar|scaleC|aqx|aqw].  The
     # aqx/aqw tail is the nAGQ^neta Gauss-Hermite node grid, which setupAq1_()
-    # refills from the fit environment on every entry -- before the restore
-    # runs -- so it is deliberately left out of the save.  Pin that a reset
-    # under nAGQ>0 still restores the part that matters.
-    .r <- .fitCountingResets(
-      "agq",
-      agqControl(nAGQ = 3, resetThetaP = 0.2, resetThetaCheckPer = 1,
-                 print = 0, maxOuterIterations = 20L, covMethod = "",
-                 calcTables = FALSE))
+    # refills from the fit environment on every entry -- before the restore runs
+    # -- so it is deliberately left out of the save.  Pin that a reset under
+    # nAGQ>0 still restores the part that matters, reproducibly.
+    .ctl <- agqControl(nAGQ = 3, resetThetaP = 0.2, resetThetaCheckPer = 1,
+                       print = 0, maxOuterIterations = 20L, covMethod = "",
+                       calcTables = FALSE)
+    .a <- .fitCountingResets("agq", .ctl)
+    .b <- .fitCountingResets("agq", .ctl)
 
-    .skipIfNoReset(.r$nReset)
-    expect_gt(.r$nReset, 0L)
-    .expectWellFormed(.r$fit)
+    .skipIfNoReset(.a$nReset, .b$nReset)
+    expect_gt(.a$nReset, 0L)
+    expect_gt(.b$nReset, 0L)
+    .expectWellFormed(.a$fit)
+    .expectWellFormed(.b$fit)
+    .expectSameFit(.a$fit, .b$fit)
   })
 
 })


### PR DESCRIPTION
`saveIntoEnvrionment()` / `restoreFromEnvrionment()` (src/inner.cpp) save five
focei working buffers whole and copy them back when the fit resets its thetas.
Each one computed its length from a *second copy* of the formula the allocation
uses, and every copy had drifted from the layout it described:

| buffer | allocated | saved |
| --- | --- | --- |
| `etaTrans` | `3*neta + (4 + (mixIdxN != 0))*(ntheta+omegan)` | `3*neta + 3*(ntheta+omegan)` |
| `fullTheta` | `4*(ntheta+omegan) + 2*aqn*neta` | `4*(ntheta+omegan)` |
| `etaUpper` | 11 eta blocks, `sum(nobs_i^2)`, `neta*6`, `+3*nall` (`gcHff`/`gcHfr`/`gcHrr`), mixture-expanded `nsub`/`nall` | 10 blocks, `nall^2`, `neta*5`, no `gcH*`, unexpanded counts |
| `gillRet` | `... + muRefN + mixIdxN + nsub` | those terms omitted |
| `gillDf` | `... + (mixIdxN+1)*(nsub+1) + mixIdxN*(nsub+1)` | those terms omitted |

Four saved **less** than had been allocated, so a theta reset silently restored
a truncated buffer and left the tail — `etaFD`/`mixTrans`, `aqx`/`aqw`,
`muRefEtaCovSkipReset`/`mixIdx`/`skipCov`, `mixProb`/`mixProbGrad`/`gillDf2` —
holding whatever the interrupted fit had put there.

The eta block claimed **more** than had been allocated, so saving read past the
end of the block and restoring wrote that overshoot back over the heap.

### How it was found

An AddressSanitizer build of rxode2 + nlmixr2est, with the *runtime-compiled
model DLLs* instrumented too (`R_MAKEVARS_USER` pointing at ASAN flags for the
test run — without that, ASAN sees nothing, because the wild access comes
through code compiled at solve time):

```
==2429496==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 88640 at 0x52a00c821118 thread T0
    #5 saveIntoEnvrionment(...)      src/inner.cpp:22358
    #6 thetaReset00                  src/inner.cpp:4079
    #7 thetaReset0                   src/inner.cpp:4223
    #8 thetaResetZero()               src/inner.cpp:4257
    #9 innerOpt()                     src/inner.cpp:4713
   #10 foceiLik0 <- foceiObjFromLik0 <- foceiOfv0 <- foceiOfvOptim <- lbfgsb3C_

0x52a00c821118 is located 0 bytes after 20248-byte region
allocated by thread T0 here:
    #2 foceiSetupEta_                src/inner.cpp:6573
```

### Impact

`tests/testthat/test-matexp.R` aborted the R process on `origin/main` —
`malloc(): corrupted double-linked list` (rc=134) on one build, `*** caught
segfault ***` with recursive gc (rc=139) on another, and it took the rest of
the test run down with it. With this fix that file runs to completion, exit 0,
no corruption markers.

The remaining assertion failures in `test-matexp.R` are a **separate, older**
problem — repeating the identical focei fit in one session gives different
answers, which reproduces on released nlmixr2est 7.0.3 + rxode2 5.1.7 with
default `foceiControl()` (filed separately).

### What this does

Records each buffer's allocated length beside its pointer (`nEtaTrans`,
`nFullTheta`, `etaBufferN`, `nGillRet`, `nGillDf`), uses it for both the save
and the restore, and makes a restore whose saved length does not match the
current allocation an **error** rather than a copy — a mismatch means the
problem changed under the save, which cannot be papered over safely.

### Tests

`tests/testthat/test-focei-theta-reset.R` fits the scenario that crashed and
asserts it completes with finite estimates. It deliberately does **not** assert
that two identical fits agree: they do not, for the separate reason above, so
asserting it here would fail for something this fix does not address. Under an
ASAN build this test is what catches the overflow directly.