### PR TITLE
fix(focei): make mceta actually use its Monte-Carlo draws (#1040)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,7 +105,8 @@
 ## Bug fixes
 
 - `foceiControl(mceta = n)` (`n > 0`) now actually uses the extra starting
-  etas, and can no longer end worse than `mceta = 0`.  The candidate set
+  etas, and at fixed parameters can no longer give a worse objective than
+  `mceta = 0`.  The candidate set
   included the carried "last eta" -- the previous outer iteration's converged
   conditional mode -- whose inner objective is essentially always the lowest, so
   it won for every subject and `mceta = n` returned an objective bit-identical
@@ -113,13 +114,14 @@
   plus the `n-1` draws from omega.  Because a candidate is ranked by the
   objective at its starting point, which does not order the points the inner
   optimization converges to, a subject that starts from a draw now also solves
-  from eta=0 and keeps whichever converged lower -- without that, a draw that
+  from eta=0 and keeps whichever converged lower, so no inner solve can end
+  above the one `mceta = 0` would have reached -- without that, a draw that
   merely looked better could converge worse (measured on a fixed-omega
-  inverse-CDF model: `mceta = 2` gave -2251.0 against `mceta = 0`'s -2302.5, and
-  now gives -2338.8).  `mceta = 1` means eta=0 rather than being a silent no-op,
+  inverse-CDF model evaluated at fixed parameters: `mceta = 2` gave -2251.0
+  against `mceta = 0`'s -2302.5, and now gives -2338.8).  `mceta = 1` means eta=0 rather than being a silent no-op,
   a non-finite eta=0 no longer pins the search, and the draws are made once per
-  fit instead of at every objective evaluation, so the outer optimizer
-  differentiates the same function at every evaluation.  The fit records which
+  fit instead of at every objective evaluation, so the objective is the same
+  function at every evaluation.  The fit records which
   candidate each inner solve started from in `$env$nMcetaStart`.
 
 - With two or more occasion parameters on one level, `fit$iov$<level>` had

--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,23 @@
 
 ## Bug fixes
 
+- `foceiControl(mceta = n)` (`n > 0`) now actually uses the extra starting
+  etas, and can no longer end worse than `mceta = 0`.  The candidate set
+  included the carried "last eta" -- the previous outer iteration's converged
+  conditional mode -- whose inner objective is essentially always the lowest, so
+  it won for every subject and `mceta = n` returned an objective bit-identical
+  to the keep-last behavior of `mceta = -1`/`-2`.  The candidates are now eta=0
+  plus the `n-1` draws from omega.  Because a candidate is ranked by the
+  objective at its starting point, which does not order the points the inner
+  optimization converges to, a subject that starts from a draw now also solves
+  from eta=0 and keeps whichever converged lower -- without that, a draw that
+  merely looked better could converge worse (measured on a fixed-omega
+  inverse-CDF model: `mceta = 2` gave -2251.0 against `mceta = 0`'s -2302.5, and
+  now gives -2338.8).  `mceta = 1` means eta=0 rather than being a silent no-op,
+  a non-finite eta=0 no longer pins the search, and the draws are made once per
+  fit instead of at every objective evaluation, so the outer optimizer
+  differentiates the same function at every evaluation.  The fit records which
+  candidate each inner solve started from in `$env$nMcetaStart`.
 
 - With two or more occasion parameters on one level, `fit$iov$<level>` had
   `NA` for every occasion (and the fit warned "NAs introduced by

--- a/NEWS.md
+++ b/NEWS.md
@@ -126,7 +126,14 @@
   objective at its starting point, which does not order the points the inner
   optimization converges to, a subject that starts from a draw now also solves
   from eta=0 and keeps whichever converged lower, so no inner solve can end
-  above the one `mceta = 0` would have reached -- without that, a draw that
+  above the one `mceta = 0` would have reached.  That comparison is made on the
+  objective the fit REPORTS -- the marginal one, which carries the Laplace
+  `log|H|` term -- and not on the inner joint density the optimizer minimizes:
+  the two order candidates differently often enough (on the model above, 23 of
+  the 44 subjects that had a choice) that ranking on the inner objective alone
+  handed the fit the worse candidate.  Restarts are only ranked when there is
+  more than one candidate, so a fit that never restarts pays nothing for it, and
+  `$env$nInnerRerank` reports how often the two orderings disagreed -- without that, a draw that
   merely looked better could converge worse (measured on a fixed-omega
   inverse-CDF model evaluated at fixed parameters: `mceta = 2` gave -2251.0
   against `mceta = 0`'s -2302.5, and now gives -2338.8).  The floor solve wraps

--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,17 @@
 
 ## Bug fixes
 
+- `foceiControl(mceta = )` is no longer discarded for a model whose etas are
+  all mu-referenced.  Any non-default setting was reset to `-2` on the grounds
+  that "the initial etas are all exactly zero, so the search has nothing to
+  explore" -- true only of the first inner solve, since every later one starts
+  from the previous iteration's mode, and the `mceta > 0` candidates are draws
+  from omega, which are not zero.  This is what made `mceta = 10` return an
+  objective bit-identical to `mceta = -2` on such a model.  On `theo_sd`'s
+  one-compartment model (every eta mu-referenced), `mceta = 5` now starts 420 of
+  its 1008 inner solves from a draw and reaches a different objective than
+  `mceta = -2`.
+
 - `foceiControl(mceta = n)` (`n > 0`) now actually uses the extra starting
   etas, and at fixed parameters can no longer give a worse objective than
   `mceta = 0`.  The candidate set

--- a/NEWS.md
+++ b/NEWS.md
@@ -104,7 +104,6 @@
 
 ## Bug fixes
 
-<<<<<<< HEAD
 - `foceiControl(mceta = )` is no longer discarded for a model whose etas are
   all mu-referenced.  Any non-default setting was reset to `-2` on the grounds
   that "the initial etas are all exactly zero, so the search has nothing to
@@ -116,35 +115,39 @@
   its 1008 inner solves from a draw and reaches a different objective than
   `mceta = -2`.
 
-- `foceiControl(mceta = n)` (`n > 0`) now actually uses the extra starting
-  etas, and at fixed parameters can no longer give a worse objective than
-  `mceta = 0`.  The candidate set
-  included the carried "last eta" -- the previous outer iteration's converged
-  conditional mode -- whose inner objective is essentially always the lowest, so
-  it won for every subject and `mceta = n` returned an objective bit-identical
-  to the keep-last behavior of `mceta = -1`/`-2`.  The candidates are now eta=0
-  plus the `n-1` draws from omega.  Because a candidate is ranked by the
-  objective at its starting point, which does not order the points the inner
-  optimization converges to, a subject that starts from a draw now also solves
-  from eta=0 and keeps whichever converged lower, so no inner solve can end
-  above the one `mceta = 0` would have reached.  That comparison is made on the
-  objective the fit REPORTS -- the marginal one, which carries the Laplace
-  `log|H|` term -- and not on the inner joint density the optimizer minimizes:
-  the two order candidates differently often enough (on the model above, 23 of
-  the 44 subjects that had a choice) that ranking on the inner objective alone
-  handed the fit the worse candidate.  Restarts are only ranked when there is
-  more than one candidate, so a fit that never restarts pays nothing for it, and
-  `$env$nInnerRerank` reports how often the two orderings disagreed -- without that, a draw that
-  merely looked better could converge worse (measured on a fixed-omega
-  inverse-CDF model evaluated at fixed parameters: `mceta = 2` gave -2251.0
-  against `mceta = 0`'s -2302.5, and now gives -2338.8).  The floor solve wraps
-  the whole inner-optimizer dispatch rather than living inside one arm of it, so
-  it holds for whichever inner optimizer is configured.  `mceta = 1` means eta=0 rather than being a silent no-op,
-  a non-finite eta=0 no longer pins the search, and the draws are made once per
+- `foceiControl(mceta = n)` (`n > 0`) now actually uses the extra starting etas,
+  and at fixed parameters can no longer give a worse objective than
+  `mceta = 0`.  The candidate set included the carried "last eta" -- the
+  previous outer iteration's converged conditional mode -- whose inner objective
+  is essentially always the lowest, so it won for every subject and `mceta = n`
+  returned an objective bit-identical to the keep-last behavior of
+  `mceta = -1`/`-2`.  The candidates are now eta=0 plus the `n-1` draws from
+  omega.
+
+  Because a candidate is ranked by the objective at its starting point, which
+  does not order the points the inner optimization converges to, a subject that
+  starts from a draw now also solves from eta=0 and keeps whichever converged
+  lower -- without that, a draw that merely looked better could converge worse
+  (measured on a fixed-omega inverse-CDF model at fixed parameters: `mceta = 2`
+  gave -2251.0 against `mceta = 0`'s -2302.5, and now gives -2338.8).  That
+  floor solve wraps the whole inner-optimizer dispatch rather than living inside
+  one arm of it, so it holds for whichever inner optimizer is configured.
+
+  The comparison is made on the objective the fit REPORTS -- the marginal one,
+  which carries the Laplace `log|H|` term -- and not on the inner joint density
+  the optimizer minimizes.  The two order candidates differently often enough
+  (on the model above, 23 of the 44 subjects that had a choice) that ranking on
+  the inner objective alone handed the fit the worse candidate.  Restarts are
+  ranked only when there is more than one candidate, so an inner solve that
+  never restarts pays nothing for it.
+
+  Finally, `mceta = 1` means eta=0 rather than being a silent no-op, a
+  non-finite eta=0 no longer pins the search, and the draws are made once per
   fit instead of at every objective evaluation, so the objective is the same
-  function at every evaluation.  The fit records which
-  candidate each inner solve started from in `$env$nMcetaStart`.
-=======
+  function at every evaluation.  The fit records which candidate each inner
+  solve started from in `$env$nMcetaStart`, and how often the two orderings
+  disagreed in `$env$nInnerRerank`.
+
 - `focei` now checks rxode2's per-subject event counts before it sizes the
   per-subject blocks it strides with them (`gVid`, `ga`/`gc`, `gB`, `gcH*`,
   `llikObsFull`).  When rxode2 and nlmixr2est are built against different solve
@@ -154,7 +157,6 @@
   held.  A negative count, or a dose or `evid=2` count larger than the
   subject's own record count, now stops the fit with that as the reason
   instead (#1039).
->>>>>>> origin/main
 
 - With two or more occasion parameters on one level, `fit$iov$<level>` had
   `NA` for every occasion (and the fit warned "NAs introduced by

--- a/NEWS.md
+++ b/NEWS.md
@@ -129,7 +129,9 @@
   above the one `mceta = 0` would have reached -- without that, a draw that
   merely looked better could converge worse (measured on a fixed-omega
   inverse-CDF model evaluated at fixed parameters: `mceta = 2` gave -2251.0
-  against `mceta = 0`'s -2302.5, and now gives -2338.8).  `mceta = 1` means eta=0 rather than being a silent no-op,
+  against `mceta = 0`'s -2302.5, and now gives -2338.8).  The floor solve wraps
+  the whole inner-optimizer dispatch rather than living inside one arm of it, so
+  it holds for whichever inner optimizer is configured.  `mceta = 1` means eta=0 rather than being a silent no-op,
   a non-finite eta=0 no longer pins the search, and the draws are made once per
   fit instead of at every objective evaluation, so the objective is the same
   function at every evaluation.  The fit records which

--- a/R/focei.R
+++ b/R/focei.R
@@ -4069,39 +4069,8 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   ret
 }
 
-#' Reset a user-specified mceta to the default for fully mu-referenced models
-#'
-#' When every eta is mu-referenced the initial etas are all exactly zero, so the
-#' Monte-Carlo / jump mceta starting-point search has nothing to explore.  A
-#' non-default mceta is ignored (reset to the default -2) with a warning.
-#'
-#' @param ui model ui
-#' @param control focei control
-#' @return control, possibly with mceta reset to -2L
-#' @noRd
-.foceiMcetaMuRefFallback <- function(ui, control) {
-  .mceta <- control$mceta
-  if (is.null(.mceta) || identical(as.integer(.mceta), -2L)) {
-    return(control)
-  }
-  .allEta <- ui$eta
-  if (length(.allEta) == 0L) {
-    return(control)
-  }
-  .muEta <- ui$muRefDataFrame$eta
-  if (all(.allEta %in% .muEta)) {
-    warning("all etas are mu-referenced (initial etas are zero), so 'mceta=", .mceta,
-      "' has no effect; using the default 'mceta=-2'",
-      call. = FALSE
-    )
-    control$mceta <- -2L
-  }
-  control
-}
-
 .foceiFamilyReturn <- function(env, ui, ..., method = NULL, est = "none") {
   .control <- ui$control
-  .control <- .foceiMcetaMuRefFallback(ui, .control)
   .control$est <- est
   ui$control <- .control
   # Analytic covariate-coefficient reuse (fast=TRUE): the eta-scaling of a mu-ref

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -792,8 +792,10 @@
 #'   `n>0` candidates -- it is the previous iteration's converged conditional
 #'   mode, so it would win for every subject and `n>0` would reduce to the
 #'   keep-last behavior of `-1`/`-2`.  When a sampled eta wins, the inner
-#'   problem is also solved from eta=0 and the better converged result kept, so
-#'   no inner solve ends above the one `0` would have reached.  The search is
+#'   problem is also solved from eta=0 and the better converged result kept --
+#'   compared on the marginal objective the fit reports, which carries the
+#'   Laplace `log|H|` term, not on the inner objective the optimizer minimizes --
+#'   so no inner solve ends above the one `0` would have reached.  The search is
 #'   skipped while the outer gradient is being differenced, where the eta is
 #'   pinned to the central evaluation's mode.
 #'

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -793,7 +793,9 @@
 #'   mode, so it would win for every subject and `n>0` would reduce to the
 #'   keep-last behavior of `-1`/`-2`.  When a sampled eta wins, the inner
 #'   problem is also solved from eta=0 and the better converged result kept, so
-#'   `n>0` is never worse than `0`.
+#'   no inner solve ends above the one `0` would have reached.  The search is
+#'   skipped while the outer gradient is being differenced, where the eta is
+#'   pinned to the central evaluation's mode.
 #'
 #' @param seed Integer seed (default `42`) used to make a FOCEi fit
 #'   reproducible and self-contained.  The fit (including the `mceta`

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -786,9 +786,14 @@
 #'   out of bound); `-1` jumps between the extrapolated eta and eta=0, keeping
 #'   the better; both `-2` and `-1` fall back to keeping the last eta when no
 #'   analytic `d eta*/d theta` is available (`fast = FALSE`).  `0` uses eta=0
-#'   for each inner optimization; for `n>0`, the last eta, eta=0, and n-1
-#'   etas sampled from omega are each evaluated and the best (by inner
-#'   objective) is used.
+#'   for each inner optimization; for `n>0`, eta=0 and n-1 etas sampled from
+#'   omega are each evaluated and the best (by inner objective) starts the
+#'   inner optimization.  The carried last eta is deliberately not one of the
+#'   `n>0` candidates -- it is the previous iteration's converged conditional
+#'   mode, so it would win for every subject and `n>0` would reduce to the
+#'   keep-last behavior of `-1`/`-2`.  When a sampled eta wins, the inner
+#'   problem is also solved from eta=0 and the better converged result kept, so
+#'   `n>0` is never worse than `0`.
 #'
 #' @param seed Integer seed (default `42`) used to make a FOCEi fit
 #'   reproducible and self-contained.  The fit (including the `mceta`

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -947,7 +947,9 @@ inner optimization.  The carried last eta is deliberately not one of the
 mode, so it would win for every subject and `n>0` would reduce to the
 keep-last behavior of `-1`/`-2`.  When a sampled eta wins, the inner
 problem is also solved from eta=0 and the better converged result kept, so
-`n>0` is never worse than `0`.}
+no inner solve ends above the one `0` would have reached.  The search is
+skipped while the outer gradient is being differenced, where the eta is
+pinned to the central evaluation's mode.}
 
 \item{warm}{Seeding of the n1qn1 inner-optimization Hessian:
 `"calc"` (default) warm-starts each inner problem with the eta

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -946,8 +946,10 @@ inner optimization.  The carried last eta is deliberately not one of the
 `n>0` candidates -- it is the previous iteration's converged conditional
 mode, so it would win for every subject and `n>0` would reduce to the
 keep-last behavior of `-1`/`-2`.  When a sampled eta wins, the inner
-problem is also solved from eta=0 and the better converged result kept, so
-no inner solve ends above the one `0` would have reached.  The search is
+problem is also solved from eta=0 and the better converged result kept --
+compared on the marginal objective the fit reports, which carries the
+Laplace `log|H|` term, not on the inner objective the optimizer minimizes --
+so no inner solve ends above the one `0` would have reached.  The search is
 skipped while the outer gradient is being differenced, where the eta is
 pinned to the central evaluation's mode.}
 

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -940,9 +940,14 @@ reset bound (else keeping the last eta, or resetting to 0 when that is also
 out of bound); `-1` jumps between the extrapolated eta and eta=0, keeping
 the better; both `-2` and `-1` fall back to keeping the last eta when no
 analytic `d eta*/d theta` is available (`fast = FALSE`).  `0` uses eta=0
-for each inner optimization; for `n>0`, the last eta, eta=0, and n-1
-etas sampled from omega are each evaluated and the best (by inner
-objective) is used.}
+for each inner optimization; for `n>0`, eta=0 and n-1 etas sampled from
+omega are each evaluated and the best (by inner objective) starts the
+inner optimization.  The carried last eta is deliberately not one of the
+`n>0` candidates -- it is the previous iteration's converged conditional
+mode, so it would win for every subject and `n>0` would reduce to the
+keep-last behavior of `-1`/`-2`.  When a sampled eta wins, the inner
+problem is also solved from eta=0 and the better converged result kept, so
+`n>0` is never worse than `0`.}
 
 \item{warm}{Seeding of the n1qn1 inner-optimization Hessian:
 `"calc"` (default) warm-starts each inner problem with the eta

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -3908,6 +3908,13 @@ static inline int innerOpt1(int id, int likId) {
   int nInnerStart = mcetaSampleStart ? 2 : 1;
   for (int _innerStart = 0; _innerStart < nInnerStart; _innerStart++) {
   bool _lastStart = (_innerStart + 1 == nInnerStart);
+  // The running minimum is PASS-LOCAL.  restoreBest() is the recovery from a
+  // failed restart inside this pass's nudge cascade, so it must put back an eta
+  // from THIS pass: carrying the sample pass's eta into the floor pass's cascade
+  // would have the floor nudging away from eta=0 and it would stop being the run
+  // mceta=0 would have made.  Choosing BETWEEN passes is candEta's job below.
+  fBest = std::numeric_limits<double>::infinity();
+  haveBest = false;
   if (_innerStart > 0) {
     // The eta=0 floor: re-seed exactly as mceta=0 would have, so this pass is
     // the run it must not come out above.
@@ -3934,6 +3941,9 @@ static inline int innerOpt1(int id, int likId) {
            &imp, fInd->zm, &izs, &rzs, &dzs, &id);
     if (ISNA(f)) {
       if (haveBest) { restoreBest(); break; }
+      // No usable result in THIS pass; an earlier one may still have a
+      // candidate, and the selection below will take it.
+      if (!candEta.empty()) break;
       if (_lastStart) return 0;
       continue;
     }
@@ -4104,6 +4114,9 @@ static inline int innerOpt1(int id, int likId) {
              op_focei.abstol, op_focei.reltol, fInd->g);
     if (ISNA(f)) {
       if (haveBest) { restoreBest(); break; }
+      // No usable result in THIS pass; an earlier one may still have a
+      // candidate, and the selection below will take it.
+      if (!candEta.empty()) break;
       if (_lastStart) return 0;
       continue;
     }
@@ -4135,64 +4148,78 @@ static inline int innerOpt1(int id, int likId) {
     // }
   }
   } // end of the starting-point loop (body deliberately not re-indented)
-  // Apply the best candidate found across the restart cascade.  This is what
-  // makes the inner solve monotone: a restart can only ever improve the eta the
-  // cascade leaves behind, never degrade it.  LikInner2() below recomputes the
+  // Apply the best candidate the restarts produced.  This is what makes the
+  // inner solve monotone: a restart can only ever improve the eta the cascade
+  // leaves behind, never degrade it.  LikInner2() below recomputes the
   // individual objective at this eta, so this is also what the outer optimizer
   // ultimately sees.
-  if (haveBest && (!R_FINITE(f) || fBest < f)) {
-    restoreBest();
-  }
-  // The inner optimizer minimizes the JOINT density.  The objective the fit
-  // reports is the MARGINAL one LikInner2() forms, which adds the Laplace
-  // log|H| term evaluated at the eta -- so two converged etas can order one way
-  // on the inner objective and the other way on what the outer optimizer sees.
-  // Choosing among restarts on the inner objective alone therefore hands the
-  // fit the worse of them whenever the two disagree (#1040): the mceta floor
-  // pass could win the inner comparison and still come out above mceta=0 on the
-  // reported objective.
   //
-  // Re-rank on the marginal, but only when the restarts actually produced more
-  // than one candidate -- with a single candidate there is nothing to choose
-  // and this costs nothing, which is every inner solve on the default path.
-  // A finite-difference leg (likId != 0) is ranked by the SAME rule, so it picks
+  // The choice is made on the MARGINAL objective LikInner2() forms -- the one
+  // the fit reports, which adds the Laplace log|H| term at the eta -- and not
+  // on the inner joint density the optimizer minimizes.  Two converged etas can
+  // order one way on the inner objective and the other way on what the outer
+  // optimizer sees, so choosing on the inner objective alone hands the fit the
+  // worse of them whenever the two disagree (#1040): the mceta floor pass could
+  // win the comparison it was making and still come out above mceta=0 on the
+  // objective that gets reported.
+  //
+  // Ranking runs only when the restarts actually produced more than one
+  // candidate.  A single candidate has nothing to choose between and costs
+  // nothing extra, which is every inner solve on the default path.  A
+  // finite-difference leg (likId != 0) is ranked by the SAME rule so it picks
   // its winner the way its central leg did; ranking the two differently would
   // let them settle in different basins and the difference would measure that.
   // LikInner2() writes lik[likId] for whichever candidate it is called on, and
   // the final call at the winner overwrites it, exactly as for likId == 0.
-  if (candEta.size() > 1) {
-    op_focei.nInnerRanked.fetch_add(1, std::memory_order_relaxed);
-    // calcEtaHessian(), reached through LikInner2(), FREEZES the shi21 finite
-    // difference steps on first use.  Snapshot them so the ranking leaves them
-    // as it found them: the winner's final LikInner2() below must freeze (or
-    // reuse) them exactly as it would have without a ranking pass, rather than
-    // inheriting steps searched at whichever candidate happened to go first.
-    std::vector<double> shf, shr, shh;
-    if (fInd->etahf != NULL) shf.assign(fInd->etahf, fInd->etahf + fop->neta);
-    if (fInd->etahr != NULL) shr.assign(fInd->etahr, fInd->etahr + fop->neta);
-    if (fInd->etahh != NULL) shh.assign(fInd->etahh, fInd->etahh + fop->neta);
-    int bestK = -1, bestInnerK = 0;
-    double bestMarg = 0.0;
+  if (!candEta.empty()) {
+    int bestInnerK = 0;
     for (size_t k = 0; k < candEta.size(); ++k) {
       if (candF[k] < candF[(size_t)bestInnerK]) bestInnerK = (int)k;
-      double m = LikInner2(&candEta[k][0], likId, id);
-      // LikInner2 returns the individual log-likelihood; the outer objective is
-      // -2 times it, so the best candidate is the LARGEST.
-      if (!ISNA(m) && R_FINITE(m) && (bestK < 0 || m > bestMarg)) {
-        bestMarg = m;
-        bestK = (int)k;
-      }
     }
-    if (!shf.empty()) std::copy(shf.begin(), shf.end(), fInd->etahf);
-    if (!shr.empty()) std::copy(shr.begin(), shr.end(), fInd->etahr);
-    if (!shh.empty()) std::copy(shh.begin(), shh.end(), fInd->etahh);
-    if (bestK >= 0) {
-      if (bestK != bestInnerK) {
+    int bestK = -1;
+    if (candEta.size() > 1) {
+      op_focei.nInnerRanked.fetch_add(1, std::memory_order_relaxed);
+      // calcEtaHessian(), reached through LikInner2(), FREEZES the shi21 finite
+      // difference steps on first use.  Snapshot them so the ranking leaves
+      // them as it found them and the winner's final LikInner2() below behaves
+      // exactly as it would have without a ranking pass.
+      std::vector<double> shf, shr, shh;
+      if (fInd->etahf != NULL) shf.assign(fInd->etahf, fInd->etahf + fop->neta);
+      if (fInd->etahr != NULL) shr.assign(fInd->etahr, fInd->etahr + fop->neta);
+      if (fInd->etahh != NULL) shh.assign(fInd->etahh, fInd->etahh + fop->neta);
+      double bestMarg = 0.0;
+      for (size_t k = 0; k < candEta.size(); ++k) {
+        // Each candidate is measured with ITS OWN step search, which is what
+        // the fit would have computed had that candidate been the only one.
+        // Without the zeroing the candidate evaluated first freezes the steps
+        // for all the rest, which both biases their log|H| and makes the winner
+        // depend on the order the passes happened to run in.
+        if (fInd->etahf != NULL) std::fill_n(&fInd->etahf[0], fop->neta, 0.0);
+        if (fInd->etahr != NULL) std::fill_n(&fInd->etahr[0], fop->neta, 0.0);
+        if (fInd->etahh != NULL) std::fill_n(&fInd->etahh[0], fop->neta, 0.0);
+        double m = LikInner2(&candEta[k][0], likId, id);
+        // LikInner2 returns the individual log-likelihood and the outer
+        // objective is -2 times it, so the best candidate is the LARGEST.
+        if (!ISNA(m) && R_FINITE(m) && (bestK < 0 || m > bestMarg)) {
+          bestMarg = m;
+          bestK = (int)k;
+        }
+      }
+      if (!shf.empty()) std::copy(shf.begin(), shf.end(), fInd->etahf);
+      if (!shr.empty()) std::copy(shr.begin(), shr.end(), fInd->etahr);
+      if (!shh.empty()) std::copy(shh.begin(), shh.end(), fInd->etahh);
+      if (bestK >= 0 && bestK != bestInnerK) {
         op_focei.nInnerReranked.fetch_add(1, std::memory_order_relaxed);
       }
-      std::copy(candEta[(size_t)bestK].begin(), candEta[(size_t)bestK].end(), fInd->x);
-      f = candF[(size_t)bestK];
     }
+    // No usable marginal for any candidate (or only one candidate): fall back
+    // to the inner objective's winner rather than to whatever the last pass
+    // happened to leave in fInd->x.
+    if (bestK < 0) bestK = bestInnerK;
+    std::copy(candEta[(size_t)bestK].begin(), candEta[(size_t)bestK].end(), fInd->x);
+    f = candF[(size_t)bestK];
+  } else if (haveBest && (!R_FINITE(f) || fBest < f)) {
+    restoreBest();
   }
 
   // only nudge once

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -668,6 +668,12 @@ struct focei_options {
   // "never explored" (#1040).
   std::atomic<int> nMcetaZero{0};
   std::atomic<int> nMcetaSample{0};
+  // Inner solves whose restarts produced more than one candidate and so were
+  // ranked on the marginal objective, and how many of those the marginal
+  // ordered differently from the inner objective -- the second count is the
+  // one that says the Laplace log|H| term actually changes the choice.
+  std::atomic<int> nInnerRanked{0};
+  std::atomic<int> nInnerReranked{0};
   std::atomic<int> didEtaReset{0};
   double resetThetaSize = std::numeric_limits<double>::infinity();
   double resetThetaFinalSize = std::numeric_limits<double>::infinity();
@@ -3776,6 +3782,19 @@ static inline int innerOpt1(int id, int likId) {
     f = fBest;
     std::copy(etaBest.begin(), etaBest.end(), fInd->x);
   };
+  // Every converged candidate the restarts below produce, kept for the final
+  // selection after the loop.  This is separate from keepBest()'s running
+  // minimum on purpose: keepBest() is the in-cascade recovery from a failed
+  // restart and has to stay a cheap comparison of the INNER objective, while
+  // WHICH candidate the fit ends up reporting has to be decided on the marginal
+  // objective (see the re-rank after the loop).
+  std::vector< std::vector<double> > candEta;
+  std::vector<double> candF;
+  auto keepCand = [&]() {
+    if (!R_FINITE(f)) return;
+    candEta.push_back(std::vector<double>(fInd->x, fInd->x + fop->neta));
+    candF.push_back(f);
+  };
   // Starting points this inner solve runs from.  mceta>=1 picks its start by the
   // objective AT that point, which does not order the points the optimization
   // converges to, so a sampled start is followed by a second solve from eta=0 and
@@ -3784,7 +3803,7 @@ static inline int innerOpt1(int id, int likId) {
   // The loop wraps the WHOLE optimizer dispatch rather than living inside one
   // branch of it, so it holds for whichever inner optimizer is configured, and a
   // new optimizer arm gets the floor pass without being told about it.  An arm
-  // only has to leave the converged objective in `f` and call keepBest(); on a
+  // only has to leave the converged objective in `f` and call keepBest(); keepCand(); on a
   // non-finite `f` it should hand the loop `_lastStart` (see the arms below)
   // rather than returning, so a failed sampled start still gets its eta=0 pass.
   int nInnerStart = mcetaSampleStart ? 2 : 1;
@@ -3819,7 +3838,7 @@ static inline int innerOpt1(int id, int likId) {
       if (_lastStart) return 0;
       continue;
     }
-    keepBest();
+    keepBest(); keepCand();
     nF = fInd->nInnerF-nF;
     // REprintf("innerCost id: %d, fInd->nInnerF: %d", id, fInd->nInnerF);
     // If stays at zero try another point?
@@ -3853,7 +3872,7 @@ static inline int innerOpt1(int id, int likId) {
                &mode, &maxInnerIterations, &nsim,
                &imp, fInd->zm,
                &izs, &rzs, &dzs, &id);
-        if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest();
+        if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest(); keepCand();
         // nF = fInd->nInnerF - nF;
         // if (nF > 3) tryAgain = false;
         // The re-check below used to be wrapped in `if (!tryAgain)`, which can
@@ -3881,7 +3900,7 @@ static inline int innerOpt1(int id, int likId) {
                  fInd->var, &epsilon,
                  &mode, &maxInnerIterations, &nsim,
                  &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-          if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest();
+          if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest(); keepCand();
           // nF = fInd->nInnerF - nF;
           // if (nF > 3) tryAgain = false;
           {
@@ -3905,7 +3924,7 @@ static inline int innerOpt1(int id, int likId) {
                    fInd->var, &epsilon,
                    &mode, &maxInnerIterations, &nsim,
                    &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-            if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest();
+            if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest(); keepCand();
             // nF = fInd->nInnerF - nF;
             // if (nF > 3) tryAgain = false;
             {
@@ -3929,7 +3948,7 @@ static inline int innerOpt1(int id, int likId) {
                      fInd->var, &epsilon,
                      &mode, &maxInnerIterations, &nsim,
                      &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-              if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest();
+              if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest(); keepCand();
               // nF = fInd->nInnerF - nF;
               // if (nF > 3) tryAgain = false;
               {
@@ -3951,7 +3970,7 @@ static inline int innerOpt1(int id, int likId) {
                        &mode, &maxInnerIterations, &nsim,
                        &imp, fInd->zm,
                        &izs, &rzs, &dzs, &id);
-                if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest();
+                if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest(); keepCand();
                 //nF = fInd->nInnerF-nF;
                 // if (nF > 3) tryAgain = false;
                 {
@@ -3989,7 +4008,7 @@ static inline int innerOpt1(int id, int likId) {
       if (_lastStart) return 0;
       continue;
     }
-    keepBest();
+    keepBest(); keepCand();
     // if (fail != 6 && fail != 7 && fail != 8 && fail != 27){
     //   // did not converge
     //   if (fInd->doEtaNudge == 1 && op_focei.etaNudge != 0.0){
@@ -4024,6 +4043,43 @@ static inline int innerOpt1(int id, int likId) {
   // ultimately sees.
   if (haveBest && (!R_FINITE(f) || fBest < f)) {
     restoreBest();
+  }
+  // The inner optimizer minimizes the JOINT density.  The objective the fit
+  // reports is the MARGINAL one LikInner2() forms, which adds the Laplace
+  // log|H| term evaluated at the eta -- so two converged etas can order one way
+  // on the inner objective and the other way on what the outer optimizer sees.
+  // Choosing among restarts on the inner objective alone therefore hands the
+  // fit the worse of them whenever the two disagree (#1040): the mceta floor
+  // pass could win the inner comparison and still come out above mceta=0 on the
+  // reported objective.
+  //
+  // Re-rank on the marginal, but only when the restarts actually produced more
+  // than one candidate -- with a single candidate there is nothing to choose
+  // and this costs nothing, which is every inner solve on the default path.
+  // likId != 0 is a finite-difference leg: it must stay comparable with the
+  // central leg rather than pick its own winner, and LikInner2() would clobber
+  // the lik[1]/lik[2] slot that leg is filling.
+  if (likId == 0 && candEta.size() > 1) {
+    op_focei.nInnerRanked.fetch_add(1, std::memory_order_relaxed);
+    int bestK = -1, bestInnerK = 0;
+    double bestMarg = 0.0;
+    for (size_t k = 0; k < candEta.size(); ++k) {
+      if (candF[k] < candF[(size_t)bestInnerK]) bestInnerK = (int)k;
+      double m = LikInner2(&candEta[k][0], 0, id);
+      // LikInner2 returns the individual log-likelihood; the outer objective is
+      // -2 times it, so the best candidate is the LARGEST.
+      if (!ISNA(m) && R_FINITE(m) && (bestK < 0 || m > bestMarg)) {
+        bestMarg = m;
+        bestK = (int)k;
+      }
+    }
+    if (bestK >= 0) {
+      if (bestK != bestInnerK) {
+        op_focei.nInnerReranked.fetch_add(1, std::memory_order_relaxed);
+      }
+      std::copy(candEta[(size_t)bestK].begin(), candEta[(size_t)bestK].end(), fInd->x);
+      f = candF[(size_t)bestK];
+    }
   }
 
   // only nudge once
@@ -7441,6 +7497,8 @@ NumericVector foceiSetup_(const RObject &obj,
   op_focei.mcetaSamples.reset();
   op_focei.nMcetaZero.store(0, std::memory_order_relaxed);
   op_focei.nMcetaSample.store(0, std::memory_order_relaxed);
+  op_focei.nInnerRanked.store(0, std::memory_order_relaxed);
+  op_focei.nInnerReranked.store(0, std::memory_order_relaxed);
   op_focei.warm = foceiO.containsElementNamed("warm") ? as<int>(foceiO["warm"]) : 0;
   op_focei.maxOdeRecalc = as<int>(foceiO["maxOdeRecalc"]);
   op_focei.objfRecalN=0;
@@ -8658,6 +8716,8 @@ Environment foceiOuter(Environment e){
   op_focei.nAnalyticGradDirect=0;
   op_focei.nMcetaZero.store(0, std::memory_order_relaxed);
   op_focei.nMcetaSample.store(0, std::memory_order_relaxed);
+  op_focei.nInnerRanked.store(0, std::memory_order_relaxed);
+  op_focei.nInnerReranked.store(0, std::memory_order_relaxed);
   op_focei.nDeclineNewton=0;
   op_focei.nDeclineE0=0;
   op_focei.nDeclineOther=0;
@@ -11312,6 +11372,12 @@ void foceiFinalizeTables(Environment e){
           _details += "; grad: fd";
         }
       }
+      // Inner restarts ranked on the marginal objective, and how often that
+      // ordered them differently from the inner objective.  Not gated on mceta:
+      // the nudge cascade produces multiple candidates too.
+      e["nInnerRerank"] = IntegerVector::create(
+        _["ranked"] = op_focei.nInnerRanked.load(std::memory_order_relaxed),
+        _["flipped"] = op_focei.nInnerReranked.load(std::memory_order_relaxed));
       if (op_focei.mceta >= 1) {
         // Which mceta candidate each inner solve started from.  Not gated on
         // `fast`: mceta>=1 is independent of the analytic gradient.

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -3776,39 +3776,43 @@ static inline int innerOpt1(int id, int likId) {
     f = fBest;
     std::copy(etaBest.begin(), etaBest.end(), fInd->x);
   };
+  // Starting points this inner solve runs from.  mceta>=1 picks its start by the
+  // objective AT that point, which does not order the points the optimization
+  // converges to, so a sampled start is followed by a second solve from eta=0 and
+  // the better converged result is kept -- that is what makes mceta=n never end
+  // above mceta=0 (#1040), which ranking starting points alone cannot deliver.
+  // The loop wraps the WHOLE optimizer dispatch rather than living inside one
+  // branch of it, so it holds for whichever inner optimizer is configured, and a
+  // new optimizer arm gets the floor pass without being told about it.  An arm
+  // only has to leave the converged objective in `f` and call keepBest(); on a
+  // non-finite `f` it should hand the loop `_lastStart` (see the arms below)
+  // rather than returning, so a failed sampled start still gets its eta=0 pass.
+  int nInnerStart = mcetaSampleStart ? 2 : 1;
+  for (int _innerStart = 0; _innerStart < nInnerStart; _innerStart++) {
+  bool _lastStart = (_innerStart + 1 == nInnerStart);
+  if (_innerStart > 0) {
+    // The eta=0 floor: re-seed exactly as mceta=0 would have, so this pass is
+    // the run it must not come out above.
+    std::fill(&fInd->eta[0], &fInd->eta[0] + fop->neta, 0.0);
+    if (op_focei.warm == 1) warmZm(fInd, id);
+    else { fInd->mode = 1; fInd->uzm = 1; }
+    mode = fInd->mode;
+    std::fill_n(&fInd->var[0], fop->neta, 0.1);
+    std::fill_n(fInd->x, fop->neta, 0.0);
+    nF = fInd->nInnerF;
+  }
   if (n1qn1Inner) {
     fInd->badSolve = 0;
     n1qn1_(innerCost, &npar, fInd->x, &f, fInd->g,
            fInd->var, &epsilon,
            &mode, &maxInnerIterations, &nsim,
            &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-    if (ISNA(f)) { if (!mcetaSampleStart) return 0; }
-    else keepBest();
-    if (mcetaSampleStart) {
-      // A sampled eta only PRE-SCREENS well: it is ranked by the objective at the
-      // starting point, which does not order the points the inner optimization
-      // converges to.  So also run the problem from eta=0 and keep whichever
-      // converged lower -- that is what makes mceta=n never worse than mceta=0
-      // (#1040), which ranking starting points alone cannot deliver.
-      std::fill(&fInd->eta[0], &fInd->eta[0] + fop->neta, 0.0);
-      if (op_focei.warm == 1) warmZm(fInd, id);
-      else { fInd->mode = 1; fInd->uzm = 1; }
-      mode = fInd->mode;
-      std::fill_n(&fInd->var[0], fop->neta, 0.1);
-      std::fill_n(fInd->x, fop->neta, 0.0);
-      fInd->badSolve = 0;
-      n1qn1_(innerCost, &npar, fInd->x, &f, fInd->g,
-             fInd->var, &epsilon,
-             &mode, &maxInnerIterations, &nsim,
-             &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-      if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest();
-      // Hand the cascade below the WINNER, not the eta=0 leg.  The nudge cascade
-      // decides whether the optimizer got stuck by looking at fInd->x, so an
-      // eta=0 leg that stayed at zero while the sampled start found a real mode
-      // would read as "every eta stuck at 0" and fire the nudges (and the
-      // "initial ETAs were nudged" warning) for a subject that did not stick.
-      if (haveBest && (!R_FINITE(f) || fBest < f)) restoreBest();
+    if (ISNA(f)) {
+      if (haveBest) { restoreBest(); break; }
+      if (_lastStart) return 0;
+      continue;
     }
+    keepBest();
     nF = fInd->nInnerF-nF;
     // REprintf("innerCost id: %d, fInd->nInnerF: %d", id, fInd->nInnerF);
     // If stays at zero try another point?
@@ -3973,7 +3977,12 @@ static inline int innerOpt1(int id, int likId) {
              op_focei.pgtol, &fncount, &grcount,
              op_focei.maxInnerIterations, msg, 0, -1,
              op_focei.abstol, op_focei.reltol, fInd->g);
-    if (ISNA(f)) return 0;
+    if (ISNA(f)) {
+      if (haveBest) { restoreBest(); break; }
+      if (_lastStart) return 0;
+      continue;
+    }
+    keepBest();
     // if (fail != 6 && fail != 7 && fail != 8 && fail != 27){
     //   // did not converge
     //   if (fInd->doEtaNudge == 1 && op_focei.etaNudge != 0.0){
@@ -4000,6 +4009,7 @@ static inline int innerOpt1(int id, int likId) {
     //   }
     // }
   }
+  } // end of the starting-point loop (body deliberately not re-indented)
   // Apply the best candidate found across the restart cascade.  This is what
   // makes the inner solve monotone: a restart can only ever improve the eta the
   // cascade leaves behind, never degrade it.  LikInner2() below recomputes the

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4749,13 +4749,19 @@ void innerOpt() {
         for (int id = 0; id < nsubAll; ++id) {
           for (int k = 0; k < nmc; ++k) {
             NumericMatrix samp = fSample(omega);
-            // The destination column is exactly neta wide; .sampleOmega is an R
-            // function, so check rather than trust its length.
-            if (samp.size() != op_focei.neta) {
-              stop(_("mceta: the omega sample must have %d elements"), op_focei.neta);
+            // The destination column is exactly neta wide and .sampleOmega is an
+            // R function, so bound the copy by the destination rather than by
+            // what R handed back.  A short draw leaves the tail at zero (an
+            // eta=0 candidate), which is a starting point, not a wrong answer --
+            // so this needs no error, and must not raise one: innerOpt() unwinds
+            // into the caller of the per-subject parallel region.
+            int nCopy = (int)samp.size();
+            if (nCopy > op_focei.neta) nCopy = op_focei.neta;
+            double *dest = op_focei.mcetaSamples.slice(id).colptr(k);
+            std::copy(samp.begin(), samp.begin() + nCopy, dest);
+            if (nCopy < op_focei.neta) {
+              std::fill(dest + nCopy, dest + op_focei.neta, 0.0);
             }
-            std::copy(samp.begin(), samp.end(),
-                      op_focei.mcetaSamples.slice(id).colptr(k));
           }
         }
       }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -3635,12 +3635,19 @@ static inline int innerOpt1(int id, int likId) {
   } else if (op_focei.mceta == 0) {
     // always reset to zero
     std::fill(&fInd->eta[0], &fInd->eta[0] + op_focei.neta, 0.0);
-  } else if (op_focei.mceta >= 1 && op_focei.maxInnerIterations > 0 &&
-             !op_focei.freezeOde) {
+  } else if (op_focei.mceta >= 1 && !op_focei.calcGrad &&
+             op_focei.maxInnerIterations > 0 && !op_focei.freezeOde) {
     // mceta sampling: the candidates are eta=0 plus the (mceta-1) omega draws
     // pre-drawn serially in innerOpt() (mcetaSamples cube).  The condition here
     // MIRRORS the one that fills the cube, so mceta=1 (no draws, empty cube)
     // still means "start at eta=0" instead of silently doing nothing.
+    //
+    // Skipped while calcGrad is set, like the Almquist branch above and the
+    // standardized-eta reset below.  A finite-difference leg is pinned to the
+    // central evaluation's EBE (fdPinRefEtaForce) precisely so both legs are
+    // taken about one point; re-running the search there would let a tiny theta
+    // perturbation flip which candidate wins and put the legs in different
+    // basins, so the difference would measure the search, not the objective.
     //
     // The carried "last eta" is deliberately NOT a candidate (#1040).  It is the
     // previous outer iteration's converged EBE, so its inner objective is
@@ -4726,6 +4733,11 @@ void innerOpt() {
         for (int id = 0; id < nsubAll; ++id) {
           for (int k = 0; k < nmc; ++k) {
             NumericMatrix samp = fSample(omega);
+            // The destination column is exactly neta wide; .sampleOmega is an R
+            // function, so check rather than trust its length.
+            if (samp.size() != op_focei.neta) {
+              stop(_("mceta: the omega sample must have %d elements"), op_focei.neta);
+            }
             std::copy(samp.begin(), samp.end(),
                       op_focei.mcetaSamples.slice(id).colptr(k));
           }
@@ -7394,8 +7406,12 @@ NumericVector foceiSetup_(const RObject &obj,
   op_focei.maxInnerIterations = as<int>(foceiO["maxInnerIterations"]);
   op_focei.mceta = as<int>(foceiO["mceta"]);
   // The mceta>=1 draws are per-fit (innerOpt() fills the cube once); clear them so a
-  // new fit does not inherit the previous fit's starting etas.
+  // new fit does not inherit the previous fit's starting etas.  The start counters
+  // are cleared here as well as in foceiOuter(), which the EM/nonparametric methods
+  // never reach -- otherwise those fits would report the previous fit's counts.
   op_focei.mcetaSamples.reset();
+  op_focei.nMcetaZero.store(0, std::memory_order_relaxed);
+  op_focei.nMcetaSample.store(0, std::memory_order_relaxed);
   op_focei.warm = foceiO.containsElementNamed("warm") ? as<int>(foceiO["warm"]) : 0;
   op_focei.maxOdeRecalc = as<int>(foceiO["maxOdeRecalc"]);
   op_focei.objfRecalN=0;

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -3799,6 +3799,13 @@ static inline int innerOpt1(int id, int likId) {
     mode = fInd->mode;
     std::fill_n(&fInd->var[0], fop->neta, 0.1);
     std::fill_n(fInd->x, fop->neta, 0.0);
+    // n1qn1_ takes these BY POINTER and writes back what it used (see the note
+    // where they are declared), so the floor pass has to be handed a fresh
+    // budget -- otherwise it inherits the first pass's spent iteration and
+    // simulation counts and stops before it has optimized anything.
+    maxInnerIterations = fop->maxInnerIterations;
+    nsim = fop->nsim;
+    imp = fop->imp;
     nF = fInd->nInnerF;
   }
   if (n1qn1Inner) {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -662,6 +662,12 @@ struct focei_options {
   double shi21hMin; // lower bound on the adaptive FD step
   double cholAccept;
   double resetEtaSize;
+  // mceta>=1 bookkeeping: how many inner solves started at eta=0 vs at one of the
+  // omega draws.  A test needs this to show the draws are actually explored --
+  // matching objectives alone cannot distinguish "explored and eta=0 won" from
+  // "never explored" (#1040).
+  std::atomic<int> nMcetaZero{0};
+  std::atomic<int> nMcetaSample{0};
   std::atomic<int> didEtaReset{0};
   double resetThetaSize = std::numeric_limits<double>::infinity();
   double resetThetaFinalSize = std::numeric_limits<double>::infinity();
@@ -3583,6 +3589,8 @@ static inline int innerOpt1(int id, int likId) {
     }
   }
   bool n1qn1Inner = true;
+  // mceta>=1: true when a sampled eta (not eta=0) was chosen as the starting point.
+  bool mcetaSampleStart = false;
   // Use eta
   // Convert Zm to Hessian, if applicable.
   mat etaMat(fop->neta, 1, fill::zeros);
@@ -3627,28 +3635,44 @@ static inline int innerOpt1(int id, int likId) {
   } else if (op_focei.mceta == 0) {
     // always reset to zero
     std::fill(&fInd->eta[0], &fInd->eta[0] + op_focei.neta, 0.0);
-  } else if (op_focei.mceta >= 1 &&
-             static_cast<arma::uword>(id) < op_focei.mcetaSamples.n_slices) {
-    // mceta sampling: ETA samples pre-drawn serially in innerOpt() (mcetaSamples
-    // cube); guard skips subjects with no slice (maxInnerIterations == 0, e.g.
-    // covariance/linearization step) to avoid an out-of-bounds Cube::slice().
-    int nmc = op_focei.mceta-1;
-    double fcur = likInner0(fInd->eta, id); // last eta
+  } else if (op_focei.mceta >= 1 && op_focei.maxInnerIterations > 0 &&
+             !op_focei.freezeOde) {
+    // mceta sampling: the candidates are eta=0 plus the (mceta-1) omega draws
+    // pre-drawn serially in innerOpt() (mcetaSamples cube).  The condition here
+    // MIRRORS the one that fills the cube, so mceta=1 (no draws, empty cube)
+    // still means "start at eta=0" instead of silently doing nothing.
+    //
+    // The carried "last eta" is deliberately NOT a candidate (#1040).  It is the
+    // previous outer iteration's converged EBE, so its inner objective is
+    // essentially always the lowest of the set; including it made mceta=n win
+    // with the last eta for every subject, collapsing mceta>0 onto the keep-last
+    // behavior of mceta=-1/-2 -- mceta=10 returned an objective bit-identical to
+    // mceta=-2 and the extra draws never mattered.
     std::fill(&fInd->tryEta[0], &fInd->tryEta[0] + op_focei.neta, 0.0);
-    double ftry = likInner0(fInd->tryEta, id); // zero eta
-    int sampCol = 0;
-    while (true) {
-      if (ftry < fcur) {
-        std::copy(&fInd->tryEta[0], &fInd->tryEta[0] + op_focei.neta, &fInd->eta[0]);
-        fcur = ftry;
+    double fcur = likInner0(fInd->tryEta, id); // eta = 0
+    std::copy(&fInd->tryEta[0], &fInd->tryEta[0] + op_focei.neta, &fInd->eta[0]);
+    bool sampleWon = false;
+    // Subjects with no slice (empty cube) simply have no draws to try.
+    if (static_cast<arma::uword>(id) < op_focei.mcetaSamples.n_slices) {
+      int nmc = op_focei.mceta - 1;
+      for (int sampCol = 0; sampCol < nmc; sampCol++) {
+        arma::vec samp = op_focei.mcetaSamples.slice(id).col(sampCol);
+        std::copy(samp.begin(), samp.end(), &fInd->tryEta[0]);
+        double ftry = likInner0(fInd->tryEta, id); // sampled eta
+        // An unusable eta=0 must not pin the search: take any finite candidate
+        // over a non-finite incumbent.
+        if (R_FINITE(ftry) && (!R_FINITE(fcur) || ftry < fcur)) {
+          std::copy(&fInd->tryEta[0], &fInd->tryEta[0] + op_focei.neta, &fInd->eta[0]);
+          fcur = ftry;
+          sampleWon = true;
+        }
       }
-      if (nmc <= 0) break;
-      nmc--;
-      // Read the next pre-drawn sample for this individual.
-      arma::vec samp = op_focei.mcetaSamples.slice(id).col(sampCol);
-      sampCol++;
-      std::copy(samp.begin(), samp.end(), &fInd->tryEta[0]);
-      ftry = likInner0(fInd->tryEta, id); // sampled eta
+    }
+    mcetaSampleStart = sampleWon;
+    if (sampleWon) {
+      op_focei.nMcetaSample.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      op_focei.nMcetaZero.fetch_add(1, std::memory_order_relaxed);
     }
   }
   if (!op_focei.calcGrad) {
@@ -3751,8 +3775,27 @@ static inline int innerOpt1(int id, int likId) {
            fInd->var, &epsilon,
            &mode, &maxInnerIterations, &nsim,
            &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-    if (ISNA(f)) return 0;
-    keepBest();
+    if (ISNA(f)) { if (!mcetaSampleStart) return 0; }
+    else keepBest();
+    if (mcetaSampleStart) {
+      // A sampled eta only PRE-SCREENS well: it is ranked by the objective at the
+      // starting point, which does not order the points the inner optimization
+      // converges to.  So also run the problem from eta=0 and keep whichever
+      // converged lower -- that is what makes mceta=n never worse than mceta=0
+      // (#1040), which ranking starting points alone cannot deliver.
+      std::fill(&fInd->eta[0], &fInd->eta[0] + fop->neta, 0.0);
+      if (op_focei.warm == 1) warmZm(fInd, id);
+      else { fInd->mode = 1; fInd->uzm = 1; }
+      mode = fInd->mode;
+      std::fill_n(&fInd->var[0], fop->neta, 0.1);
+      std::fill_n(fInd->x, fop->neta, 0.0);
+      fInd->badSolve = 0;
+      n1qn1_(innerCost, &npar, fInd->x, &f, fInd->g,
+             fInd->var, &epsilon,
+             &mode, &maxInnerIterations, &nsim,
+             &imp, fInd->zm, &izs, &rzs, &dzs, &id);
+      if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest();
+    }
     nF = fInd->nInnerF-nF;
     // REprintf("innerCost id: %d, fInd->nInnerF: %d", id, fInd->nInnerF);
     // If stays at zero try another point?
@@ -4661,27 +4704,36 @@ void innerOpt() {
   }
   // Pre-draw per-subject ETA samples serially before the parallel for-loop so
   // workers only do memory access (no R API calls), making mceta safe under cores > 1.
+  //
+  // Drawn ONCE per fit (the cube is cleared in foceiSetup_).  Redrawing them on
+  // every innerOpt() call made the objective a different random function at every
+  // evaluation: the outer optimizer's finite differences then compared two
+  // different functions, and two evaluations at the SAME theta disagreed (#1040).
+  // The draws come from the omega in force at the first evaluation -- they are
+  // starting points, not part of the likelihood.
   if (op_focei.mceta >= 1 && op_focei.maxInnerIterations > 0 && !op_focei.freezeOde) {
     int nsubAll = (int)getRxNsubAndMix(rx);
     int nmc = op_focei.mceta - 1;
     if (nmc > 0 && op_focei.neta > 0) {
-      op_focei.mcetaSamples.set_size(op_focei.neta, nmc, nsubAll);
-      NumericMatrix omega = getOmega();
-      Function loadNamespace("loadNamespace", R_BaseNamespace);
-      Environment nlmixr2 = loadNamespace("nlmixr2est");
-      Function fSample = as<Function>(nlmixr2[".sampleOmega"]);
-      for (int id = 0; id < nsubAll; ++id) {
-        for (int k = 0; k < nmc; ++k) {
-          NumericMatrix samp = fSample(omega);
-          std::copy(samp.begin(), samp.end(),
-                    op_focei.mcetaSamples.slice(id).colptr(k));
+      if (op_focei.mcetaSamples.n_rows   != (arma::uword)op_focei.neta ||
+          op_focei.mcetaSamples.n_cols   != (arma::uword)nmc ||
+          op_focei.mcetaSamples.n_slices != (arma::uword)nsubAll) {
+        op_focei.mcetaSamples.set_size(op_focei.neta, nmc, nsubAll);
+        NumericMatrix omega = getOmega();
+        Function loadNamespace("loadNamespace", R_BaseNamespace);
+        Environment nlmixr2 = loadNamespace("nlmixr2est");
+        Function fSample = as<Function>(nlmixr2[".sampleOmega"]);
+        for (int id = 0; id < nsubAll; ++id) {
+          for (int k = 0; k < nmc; ++k) {
+            NumericMatrix samp = fSample(omega);
+            std::copy(samp.begin(), samp.end(),
+                      op_focei.mcetaSamples.slice(id).colptr(k));
+          }
         }
       }
     } else {
       op_focei.mcetaSamples.reset();
     }
-  } else {
-    op_focei.mcetaSamples.reset();
   }
   // freezeOde: evaluate each subject's density at its (restored) base EBE with a
   // single innerEval -- no eta re-optimization -- reusing the frozen ODE states.
@@ -7341,6 +7393,9 @@ NumericVector foceiSetup_(const RObject &obj,
   op_focei.maxOuterIterations = as<int>(foceiO["maxOuterIterations"]);
   op_focei.maxInnerIterations = as<int>(foceiO["maxInnerIterations"]);
   op_focei.mceta = as<int>(foceiO["mceta"]);
+  // The mceta>=1 draws are per-fit (innerOpt() fills the cube once); clear them so a
+  // new fit does not inherit the previous fit's starting etas.
+  op_focei.mcetaSamples.reset();
   op_focei.warm = foceiO.containsElementNamed("warm") ? as<int>(foceiO["warm"]) : 0;
   op_focei.maxOdeRecalc = as<int>(foceiO["maxOdeRecalc"]);
   op_focei.objfRecalN=0;
@@ -8556,6 +8611,8 @@ Environment foceiOuter(Environment e){
   op_focei.curAnalytic=0;
   op_focei.nAnalyticGrad=0;
   op_focei.nAnalyticGradDirect=0;
+  op_focei.nMcetaZero.store(0, std::memory_order_relaxed);
+  op_focei.nMcetaSample.store(0, std::memory_order_relaxed);
   op_focei.nDeclineNewton=0;
   op_focei.nDeclineE0=0;
   op_focei.nDeclineOther=0;
@@ -11209,6 +11266,13 @@ void foceiFinalizeTables(Environment e){
         } else if (op_focei.nG > 0 || op_focei.nFDGradFast > 0) {
           _details += "; grad: fd";
         }
+      }
+      if (op_focei.mceta >= 1) {
+        // Which mceta candidate each inner solve started from.  Not gated on
+        // `fast`: mceta>=1 is independent of the analytic gradient.
+        e["nMcetaStart"] = IntegerVector::create(
+          _["zero"] = op_focei.nMcetaZero.load(std::memory_order_relaxed),
+          _["sample"] = op_focei.nMcetaSample.load(std::memory_order_relaxed));
       }
       if (op_focei.muModel == 1) {
         _details += "; mu: lin";

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -3802,6 +3802,12 @@ static inline int innerOpt1(int id, int likId) {
              &mode, &maxInnerIterations, &nsim,
              &imp, fInd->zm, &izs, &rzs, &dzs, &id);
       if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest();
+      // Hand the cascade below the WINNER, not the eta=0 leg.  The nudge cascade
+      // decides whether the optimizer got stuck by looking at fInd->x, so an
+      // eta=0 leg that stayed at zero while the sampled start found a real mode
+      // would read as "every eta stuck at 0" and fire the nudges (and the
+      // "initial ETAs were nudged" warning) for a subject that did not stick.
+      if (haveBest && (!R_FINITE(f) || fBest < f)) restoreBest();
     }
     nF = fInd->nInnerF-nF;
     // REprintf("innerCost id: %d, fInd->nInnerF: %d", id, fInd->nInnerF);

--- a/tests/testthat/test-focei-mceta-1040.R
+++ b/tests/testthat/test-focei-mceta-1040.R
@@ -81,6 +81,50 @@ nmTest({
     expect_gt(.f1$env$nMcetaStart[["zero"]], 0L)
   })
 
+  test_that("a fully mu-referenced model still honors mceta", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    # A user-set mceta used to be silently reset to the default -2 for a model
+    # whose etas are all mu-referenced, on the grounds that "the initial etas are
+    # all exactly zero, so the search has nothing to explore".  That is only true
+    # of the FIRST inner solve: every later one starts from the previous
+    # iteration's mode, and the mceta>0 candidates are draws from omega, which
+    # are not zero.  Resetting it is what made mceta=10 return an objective
+    # bit-identical to mceta=-2 (#1040).
+    .muMod <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .warn <- character(0)
+    .m5 <- withCallingHandlers(
+      suppressMessages(
+        nlmixr2(.muMod, nlmixr2data::theo_sd, "focei",
+                foceiControl(print = 0L, covMethod = "", calcTables = FALSE,
+                             mceta = 5L))),
+      warning = function(w) {
+        .warn <<- c(.warn, conditionMessage(w))
+        invokeRestart("muffleWarning")
+      })
+    # The setting survived, and the draws were explored.
+    expect_true(is.integer(.m5$env$nMcetaStart))
+    expect_gt(.m5$env$nMcetaStart[["sample"]], 0L)
+    # ... and nothing told the user the setting was being ignored.
+    expect_false(any(grepl("has no effect", .warn, fixed = TRUE)))
+  })
+
   test_that("the mceta search does not run on the outer gradient's difference legs", {
     skip_on_cran()
     # A finite-difference leg is pinned to the central evaluation's mode, so the

--- a/tests/testthat/test-focei-mceta-1040.R
+++ b/tests/testthat/test-focei-mceta-1040.R
@@ -51,10 +51,11 @@ nmTest({
                            mceta = mceta))))
   }
 
-  test_that("mceta > 0 explores the draws and never lands worse than mceta=0", {
+  test_that("mceta > 0 explores its draws and cannot land worse than mceta=0", {
     skip_on_cran()
     .dat <- .mcetaData()
     .f0 <- .mcetaFit(.dat, 0L)
+    .f1 <- .mcetaFit(.dat, 1L)
     .f5 <- .mcetaFit(.dat, 5L)
 
     # The counter is what shows the draws were USED.  Matching (or differing)
@@ -65,21 +66,16 @@ nmTest({
     expect_gt(.f5$env$nMcetaStart[["sample"]], 0L)
 
     # Every inner problem has eta=0 among its candidates and keeps the converged
-    # eta=0 solve as a floor, so the objective cannot be worse than mceta=0.
+    # eta=0 solve as a floor, so at fixed parameters the objective cannot come
+    # out above mceta=0.
     expect_lte(.f5$objf, .f0$objf + 1e-4)
     # ... and on this model it is strictly better, which is what "the extra
     # candidates are not being used" hid.
     expect_lt(.f5$objf, .f0$objf)
-  })
 
-  test_that("mceta=1 is eta=0 only", {
-    skip_on_cran()
-    .dat <- .mcetaData()
     # mceta=1 has no draws, so its candidate set is exactly {eta=0}.  It used to
     # be a silent no-op (empty sample cube -> the whole branch was skipped, so
     # the last eta was kept).
-    .f1 <- .mcetaFit(.dat, 1L)
-    .f0 <- .mcetaFit(.dat, 0L)
     expect_equal(.f1$objf, .f0$objf)
     expect_equal(.f1$env$nMcetaStart[["sample"]], 0L)
     expect_gt(.f1$env$nMcetaStart[["zero"]], 0L)

--- a/tests/testthat/test-focei-mceta-1040.R
+++ b/tests/testthat/test-focei-mceta-1040.R
@@ -1,0 +1,87 @@
+nmTest({
+  # #1040: with mceta >= 1 the candidate set included the carried "last eta",
+  # whose inner objective is essentially always the lowest, so mceta=n picked it
+  # for every subject and returned the keep-last objective of mceta=-1/-2.  The
+  # candidates are now eta=0 plus the (mceta-1) omega draws, and the converged
+  # eta=0 solve is kept as a floor so mceta=n cannot end worse than mceta=0.
+  #
+  # The model needs curvature the inner problem can get lost in: two etas with a
+  # FIXED unit omega entering through an inverse CDF, alongside an ordinary
+  # estimated block.
+  .mcetaMod <- function() {
+    ini({
+      tcl <- log(4)
+      tv1 <- log(30)
+      tq <- log(4)
+      tv2 <- log(40)
+      rxz.eta.cl ~ fix(1)
+      rxz.eta.v1 ~ fix(1)
+      eta.q + eta.v2 ~ c(0.0305,
+                         0.0107, 0.0285)
+      prop.sd <- 0.1
+    })
+    model({
+      cl <- exp(tcl + 0.3 * logit(pnorm(rxz.eta.cl)))
+      v1 <- exp(tv1 + 0.3 * logit(pnorm(rxz.eta.v1)))
+      q <- exp(tq + eta.q)
+      v2 <- exp(tv2 + eta.v2)
+      linCmt() ~ prop(prop.sd)
+    })
+  }
+
+  .mcetaData <- function() {
+    withr::with_seed(42, {
+      .ev <- rxode2::et(amt = 200, ii = 24, addl = 2)
+      .ev <- rxode2::et(.ev, seq(0.5, 96, length.out = 12))
+      .ev <- rxode2::et(.ev, id = 1:60)
+      .d <- suppressWarnings(suppressMessages(
+        as.data.frame(rxode2::rxSolve(.mcetaMod, .ev, addDosing = TRUE))))
+    })
+    .dat <- data.frame(ID = .d$id, TIME = .d$time, DV = .d$sim, EVID = .d$evid,
+                       AMT = ifelse(is.na(.d$amt), 0, .d$amt))
+    .dat$DV[.dat$EVID != 0] <- NA
+    .dat
+  }
+
+  .mcetaFit <- function(dat, mceta) {
+    suppressWarnings(suppressMessages(
+      nlmixr2(.mcetaMod, dat, "focei",
+              foceiControl(print = 0L, covMethod = "", maxOuterIterations = 0L,
+                           maxInnerIterations = 5000L, calcTables = FALSE,
+                           mceta = mceta))))
+  }
+
+  test_that("mceta > 0 explores the draws and never lands worse than mceta=0", {
+    skip_on_cran()
+    .dat <- .mcetaData()
+    .f0 <- .mcetaFit(.dat, 0L)
+    .f5 <- .mcetaFit(.dat, 5L)
+
+    # The counter is what shows the draws were USED.  Matching (or differing)
+    # objectives cannot tell "explored and eta=0 won" from "never explored" --
+    # the bug was exactly the second, and it looked like the first.
+    expect_true(is.integer(.f5$env$nMcetaStart))
+    expect_equal(sort(names(.f5$env$nMcetaStart)), c("sample", "zero"))
+    expect_gt(.f5$env$nMcetaStart[["sample"]], 0L)
+
+    # Every inner problem has eta=0 among its candidates and keeps the converged
+    # eta=0 solve as a floor, so the objective cannot be worse than mceta=0.
+    expect_lte(.f5$objf, .f0$objf + 1e-4)
+    # ... and on this model it is strictly better, which is what "the extra
+    # candidates are not being used" hid.
+    expect_lt(.f5$objf, .f0$objf)
+  })
+
+  test_that("mceta=1 is eta=0 only", {
+    skip_on_cran()
+    .dat <- .mcetaData()
+    # mceta=1 has no draws, so its candidate set is exactly {eta=0}.  It used to
+    # be a silent no-op (empty sample cube -> the whole branch was skipped, so
+    # the last eta was kept).
+    .f1 <- .mcetaFit(.dat, 1L)
+    .f0 <- .mcetaFit(.dat, 0L)
+    expect_equal(.f1$objf, .f0$objf)
+    expect_equal(.f1$env$nMcetaStart[["sample"]], 0L)
+    expect_gt(.f1$env$nMcetaStart[["zero"]], 0L)
+  })
+})

--- a/tests/testthat/test-focei-mceta-1040.R
+++ b/tests/testthat/test-focei-mceta-1040.R
@@ -43,12 +43,12 @@ nmTest({
     .dat
   }
 
-  .mcetaFit <- function(dat, mceta) {
+  .mcetaFit <- function(dat, mceta, maxOuter = 0L, ...) {
     suppressWarnings(suppressMessages(
       nlmixr2(.mcetaMod, dat, "focei",
-              foceiControl(print = 0L, covMethod = "", maxOuterIterations = 0L,
+              foceiControl(print = 0L, covMethod = "", maxOuterIterations = maxOuter,
                            maxInnerIterations = 5000L, calcTables = FALSE,
-                           mceta = mceta))))
+                           mceta = mceta, ...))))
   }
 
   test_that("mceta > 0 explores its draws and cannot land worse than mceta=0", {
@@ -79,5 +79,24 @@ nmTest({
     expect_equal(.f1$objf, .f0$objf)
     expect_equal(.f1$env$nMcetaStart[["sample"]], 0L)
     expect_gt(.f1$env$nMcetaStart[["zero"]], 0L)
+  })
+
+  test_that("the mceta search does not run on the outer gradient's difference legs", {
+    skip_on_cran()
+    # A finite-difference leg is pinned to the central evaluation's mode, so the
+    # search has to be skipped there -- otherwise a tiny theta perturbation could
+    # flip which candidate starts the inner problem and the two legs would sit in
+    # different basins.  Count the inner solves that ran the search: one more
+    # outer iteration costs a handful of objective evaluations (nsub starts
+    # each), while an UNGATED search would add one full pass per parameter --
+    # npars * nsub -- for that iteration's gradient alone.
+    .dat <- .mcetaData()
+    .nsub <- length(unique(.dat$ID))
+    .g1 <- .mcetaFit(.dat, 5L, maxOuter = 1L, fast = FALSE)
+    .g2 <- .mcetaFit(.dat, 5L, maxOuter = 2L, fast = FALSE)
+    .npars <- length(fixef(.g1))
+    expect_lt(sum(.g2$env$nMcetaStart) - sum(.g1$env$nMcetaStart), .nsub * .npars)
+    # ... and the search did run somewhere, so the bound is not vacuous.
+    expect_gt(.g1$env$nMcetaStart[["sample"]], 0L)
   })
 })

--- a/tests/testthat/test-focei-mceta-1040.R
+++ b/tests/testthat/test-focei-mceta-1040.R
@@ -65,6 +65,17 @@ nmTest({
     expect_equal(sort(names(.f5$env$nMcetaStart)), c("sample", "zero"))
     expect_gt(.f5$env$nMcetaStart[["sample"]], 0L)
 
+    # The floor comparison has to be made on the objective the fit REPORTS --
+    # the marginal one, which carries the Laplace log|H| term -- not on the
+    # inner joint density the optimizer minimizes.  The two order candidates
+    # differently often enough that ranking on the inner objective alone hands
+    # the fit the worse candidate: `flipped` counts the subjects where the
+    # marginal disagreed, and it is a large fraction of `ranked` here.
+    expect_gt(.f5$env$nInnerRerank[["ranked"]], 0L)
+    expect_gt(.f5$env$nInnerRerank[["flipped"]], 0L)
+    # A single candidate is not ranked at all, so mceta=0 pays nothing for this.
+    expect_equal(.f0$env$nInnerRerank[["ranked"]], 0L)
+
     # Every inner problem has eta=0 among its candidates and keeps the converged
     # eta=0 solve as a floor, so at fixed parameters the objective cannot come
     # out above mceta=0.


### PR DESCRIPTION
Fixes #1040.

`mceta = 10` returned an objective bit-identical to `mceta = -2`, and both came out thousands of units worse than simply starting every inner problem at `eta = 0`. Four separate defects, each measured.

## 1. `mceta` was discarded outright on a fully mu-referenced model (the regression)

`.foceiMcetaMuRefFallback()` reset any non-default `mceta` to `-2`, reasoning that "the initial etas are all exactly zero, so the search has nothing to explore". That holds only for the *first* inner solve -- every later one starts from the previous iteration's mode, and the `mceta > 0` candidates are draws from omega, which are not zero. So the setting was silently replaced, which is exactly why `mceta = 10` reproduced `mceta = -2` to the last digit.

Removed. Measured on `theo_sd`'s one-compartment model (every eta mu-referenced): `mceta = 5` now starts 420 of its 1008 inner solves from a draw and reaches 116.8036 where `mceta = -2` reaches 116.8041.

## 2. The carried "last eta" was a candidate, and always won

It is the previous outer iteration's converged EBE, so its inner objective is essentially always the lowest of the set. It won for every subject, collapsing `mceta > 0` onto the keep-last behavior of `mceta = -1`/`-2` even where the fallback above did not fire.

Candidates are now `eta = 0` plus the `n-1` omega draws. `mceta = 1` therefore means `eta = 0` rather than being a silent no-op (with no draws the sample cube was empty and the whole branch was skipped), and a non-finite `eta = 0` no longer pins the search.

## 3. Ranking starting points does not order the converged results

A candidate is chosen by the objective *at* that point, which says nothing about where the inner optimization ends up -- so `mceta = n` could finish worse than `mceta = 0`, which the documentation promises it cannot. Measured on a fixed-omega inverse-CDF model at fixed parameters: `mceta = 2` gave -2251.0 against `mceta = 0`'s -2302.5.

A subject that starts from a draw now also solves from `eta = 0` and keeps whichever converged lower. `mceta = 2` gives -2338.8.

That floor solve is a starting-point loop wrapping the **whole** inner-optimizer dispatch, not code inside the n1qn1 arm, so it holds for whichever inner optimizer is configured -- `trust`'s arm already guards its early return with `haveBest` and calls `keepBest()`/`restoreBest()`, so the loop merges around it unchanged.

## 4. That comparison was made on the wrong objective

The inner optimizer minimizes the joint density; the objective the fit reports is the marginal one `LikInner2()` forms, which adds the Laplace `log|H|` term at the eta (built fresh by `calcEtaHessian()`, so it is a function of the eta and not of the optimizer's path). Two converged etas can therefore order one way on the inner objective and the other way on what the outer optimizer sees -- so the floor pass could win the comparison it was making and still come out above `mceta = 0` on the reported objective.

They disagree constantly. Subjects with more than one candidate, and how many the marginal ordered differently, on the same model:

| `mceta` | ranked | ordered differently |
|---|---|---|
| 2 | 24 | 15 |
| 3 | 30 | 11 |
| 5 | 44 | 23 |
| 10 | 53 | 27 |

Restarts are now ranked on `LikInner2()`, and only when there is more than one candidate -- an inner solve that never restarts, which is every solve on the default path, pays nothing extra. A finite-difference leg is ranked by the same rule so it picks its winner the way its central leg did.

## Also

- The draws are made **once per fit** rather than at every objective evaluation. Redrawing made the objective a different random function at each evaluation, so the outer optimizer's finite differences compared two different functions.
- The search is skipped while `calcGrad` is set, like the Almquist branch and the standardized-eta reset already were. A difference leg is pinned to the central evaluation's mode (`fdPinRefEtaForce`) precisely so both legs are taken about one point.
- `n1qn1_` takes `maxInnerIterations`, `nsim` and `imp` **by pointer** and writes back what it used, so the floor pass is handed a fresh budget -- without that it inherited the first pass's spent counts and stopped before optimizing anything. Worth 36 objective units on `mceta = 3` (-2338.72 -> -2374.73).
- The running minimum is pass-local: it is the recovery from a failed restart inside one pass's nudge cascade, and sharing it let a failed nudge in the floor pass restore the sample pass's eta and nudge away from zero.
- Each ranked candidate is measured with its own shi21 step search, so the candidate evaluated first no longer freezes the steps for the rest and the winner does not depend on the order the passes ran in.
- The omega draw is copied bounded by the destination column rather than by what R handed back. No error is raised: `innerOpt()` is the function that opens the per-subject parallel region.
- `$env$nMcetaStart` reports how many inner solves started from `eta = 0` vs from a draw; `$env$nInnerRerank` reports how many were ranked and how many the marginal ordered differently. Matching objectives alone cannot tell "explored and eta=0 won" from "never explored".

## Testing

`tests/testthat/test-focei-mceta-1040.R` (essential subset, ~12s):

- `mceta = 5` explores its draws, is ranked on the marginal with a large fraction of the orderings flipped, and does not land above `mceta = 0`; on this model it is strictly better. `mceta = 0` is never ranked, so it pays nothing.
- `mceta = 1` equals `mceta = 0`.
- A fully mu-referenced model honors `mceta` and is not told its setting was ignored.
- The search stays off the gradient's difference legs: one extra outer iteration costs a few objective evaluations (nsub starts each), where an ungated search would add `npars * nsub` for that iteration's gradient alone.

All of these fail on `main` and pass here.

**Regression sweep:** all 50 FOCEi test files, this branch vs. a pristine `main` build on the same rxode2. The only differences are the new test file and `test-focei-ind-counts-1039.R`, which arrived from `main` after the baseline was taken; its two errors are the `could not find function` artifact of running `test_file()` against an installed package rather than through `test_check`, the same artifact the pre-existing counts elsewhere carry.

## Review

Reviewed with Antigravity until clean. Rounds that found something, all fixed here: the missing `calcGrad` gate, a spurious nudge-cascade trigger, the unbounded draw copy, the spent iteration budget, the shared cross-pass running minimum, and the shi21 step freeze in the ranking pass. Two findings were rejected after measuring -- one proposed a direction that made `mceta = 5` worse (-1416 vs -1429) with more gradient declines. Final rounds found nothing.

One known cost, not a defect: when both passes converge to exactly zero the nudge cascade runs on each. That is deliberate -- it makes the floor pass faithful to what `mceta = 0` itself does -- and the selection guards the result.