### PR TITLE
fix(control): drop the unreachable sigdigTable fallback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Internal
 
+- `foceiControl()` resolves `sigdigTable` to `sigdig` whenever it is not
+  supplied.  The fallback to a hard-coded `3` applied only when `sigdig` was
+  `NULL`, which a caller cannot arrange: `foceiControl(sigdig = NULL)` fails
+  earlier on the `epsilon` assertion.  No change to any value a control
+  function returns.
+
 - `getBaseSimModelFit()` for the focei family (`focei`, `foce`, `focep`, `fo`,
   `foi`, `posthoc`) no longer does three times the work for the same answer.
   The method built a `predOnly`-based simulation model expression and then

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -1066,11 +1066,7 @@ foceiControl <- function(sigdig = 3, #
     }
   }
   if (is.null(sigdigTable)) {
-    if (is.null(sigdig)) {
-      sigdigTable <- 3L
-    } else {
-      sigdigTable <- sigdig
-    }
+    sigdigTable <- sigdig
   } else {
     checkmate::assertNumeric(sigdigTable, lower = 1, finite = TRUE, any.missing = TRUE, len = 1)
   }

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -43,6 +43,15 @@ nmTest({
     expect_error(foceiControl(foceiControl="matt"))
   })
 
+  test_that("foceiControl sigdigTable defaults to sigdig", {
+    # not given -> sigdig, whatever sigdig is
+    expect_equal(foceiControl()$sigdigTable, foceiControl()$sigdig)
+    expect_equal(foceiControl(sigdig = 7)$sigdigTable, 7)
+    # an explicit sigdigTable is respected and overrides sigdig
+    expect_equal(foceiControl(sigdigTable = 2)$sigdigTable, 2)
+    expect_equal(foceiControl(sigdig = 7, sigdigTable = 2)$sigdigTable, 2)
+  })
+
   test_that("saemControl sanity", {
     expect_error(saemControl(), NA)
     nlmixrControlTest(saemControl())


### PR DESCRIPTION
`sigdigTable` resolved to a hard-coded `3L` when `sigdig` was `NULL`, and to
`sigdig` otherwise. The first branch is dead: `foceiControl(sigdig = NULL)`
never reaches it, because several arguments (`epsilon`, `rel.tol`, `x.tol`,
`derivSwitchTol`, …) are derived from `sigdig` only when it is non-NULL, and the
`epsilon` assertion then fails on the `NULL` default.

Resolve `sigdigTable` to `sigdig` whenever it is not supplied. No control
function returns a different value than before; this removes a branch that could
not be taken, and the reader's need to work out whether it could.

`tests/testthat/test-control.R` covers the resolution both ways: not supplied
follows `sigdig` (including a non-default `sigdig`), and an explicit
`sigdigTable` overrides it. `FAIL 0 | PASS 55` in that file.

This is the last piece of nlmixr2est `dev-2026-06` that existed nowhere else —
its other three commits are either on `perf/saem-dedup-aliases`, reimplemented
on `main`, or carried forward in `fix/parfixed-bsv-column-type`.