### PR TITLE
docs(focei): repair the comment above innerOpt1's starting-point loop

### DIFF
--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -3902,9 +3902,11 @@ static inline int innerOpt1(int id, int likId) {
   // The loop wraps the WHOLE optimizer dispatch rather than living inside one
   // branch of it, so it holds for whichever inner optimizer is configured, and a
   // new optimizer arm gets the floor pass without being told about it.  An arm
-  // only has to leave the converged objective in `f` and call keepBest(); keepCand(); on a
-  // non-finite `f` it should hand the loop `_lastStart` (see the arms below)
-  // rather than returning, so a failed sampled start still gets its eta=0 pass.
+  // only has to leave the converged objective in `f` and call both keepBest()
+  // (this pass's running minimum) and keepCand() (the candidate the marginal
+  // re-rank below chooses from).  On a non-finite `f` it should hand the loop
+  // `_lastStart` (see the arms below) rather than returning, so a failed
+  // sampled start still gets its eta=0 pass.
   int nInnerStart = mcetaSampleStart ? 2 : 1;
   for (int _innerStart = 0; _innerStart < nInnerStart; _innerStart++) {
   bool _lastStart = (_innerStart + 1 == nInnerStart);


### PR DESCRIPTION
Comment only, no behavior change.

Adding `keepCand()` in #1042 was done with a blanket replacement of `keepBest();`, which also matched the string inside this comment and ran two sentences together:

```
// only has to leave the converged objective in `f` and call keepBest(); keepCand(); on a
// non-finite `f` it should hand the loop `_lastStart` (see the arms below)
```

Restores the prose and names what each of the two calls is for -- `keepBest()` is the pass's running minimum on the inner objective, `keepCand()` records the candidate the marginal re-rank chooses from. Every changed line is inside the `//` block.