### PR TITLE
test(focei): lock in that the same fit twice gives the same answer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # nlmixr2est 7.0.3
 
+## Bug fixes
+
+- Fitting the same data twice in one session gives the same answer again
+  (#1020).  On a machine with at least twice as many threads as the problem
+  has subjects, the objective function and the estimates differed between two
+  identical `nlmixr2(..., est = "focei")` calls, and the optimizer frequently
+  stopped at (or beside) the initial estimates.  The cause is in rxode2 --
+  `sortIds()` ordered subjects by their *measured* solve time, so FOCEi, which
+  re-sorts around every inner-optimization and gradient loop, handed its
+  subjects to different threads on every pass and carried different per-thread
+  solver state into each likelihood and gradient.  It is fixed there by
+  ordering on the number of events a subject is solved over; this package
+  gains the regression test.
+
 ## Internal
 
 - A covariate whose value is carried on the model in `rxode2::rxForcedPars()` is

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,12 +6,12 @@
   (#1020).  On a machine with at least twice as many threads as the problem
   has subjects, the objective function and the estimates differed between two
   identical `nlmixr2(..., est = "focei")` calls, and the optimizer frequently
-  stopped at (or beside) the initial estimates.  The cause is in rxode2 --
-  `sortIds()` ordered subjects by their *measured* solve time, so FOCEi, which
-  re-sorts around every inner-optimization and gradient loop, handed its
-  subjects to different threads on every pass and carried different per-thread
-  solver state into each likelihood and gradient.  It is fixed there by
-  ordering on the number of events a subject is solved over; this package
+  stopped at (or beside) the initial estimates.  The cause is in rxode2, where
+  two bugs met on the path FOCEi takes: `sortIds()` ordered subjects by their
+  *measured* solve time, so the order was a function of wall-clock timing, and
+  several per-individual drivers read `ind_solve()`'s subject id as a position
+  in the reordered `rx->ordId` -- so once the order stopped being the identity
+  the wrong individual was integrated.  The fixes are in rxode2; this package
   gains the regression test.
 - Fixed a heap overflow in the FOCEi theta-reset path.  The buffers it saves
   and copies back on a restart each had their length re-derived from a second

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -102,7 +102,7 @@ if (identical(Sys.info()[["sysname"]], "Darwin")) {
   c(
     "focei-wang2007-boxcox-lnorm", "nlme-cov", "agq-fast-grad",
     "focei-ll-fast-grad-fit", "focei-fast-methods-fit", "odeswap-fit",
-    "focei-factr-fit"
+    "focei-factr-fit", "focei-reproducible"
   ),
   # batch 6
   c(

--- a/tests/testthat/test-focei-reproducible.R
+++ b/tests/testthat/test-focei-reproducible.R
@@ -1,18 +1,32 @@
 ## Fitting the same data twice in one session has to give the same answer
 ## (nlmixr2est issue 1020).
 ##
-## FOCEi solves one subject at a time through rxode2's `ind_solve()`, whose
-## argument is a subject id.  Several of rxode2's per-individual drivers read
-## that argument as a position in `rx->ordId` instead, and `rx->ordId` stops
-## being the identity once rxode2 reorders subjects most-expensive-first --
-## which it does when there are at least `throttle` (2) times more threads than
-## subjects.  Past that threshold the wrong individual was integrated, so the
-## likelihood, its gradient, and hence the whole fit depended on a solve order
-## that comes from wall-clock timing.  Fixed in rxode2; these tests need that
-## fix to pass.
+## FOCEi solves one subject at a time through rxode2's `ind_solve()` and
+## re-sorts the subjects around every inner-optimization and every gradient
+## loop.  Two rxode2 bugs met there:
 ##
-## The tests need threads >= 2 * subjects to exercise the path at all, so they
-## raise the thread count for their own duration.
+##   * `sortIds()` ordered the subjects most-expensive-first from
+##     `ind->solveTime`, the accumulated `clock()` time of their earlier
+##     solves, so the order was a function of wall-clock timing -- it differed
+##     between two runs of the same problem and between successive passes of
+##     one run.
+##   * `ind_solve()`'s argument is a subject id, but several of rxode2's
+##     per-individual drivers read it as a position in `rx->ordId`.  While
+##     `ordId` is the identity the two agree; once it is not, the wrong
+##     individual is integrated.
+##
+## The reorder only fires when there are at least `throttle` (2) times more
+## threads than subjects, so past that threshold the likelihood, its gradient
+## and hence the whole fit followed a solve order that came from thread
+## timing.  Both are fixed in rxode2; these tests are the gate.
+##
+## Two things the tests have to do deliberately, or they prove nothing:
+##
+##   * raise the thread count to 2x the subject count for their own duration,
+##     because the reorder does not trigger below it, and
+##   * give the subjects DIFFERENT numbers of samples.  Equal-sized subjects
+##     sort to the identity order, and an identity `ordId` hides the
+##     id-vs-position confusion completely.
 
 nmTest({
 
@@ -54,12 +68,22 @@ nmTest({
     })
   }
 
+  .ini <- c(tka = 0.45, tcl = 1.0, tv = 3.45, add.sd = 0.7)
+
   # simulated from parameters away from the initial estimates, so the optimizer
-  # has to travel -- a fit that stops where it started hides the problem
-  .reproData <- function(model, nid = 6, seed = 1234) {
+  # has to travel -- a fit that stops where it started hides the problem.
+  # Subject i gets 8 + 2i samples: the sizes have to differ for the solve order
+  # to be anything but the identity.
+  .reproData <- function(model, nid, seed = 1234) {
     rxode2::rxWithSeed(seed, {
-      .ev <- rxode2::et(amt = 320, cmt = "depot", id = seq_len(nid))
-      .ev <- rxode2::et(.ev, seq(0.5, 24, by = 1.5))
+      .ev <- do.call(
+        rbind,
+        lapply(seq_len(nid), function(.i) {
+          rbind(data.frame(id = .i, time = 0, amt = 320, evid = 1),
+                data.frame(id = .i,
+                           time = seq(0.5, 24, length.out = 8L + 2L * .i),
+                           amt = 0, evid = 0))
+        }))
       .sim <- rxode2::rxSolve(model, .ev,
                               params = c(tka = 0.6, tcl = 1.1, tv = 3.6))
       .dat <- as.data.frame(.sim)[, c("id", "time", "cp")]
@@ -74,29 +98,41 @@ nmTest({
     })
   }
 
-  .ini <- c(tka = 0.45, tcl = 1.0, tv = 3.45, add.sd = 0.7)
-
-  test_that("the same focei fit twice in one session gives the same answer", {
-    .nid <- 6L
-    .dat <- .reproData(.reproModel(), .nid)
-    # the reorder only triggers at cores >= subjects * throttle (throttle is 2)
-    .threads <- 2L * .nid
-    skip_if(rxode2::rxCores() < .threads,
-            "needs at least 2 threads per subject to exercise the reorder")
+  # How many subjects this machine can exercise the reorder with: it needs
+  # `throttle` (2) threads per subject, so the widest useful problem is half
+  # the logical CPUs.  Capped at `want`, which is a big enough problem for the
+  # estimates to mean something.
+  .reproNid <- function(want = 6L) {
     .old <- rxode2::getRxThreads()
-    on.exit(rxode2::setRxThreads(.old))
-    rxode2::setRxThreads(.threads)
+    on.exit(rxode2::setRxThreads(.old), add = TRUE)
+    rxode2::setRxThreads(0L) # 0 means every logical CPU
+    max(2L, min(want, rxode2::getRxThreads() %/% 2L))
+  }
 
+  # Fit twice at the raised thread count and once at two threads, and demand
+  # all three agree.  `skip_if()` is on what `setRxThreads()` actually granted
+  # -- it clamps to the machine silently, and `getRxThreads()` reports the
+  # current SETTING rather than the number of CPUs, so asking before setting
+  # skips machines that could have run this.
+  .expectReproducible <- function(model, nid) {
+    .threads <- 2L * nid
+    .old <- rxode2::getRxThreads()
+    on.exit(rxode2::setRxThreads(.old), add = TRUE)
+    rxode2::setRxThreads(.threads)
+    skip_if(rxode2::getRxThreads() < .threads,
+            paste0("needs ", .threads, " threads (2 per subject) to reorder"))
+
+    .dat <- .reproData(model, nid)
     .ctl <- foceiControl(print = 0, covMethod = "")
-    .f1 <- .nlmixr(.reproModel(), .dat, est = "focei", control = .ctl)
-    .f2 <- .nlmixr(.reproModel(), .dat, est = "focei", control = .ctl)
+    .f1 <- .nlmixr(model, .dat, est = "focei", control = .ctl)
+    .f2 <- .nlmixr(model, .dat, est = "focei", control = .ctl)
 
     expect_equal(.f1$objf, .f2$objf)
     expect_equal(unname(fixef(.f1)), unname(fixef(.f2)))
 
     # ... and the answer must not depend on how many threads are available
     rxode2::setRxThreads(2L)
-    .f3 <- .nlmixr(.reproModel(), .dat, est = "focei", control = .ctl)
+    .f3 <- .nlmixr(model, .dat, est = "focei", control = .ctl)
     expect_equal(.f1$objf, .f3$objf)
     expect_equal(unname(fixef(.f1)), unname(fixef(.f3)))
 
@@ -104,37 +140,21 @@ nmTest({
     # optimizer that gave up at (or beside) the initial estimates
     expect_false(isTRUE(all.equal(unname(fixef(.f1)[names(.ini)]),
                                   unname(.ini), tolerance = 1e-4)))
-    # it converges to what the data was simulated from
-    expect_equal(unname(fixef(.f1)[c("tka", "tcl", "tv")]),
-                 c(0.6, 1.1, 3.6), tolerance = 0.1)
+    # ... and somewhere right.  Only worth asking of the full-size problem;
+    # a narrow machine runs this with too few subjects to pin the estimates.
+    if (nid >= 6L) {
+      expect_equal(unname(fixef(.f1)[c("tka", "tcl", "tv")]),
+                   c(0.6, 1.1, 3.6), tolerance = 0.1)
+    }
+    invisible(.f1)
+  }
+
+  test_that("the same focei fit twice in one session gives the same answer", {
+    .expectReproducible(.reproModel(), .reproNid())
   })
 
   test_that("a linCmt() focei fit twice in one session gives the same answer", {
-    .nid <- 6L
-    .dat <- .reproData(.reproModelLinCmt(), .nid)
-    .threads <- 2L * .nid
-    skip_if(rxode2::rxCores() < .threads,
-            "needs at least 2 threads per subject to exercise the reorder")
-    .old <- rxode2::getRxThreads()
-    on.exit(rxode2::setRxThreads(.old))
-    rxode2::setRxThreads(.threads)
-
-    .ctl <- foceiControl(print = 0, covMethod = "")
-    .f1 <- .nlmixr(.reproModelLinCmt(), .dat, est = "focei", control = .ctl)
-    .f2 <- .nlmixr(.reproModelLinCmt(), .dat, est = "focei", control = .ctl)
-
-    expect_equal(.f1$objf, .f2$objf)
-    expect_equal(unname(fixef(.f1)), unname(fixef(.f2)))
-
-    rxode2::setRxThreads(2L)
-    .f3 <- .nlmixr(.reproModelLinCmt(), .dat, est = "focei", control = .ctl)
-    expect_equal(.f1$objf, .f3$objf)
-    expect_equal(unname(fixef(.f1)), unname(fixef(.f3)))
-
-    expect_false(isTRUE(all.equal(unname(fixef(.f1)[names(.ini)]),
-                                  unname(.ini), tolerance = 1e-4)))
-    expect_equal(unname(fixef(.f1)[c("tka", "tcl", "tv")]),
-                 c(0.6, 1.1, 3.6), tolerance = 0.1)
+    .expectReproducible(.reproModelLinCmt(), .reproNid())
   })
 
 })

--- a/tests/testthat/test-focei-reproducible.R
+++ b/tests/testthat/test-focei-reproducible.R
@@ -1,0 +1,140 @@
+## Fitting the same data twice in one session has to give the same answer
+## (nlmixr2est issue 1020).
+##
+## FOCEi solves one subject at a time through rxode2's `ind_solve()`, whose
+## argument is a subject id.  Several of rxode2's per-individual drivers read
+## that argument as a position in `rx->ordId` instead, and `rx->ordId` stops
+## being the identity once rxode2 reorders subjects most-expensive-first --
+## which it does when there are at least `throttle` (2) times more threads than
+## subjects.  Past that threshold the wrong individual was integrated, so the
+## likelihood, its gradient, and hence the whole fit depended on a solve order
+## that comes from wall-clock timing.  Fixed in rxode2; these tests need that
+## fix to pass.
+##
+## The tests need threads >= 2 * subjects to exercise the path at all, so they
+## raise the thread count for their own duration.
+
+nmTest({
+
+  .reproModel <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1.0
+      tv <- 3.45
+      eta.ka ~ 0.09
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / v * central
+      cp <- central / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  # the same structural model as an analytic solution, which reaches a
+  # different family of rxode2 drivers (ind_linCmt0 / ind_linCmt0H)
+  .reproModelLinCmt <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1.0
+      tv <- 3.45
+      eta.ka ~ 0.09
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      cp <- linCmt()
+      cp ~ add(add.sd)
+    })
+  }
+
+  # simulated from parameters away from the initial estimates, so the optimizer
+  # has to travel -- a fit that stops where it started hides the problem
+  .reproData <- function(model, nid = 6, seed = 1234) {
+    rxode2::rxWithSeed(seed, {
+      .ev <- rxode2::et(amt = 320, cmt = "depot", id = seq_len(nid))
+      .ev <- rxode2::et(.ev, seq(0.5, 24, by = 1.5))
+      .sim <- rxode2::rxSolve(model, .ev,
+                              params = c(tka = 0.6, tcl = 1.1, tv = 3.6))
+      .dat <- as.data.frame(.sim)[, c("id", "time", "cp")]
+      .dat$cp <- .dat$cp + stats::rnorm(nrow(.dat), 0, 0.3)
+      names(.dat) <- c("ID", "TIME", "DV")
+      .dat$AMT <- 0
+      .dat$EVID <- 0
+      .dat <- rbind(data.frame(ID = seq_len(nid), TIME = 0, DV = NA,
+                               AMT = 320, EVID = 1),
+                    .dat)
+      .dat[order(.dat$ID, .dat$TIME, -.dat$EVID), ]
+    })
+  }
+
+  .ini <- c(tka = 0.45, tcl = 1.0, tv = 3.45, add.sd = 0.7)
+
+  test_that("the same focei fit twice in one session gives the same answer", {
+    .nid <- 6L
+    .dat <- .reproData(.reproModel(), .nid)
+    # the reorder only triggers at cores >= subjects * throttle (throttle is 2)
+    .threads <- 2L * .nid
+    skip_if(rxode2::rxCores() < .threads,
+            "needs at least 2 threads per subject to exercise the reorder")
+    .old <- rxode2::getRxThreads()
+    on.exit(rxode2::setRxThreads(.old))
+    rxode2::setRxThreads(.threads)
+
+    .ctl <- foceiControl(print = 0, covMethod = "")
+    .f1 <- .nlmixr(.reproModel(), .dat, est = "focei", control = .ctl)
+    .f2 <- .nlmixr(.reproModel(), .dat, est = "focei", control = .ctl)
+
+    expect_equal(.f1$objf, .f2$objf)
+    expect_equal(unname(fixef(.f1)), unname(fixef(.f2)))
+
+    # ... and the answer must not depend on how many threads are available
+    rxode2::setRxThreads(2L)
+    .f3 <- .nlmixr(.reproModel(), .dat, est = "focei", control = .ctl)
+    expect_equal(.f1$objf, .f3$objf)
+    expect_equal(unname(fixef(.f1)), unname(fixef(.f3)))
+
+    # the fit also has to have gone somewhere: the failure mode was an
+    # optimizer that gave up at (or beside) the initial estimates
+    expect_false(isTRUE(all.equal(unname(fixef(.f1)[names(.ini)]),
+                                  unname(.ini), tolerance = 1e-4)))
+    # it converges to what the data was simulated from
+    expect_equal(unname(fixef(.f1)[c("tka", "tcl", "tv")]),
+                 c(0.6, 1.1, 3.6), tolerance = 0.1)
+  })
+
+  test_that("a linCmt() focei fit twice in one session gives the same answer", {
+    .nid <- 6L
+    .dat <- .reproData(.reproModelLinCmt(), .nid)
+    .threads <- 2L * .nid
+    skip_if(rxode2::rxCores() < .threads,
+            "needs at least 2 threads per subject to exercise the reorder")
+    .old <- rxode2::getRxThreads()
+    on.exit(rxode2::setRxThreads(.old))
+    rxode2::setRxThreads(.threads)
+
+    .ctl <- foceiControl(print = 0, covMethod = "")
+    .f1 <- .nlmixr(.reproModelLinCmt(), .dat, est = "focei", control = .ctl)
+    .f2 <- .nlmixr(.reproModelLinCmt(), .dat, est = "focei", control = .ctl)
+
+    expect_equal(.f1$objf, .f2$objf)
+    expect_equal(unname(fixef(.f1)), unname(fixef(.f2)))
+
+    rxode2::setRxThreads(2L)
+    .f3 <- .nlmixr(.reproModelLinCmt(), .dat, est = "focei", control = .ctl)
+    expect_equal(.f1$objf, .f3$objf)
+    expect_equal(unname(fixef(.f1)), unname(fixef(.f3)))
+
+    expect_false(isTRUE(all.equal(unname(fixef(.f1)[names(.ini)]),
+                                  unname(.ini), tolerance = 1e-4)))
+    expect_equal(unname(fixef(.f1)[c("tka", "tcl", "tv")]),
+                 c(0.6, 1.1, 3.6), tolerance = 0.1)
+  })
+
+})


### PR DESCRIPTION
Closes #1020

Regression test for issue 1020: fitting the same data twice in one session has
to give the same answer.

On a machine with at least twice as many threads as the problem has subjects,
two identical `nlmixr2(..., est = "focei")` calls returned different objective
functions and different estimates, and the optimizer frequently stopped at (or
beside) the initial estimates.

FOCEi solves one subject at a time through rxode2's `ind_solve()` and re-sorts
the subjects around every inner-optimization and every gradient loop. Two rxode2
bugs met there: `sortIds()` ordered subjects by their *measured* solve time, so
the order was a function of wall-clock timing, and several of the per-individual
drivers read `ind_solve()`'s **subject id** as a **position** in `rx->ordId` --
so once the order stopped being the identity, the wrong individual was
integrated. The reorder only fires above `cores >= nsub*nsim*throttle`, which is
why the problem appeared only on wide machines.

**No rxode2 dependency.** The id convention is fixed in nlmixr2/rxode2#1292 and
#1293, both merged, and this file passes `FAIL 0 | PASS 12` against rxode2 `main`
(`8e9dda2`). An earlier version of this description listed
`fix/ind-solve-subject-id` as a blocker; that is stale. Note also that the
unmerged `fix/deterministic-solve-order` branch must **not** be merged under this
test -- it makes every fit return a different, badly wrong objective
(nlmixr2/rxode2#1303).

Both the ODE drivers and the analytic `linCmt()` drivers were affected, so
`tests/testthat/test-focei-reproducible.R` covers both: the same structural model
is fitted as an ODE and as `linCmt()`.

Two things the test has to do deliberately, or it proves nothing:

* **raise the thread count** to 2x the subject count for its own duration,
  because the reorder does not trigger below that. It sets the count first and
  skips on what `setRxThreads()` actually granted -- `rxCores()` is an alias of
  `getRxThreads()`, i.e. the current *setting* (50% of logical CPUs by default)
  rather than the CPU count, so asking before setting made the test skip itself
  on a 22-thread machine.
* **give the subjects different numbers of samples** (subject `i` gets `8 + 2i`).
  Equal-sized subjects sort to the identity order, and an identity `ordId` is
  exactly where reading the argument as an id and reading it as a position agree.

It then asserts that

* two fits of the same data agree -- objective function and fixed effects,
* a third fit at 2 threads agrees with them, so the answer does not depend on
  how many threads are available,
* the fit moved off its initial estimates at all (the failure mode was an
  optimizer that gave up where it started), and
* it converges to the parameters the data was simulated from.

The problem is sized to the machine, and the file runs in weekly slow batch 5
(six fits), not the essential push/PR subset.

## Does not close #1015

The `Closes` line used to point at #1015; that was wrong, and #1015 is a
different bug that this test cannot see. #1015 is about a fit's dependence on its
*position in the session* -- the FIRST fit in a fresh session differs from every
later one. It still reproduces on rxode2 `main` today:

```
fit1 objf=    -29.006916  max|eta.f|=0.0834     max|eta.lag|=0.131
fit2 objf=    -29.641287  max|eta.f|=1.17e-07   max|eta.lag|=1.85e-08
fit3 objf=    -29.641287  max|eta.f|=1.17e-07   max|eta.lag|=1.85e-08
```

(the `linToOde()` arm of `test-focei-lincmt-carry-jump-fit.R`, `useLinCmt = FALSE`,
`maxOuterIterations = 200`; the event etas collapse to zero after the first fit.)

Note `fit2 == fit3`. This file compares two *consecutive* fits, and its first fit
is never the session's first -- the `helper-zzz-fits.R` fixtures run well before
it -- so it is structurally blind to #1015. Catching that one needs a fresh-session
harness, which is a separate piece of work.
