### PR TITLE
build: track header dependencies so an object cannot go stale

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -121,3 +121,4 @@ BinaryFiles$
 # The fixtures CRAN's own checks read are the CHECKED-IN csv references
 # (npag/pmetrics_reference.csv, npag/ipm/burke-golden.csv) and are kept.
 ^tests/testthat/fixtures/.*\.rds$
+^src/.*[.]d$

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ inst/tools/*.Rout
 src/Makevars.win
 .habit-hooks/
 compile_commands.json
+/src/*.d

--- a/NEWS.md
+++ b/NEWS.md
@@ -231,6 +231,15 @@
 
 ## Internal
 
+- The build now tracks header dependencies.  R's rules rebuild an object only
+  when its own source is newer, so an incremental build silently kept objects
+  that had been compiled against an earlier version of a header they include.
+  That reaches across packages: a `LinkingTo` package's headers are just
+  another include path, so a struct whose layout changes there leaves objects
+  here compiled to the old layout and the resulting shared library mixes both
+  -- a corrupt binary rather than a compile error.  `src/Makevars*` now
+  compiles with `-MMD -MP` and reads back the generated `.d` files.
+
 - The SAEM `predOnly` model (used for residuals, tables and the covariance
   step) no longer emits a THETA/ETA alias assignment that exactly duplicates
   one the mu-reference replacement block already emitted.  These were trailing

--- a/cleanup
+++ b/cleanup
@@ -1,2 +1,3 @@
 #! /bin/sh
 rm -f src/Makevars
+rm -f src/*.d

--- a/cleanup.win
+++ b/cleanup.win
@@ -1,2 +1,3 @@
 #! /bin/sh
 rm -f src/Makevars.win
+rm -f src/*.d

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -8,7 +8,8 @@ EG=@EG@
 CXX_STD     = CXX17
 
 PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)
-PKG_CXXFLAGS = -Id -I../inst/include -DBOOST_DISABLE_ASSERTS -DBOOST_NO_CXX11_STATIC_ASSERT -@ISYSTEM@"$(BH)" -@ISYSTEM@"$(RCPP)" -@ISYSTEM@"$(ARMA)" -@ISYSTEM@"$(RXP)" -@ISYSTEM@"$(EG)"  $(SHLIB_OPENMP_CXXFLAGS) -DARMA_64BIT_WORD=1 -DARMA_USE_CURRENT -DARMA_DONT_USE_OPENMP -DEIGEN_DONT_PARALLELIZE
+PKG_CXXFLAGS = -Id -I../inst/include -DBOOST_DISABLE_ASSERTS -DBOOST_NO_CXX11_STATIC_ASSERT -@ISYSTEM@"$(BH)" -@ISYSTEM@"$(RCPP)" -@ISYSTEM@"$(ARMA)" -@ISYSTEM@"$(RXP)" -@ISYSTEM@"$(EG)"  $(SHLIB_OPENMP_CXXFLAGS) -DARMA_64BIT_WORD=1 -DARMA_USE_CURRENT -DARMA_DONT_USE_OPENMP -DEIGEN_DONT_PARALLELIZE -MMD -MP
+PKG_CFLAGS = -MMD -MP
 SHLIB_LDFLAGS = $(SHLIB_CXXLDFLAGS)
 SHLIB_LD = $(SHLIB_CXXLD)
 SOURCES_C = init.c rprintf.c merge3.c lbfgsR.c utilc.c
@@ -17,3 +18,24 @@ OBJECTS = $(SOURCES_CPP:.cpp=.o) $(SOURCES_C:.c=.o)
 
 all: $(SHLIB)
 $(SHLIB): $(OBJECTS)
+
+################################################################################
+## Header dependency tracking.
+##
+## R's build rules make an object depend on its own source only, so an object
+## goes stale -- silently -- when a header it includes changes and the source
+## does not.  That reaches across packages too: a LinkingTo package's headers
+## are just another include path, so a struct that changes there leaves the
+## objects here compiled to the previous layout.
+##
+## -MMD (in PKG_CFLAGS/PKG_CXXFLAGS above) records each object's headers in a
+## .d file beside it; -MP emits a phony target per header so one that is later
+## renamed or deleted does not break the build.  The .d files the previous
+## build wrote are read back below.
+##
+## Makevars is read before shlib.mk defines "all", so without .DEFAULT_GOAL the
+## first target of the first .d file becomes make's default goal and the shared
+## library is never linked.
+################################################################################
+.DEFAULT_GOAL := all
+-include $(wildcard *.d)


### PR DESCRIPTION
R's build rules make an object depend on its own source alone, so make reuses an object whenever only a header it includes has changed.  Nothing warns; the object simply keeps whatever layout that header had when it was last compiled.

That crosses package boundaries.  A LinkingTo package's headers are just another include path, so when a struct there gains or reorders a field, the objects here that were compiled against the previous layout are kept and linked alongside freshly compiled ones.  The result is a shared library whose halves disagree about member offsets -- a corrupt binary rather than a compile error, surfacing as a segfault far from the cause.

Compile with -MMD -MP so each object records its headers in a .d file beside it, and read those files back.  -MP emits a phony target per header so renaming or deleting one does not break the next build.

.DEFAULT_GOAL := all is required, not cosmetic: Makevars is read before shlib.mk defines "all", so without it the first target of the first included .d file becomes make's default goal and the shared library is never linked even though its objects rebuild.