### PR TITLE
fix(iov): stop the template-copy rows inheriting another parameter's prior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,12 @@
   `fix` was read from a vector over the whole occasion rather than from each
   parameter's own row, so the model errored with "replacement has 2 rows, data
   has 1".
+- The IOV parameter restored onto a finished fit keeps its own prior.
+  `.uiFinalizeIov()` rebuilds the user's `iov.x ~ v | occ` row from a template
+  copied from the first remaining eta and restored eight fields from the
+  original but not `prior`, so `fit$ui$iniDf` reported the FIRST eta's prior
+  on every IOV parameter -- the same template-copy mistake as above, on the
+  way back out.
 - An occasion parameter with two variance declarations
   (`iov.cl ~ 0.1 | occ; iov.cl ~ 0.15 | occ`) is named in the error.  rxode2
   does build that ui, so every per-parameter field the rewrite read was a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,34 @@
 # nlmixr2est 7.0.3
 
+## Bug fixes
+
+- IOV (`iov.x ~ v | OCC`) no longer copies an unrelated parameter's `prior`
+  onto the parameters the expansion creates, and now carries the prior the
+  user declared.  `.uiApplyIov()` builds the IOV magnitude theta and the
+  per-occasion etas by copying an existing `iniDf` row as a template, and did
+  not clear the template's `prior`.  So the magnitude theta silently inherited
+  the FIRST theta's prior (an estimation method with prior support sampled it
+  against a distribution belonging to another parameter), a `prior(iov.x)`
+  written on the occasion eta was dropped with the row the rewrite deletes,
+  a `fix()`ed IOV parameter was refused outright ("a prior given for fixed
+  parameter(s)"), and so was any model whose first eta carried a prior --
+  every per-occasion `rx.<iov>.<occ>` eta inherited it.  The magnitude theta
+  now carries `prior(iov.x)` (on the `iovXform` scale, `"sd"` by default);
+  the copied rows carry no prior otherwise.
+- Several IOV parameters on ONE occasion variable
+  (`iov.cl ~ 0.1 | occ; iov.v ~ 0.04 | occ`) work.  The occasion variable was
+  visited once per parameter riding it, duplicating every magnitude theta, and
+  `fix` was read from a vector over the whole occasion rather than from each
+  parameter's own row, so the model errored with "replacement has 2 rows, data
+  has 1".
+- Correlated inter-occasion random effects
+  (`iov.cl + iov.v ~ c(...) | occ`) are refused with an explanatory error.
+  The expansion gives each occasion parameter its own magnitude theta and
+  unit-variance etas, which cannot represent a correlation between two of
+  them; the off-diagonal row was treated as one more occasion parameter named
+  `(iov.cl,iov.v)`, and the model died in `rxRename()` with
+  `unexpected '='`.
+
 ## Internal
 
 - `getBaseSimModelFit()` for the focei family (`focei`, `foce`, `focep`, `fo`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,11 @@
   `fix` was read from a vector over the whole occasion rather than from each
   parameter's own row, so the model errored with "replacement has 2 rows, data
   has 1".
+- An occasion parameter with two variance declarations
+  (`iov.cl ~ 0.1 | occ; iov.cl ~ 0.15 | occ`) is named in the error.  rxode2
+  does build that ui, so every per-parameter field the rewrite read was a
+  vector and it died on "replacement has 2 rows, data has 1" without saying
+  which parameter was at fault.
 - Correlated inter-occasion random effects
   (`iov.cl + iov.v ~ c(...) | occ`) are refused with an explanatory error.
   The expansion gives each occasion parameter its own magnitude theta and

--- a/R/iov.R
+++ b/R/iov.R
@@ -122,9 +122,23 @@ nlmixr2iovVarSd <- function(val) {
   }
   .ui <- ui
   .iniDf <- .ui$iniDf
-  .lvls <- .iniDf$condition[which(!is.na(.iniDf$condition) &
-                                    .iniDf$condition != "id" &
-                                     is.na(.iniDf$err))]
+  .wOcc <- which(!is.na(.iniDf$condition) &
+                   .iniDf$condition != "id" &
+                   is.na(.iniDf$err))
+  # the expansion gives each occasion parameter its OWN magnitude theta and
+  # per-occasion unit-variance etas, which cannot represent a correlation
+  # between two of them; an off-diagonal row here would otherwise be treated
+  # as one more occasion parameter named "(iov.a,iov.b)"
+  .wOff <- .wOcc[which(!is.na(.iniDf$neta1[.wOcc]) &
+                         .iniDf$neta1[.wOcc] != .iniDf$neta2[.wOcc])]
+  if (length(.wOff) > 0L) {
+    stop("correlated inter-occasion random effects are not supported: ",
+         paste0("'", .iniDf$name[.wOff], "'", collapse=", "),
+         "; give each occasion parameter its own variance",
+         call.=FALSE)
+  }
+  # one entry per occasion VARIABLE, however many parameters ride on it
+  .lvls <- unique(.iniDf$condition[.wOcc])
 
   .uiIovEnv$iovRename <- NULL
   if (length(.lvls) > 0) {
@@ -155,6 +169,12 @@ nlmixr2iovVarSd <- function(val) {
     .eta1$fix <- TRUE
     .eta1$neta1 <- .eta1$neta2 <- 0
     .eta1$est <- 1
+    # Both rows are COPIES of an unrelated parameter's row used as a
+    # template; a `prior` carried over from it belongs to that parameter,
+    # not to the IOV magnitude / occasion eta this becomes.  The magnitude
+    # gets the prior declared on the occasion eta itself below.
+    if (any(names(.theta1) == "prior")) .theta1$prior <- NA_character_
+    if (any(names(.eta1) == "prior")) .eta1$prior <- NA_character_
 
     .etas <- .etas[which(!(.etas$condition %in% .lvls)), , drop=FALSE]
     if (length(.etas$name) > 0) {
@@ -195,13 +215,17 @@ nlmixr2iovVarSd <- function(val) {
                      function(l1) {
                        .w <-which(.iniDf$condition == l1)
                        .var <- .iniDf$name[.w]
-                       .fixed <- .iniDf$fix[.w]
                        .lst <- c(lapply(.var, function(v) {
                          # Add theta to dataset; represents variance of iov,
                          # converted below based on the xform
                          .curTheta <- .theta1
-                         .est <- .iniDf[which(.iniDf$name == v &
-                                                is.na(.iniDf$ntheta)), "est"]
+                         # this occasion parameter's OWN row -- `.var` can
+                         # hold several parameters riding on one occasion
+                         # variable, so every per-parameter field has to be
+                         # read from here rather than from a vector over the
+                         # whole condition
+                         .wv <- which(.iniDf$name == v & is.na(.iniDf$ntheta))
+                         .est <- .iniDf[.wv, "est"]
                          if (.xform == "var") {
                            .curTheta$est <- .est
                          } else if (.xform == "sd") {
@@ -213,7 +237,16 @@ nlmixr2iovVarSd <- function(val) {
                          }
                          .curTheta$name <- v
                          .uiIovEnv$iovVars <- c(.uiIovEnv$iovVars, v)
-                         .curTheta$fix <- .fixed
+                         .curTheta$fix <- .iniDf$fix[.wv]
+                         # the prior the user declared with `prior(iov.x)`
+                         # describes this magnitude: carry it across the
+                         # rewrite, which deletes the row it was written on.
+                         # A fixed magnitude is a constant and cannot hold
+                         # one.
+                         if (any(names(.curTheta) == "prior") &&
+                               !isTRUE(.curTheta$fix)) {
+                           .curTheta$prior <- .iniDf$prior[.wv]
+                         }
 
                          .w <- which(ui$muRefCurEval$parameter == v)
                          if (length(.w) == 1L) {

--- a/R/iov.R
+++ b/R/iov.R
@@ -252,10 +252,10 @@ nlmixr2iovVarSd <- function(val) {
                          # the prior the user declared with `prior(iov.x)`
                          # describes this magnitude: carry it across the
                          # rewrite, which deletes the row it was written on.
-                         # A fixed magnitude is a constant and cannot hold
-                         # one.
-                         if (any(names(.curTheta) == "prior") &&
-                               !isTRUE(.curTheta$fix)) {
+                         # No `fix` guard is needed -- lotri refuses a prior
+                         # on a fixed parameter while the ui is built, so a
+                         # fixed magnitude reaching here always has none.
+                         if (any(names(.curTheta) == "prior")) {
                            .curTheta$prior <- .iniDf$prior[.wv]
                          }
 
@@ -429,6 +429,13 @@ nlmixr2iovVarSd <- function(val) {
           .cur$err <- .iovDf$err[i]
           .cur$name <- paste0("rx.", .iovDf$name[i]) # Matches replacement
           .cur$condition <- .iovDf$condition[i]
+          # .etaTemplate is a COPY of the first remaining eta (or of the
+          # first iniDf row): its prior belongs to that parameter.  This row
+          # is the user's own `iov.x ~ v | occ` being restored, so it takes
+          # the prior they wrote on it.
+          if (any(names(.cur) == "prior")) {
+            .cur$prior <- .iovDf$prior[i]
+          }
           .etaDf <- rbind(.etaDf, .cur)
           .thetaDf <- .thetaDf[-.w, , drop=FALSE]
         }

--- a/R/iov.R
+++ b/R/iov.R
@@ -225,6 +225,17 @@ nlmixr2iovVarSd <- function(val) {
                          # read from here rather than from a vector over the
                          # whole condition
                          .wv <- which(.iniDf$name == v & is.na(.iniDf$ntheta))
+                         if (length(.wv) != 1L) {
+                           # rxode2 does build a ui with the same occasion
+                           # parameter declared twice; every field read from
+                           # .wv below would then be a vector, and the
+                           # rewrite would die on "replacement has 2 rows,
+                           # data has 1" without naming the parameter
+                           stop("the inter-occasion parameter '", v,
+                                "' has ", length(.wv), " variance ",
+                                "declarations; it needs exactly one",
+                                call.=FALSE)
+                         }
                          .est <- .iniDf[.wv, "est"]
                          if (.xform == "var") {
                            .curTheta$est <- .est

--- a/tests/testthat/test-iov-template-copy.R
+++ b/tests/testthat/test-iov-template-copy.R
@@ -193,3 +193,30 @@ test_that("correlated occasion random effects are refused explicitly", {
   # error from rxRename() about "rx.(iov.cl,iov.v)="
   expect_error(.iovApply(.mod), "correlated inter-occasion")
 })
+
+test_that("an occasion parameter declared twice is named in the error", {
+  skip_on_cran()
+  .mod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      eta.cl ~ 0.3
+      iov.cl ~ 0.1 | occ
+      iov.cl ~ 0.15 | occ
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  # rxode2 builds this ui (two eta rows share the name), so the rewrite is
+  # what has to catch it; every per-parameter field would otherwise be a
+  # vector and it would die on "replacement has 2 rows, data has 1" without
+  # saying which parameter
+  expect_equal(sum(rxode2::rxode2(.mod)$iniDf$name == "iov.cl"), 2L)
+  expect_error(.iovApply(.mod), "'iov.cl' has 2 variance declarations")
+})

--- a/tests/testthat/test-iov-template-copy.R
+++ b/tests/testthat/test-iov-template-copy.R
@@ -1,0 +1,195 @@
+# .uiApplyIov() builds the IOV magnitude theta and the per-occasion etas by
+# COPYING an existing iniDf row as a template.  Everything the template
+# carries that is per-parameter has to be overwritten, or it silently
+# becomes this parameter's -- `prior` was not, and `fix` was read from a
+# vector over the whole occasion rather than from the parameter's own row.
+#
+# These exercise the rewrite directly (no fit), so they stay fast.
+
+.iovData <- function() {
+  .d <- nlmixr2data::theo_md
+  .d$occ <- 1
+  .d$occ[.d$TIME >= 144] <- 2
+  .d
+}
+
+.iovApply <- function(f, data = .iovData()) {
+  .uiApplyIov(rxode2::rxode2(f), "focei", data, foceiControl())
+}
+
+test_that("the magnitude theta carries prior(iov.x), not theta #1's", {
+  skip_on_cran()
+  .mod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      prior(tka) ~ dnorm(-7.25, 0.125)   # deliberately distinctive
+      prior(iov.cl) ~ dcauchy(0, 1)
+      eta.cl ~ 0.3
+      iov.cl ~ 0.1 | occ
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  skip_if_not("prior" %in% names(rxode2::rxode2(.mod)$iniDf),
+              "this lotri has no prior support")
+  .ini <- .iovApply(.mod)$ui$iniDf
+  .mag <- .ini[!is.na(.ini$ntheta) & .ini$name == "iov.cl", ]
+  expect_equal(nrow(.mag), 1L)
+  # the declared prior survives the rewrite that deletes the row it was
+  # written on ...
+  expect_equal(.mag$prior, "dcauchy(0, 1)")
+  # ... and the first theta's prior stays on the first theta
+  expect_equal(.ini$prior[.ini$name == "tka"], "dnorm(-7.25, 0.125)")
+  # the per-occasion etas are not given a prior at all
+  .occ <- .ini[grepl("^rx\\.iov\\.cl\\.", .ini$name), ]
+  expect_equal(nrow(.occ), 2L)
+  expect_true(all(is.na(.occ$prior)))
+})
+
+test_that("an undeclared magnitude, and a fixed one, carry no prior", {
+  skip_on_cran()
+  .mod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      prior(tka) ~ dnorm(-7.25, 0.125)
+      eta.cl ~ 0.3
+      iov.cl ~ 0.1 | occ
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  skip_if_not("prior" %in% names(rxode2::rxode2(.mod)$iniDf),
+              "this lotri has no prior support")
+  .ini <- .iovApply(.mod)$ui$iniDf
+  expect_true(is.na(.ini$prior[!is.na(.ini$ntheta) & .ini$name == "iov.cl"]))
+
+  # a FIXED magnitude is a constant: it cannot hold a prior, and inheriting
+  # the template's made rxode2 refuse the rewritten model outright
+  .fixMod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      prior(tka) ~ dnorm(-7.25, 0.125)
+      eta.cl ~ 0.3
+      iov.cl ~ fix(0.1) | occ
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  .iniF <- .iovApply(.fixMod)$ui$iniDf
+  .magF <- .iniF[!is.na(.iniF$ntheta) & .iniF$name == "iov.cl", ]
+  expect_true(.magF$fix)
+  expect_true(is.na(.magF$prior))
+})
+
+test_that("a prior on the FIRST eta does not become the occasion etas'", {
+  skip_on_cran()
+  .mod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      prior(eta.cl) ~ invWishart(4)
+      eta.cl ~ 0.3
+      iov.cl ~ 0.1 | occ
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  skip_if_not("prior" %in% names(rxode2::rxode2(.mod)$iniDf),
+              "this lotri has no prior support")
+  .ini <- .iovApply(.mod)$ui$iniDf
+  # eta.cl keeps its own prior; the fixed per-occasion etas copied from it
+  # get none (rxode2 refuses a prior on a fixed parameter, so inheriting it
+  # made the whole model unusable)
+  expect_equal(.ini$prior[.ini$name == "eta.cl"], "invWishart(4)")
+  expect_true(all(is.na(.ini$prior[grepl("^rx\\.iov\\.cl\\.", .ini$name)])))
+})
+
+test_that("several occasion parameters ride one occasion variable", {
+  skip_on_cran()
+  .mod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      eta.cl ~ 0.3
+      iov.cl ~ 0.1 | occ
+      iov.v ~ fix(0.04) | occ
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv + iov.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  .ini <- .iovApply(.mod)$ui$iniDf
+  .th <- .ini[!is.na(.ini$ntheta), ]
+  # one magnitude theta each, ONCE (the occasion variable used to be
+  # visited once per parameter riding it, duplicating every theta) ...
+  expect_equal(sum(.th$name == "iov.cl"), 1L)
+  expect_equal(sum(.th$name == "iov.v"), 1L)
+  # ... and `fix` comes from each parameter's own row rather than from a
+  # vector over the whole occasion, which errored with "replacement has 2
+  # rows, data has 1"
+  expect_false(.th$fix[.th$name == "iov.cl"])
+  expect_true(.th$fix[.th$name == "iov.v"])
+  expect_equal(.th$est[.th$name == "iov.cl"], sqrt(0.1))
+  expect_equal(.th$est[.th$name == "iov.v"], sqrt(0.04))
+  # per-occasion etas for both, two occasions each
+  expect_equal(sum(grepl("^rx\\.iov\\.cl\\.", .ini$name)), 2L)
+  expect_equal(sum(grepl("^rx\\.iov\\.v\\.", .ini$name)), 2L)
+})
+
+test_that("correlated occasion random effects are refused explicitly", {
+  skip_on_cran()
+  .mod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      eta.cl ~ 0.3
+      iov.cl + iov.v ~ c(0.1,
+                         0.01, 0.1) | occ
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv + iov.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  # the expansion gives each occasion parameter its own magnitude theta and
+  # unit-variance etas, which cannot carry a correlation; the off-diagonal
+  # row used to be treated as a third occasion parameter, giving a syntax
+  # error from rxRename() about "rx.(iov.cl,iov.v)="
+  expect_error(.iovApply(.mod), "correlated inter-occasion")
+})

--- a/tests/testthat/test-iov-template-copy.R
+++ b/tests/testthat/test-iov-template-copy.R
@@ -220,3 +220,64 @@ test_that("an occasion parameter declared twice is named in the error", {
   expect_equal(sum(rxode2::rxode2(.mod)$iniDf$name == "iov.cl"), 2L)
   expect_error(.iovApply(.mod), "'iov.cl' has 2 variance declarations")
 })
+
+test_that("a prior on a FIXED occasion magnitude is refused by name", {
+  skip_on_cran()
+  .mod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      prior(iov.cl) ~ dcauchy(0, 1)
+      eta.cl ~ 0.3
+      iov.cl ~ fix(0.1) | occ
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  # a fixed magnitude is a constant and cannot carry a prior.  lotri
+  # already refuses the contradiction while the ui is BUILT, naming the
+  # parameter the user wrote, so the rewrite never sees one and needs no
+  # `fix` guard of its own when it carries the prior across.
+  expect_error(rxode2::rxode2(.mod),
+               "prior given for fixed parameter\\(s\\): 'iov.cl'")
+})
+
+test_that("the restored occasion parameter keeps its OWN prior", {
+  skip_on_cran()
+  .mod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd <- 0.7
+      prior(eta.cl) ~ invWishart(4)   # the template row's prior
+      prior(iov.cl) ~ dcauchy(0, 1)
+      eta.cl ~ 0.3
+      iov.cl ~ 0.1 | occ
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl + iov.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+  skip_if_not("prior" %in% names(rxode2::rxode2(.mod)$iniDf),
+              "this lotri has no prior support")
+  # .uiFinalizeIov() rebuilds the user's `iov.cl ~ v | occ` row from a
+  # template copied from the FIRST eta; it restored eight fields but not
+  # `prior`, so the finished fit reported eta.cl's prior on iov.cl
+  .fit <- suppressMessages(suppressWarnings(
+    nlmixr2(.mod, .iovData(), est = "focei",
+            control = foceiControl(print = 0, maxOuterIterations = 0,
+                                   maxInnerIterations = 5))))
+  .ini <- .fit$ui$iniDf
+  expect_equal(.ini$prior[.ini$name == "iov.cl"], "dcauchy(0, 1)")
+  expect_equal(.ini$prior[.ini$name == "eta.cl"], "invWishart(4)")
+})


### PR DESCRIPTION
`.uiApplyIov()` builds the IOV magnitude theta and the per-occasion etas by **copying an existing `iniDf` row as a template**, and `.uiFinalizeIov()` rebuilds the user's original row the same way on the way back out. Everything per-parameter the template carries has to be overwritten or it silently becomes this parameter's — `prior` was not, on either path, and `fix`/`est` were read from a vector over the whole occasion instead of from the parameter's own row.

Found while fixing [nlmixr2bayes#15](https://github.com/nlmixr2/nlmixr2bayes/issues/15), where an `est="stan"` model sampled the IOV magnitude against a prior belonging to an unrelated parameter.

## What was broken

Eight failures, two causes.

**The template's `prior` was never cleared or restored** (`.theta1 <- .thetas[1, ]`, `.eta1 <- .etas[1, ]`, `.etaTemplate <- .etaDf[1, ]`):

- The magnitude theta inherited the **first theta's** prior. Nothing errors and nothing warns — a method with prior support just samples against another parameter's distribution.
- `prior(iov.x)` written on the occasion eta was dropped with the row the rewrite deletes, so it never reached any estimation method.
- A `fix()`ed IOV parameter was refused outright: `prior given for fixed parameter(s): 'iov.cl'; a fixed parameter is a constant and cannot carry a prior`.
- So was any model whose **first eta** carried a prior — `.eta1` is the template for every `rx.<iov>.<occ>` row, so the refusal named a parameter the user never wrote.
- On the way back out, the IOV row restored onto the finished fit inherited the **first eta's** prior: with `prior(eta.cl) ~ invWishart(4)` and `prior(iov.cl) ~ dcauchy(0, 1)`, `fit$ui$iniDf` reported `invWishart(4)` for `iov.cl`. `.uiFinalizeIov()` restored eight fields from the original row but not `prior`.

**Per-parameter fields read per-occasion instead:**

- Several IOV parameters on one occasion variable (`iov.cl ~ 0.1 | occ; iov.v ~ 0.04 | occ`) errored with `replacement has 2 rows, data has 1` — `.curTheta$fix <- .fixed` assigned a vector over the whole condition into one row. The occasion variable was also visited once per parameter riding it, which would have duplicated every magnitude theta.
- The same opaque error came from one parameter declared twice (`iov.cl ~ 0.1 | occ; iov.cl ~ 0.15 | occ`) — rxode2 does build that ui, so the rewrite is what has to catch it, and it did not say which parameter was at fault.
- A correlated occasion block (`iov.cl + iov.v ~ c(...) | occ`) treated the off-diagonal row as one more occasion parameter named `(iov.cl,iov.v)` and died in `rxRename()` with `<text>:1:58: unexpected '='`.

## What this does

- The copied rows start with **no** prior, on both paths.
- The magnitude theta **carries `prior(iov.x)`** — the prior the user declared on the occasion eta, on the `iovXform` scale (`"sd"` by default). So `prior(iov.x)` now works for every method that implements priors, not just one, and **round-trips** onto the finished fit.
- `fix`, `est` and `prior` all come from each parameter's own row, guarded so a duplicate declaration is refused **by name**; the occasion list is deduplicated so one variable is visited once however many parameters ride it.
- Correlated inter-occasion random effects are **refused with an explanatory error**. The expansion gives each occasion parameter its own magnitude theta and unit-variance etas, which cannot represent a correlation between two of them — a real refusal rather than a syntax error from a mangled rename.

## Tests

New `tests/testthat/test-iov-template-copy.R` (24 assertions). Most exercise `.uiApplyIov()` **directly on the ui rather than through a fit**, so they stay fast: the declared prior survives / theta #1's stays put / the occasion etas get none; undeclared and fixed magnitudes carry no prior; a prior on the first eta stays on the first eta; several parameters on one occasion variable get one theta each with their own `fix` and `est`; a duplicate declaration and a correlated block are each refused by name. One runs a short `focei` fit to cover the round trip — it fails on `main` with `iov.cl` reporting `invWishart(4)`.

Existing suites pass unchanged: `test-iov.R` (40), `test-iov-zero-eta.R` (4), `test-vae-iov.R` (18), `test-focei-prior.R` (18), `test-priors-assert.R` (32), `test-priors-output.R` (12). THETA/eta order is unchanged for models that previously worked — the `unique()` only differs where the old code errored — which the ordering assertion already in `test-iov.R` covers.