### PR TITLE
focei: validate rxode2's per-subject event counts before sizing from them

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -110,8 +110,9 @@
   layouts those counts are read from the wrong bytes, and the setup sized
   megabytes of storage from garbage -- reported as "dataset too large", as an
   `R_Calloc` failure, or as a segfault, depending on what the mis-read bytes
-  held.  The counts have to add back up to the dataset's record count, and the
-  fit now stops with that as the reason instead (#1039).
+  held.  A negative count, or a dose or `evid=2` count larger than the
+  subject's own record count, now stops the fit with that as the reason
+  instead (#1039).
 
 - With two or more occasion parameters on one level, `fit$iov$<level>` had
   `NA` for every occasion (and the fit warned "NAs introduced by

--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,14 @@
 
 ## Bug fixes
 
+- `focei` now checks rxode2's per-subject event counts before it sizes the
+  per-subject blocks it strides with them (`gVid`, `ga`/`gc`, `gB`, `gcH*`,
+  `llikObsFull`).  When rxode2 and nlmixr2est are built against different solve
+  layouts those counts are read from the wrong bytes, and the setup sized
+  megabytes of storage from garbage -- reported as "dataset too large", as an
+  `R_Calloc` failure, or as a segfault, depending on what the mis-read bytes
+  held.  The counts have to add back up to the dataset's record count, and the
+  fit now stops with that as the reason instead (#1039).
 
 - With two or more occasion parameters on one level, `fit$iov$<level>` had
   `NA` for every occasion (and the fit warned "NAs introduced by

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -75,6 +75,10 @@ impQrPoints_ <- function(isample, neta, shift) {
     .Call(`_nlmixr2est_impQrPoints_`, isample, neta, shift)
 }
 
+foceiCheckIndCounts_ <- function(counts, nall) {
+    invisible(.Call(`_nlmixr2est_foceiCheckIndCounts_`, counts, nall))
+}
+
 foceiIndEventCounts_ <- function() {
     .Call(`_nlmixr2est_foceiIndEventCounts_`)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -75,8 +75,8 @@ impQrPoints_ <- function(isample, neta, shift) {
     .Call(`_nlmixr2est_impQrPoints_`, isample, neta, shift)
 }
 
-foceiCheckIndCounts_ <- function(counts, nall) {
-    invisible(.Call(`_nlmixr2est_foceiCheckIndCounts_`, counts, nall))
+foceiCheckIndCounts_ <- function(counts) {
+    invisible(.Call(`_nlmixr2est_foceiCheckIndCounts_`, counts))
 }
 
 foceiIndEventCounts_ <- function() {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -75,6 +75,10 @@ impQrPoints_ <- function(isample, neta, shift) {
     .Call(`_nlmixr2est_impQrPoints_`, isample, neta, shift)
 }
 
+foceiIndEventCounts_ <- function() {
+    .Call(`_nlmixr2est_foceiIndEventCounts_`)
+}
+
 freeFocei <- function() {
     invisible(.Call(`_nlmixr2est_freeFocei`))
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -466,13 +466,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // foceiCheckIndCounts_
-void foceiCheckIndCounts_(Rcpp::IntegerMatrix counts, int nall);
-RcppExport SEXP _nlmixr2est_foceiCheckIndCounts_(SEXP countsSEXP, SEXP nallSEXP) {
+void foceiCheckIndCounts_(Rcpp::IntegerMatrix counts);
+RcppExport SEXP _nlmixr2est_foceiCheckIndCounts_(SEXP countsSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::IntegerMatrix >::type counts(countsSEXP);
-    Rcpp::traits::input_parameter< int >::type nall(nallSEXP);
-    foceiCheckIndCounts_(counts, nall);
+    foceiCheckIndCounts_(counts);
     return R_NilValue;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -465,6 +465,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// foceiCheckIndCounts_
+void foceiCheckIndCounts_(Rcpp::IntegerMatrix counts, int nall);
+RcppExport SEXP _nlmixr2est_foceiCheckIndCounts_(SEXP countsSEXP, SEXP nallSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::IntegerMatrix >::type counts(countsSEXP);
+    Rcpp::traits::input_parameter< int >::type nall(nallSEXP);
+    foceiCheckIndCounts_(counts, nall);
+    return R_NilValue;
+END_RCPP
+}
 // foceiIndEventCounts_
 Rcpp::IntegerMatrix foceiIndEventCounts_();
 RcppExport SEXP _nlmixr2est_foceiIndEventCounts_() {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -465,6 +465,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// foceiIndEventCounts_
+Rcpp::IntegerMatrix foceiIndEventCounts_();
+RcppExport SEXP _nlmixr2est_foceiIndEventCounts_() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(foceiIndEventCounts_());
+    return rcpp_result_gen;
+END_RCPP
+}
 // freeFocei
 void freeFocei();
 RcppExport SEXP _nlmixr2est_freeFocei() {

--- a/src/init.c
+++ b/src/init.c
@@ -114,6 +114,7 @@ SEXP _nlmixr2est_foceiOuter(SEXP);
 SEXP _nlmixr2est_sqrtm(SEXP);
 SEXP _nlmixr2est_foceiCalcCov(SEXP);
 SEXP _nlmixr2est_foceiFitCpp_(SEXP);
+SEXP _nlmixr2est_foceiCheckIndCounts_(SEXP, SEXP);
 SEXP _nlmixr2est_foceiIndEventCounts_(void);
 SEXP _nlmixr2est_boxCox_(SEXP, SEXP, SEXP);
 SEXP _nlmixr2est_iBoxCox_(SEXP, SEXP, SEXP);
@@ -341,6 +342,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_sqrtm", (DL_FUNC) &_nlmixr2est_sqrtm, 1},
   {"_nlmixr2est_foceiCalcCov", (DL_FUNC) &_nlmixr2est_foceiCalcCov, 1},
   {"_nlmixr2est_foceiFitCpp_", (DL_FUNC) &_nlmixr2est_foceiFitCpp_, 1},
+  {"_nlmixr2est_foceiCheckIndCounts_", (DL_FUNC) &_nlmixr2est_foceiCheckIndCounts_, 2},
   {"_nlmixr2est_foceiIndEventCounts_", (DL_FUNC) &_nlmixr2est_foceiIndEventCounts_, 0},
   {"_nlmixr2est_boxCox_", (DL_FUNC) &_nlmixr2est_boxCox_, 3},
   {"_nlmixr2est_iBoxCox_", (DL_FUNC) &_nlmixr2est_iBoxCox_, 3},

--- a/src/init.c
+++ b/src/init.c
@@ -114,7 +114,7 @@ SEXP _nlmixr2est_foceiOuter(SEXP);
 SEXP _nlmixr2est_sqrtm(SEXP);
 SEXP _nlmixr2est_foceiCalcCov(SEXP);
 SEXP _nlmixr2est_foceiFitCpp_(SEXP);
-SEXP _nlmixr2est_foceiCheckIndCounts_(SEXP, SEXP);
+SEXP _nlmixr2est_foceiCheckIndCounts_(SEXP);
 SEXP _nlmixr2est_foceiIndEventCounts_(void);
 SEXP _nlmixr2est_boxCox_(SEXP, SEXP, SEXP);
 SEXP _nlmixr2est_iBoxCox_(SEXP, SEXP, SEXP);
@@ -342,7 +342,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_sqrtm", (DL_FUNC) &_nlmixr2est_sqrtm, 1},
   {"_nlmixr2est_foceiCalcCov", (DL_FUNC) &_nlmixr2est_foceiCalcCov, 1},
   {"_nlmixr2est_foceiFitCpp_", (DL_FUNC) &_nlmixr2est_foceiFitCpp_, 1},
-  {"_nlmixr2est_foceiCheckIndCounts_", (DL_FUNC) &_nlmixr2est_foceiCheckIndCounts_, 2},
+  {"_nlmixr2est_foceiCheckIndCounts_", (DL_FUNC) &_nlmixr2est_foceiCheckIndCounts_, 1},
   {"_nlmixr2est_foceiIndEventCounts_", (DL_FUNC) &_nlmixr2est_foceiIndEventCounts_, 0},
   {"_nlmixr2est_boxCox_", (DL_FUNC) &_nlmixr2est_boxCox_, 3},
   {"_nlmixr2est_iBoxCox_", (DL_FUNC) &_nlmixr2est_iBoxCox_, 3},

--- a/src/init.c
+++ b/src/init.c
@@ -114,6 +114,7 @@ SEXP _nlmixr2est_foceiOuter(SEXP);
 SEXP _nlmixr2est_sqrtm(SEXP);
 SEXP _nlmixr2est_foceiCalcCov(SEXP);
 SEXP _nlmixr2est_foceiFitCpp_(SEXP);
+SEXP _nlmixr2est_foceiIndEventCounts_(void);
 SEXP _nlmixr2est_boxCox_(SEXP, SEXP, SEXP);
 SEXP _nlmixr2est_iBoxCox_(SEXP, SEXP, SEXP);
 SEXP _nlmixr2est_freeFocei(void);
@@ -340,6 +341,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_sqrtm", (DL_FUNC) &_nlmixr2est_sqrtm, 1},
   {"_nlmixr2est_foceiCalcCov", (DL_FUNC) &_nlmixr2est_foceiCalcCov, 1},
   {"_nlmixr2est_foceiFitCpp_", (DL_FUNC) &_nlmixr2est_foceiFitCpp_, 1},
+  {"_nlmixr2est_foceiIndEventCounts_", (DL_FUNC) &_nlmixr2est_foceiIndEventCounts_, 0},
   {"_nlmixr2est_boxCox_", (DL_FUNC) &_nlmixr2est_boxCox_, 3},
   {"_nlmixr2est_iBoxCox_", (DL_FUNC) &_nlmixr2est_iBoxCox_, 3},
   {"_nlmixr2est_nlmixr2Gill83_", (DL_FUNC) &_nlmixr2est_nlmixr2Gill83_, 9},

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -911,6 +911,33 @@ static inline size_t foceiSzAdd(size_t a, size_t b, const char *what) {
   return a + b;
 }
 
+// The rules foceiCheckIndCounts() enforces, taking the counts rather than `rx`
+// so a test can drive them.  `nall` is rxode2's record count for ONE replicate
+// of the event data, which is what subjects [0, nsub) hold however many
+// replicates rx->nsim asks for -- so the sum has to match it exactly, with no
+// nsim special case (and none read off the same suspect solve).
+static inline void foceiCheckIndCountsCore(const int *nAllTimes,
+                                           const int *nDoses,
+                                           const int *nEvid2,
+                                           int nsub, int nall) {
+  int64_t tot = 0;
+  for (int i = 0; i < nsub; ++i) {
+    if (nAllTimes[i] < 0 || nDoses[i] < 0 || nEvid2[i] < 0 ||
+        nAllTimes[i] > nall || nDoses[i] + nEvid2[i] > nAllTimes[i]) {
+      stop("focei: rxode2 reports an impossible event layout for subject %d "
+           "(records: %d, doses: %d, evid=2: %d of %d total); reinstall "
+           "rxode2 and nlmixr2est from source",
+           i + 1, nAllTimes[i], nDoses[i], nEvid2[i], nall);
+    }
+    tot += nAllTimes[i];
+  }
+  if (tot != (int64_t)nall) {
+    stop("focei: rxode2's per-subject record counts add to %g, not the %d "
+         "records in the dataset; reinstall rxode2 and nlmixr2est from source",
+         (double)tot, nall);
+  }
+}
+
 // Every per-subject block in the FOCEi setup (gVid, ga/gc, gB, gcH*,
 // llikObsFull) is sized and strided from rxode2's per-subject event counts,
 // and nothing re-derives them.  They are read through the rxode2 pointer
@@ -921,30 +948,41 @@ static inline size_t foceiSzAdd(size_t a, size_t b, const char *what) {
 // into rx->nall, so the per-subject counts must split it exactly.  Check that
 // before anything is sized from them (#1039).
 static inline void foceiCheckIndCounts(rx_solve* rx) {
-  int nall = getRxNall(rx);
-  int64_t tot = 0;
-  for (int i = getRxNsub(rx); i--;) {
+  int nsub = getRxNsub(rx);
+  if (nsub < 0) nsub = 0;
+  std::vector<int> nAllTimes((size_t)nsub), nDoses((size_t)nsub),
+    nEvid2((size_t)nsub);
+  for (int i = 0; i < nsub; ++i) {
     rx_solving_options_ind *ind = getSolvingOptionsInd(rx, i);
-    int nAllTimes = getIndNallTimes(ind);
-    int nDoses = getIndNdoses(ind);
-    int nEvid2 = getIndNevid2(ind);
-    if (nAllTimes < 0 || nDoses < 0 || nEvid2 < 0 ||
-        nAllTimes > nall || nDoses + nEvid2 > nAllTimes) {
-      stop("focei: rxode2 reports an impossible event layout for subject %d "
-           "(records: %d, doses: %d, evid=2: %d of %d total); reinstall "
-           "rxode2 and nlmixr2est from source",
-           i + 1, nAllTimes, nDoses, nEvid2, nall);
-    }
-    tot += nAllTimes;
+    nAllTimes[(size_t)i] = getIndNallTimes(ind);
+    nDoses[(size_t)i] = getIndNdoses(ind);
+    nEvid2[(size_t)i] = getIndNevid2(ind);
   }
-  // nsim > 1 replicates subjects past rx->nsub without scaling rx->nall, so
-  // the sum only has to match the data for a single replicate -- which is the
-  // only case FOCEi sets up.
-  if (getRxNsim(rx) == 1 && tot != (int64_t)nall) {
-    stop("focei: rxode2's per-subject record counts add to %g, not the %d "
-         "records in the dataset; reinstall rxode2 and nlmixr2est from source",
-         (double)tot, nall);
+  foceiCheckIndCountsCore(nsub == 0 ? NULL : &nAllTimes[0],
+                          nsub == 0 ? NULL : &nDoses[0],
+                          nsub == 0 ? NULL : &nEvid2[0], nsub,
+                          getRxNall(rx));
+}
+
+// The same rules, on counts supplied from R, so a test can drive the rejection
+// paths -- they need a build whose rxode2 and nlmixr2est disagree on the solve
+// layout, which no test can produce.
+// [[Rcpp::export]]
+void foceiCheckIndCounts_(Rcpp::IntegerMatrix counts, int nall) {
+  int nsub = counts.nrow();
+  if (counts.ncol() != 3) {
+    stop("focei: counts must have three columns");
   }
+  std::vector<int> nAllTimes((size_t)nsub), nDoses((size_t)nsub),
+    nEvid2((size_t)nsub);
+  for (int i = 0; i < nsub; ++i) {
+    nAllTimes[(size_t)i] = counts(i, 0);
+    nDoses[(size_t)i] = counts(i, 1);
+    nEvid2[(size_t)i] = counts(i, 2);
+  }
+  foceiCheckIndCountsCore(nsub == 0 ? NULL : &nAllTimes[0],
+                          nsub == 0 ? NULL : &nDoses[0],
+                          nsub == 0 ? NULL : &nEvid2[0], nsub, nall);
 }
 
 // The counts foceiCheckIndCounts() validates, exposed so a test can compare
@@ -953,6 +991,7 @@ static inline void foceiCheckIndCounts(rx_solve* rx) {
 // [[Rcpp::export]]
 Rcpp::IntegerMatrix foceiIndEventCounts_() {
   rx_solve* rxl = getRxSolve_();
+  if (rxl == NULL) return Rcpp::IntegerMatrix(0, 3);
   int nsub = getRxNsub(rxl);
   Rcpp::IntegerMatrix ret(nsub, 3);
   for (int i = 0; i < nsub; ++i) {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -911,6 +911,63 @@ static inline size_t foceiSzAdd(size_t a, size_t b, const char *what) {
   return a + b;
 }
 
+// Every per-subject block in the FOCEi setup (gVid, ga/gc, gB, gcH*,
+// llikObsFull) is sized and strided from rxode2's per-subject event counts,
+// and nothing re-derives them.  They are read through the rxode2 pointer
+// table, so a build where rxode2 and nlmixr2est disagree on the solve layout
+// -- a stale object file in either package -- makes every count garbage: an
+// absurd total that the size guards refuse, or a plausible one that leaves a
+// short buffer the setup then strides past.  rxode2 counted the same records
+// into rx->nall, so the per-subject counts must split it exactly.  Check that
+// before anything is sized from them (#1039).
+static inline void foceiCheckIndCounts(rx_solve* rx) {
+  int nall = getRxNall(rx);
+  int64_t tot = 0;
+  for (int i = getRxNsub(rx); i--;) {
+    rx_solving_options_ind *ind = getSolvingOptionsInd(rx, i);
+    int nAllTimes = getIndNallTimes(ind);
+    int nDoses = getIndNdoses(ind);
+    int nEvid2 = getIndNevid2(ind);
+    if (nAllTimes < 0 || nDoses < 0 || nEvid2 < 0 ||
+        nAllTimes > nall || nDoses + nEvid2 > nAllTimes) {
+      stop("focei: rxode2 reports an impossible event layout for subject %d "
+           "(records: %d, doses: %d, evid=2: %d of %d total); reinstall "
+           "rxode2 and nlmixr2est from source",
+           i + 1, nAllTimes, nDoses, nEvid2, nall);
+    }
+    tot += nAllTimes;
+  }
+  // nsim > 1 replicates subjects past rx->nsub without scaling rx->nall, so
+  // the sum only has to match the data for a single replicate -- which is the
+  // only case FOCEi sets up.
+  if (getRxNsim(rx) == 1 && tot != (int64_t)nall) {
+    stop("focei: rxode2's per-subject record counts add to %g, not the %d "
+         "records in the dataset; reinstall rxode2 and nlmixr2est from source",
+         (double)tot, nall);
+  }
+}
+
+// The counts foceiCheckIndCounts() validates, exposed so a test can compare
+// them against the dataset directly instead of inferring the layout from a
+// fit's output.
+// [[Rcpp::export]]
+Rcpp::IntegerMatrix foceiIndEventCounts_() {
+  rx_solve* rxl = getRxSolve_();
+  int nsub = getRxNsub(rxl);
+  Rcpp::IntegerMatrix ret(nsub, 3);
+  for (int i = 0; i < nsub; ++i) {
+    rx_solving_options_ind *ind = getSolvingOptionsInd(rxl, i);
+    ret(i, 0) = getIndNallTimes(ind);
+    ret(i, 1) = getIndNdoses(ind);
+    ret(i, 2) = getIndNevid2(ind);
+  }
+  ret.attr("dimnames") =
+    Rcpp::List::create(R_NilValue,
+                       Rcpp::CharacterVector::create("nAllTimes", "nDoses",
+                                                     "nEvid2"));
+  return ret;
+}
+
 // Size of the gVid block.  Each subject holds its own nobs_i x nobs_i
 // residual variance matrix, so the block is sum(nobs_i^2) -- NOT nall^2:
 // nall counts dose (and evid=2) records too, and (sum x)^2 only equals
@@ -6758,6 +6815,7 @@ static inline void foceiSetupNoEta_(){
 
   // Mixtures only work in population only models;
   rx = getRxSolve_();
+  foceiCheckIndCounts(rx);
 
   if (inds_focei != NULL) R_Free(inds_focei);
   inds_focei = R_Calloc(getRxNsub(rx), focei_ind);
@@ -6813,6 +6871,7 @@ static inline void foceiSetupNoEta_(){
 
 static inline void foceiSetupEta_(NumericMatrix etaMat0){
   rx = getRxSolve_();
+  foceiCheckIndCounts(rx);
 
   if (inds_focei != NULL) R_Free(inds_focei);
   inds_focei = R_Calloc(getRxNsubAndMix(rx), focei_ind);

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -912,29 +912,34 @@ static inline size_t foceiSzAdd(size_t a, size_t b, const char *what) {
 }
 
 // The rules foceiCheckIndCounts() enforces, taking the counts rather than `rx`
-// so a test can drive them.  `nall` is rxode2's record count for ONE replicate
-// of the event data, which is what subjects [0, nsub) hold however many
-// replicates rx->nsim asks for -- so the sum has to match it exactly, with no
-// nsim special case (and none read off the same suspect solve).
+// so a test can drive them.
+//
+// Every rule is about ONE subject's own three numbers, deliberately: nlmixr2est
+// has to run against rxode2 releases it is not built alongside, and a rule
+// resting on an rxode2-wide total (rx->nall) would turn a change in how rxode2
+// accounts for records into a failed fit for everyone on that release -- and,
+// on CRAN, a failed submission.  A dose or evid=2 count larger than the
+// subject's own record count, or any of the three negative, is not an
+// accounting convention: no working rxode2 of any version reports it.
+//
+// The cost is that counts which are individually plausible but collectively
+// wrong -- a subject that comes back with none of its records -- are accepted
+// here.  Sizing gVid from those under-allocates rather than over-allocates, so
+// it is the dangerous shape; what keeps it from arising is the stride fix on
+// the rxode2 side (nlmixr2/rxode2#1357), not this check.
 static inline void foceiCheckIndCountsCore(const int *nAllTimes,
                                            const int *nDoses,
                                            const int *nEvid2,
-                                           int nsub, int nall) {
-  int64_t tot = 0;
+                                           int nsub) {
   for (int i = 0; i < nsub; ++i) {
+    // in int64_t: two garbage counts can sum past INT_MAX
     if (nAllTimes[i] < 0 || nDoses[i] < 0 || nEvid2[i] < 0 ||
-        nAllTimes[i] > nall || nDoses[i] + nEvid2[i] > nAllTimes[i]) {
+        (int64_t)nDoses[i] + (int64_t)nEvid2[i] > (int64_t)nAllTimes[i]) {
       stop("focei: rxode2 reports an impossible event layout for subject %d "
-           "(records: %d, doses: %d, evid=2: %d of %d total); reinstall "
-           "rxode2 and nlmixr2est from source",
-           i + 1, nAllTimes[i], nDoses[i], nEvid2[i], nall);
+           "(records: %d, doses: %d, evid=2: %d); reinstall rxode2 and "
+           "nlmixr2est from source",
+           i + 1, nAllTimes[i], nDoses[i], nEvid2[i]);
     }
-    tot += nAllTimes[i];
-  }
-  if (tot != (int64_t)nall) {
-    stop("focei: rxode2's per-subject record counts add to %g, not the %d "
-         "records in the dataset; reinstall rxode2 and nlmixr2est from source",
-         (double)tot, nall);
   }
 }
 
@@ -944,9 +949,8 @@ static inline void foceiCheckIndCountsCore(const int *nAllTimes,
 // table, so a build where rxode2 and nlmixr2est disagree on the solve layout
 // -- a stale object file in either package -- makes every count garbage: an
 // absurd total that the size guards refuse, or a plausible one that leaves a
-// short buffer the setup then strides past.  rxode2 counted the same records
-// into rx->nall, so the per-subject counts must split it exactly.  Check that
-// before anything is sized from them (#1039).
+// short buffer the setup then strides past.  Refuse the counts that cannot be
+// right before anything is sized from them (#1039).
 static inline void foceiCheckIndCounts(rx_solve* rx) {
   int nsub = getRxNsub(rx);
   if (nsub < 0) nsub = 0;
@@ -960,15 +964,14 @@ static inline void foceiCheckIndCounts(rx_solve* rx) {
   }
   foceiCheckIndCountsCore(nsub == 0 ? NULL : &nAllTimes[0],
                           nsub == 0 ? NULL : &nDoses[0],
-                          nsub == 0 ? NULL : &nEvid2[0], nsub,
-                          getRxNall(rx));
+                          nsub == 0 ? NULL : &nEvid2[0], nsub);
 }
 
 // The same rules, on counts supplied from R, so a test can drive the rejection
 // paths -- they need a build whose rxode2 and nlmixr2est disagree on the solve
 // layout, which no test can produce.
 // [[Rcpp::export]]
-void foceiCheckIndCounts_(Rcpp::IntegerMatrix counts, int nall) {
+void foceiCheckIndCounts_(Rcpp::IntegerMatrix counts) {
   int nsub = counts.nrow();
   if (counts.ncol() != 3) {
     stop("focei: counts must have three columns");
@@ -982,7 +985,7 @@ void foceiCheckIndCounts_(Rcpp::IntegerMatrix counts, int nall) {
   }
   foceiCheckIndCountsCore(nsub == 0 ? NULL : &nAllTimes[0],
                           nsub == 0 ? NULL : &nDoses[0],
-                          nsub == 0 ? NULL : &nEvid2[0], nsub, nall);
+                          nsub == 0 ? NULL : &nEvid2[0], nsub);
 }
 
 // The counts foceiCheckIndCounts() validates, exposed so a test can compare

--- a/tests/testthat/test-focei-ind-counts-1039.R
+++ b/tests/testthat/test-focei-ind-counts-1039.R
@@ -8,6 +8,13 @@ nmTest({
   # the start of the subject array, so it reads correctly under any stride.
 
   test_that("rxode2's per-subject event counts split the dataset (#1039)", {
+    # NOT on CRAN: the counts and their total are rxode2's own record
+    # accounting, and CRAN pairs this package with whatever rxode2 is already
+    # there.  A release that accounts for records differently should show up
+    # here as a test failure for us, never as a check failure on CRAN -- which
+    # is the whole reason foceiCheckIndCounts() does not enforce this.
+    skip_on_cran()
+
     # unequal per-subject record counts, so a wrong stride cannot pass by
     # reading a neighbouring (identical) subject
     nObsI <- c(3, 5, 2, 7, 4, 6)
@@ -41,6 +48,9 @@ nmTest({
     expect_equal(sum(cnt[, "nAllTimes"]), nrow(d))
   })
 
+  # This one has no skip_on_cran(): it drives the rules on counts supplied from
+  # R and never touches a solve, so it cannot depend on which rxode2 is
+  # installed -- which is exactly the property the rules were narrowed to have.
   test_that("an impossible per-subject event layout is refused (#1039)", {
     # the rejection paths need a build whose rxode2 and nlmixr2est disagree on
     # the solve layout, which no test can produce -- so drive the rules on
@@ -75,6 +85,10 @@ nmTest({
   })
 
   test_that("a multi-subject focei fit sizes its per-subject blocks correctly", {
+    # NOT on CRAN: this asserts llikObs lands on the dose rows of the event
+    # table, which is rxode2's record layout, against whatever rxode2 CRAN has
+    skip_on_cran()
+
     # the report's own reproduction: on a mismatched build this failed at
     # .foceiFitInternal() with "dataset too large", an R_Calloc failure, or a
     # segfault, depending on what the mis-read bytes happened to hold

--- a/tests/testthat/test-focei-ind-counts-1039.R
+++ b/tests/testthat/test-focei-ind-counts-1039.R
@@ -38,6 +38,35 @@ nmTest({
     expect_equal(sum(cnt[, "nAllTimes"]), nrow(d))
   })
 
+  test_that("an inconsistent per-subject event layout is refused (#1039)", {
+    # the rejection paths need a build whose rxode2 and nlmixr2est disagree on
+    # the solve layout, which no test can produce -- so drive the rules on
+    # counts supplied from R instead.  Columns: nAllTimes, nDoses, nEvid2.
+    ok <- cbind(c(12L, 10L, 8L), c(1L, 1L, 1L), c(0L, 0L, 0L))
+    expect_silent(foceiCheckIndCounts_(ok, 30L))
+
+    # a subject whose records went missing -- the counts stay individually
+    # plausible, so only the sum catches it.  This is the dangerous shape: it
+    # under-sizes gVid rather than asking for an absurd block.
+    dropped <- ok
+    dropped[2, 1] <- 0L
+    dropped[2, 2] <- 0L
+    expect_error(foceiCheckIndCounts_(dropped, 30L),
+                 "record counts add to")
+
+    # garbage read out of unrelated memory: negative, or wider than the whole
+    # dataset, or a dose/evid=2 split that does not fit in the subject
+    expect_error(foceiCheckIndCounts_(rbind(ok, c(-1L, 0L, 0L)), 30L),
+                 "impossible event layout")
+    expect_error(foceiCheckIndCounts_(rbind(ok, c(1000L, 1L, 0L)), 30L),
+                 "impossible event layout")
+    expect_error(foceiCheckIndCounts_(rbind(ok, c(4L, 3L, 2L)), 30L),
+                 "impossible event layout")
+    # the message names the offending subject, counting from 1
+    expect_error(foceiCheckIndCounts_(rbind(ok, c(-1L, 0L, 0L)), 30L),
+                 "subject 4")
+  })
+
   test_that("a multi-subject focei fit sizes its per-subject blocks correctly", {
     # the report's own reproduction: on a mismatched build this failed at
     # .foceiFitInternal() with "dataset too large", an R_Calloc failure, or a

--- a/tests/testthat/test-focei-ind-counts-1039.R
+++ b/tests/testthat/test-focei-ind-counts-1039.R
@@ -33,38 +33,45 @@ nmTest({
     expect_equal(as.integer(cnt[, "nAllTimes"]), as.integer(nObsI) + 1L)
     expect_equal(as.integer(cnt[, "nDoses"]), rep(1L, length(nObsI)))
     expect_equal(as.integer(cnt[, "nEvid2"]), rep(0L, length(nObsI)))
-    # this is the invariant foceiCheckIndCounts() enforces before it sizes
-    # anything: the per-subject counts have to add back up to the dataset
+    # the counts have to add back up to the dataset.  This is asserted here, on
+    # a known dataset, rather than enforced in foceiCheckIndCounts(): the only
+    # total available at setup is rxode2's own rx->nall, and a rule resting on
+    # that would fail every fit on any rxode2 release that accounts for records
+    # differently.
     expect_equal(sum(cnt[, "nAllTimes"]), nrow(d))
   })
 
-  test_that("an inconsistent per-subject event layout is refused (#1039)", {
+  test_that("an impossible per-subject event layout is refused (#1039)", {
     # the rejection paths need a build whose rxode2 and nlmixr2est disagree on
     # the solve layout, which no test can produce -- so drive the rules on
     # counts supplied from R instead.  Columns: nAllTimes, nDoses, nEvid2.
     ok <- cbind(c(12L, 10L, 8L), c(1L, 1L, 1L), c(0L, 0L, 0L))
-    expect_silent(foceiCheckIndCounts_(ok, 30L))
+    expect_silent(foceiCheckIndCounts_(ok))
 
-    # a subject whose records went missing -- the counts stay individually
-    # plausible, so only the sum catches it.  This is the dangerous shape: it
-    # under-sizes gVid rather than asking for an absurd block.
+    # garbage read out of unrelated memory: a negative count, or a dose /
+    # evid=2 split that does not fit inside the subject's own records
+    expect_error(foceiCheckIndCounts_(rbind(ok, c(-1L, 0L, 0L))),
+                 "impossible event layout")
+    expect_error(foceiCheckIndCounts_(rbind(ok, c(5L, 0L, -2L))),
+                 "impossible event layout")
+    expect_error(foceiCheckIndCounts_(rbind(ok, c(4L, 3L, 2L))),
+                 "impossible event layout")
+    # a garbage pair that would overflow int if summed in int
+    expect_error(foceiCheckIndCounts_(rbind(ok, c(4L, 2000000000L, 2000000000L))),
+                 "impossible event layout")
+    # the message names the offending subject, counting from 1
+    expect_error(foceiCheckIndCounts_(rbind(ok, c(-1L, 0L, 0L))),
+                 "subject 4")
+
+    # DELIBERATELY accepted: a subject that came back with none of its records
+    # is individually plausible.  Rejecting it needs a total to compare against,
+    # and the only one available is rxode2's own rx->nall -- a rule nlmixr2est
+    # cannot hold across rxode2 releases it is not built alongside.  See
+    # foceiCheckIndCountsCore() in src/inner.cpp.
     dropped <- ok
     dropped[2, 1] <- 0L
     dropped[2, 2] <- 0L
-    expect_error(foceiCheckIndCounts_(dropped, 30L),
-                 "record counts add to")
-
-    # garbage read out of unrelated memory: negative, or wider than the whole
-    # dataset, or a dose/evid=2 split that does not fit in the subject
-    expect_error(foceiCheckIndCounts_(rbind(ok, c(-1L, 0L, 0L)), 30L),
-                 "impossible event layout")
-    expect_error(foceiCheckIndCounts_(rbind(ok, c(1000L, 1L, 0L)), 30L),
-                 "impossible event layout")
-    expect_error(foceiCheckIndCounts_(rbind(ok, c(4L, 3L, 2L)), 30L),
-                 "impossible event layout")
-    # the message names the offending subject, counting from 1
-    expect_error(foceiCheckIndCounts_(rbind(ok, c(-1L, 0L, 0L)), 30L),
-                 "subject 4")
+    expect_silent(foceiCheckIndCounts_(dropped))
   })
 
   test_that("a multi-subject focei fit sizes its per-subject blocks correctly", {

--- a/tests/testthat/test-focei-ind-counts-1039.R
+++ b/tests/testthat/test-focei-ind-counts-1039.R
@@ -1,0 +1,82 @@
+nmTest({
+  # Issue #1039 -- every per-subject block in the FOCEi setup (gVid, ga/gc, gB,
+  # gcH*, llikObsFull) is sized and strided from rxode2's per-subject event
+  # counts, read through the rxode2 pointer table.  A build whose rxode2 and
+  # nlmixr2est disagree on the solve layout returns those counts from the wrong
+  # bytes, and the setup then sizes megabytes of per-subject storage from
+  # garbage.  Both checks below need more than one subject: subject 0 sits at
+  # the start of the subject array, so it reads correctly under any stride.
+
+  test_that("rxode2's per-subject event counts split the dataset (#1039)", {
+    # unequal per-subject record counts, so a wrong stride cannot pass by
+    # reading a neighbouring (identical) subject
+    nObsI <- c(3, 5, 2, 7, 4, 6)
+    d <- do.call(rbind, lapply(seq_along(nObsI), function(id) {
+      rbind(data.frame(ID = id, TIME = 0, DV = NA_real_, AMT = 320, EVID = 1,
+                       CMT = 1),
+            data.frame(ID = id, TIME = seq(0.5, 12, length.out = nObsI[id]),
+                       DV = 5, AMT = 0, EVID = 0, CMT = 1))
+    }))
+
+    m <- rxode2::rxode2({
+      ka <- 1
+      cl <- 3
+      v <- 30
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+    })
+    suppressMessages(rxode2::rxSolve(m, d))
+
+    cnt <- foceiIndEventCounts_()
+    expect_equal(nrow(cnt), length(nObsI))
+    expect_equal(as.integer(cnt[, "nAllTimes"]), as.integer(nObsI) + 1L)
+    expect_equal(as.integer(cnt[, "nDoses"]), rep(1L, length(nObsI)))
+    expect_equal(as.integer(cnt[, "nEvid2"]), rep(0L, length(nObsI)))
+    # this is the invariant foceiCheckIndCounts() enforces before it sizes
+    # anything: the per-subject counts have to add back up to the dataset
+    expect_equal(sum(cnt[, "nAllTimes"]), nrow(d))
+  })
+
+  test_that("a multi-subject focei fit sizes its per-subject blocks correctly", {
+    # the report's own reproduction: on a mismatched build this failed at
+    # .foceiFitInternal() with "dataset too large", an R_Calloc failure, or a
+    # segfault, depending on what the mis-read bytes happened to hold
+    oneCompartment <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+
+    fit <- suppressMessages(suppressWarnings(
+      nlmixr(oneCompartment(), nlmixr2data::theo_sd, "focei",
+             control = foceiControl(maxOuterIterations = 0, covMethod = "",
+                                    print = 0))))
+    expect_true(length(unique(fit$ID)) > 1)
+    expect_true(is.finite(fit$objf))
+    expect_true(all(is.finite(fit$IPRED)))
+    # llikObsFull is the one per-subject block handed back to R in record
+    # order, so its per-subject offsets come straight from these counts: a
+    # subject given the wrong offset leaves its records unwritten and moves the
+    # dose records (the NA entries) off the dose rows of the event table
+    ll <- fit$llikObs
+    expect_equal(length(ll), nrow(fit$dataSav))
+    expect_equal(which(is.na(ll)), which(fit$dataSav$EVID != 0))
+    expect_true(all(is.finite(ll[!is.na(ll)])))
+  })
+})


### PR DESCRIPTION
Refs #1039. Note this PR does **not** by itself fix that issue -- nlmixr2/rxode2#1357 does. This is what keeps the same class of breakage from reaching the allocator quietly.

## Background

#1039 reproduces as `focei: dataset too large`, an `R_Calloc` failure for an
absurd size, or a segfault, on every multi-subject FOCEi fit. The cause turned
out to be entirely on the rxode2 side: an installed `rxode2.so` linked from
object files compiled against two different `rx_solving_options_ind` layouts.
Under gdb, in one loaded library, `rx2api.c`'s translation unit reports
`sizeof == 976` while `rxData.cpp`/`par_solve.cpp` report `1664`. So the subject
array was laid out at a 1664 stride and `getSolvingOptionsInd()` returned
`base + 976*i`. Subject 0 sits at the start of the array either way, which is
why a single-subject dataset fits and every multi-subject one does not.

nlmixr2est was already clean here: it goes through function pointers only, never
dereferences `rx_solving_options_ind`, and never does subject-array arithmetic.
nlmixr2/rxode2#1357 removes the layout from the ABI accessor.

## The change

What was missing on this side is that a mis-read count reached the allocator at
all. Every per-subject block in the FOCEi setup -- `gVid`, `ga`/`gc`, `gB`,
`gcH*`, `llikObsFull` -- is sized and strided from rxode2's per-subject event
counts, and nothing re-derives them.

`foceiCheckIndCounts()` runs before anything is sized from them, and refuses
counts that cannot be right: a negative one, or a dose or `evid=2` count larger
than that subject's own record count. On a mismatched build the reproduction
now stops with

```
focei: rxode2 reports an impossible event layout for subject 6 (records:
101650104, doses: 435033104, evid=2: 435031952); reinstall rxode2 and
nlmixr2est from source
```

instead of a bogus allocation size or a segfault.

### Only rules that hold across rxode2 releases

Every rule is about **one subject's own three numbers**, deliberately.
nlmixr2est has to run against rxode2 releases it is not built alongside -- CRAN
pairs the current nlmixr2est with whatever rxode2 is already there -- and a
rule resting on an rxode2-wide total would turn a change in how rxode2 accounts
for records into a failed fit for everyone on that release, and a failed
submission with it. An earlier revision of this PR did exactly that (each
subject's records had to fit inside `rx->nall`, and the counts had to sum to
it); those two rules are gone.

The cost is stated rather than hidden: counts that are individually plausible
but collectively wrong -- a subject that comes back with none of its records --
are accepted here, and that is the shape that *under*-sizes `gVid`. What keeps
it from arising is nlmixr2/rxode2#1357, not this check. The sum invariant is
asserted in the test instead, on a known dataset, where a change in rxode2's
accounting surfaces as a test failure rather than as a broken fit.

The narrowed rules still catch the build that prompted #1039: three runs
against it, all stopping at subject 6.

The `// nocov` on the overflow branches stays. Those need a dataset with more
than 2^32 records on a 32-bit `size_t`; no test can reach them, and the case
that reaches users in practice is now caught earlier with a better message.

## Tests

`tests/testthat/test-focei-ind-counts-1039.R`. Both checks need more than one
subject with *unequal* record counts: subject 0 reads correctly under any
stride, and equal counts let a neighbouring subject stand in for the right one.

- `foceiIndEventCounts_()` exposes the counts, so the test asserts the layout
  against the dataset directly rather than inferring it from a fit's output.
- `foceiCheckIndCounts_()` drives the rules on counts supplied from R, which is
  the only way to reach the rejection paths -- they need a build whose rxode2
  and nlmixr2est disagree on the solve layout. It also pins what is
  deliberately *accepted*, so the trade-off above cannot be un-made by accident.
- A multi-subject `theo_sd` FOCEi fit, asserting `llikObs` comes back with its
  NA entries on the dose rows of the event table -- that block's per-subject
  offsets come straight from these counts.

The two assertions that read the counts off a real solve carry
`skip_on_cran()`, for the same reason the rules dropped the total: they are
rxode2's record accounting, and CRAN pairs this package with whatever rxode2 is
already installed. A release that accounts for records differently has to show
up as a test failure here, never as a check failure on CRAN. (`nmTest()`
already returns early off `NOT_CRAN`; the skips say per test which ones depend
on the installed rxode2.) The rules test carries no skip -- it never touches a
solve, which is exactly the property the rules were narrowed to have.

Ran clean across all 79 FOCEi-family test files. The single failure there is
the known `censInformation` process-global carryover, which passes when that
file is run on its own.

## Review

Three rounds of independent review (Antigravity, Gemini). Fixed from it:

- The sum check was gated on `getRxNsim(rx) == 1`, a value read through the same
  accessors the check exists to distrust -- garbage there skipped the check
  entirely. The gate was also unnecessary: `rx->nall` counts one replicate of
  the event data and subjects `[0, nsub)` are that replicate whatever `rx->nsim`
  asks for.
- Nothing covered the rejection paths; `foceiCheckIndCounts_()` was added for
  that.
- `foceiIndEventCounts_()` now guards its `getRxSolve_()` result the way
  `foceiIndLik_` does.

One finding rejected: a claimed NULL dereference when `rx->subjects` is unset.
`getSolvingOptionsInd()` bounds-checks and raises a clean R error there; checked
by calling the accessor after `rxClean()`.

One considered and dropped: cross-checking `getRxNsub(rx)` against nlmixr2est's
own count of the dataset's IDs. rxode2's `rxHomGroups` datasets carry one row
block per group and expand to more subjects than an ID-transition count sees, so
the cross-check would falsely reject them. The scenario it defends against needs
`rx_solve`'s own layout corrupted, at which point nothing about the solve is
readable anyway.
