### PR TITLE
docs(control): describe what sigdigTable actually falls back to

### DIFF
--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -48,8 +48,7 @@
 #'   this is \code{atol = 1e-6}, \code{rtol = 1e-3}.
 #'
 #' @param sigdigTable Significant digits in the final output table.
-#'   If not specified, then it matches the significant digits in the
-#'   `sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.
+#'   If not specified (`NULL`), it defaults to `sigdig`.
 #'
 #' @param epsilon Precision of estimate for n1qn1 optimization.
 #'

--- a/man/bobyqaControl.Rd
+++ b/man/bobyqaControl.Rd
@@ -183,8 +183,7 @@ exactly the precision the solve supports.  At the default \code{sigdig = 3}
 this is \code{atol = 1e-6}, \code{rtol = 1e-3}.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{eventSens}{Controls how dosing/event-parameter (`alag`, `F`,
 `rate`, `dur`) sensitivities are computed for THETA/ETA gradients:

--- a/man/emviControl.Rd
+++ b/man/emviControl.Rd
@@ -347,8 +347,7 @@ against a default \code{rtol = 1e-6}.  Raise \code{sigdig}, or set
 \code{atol}/\code{rtol} directly, when you want a tighter solve.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{stickyRecalcN}{The number of bad ODE solves before reducing
 the atol/rtol for the rest of the problem.}

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -861,8 +861,7 @@ solve.}
 \item{rxControl}{`rxode2` ODE solving options during fitting, created with `rxControl()`}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{fallbackFD}{Fallback to the finite differences if the
 sensitivity equations do not solve.}

--- a/man/lbfgsb3cControl.Rd
+++ b/man/lbfgsb3cControl.Rd
@@ -208,8 +208,7 @@ exactly the precision the solve supports.  At the default \code{sigdig = 3}
 this is \code{atol = 1e-6}, \code{rtol = 1e-3}.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{...}{Ignored parameters}
 }

--- a/man/n1qn1Control.Rd
+++ b/man/n1qn1Control.Rd
@@ -199,8 +199,7 @@ exactly the precision the solve supports.  At the default \code{sigdig = 3}
 this is \code{atol = 1e-6}, \code{rtol = 1e-3}.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{boundedTransform}{When `TRUE` (default), bounded parameters are
 transformed for unbounded optimization methods and back-transformed

--- a/man/newuoaControl.Rd
+++ b/man/newuoaControl.Rd
@@ -185,8 +185,7 @@ exactly the precision the solve supports.  At the default \code{sigdig = 3}
 this is \code{atol = 1e-6}, \code{rtol = 1e-3}.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{boundedTransform}{When `TRUE` (default), bounded parameters are
 transformed for unbounded optimization methods and back-transformed

--- a/man/nlmControl.Rd
+++ b/man/nlmControl.Rd
@@ -280,8 +280,7 @@ exactly the precision the solve supports.  At the default \code{sigdig = 3}
 this is \code{atol = 1e-6}, \code{rtol = 1e-3}.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{boundedTransform}{When `TRUE` (default), bounded parameters are
 transformed for unbounded optimization methods and back-transformed

--- a/man/nlminbControl.Rd
+++ b/man/nlminbControl.Rd
@@ -264,8 +264,7 @@ exactly the precision the solve supports.  At the default \code{sigdig = 3}
 this is \code{atol = 1e-6}, \code{rtol = 1e-3}.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{...}{Further arguments to be supplied to \code{objective}.}
 }

--- a/man/nlmixr2NlmeControl.Rd
+++ b/man/nlmixr2NlmeControl.Rd
@@ -276,8 +276,7 @@ exactly the precision the solve supports.  At the default \code{sigdig = 3}
 this is \code{atol = 1e-6}, \code{rtol = 1e-3}.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{muRefCovAlg}{When `TRUE` (default), algebraic expressions that can
 be mu-referenced are internally rewritten as mu-referenced

--- a/man/nlsControl.Rd
+++ b/man/nlsControl.Rd
@@ -314,8 +314,7 @@ exactly the precision the solve supports.  At the default \code{sigdig = 3}
 this is \code{atol = 1e-6}, \code{rtol = 1e-3}.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{boundedTransform}{When `TRUE` (default), bounded parameters are
 transformed for unbounded optimization methods and back-transformed

--- a/man/optimControl.Rd
+++ b/man/optimControl.Rd
@@ -295,8 +295,7 @@ exactly the precision the solve supports.  At the default \code{sigdig = 3}
 this is \code{atol = 1e-6}, \code{rtol = 1e-3}.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{boundedTransform}{When `TRUE` (default), bounded parameters are
 transformed for unbounded optimization methods and back-transformed

--- a/man/saemControl.Rd
+++ b/man/saemControl.Rd
@@ -295,8 +295,7 @@ against a default \code{rtol = 1e-6}.  Raise \code{sigdig}, or set
 \code{atol}/\code{rtol} directly, when you want a tighter solve.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{ci}{Confidence level for some tables.  By default this is
 0.95 or 95\% confidence.}

--- a/man/uobyqaControl.Rd
+++ b/man/uobyqaControl.Rd
@@ -185,8 +185,7 @@ exactly the precision the solve supports.  At the default \code{sigdig = 3}
 this is \code{atol = 1e-6}, \code{rtol = 1e-3}.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{boundedTransform}{When `TRUE` (default), bounded parameters are
 transformed for unbounded optimization methods and back-transformed

--- a/man/vaeControl.Rd
+++ b/man/vaeControl.Rd
@@ -568,8 +568,7 @@ against a default \code{rtol = 1e-6}.  Raise \code{sigdig}, or set
 \code{atol}/\code{rtol} directly, when you want a tighter solve.}
 
 \item{sigdigTable}{Significant digits in the final output table.
-If not specified, then it matches the significant digits in the
-`sigdig` optimization algorithm.  If `sigdig` is NULL, use 3.}
+If not specified (`NULL`), it defaults to `sigdig`.}
 
 \item{rhoend}{Final trust-region radius (`rhoend`) of the inner bounded
 `bobyqa` used by the non-mu / covariate regress M-step.  `NULL` (default)


### PR DESCRIPTION
The `@param sigdigTable` text says the fallback is `sigdig`, "If `sigdig` is
NULL, use 3." That second sentence describes a case a caller cannot reach:
`foceiControl(sigdig = NULL)` fails earlier, on the `epsilon` assertion, since
`epsilon` is one of several arguments derived from `sigdig` only when `sigdig`
is non-NULL. So the documented `3` is never what a user gets, and the sentence
sends readers looking for behavior that is not there.

Document the reachable behavior: not specified means `sigdig`.

Documentation only — no change to what any control function returns. The 14
regenerated `.Rd` files are the control functions that inherit the parameter
from `foceiControl()`. They were edited to match the roxygen block rather than
regenerated wholesale: the installed roxygen2 is 8.1.0, which rewrites far more
of this package's generated files than this one paragraph.