### PR TITLE
fix(output): keep the $parFixed BSV column numeric

### DIFF
--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -136,12 +136,17 @@
 #' @author Matthew L. Fidler and Bill Denney
 #' @noRd
 .updateParFixedGetEtaRow <- function(.eta, .env, .ome, .omegaFix, .muRefCurEval, .sigdig) {
+  # Every return is a one-row data.frame with a character `ch` and a numeric
+  # `v`.  .updateParFixedAddBsv() rbinds these rows and takes the `v` column, so
+  # a return of a different shape or type there coerces the whole BSV column --
+  # a character scalar turns the numeric values into full-precision strings
+  # (e.g. "22.6896152419656") and the empty ones into "<NA>".
   if (is.null(.ome)) {
     # This can happen if there are no BSV parameters in a model
-    return("")
+    return(data.frame(ch = "", v = NA_real_))
   } else if (!(.eta %in% rownames(.ome))) {
     # This can happen if .eta is a fixed BSV parameter
-    return("")
+    return(data.frame(ch = "", v = NA_real_))
   }
   .v <- .ome[.eta, .eta]
   .w <- which(.muRefCurEval$parameter == .eta)

--- a/tests/testthat/test-nlmixr2output.R
+++ b/tests/testthat/test-nlmixr2output.R
@@ -28,6 +28,70 @@ nmTest({
     )
     expect_false(envPrep$.sdOnly)
   })
+
+  test_that(".updateParFixedGetEtaRow returns a numeric `v` when there is no BSV", {
+    # The rows are rbound and their `v` column taken as the BSV values, so a
+    # row of a different type there turns the whole column character.
+    expect_equal(
+      .updateParFixedGetEtaRow(
+        .eta = "iivemax",
+        .env = new.env(),
+        .ome = NULL,
+        .omegaFix = c(iivemax = FALSE),
+        .muRefCurEval = data.frame(parameter = "iivemax", curEval = "",
+                                   low = NA_real_, hi = NA_real_),
+        .sigdig = 3L
+      ),
+      data.frame(ch = "", v = NA_real_)
+    )
+    # an eta that is not in the omega matrix, e.g. a fixed BSV parameter
+    .row <-
+      .updateParFixedGetEtaRow(
+        .eta = "iivemax",
+        .env = new.env(),
+        .ome = matrix(0.4, nrow = 1, dimnames = list("iivcl", "iivcl")),
+        .omegaFix = c(iivemax = FALSE),
+        .muRefCurEval = data.frame(parameter = "iivemax", curEval = "",
+                                   low = NA_real_, hi = NA_real_),
+        .sigdig = 3L
+      )
+    expect_equal(.row, data.frame(ch = "", v = NA_real_))
+    expect_true(is.numeric(.row$v))
+  })
+
+  test_that(".updateParFixedAddBsv keeps the BSV column numeric when a mu-referenced eta is absent from omega", {
+    ui <- one.compartment
+
+    popDf <- data.frame(
+      Estimate = c(0.45, 1, 3.45, 0.7),
+      row.names = c("tka", "tcl", "tv", "add.sd"),
+      check.names = FALSE
+    )
+    # omega is missing eta.ka, and tka is still mu-referenced to it
+    omega <- diag(c(0.3, 0.1))
+    dimnames(omega) <- list(c("eta.cl", "eta.v"), c("eta.cl", "eta.v"))
+
+    res <-
+      .updateParFixedAddBsv(
+        popDf, iniDf = ui$iniDf, omega = omega, .sigdig = 3L,
+        .muRefDataFrame = ui$muRefDataFrame, .muRefCurEval = ui$muRefCurEval
+      )
+
+    expect_true(is.numeric(res$popDf[["BSV(CV%)"]]))
+    expect_equal(
+      res$popDf[["BSV(CV%)"]],
+      c(NA_real_, sqrt(exp(0.3) - 1) * 100, sqrt(exp(0.1) - 1) * 100, NA_real_)
+    )
+
+    # and the formatted table shows the requested significant figures, with ""
+    # for the parameters that have no BSV
+    fmt <-
+      .updateParFixedApplySig(
+        res$popDf, digits = 3L, ci = 0.95,
+        fixedNames = character(), bsvFixedNames = res$bsvFixedNames
+      )
+    expect_equal(fmt[["BSV(CV%)"]], c("", "59.1", "32.4", ""))
+  })
 })
 
 test_that("formatMinWidth", {


### PR DESCRIPTION
`.updateParFixedGetEtaRow()` returns a one-row data frame for every parameter it
can describe, but returned a bare `""` from its two early-return branches (no
omega at all, and a mu-referenced eta that is not in the omega matrix).
`.updateParFixedAddBsv()` rbinds those rows and takes the `v` column, so mixing
a character scalar into the rbind coerced the whole BSV column: the numeric
values reached `$parFixedDf` as full-precision strings (e.g.
`"22.6896152419656"`) and the empty ones printed as `<NA>` instead of `""`.

Return the same one-row data frame with a numeric `v` from those branches too.

Today this is latent rather than user-visible — a `fix(0.09)` eta stays in the
omega matrix and formats correctly, and an eta fixed to 0 drops out of
`muRefDataFrame` and takes the numeric branch — but the function's contract is
that every return has the same shape, and the caller depends on it.

### Tests

Both early returns directly, plus the assembled BSV column through
`.updateParFixedAddBsv()` and its formatting:
**`FAIL 6 | PASS 23` before → `FAIL 0 | PASS 29` after** (gate-checked against a
build without the fix, not just asserted).

### Provenance

Split out of two much older branches (`fix-parfixed-table-issues`,
`fix-parfixed-backtransform-fixed`, both 2250 commits behind and now deleted).
Their other two fixes have since been done independently on main and were
verified against it before this was carried forward:

* reading the table's `sigdig`/`ci` from the fit's control rather than from the
  control-free `uiUnfix` model → `.parFixedNum()` (verified: `ci = 0.9,
  sigdig = 4` gives `Back-transformed(90%CI)` and `0.9584`);
* back-transforming FIXED parameters in `$parFixed` →
  `.updateParFixedBackTransformFixed()`, which also honours a manual
  `backTransform`, `muRefExtra` and covariate parameters (verified: fixed `tka`
  reports `1.570` = `exp(0.4510756)`).