### PR TITLE
focei: report whether the inner solves converged, and stop selecting failed candidates (#1044)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,32 @@
 
 ## Bug fixes
 
+- A `focei`-family fit now reports whether its inner solves actually
+  converged.  `fit$env$nTrustInner` breaks the `innerOpt="trust"` per-subject
+  Newton solves down by outcome (`calls`, `error`, `notConverged`,
+  `solverFail`, `newtonGate`, `warmRetry`, `radiusRetry`, `nudge`, `failed`)
+  and `fit$env$nInnerRerank` gains `noGood` and `dropped`.  Only the call count
+  existed before, and only through an internal accessor, so a fit whose inner
+  solves were all failing was indistinguishable from one where they all
+  converged.
+
+- The inner restart candidates are no longer chosen from without regard to
+  whether the attempt that produced them succeeded.  A failed attempt's eta
+  could win the marginal re-rank over a converged one -- its Laplace
+  `log|H|` term is measured at a point the inner objective never descended to
+  -- which `mceta >= 1` makes more likely, since the extra starting points are
+  what produce a mixed candidate set.  A failed attempt is now used only when
+  no succeeded one is available.
+
+- `innerOpt="trust"` re-solves in place before falling back to its eta-nudge
+  restarts.  When the inner Newton step still fits inside the current trust
+  radius, the solve stopped on its own step-size criterion rather than on the
+  model's remaining decrease, and the cascade threw that point away to restart
+  from a nudge fill.  On a 300-subject fit swept away from the true parameters,
+  subjects whose whole cascade is exhausted drop by up to half and the total
+  number of inner solves drops with them; a fit where nothing trips the check
+  is unchanged.
+
 - A fit no longer reports the PREVIOUS fit's censoring.  `$censInformation`
   is built from a process-global flag recording which censoring methods
   (M2/M3/M4) a fit used, and that flag was cleared only after being read at

--- a/NEWS.md
+++ b/NEWS.md
@@ -121,6 +121,12 @@
   what produce a mixed candidate set.  A failed attempt is now used only when
   no succeeded one is available.
 
+- `innerOpt="trust"` with `mceta >= 1` no longer fails a subject whose eta=0
+  floor pass produced nothing.  The "did this pass find anything" check is
+  per-pass, but the trust arm treated it as "did this subject find anything"
+  and returned a failed inner solve, discarding a converged candidate an
+  earlier starting point had already produced.
+
 - `innerOpt="trust"` re-solves in place before falling back to its eta-nudge
   restarts.  When the inner Newton step still fits inside the current trust
   radius, the solve stopped on its own step-size criterion rather than on the

--- a/NEWS.md
+++ b/NEWS.md
@@ -121,11 +121,11 @@
   what produce a mixed candidate set.  A failed attempt is now used only when
   no succeeded one is available.
 
-- `innerOpt="trust"` with `mceta >= 1` no longer fails a subject whose eta=0
-  floor pass produced nothing.  The "did this pass find anything" check is
-  per-pass, but the trust arm treated it as "did this subject find anything"
-  and returned a failed inner solve, discarding a converged candidate an
-  earlier starting point had already produced.
+- `mceta >= 1` no longer fails a subject whose eta=0 floor pass produced
+  nothing.  The "did this pass find anything" check is per-pass, but the trust
+  arm and the n1qn1 restart cascade both treated it as "did this subject find
+  anything" and returned a failed inner solve, discarding a converged candidate
+  an earlier starting point had already produced.
 
 - `innerOpt="trust"` re-solves in place before falling back to its eta-nudge
   restarts.  When the inner Newton step still fits inside the current trust

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4203,7 +4203,17 @@ static inline int innerOpt1(int id, int likId) {
                &mode, &maxInnerIterations, &nsim,
                &imp, fInd->zm,
                &izs, &rzs, &dzs, &id);
-        if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else { keepBest(); keepCand(fInd->badSolve == 0); }
+        if (ISNA(f)) {
+          if (!haveBest) {
+            // Nothing usable in THIS pass.  haveBest is pass-local, so that is
+            // not "nothing usable for this subject": an earlier starting point
+            // may already have a candidate the selection will take (#1044).
+            if (!candEta.empty()) break;
+            if (_lastStart) return 0;
+            continue;
+          }
+          restoreBest();
+        } else { keepBest(); keepCand(fInd->badSolve == 0); }
         // nF = fInd->nInnerF - nF;
         // if (nF > 3) tryAgain = false;
         // The re-check below used to be wrapped in `if (!tryAgain)`, which can
@@ -4231,7 +4241,17 @@ static inline int innerOpt1(int id, int likId) {
                  fInd->var, &epsilon,
                  &mode, &maxInnerIterations, &nsim,
                  &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-          if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else { keepBest(); keepCand(fInd->badSolve == 0); }
+          if (ISNA(f)) {
+            if (!haveBest) {
+              // Nothing usable in THIS pass.  haveBest is pass-local, so that is
+              // not "nothing usable for this subject": an earlier starting point
+              // may already have a candidate the selection will take (#1044).
+              if (!candEta.empty()) break;
+              if (_lastStart) return 0;
+              continue;
+            }
+            restoreBest();
+          } else { keepBest(); keepCand(fInd->badSolve == 0); }
           // nF = fInd->nInnerF - nF;
           // if (nF > 3) tryAgain = false;
           {
@@ -4255,7 +4275,17 @@ static inline int innerOpt1(int id, int likId) {
                    fInd->var, &epsilon,
                    &mode, &maxInnerIterations, &nsim,
                    &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-            if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else { keepBest(); keepCand(fInd->badSolve == 0); }
+            if (ISNA(f)) {
+              if (!haveBest) {
+                // Nothing usable in THIS pass.  haveBest is pass-local, so that is
+                // not "nothing usable for this subject": an earlier starting point
+                // may already have a candidate the selection will take (#1044).
+                if (!candEta.empty()) break;
+                if (_lastStart) return 0;
+                continue;
+              }
+              restoreBest();
+            } else { keepBest(); keepCand(fInd->badSolve == 0); }
             // nF = fInd->nInnerF - nF;
             // if (nF > 3) tryAgain = false;
             {
@@ -4279,7 +4309,17 @@ static inline int innerOpt1(int id, int likId) {
                      fInd->var, &epsilon,
                      &mode, &maxInnerIterations, &nsim,
                      &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-              if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else { keepBest(); keepCand(fInd->badSolve == 0); }
+              if (ISNA(f)) {
+                if (!haveBest) {
+                  // Nothing usable in THIS pass.  haveBest is pass-local, so that is
+                  // not "nothing usable for this subject": an earlier starting point
+                  // may already have a candidate the selection will take (#1044).
+                  if (!candEta.empty()) break;
+                  if (_lastStart) return 0;
+                  continue;
+                }
+                restoreBest();
+              } else { keepBest(); keepCand(fInd->badSolve == 0); }
               // nF = fInd->nInnerF - nF;
               // if (nF > 3) tryAgain = false;
               {
@@ -4301,7 +4341,17 @@ static inline int innerOpt1(int id, int likId) {
                        &mode, &maxInnerIterations, &nsim,
                        &imp, fInd->zm,
                        &izs, &rzs, &dzs, &id);
-                if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else { keepBest(); keepCand(fInd->badSolve == 0); }
+                if (ISNA(f)) {
+                  if (!haveBest) {
+                    // Nothing usable in THIS pass.  haveBest is pass-local, so that is
+                    // not "nothing usable for this subject": an earlier starting point
+                    // may already have a candidate the selection will take (#1044).
+                    if (!candEta.empty()) break;
+                    if (_lastStart) return 0;
+                    continue;
+                  }
+                  restoreBest();
+                } else { keepBest(); keepCand(fInd->badSolve == 0); }
                 //nF = fInd->nInnerF-nF;
                 // if (nF > 3) tryAgain = false;
                 {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -563,7 +563,8 @@ struct focei_options {
   // so a fit whose inner solves all converged and one where every one of them
   // failed look identical from the fit object; these separate the two.
   std::atomic<int> nTrustError{0};   // tres.error < 0 -- no usable eta at all
-  std::atomic<int> nTrustNoConv{0};  // solved, but trust_solve_c said not converged
+  std::atomic<int> nTrustNoConv{0};  // attempts that ended non-converged, either way
+  std::atomic<int> nTrustSolverNoConv{0}; // trust_solve_c's OWN flag said not converged
   std::atomic<int> nTrustPush{0};    // converged flag withdrawn by the Newton-decrement gate
   std::atomic<int> nTrustRetry{0};   // radius-escalation retries attempted
   std::atomic<int> nTrustNudge{0};   // nudge-cascade attempts
@@ -4458,10 +4459,20 @@ static inline int innerOpt1(int id, int likId) {
       trust_solve_c_ptr(npar, fInd->x, trustInnerObjfun, (void*)(&id), &topts, &tres);
       op_focei.nTrustInner.fetch_add(1, std::memory_order_relaxed);
       bool conv = false;
+      // trust_solve_c()'s OWN verdict, kept separate from `conv` because the
+      // Newton-decrement gate below withdraws `conv` to trigger a retry.  That
+      // gate is deliberately eager -- it exists to make the cascade try harder
+      // -- so it is the wrong thing to disqualify a candidate with: measured
+      // against n1qn1 on the same model, treating a gate withdrawal as "bad"
+      // discarded etas n1qn1 finds too and cost thousands of objective units.
+      // A candidate is bad only when the optimizer itself failed.
+      bool solveOk = false;
       if (tres.error >= 0 && tres.argument != NULL) {
         std::copy(tres.argument, tres.argument + npar, fInd->x);
         f = tres.value;
         conv = (bool)tres.converged;
+        solveOk = conv;
+        if (!conv) op_focei.nTrustSolverNoConv.fetch_add(1, std::memory_order_relaxed);
         if (R_FINITE(f) && !ISNA(f)) {
           keepBest();
           if (tres.gradient != NULL) std::copy(tres.gradient, tres.gradient + npar, fInd->g);
@@ -4498,7 +4509,7 @@ static inline int innerOpt1(int id, int likId) {
           // this attempt's final verdict: a candidate marked converged on
           // trust_solve_c()'s own flag and then withdrawn by the gate would
           // otherwise still be eligible to win the re-rank.
-          keepCand(conv && fInd->badSolve == 0);
+          keepCand(solveOk && fInd->badSolve == 0);
           if (!conv) op_focei.nTrustNoConv.fetch_add(1, std::memory_order_relaxed);
         } else {
           op_focei.nTrustNoConv.fetch_add(1, std::memory_order_relaxed);
@@ -4636,14 +4647,16 @@ static inline int innerOpt1(int id, int likId) {
   // LikInner2() writes lik[likId] for whichever candidate it is called on, and
   // the final call at the winner overwrites it, exactly as for likId == 0.
   if (!candEta.empty()) {
-    // A candidate whose attempt did not converge is a FALLBACK, not a choice.
-    // Both the inner-objective winner and the marginal re-rank below therefore
-    // look only at converged candidates whenever there is at least one; a
-    // failed attempt is considered only when nothing else survived (#1044).
-    // This matters most under mceta>=1, where the extra starting points make a
-    // mixed set of converged and failed candidates the common case: a failed
-    // attempt's eta can carry a larger marginal (its Laplace log|H| is measured
-    // at a point the inner objective never descended to) and would then win.
+    // A candidate the optimizer FAILED on is a fallback, not a choice.  Both
+    // the inner-objective winner and the marginal re-rank below therefore look
+    // only at candidates whose attempt succeeded whenever there is at least
+    // one; a failed attempt is used only when nothing else survived (#1044).
+    // This matters most under mceta>=1, where the extra starting points are
+    // what make a mixed candidate set common in the first place: a failed
+    // attempt's eta can carry the larger marginal (its Laplace log|H| is
+    // measured at a point the inner objective never descended to) and win.
+    // "Failed" is the optimizer's own verdict plus a latched bad solve, NOT a
+    // heuristic staleness gate -- see the trust arm's solveOk.
     bool anyOk = false;
     for (size_t k = 0; k < candOk.size(); ++k) {
       if (candOk[k]) { anyOk = true; break; }
@@ -8596,6 +8609,7 @@ NumericVector foceiSetup_(const RObject &obj,
   op_focei.nTrustInner.store(0, std::memory_order_relaxed);
   op_focei.nTrustError.store(0, std::memory_order_relaxed);
   op_focei.nTrustNoConv.store(0, std::memory_order_relaxed);
+  op_focei.nTrustSolverNoConv.store(0, std::memory_order_relaxed);
   op_focei.nTrustPush.store(0, std::memory_order_relaxed);
   op_focei.nTrustRetry.store(0, std::memory_order_relaxed);
   op_focei.nTrustNudge.store(0, std::memory_order_relaxed);
@@ -12151,8 +12165,10 @@ void foceiFinalizeTables(Environment e){
           _["error"] = op_focei.nTrustError.load(std::memory_order_relaxed),
           // Attempts that ended non-converged (includes the "error" ones).
           _["notConverged"] = op_focei.nTrustNoConv.load(std::memory_order_relaxed),
-          // Convergence trust_solve_c() claimed and the Newton-decrement gate
-          // withdrew.
+          // Of those, the ones trust_solve_c() itself declared non-converged.
+          // Only these disqualify a candidate from the selection; the rest are
+          // convergence the Newton-decrement gate withdrew to force a retry.
+          _["solverFail"] = op_focei.nTrustSolverNoConv.load(std::memory_order_relaxed),
           _["newtonGate"] = op_focei.nTrustPush.load(std::memory_order_relaxed),
           _["radiusRetry"] = op_focei.nTrustRetry.load(std::memory_order_relaxed),
           _["nudge"] = op_focei.nTrustNudge.load(std::memory_order_relaxed),

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4092,11 +4092,11 @@ static inline int innerOpt1(int id, int likId) {
   std::vector<double> candF;
   // Whether the attempt that produced each candidate actually SUCCEEDED (the
   // optimizer reported convergence and no solve failure latched).  A candidate
-  // that did not is a fallback, never a choice: the marginal re-rank below could
-  // otherwise hand a failed attempt's eta to the fit even though a converged
-  // attempt was available, and with mceta>=1 that is exactly what happened
-  // (#1044) -- the failed candidate wins the marginal because its Laplace
-  // log|H| term is computed at a point the objective never actually descended.
+  // that did not is a fallback, never a choice: the marginal re-rank below can
+  // otherwise hand a failed attempt's eta to the fit even though a succeeded
+  // attempt was available, because a failed attempt's Laplace log|H| term is
+  // computed at a point the objective never actually descended to and can come
+  // out larger.  mceta>=1 is where a mixed candidate set is common (#1044).
   std::vector<char> candOk;
   auto keepCand = [&](bool ok) {
     if (!R_FINITE(f)) return;
@@ -4472,13 +4472,17 @@ static inline int innerOpt1(int id, int likId) {
       // discarded etas n1qn1 finds too and cost thousands of objective units.
       // A candidate is bad only when the optimizer itself failed.
       bool solveOk = false;
+      // Whether this attempt produced a result at all.  A hard error and a
+      // finite-looking call that returned NaN/Inf are the same thing here.
+      bool usable = false;
       if (tres.error >= 0 && tres.argument != NULL) {
         std::copy(tres.argument, tres.argument + npar, fInd->x);
         f = tres.value;
         conv = (bool)tres.converged;
         solveOk = conv;
-        if (!conv) op_focei.nTrustSolverNoConv.fetch_add(1, std::memory_order_relaxed);
         if (R_FINITE(f) && !ISNA(f)) {
+          usable = true;
+          if (!conv) op_focei.nTrustSolverNoConv.fetch_add(1, std::memory_order_relaxed);
           keepBest();
           if (tres.gradient != NULL) std::copy(tres.gradient, tres.gradient + npar, fInd->g);
           if (tres.gradient != NULL && tres.hessian != NULL) {
@@ -4510,27 +4514,28 @@ static inline int innerOpt1(int id, int likId) {
           // (the recovery from a failed restart within this pass); the choice of
           // which candidate the fit reports is made on LikInner2()'s marginal,
           // which sees only what keepCand() recorded (#1040, #1044).  It is
-          // recorded here, AFTER the Newton-decrement gate above, so `conv` is
-          // this attempt's final verdict: a candidate marked converged on
-          // trust_solve_c()'s own flag and then withdrawn by the gate would
-          // otherwise still be eligible to win the re-rank.
+          // recorded on solveOk, not on the gated `conv`, so an eager retry
+          // trigger cannot also disqualify the point it was triggered at.
           keepCand(solveOk && fInd->badSolve == 0);
-          if (!conv) op_focei.nTrustNoConv.fetch_add(1, std::memory_order_relaxed);
-        } else {
-          op_focei.nTrustNoConv.fetch_add(1, std::memory_order_relaxed);
         }
-      } else {
-        // Hard error (e.g. tres.error==-3: the nudged starting point itself
-        // was infeasible) -- fInd->x was already overwritten with the raw
-        // nudge fill above, but f is left untouched here otherwise. If a
-        // PRIOR attempt succeeded, f still equals fBest, so the shared
-        // restoreBest() guard below (`fBest < f`) would silently skip
-        // restoring: the reported objective would say fBest while fInd->x
-        // actually held this failed nudge point. Force f to +Inf so that
-        // guard always fires when this attempt didn't produce a usable eta.
+      }
+      if (!usable) {
+        // Either a hard error (e.g. tres.error==-3: the nudged starting point
+        // itself was infeasible) or a call that came back NaN/Inf.  fInd->x may
+        // already hold the raw nudge fill, and f is otherwise left untouched:
+        // if a PRIOR attempt succeeded, f still equals fBest, so the shared
+        // restoreBest() guard below (`fBest < f`) would silently skip restoring
+        // -- the reported objective would say fBest while fInd->x actually held
+        // this failed nudge point.  (A NaN f fails that comparison too.)  Force
+        // f to +Inf so the guard always fires when this attempt didn't produce
+        // a usable eta, and never report convergence on an unusable one.
         f = std::numeric_limits<double>::infinity();
+        conv = false;
         op_focei.nTrustError.fetch_add(1, std::memory_order_relaxed);
       }
+      // Attempts that did not end converged, however they got there:
+      // error + solverFail + newtonGate.
+      if (!conv) op_focei.nTrustNoConv.fetch_add(1, std::memory_order_relaxed);
       trust_result_free_ptr(&tres);
       return conv;
     };

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -567,6 +567,7 @@ struct focei_options {
   std::atomic<int> nTrustSolverNoConv{0}; // trust_solve_c's OWN flag said not converged
   std::atomic<int> nTrustPush{0};    // converged flag withdrawn by the Newton-decrement gate
   std::atomic<int> nTrustRetry{0};   // radius-escalation retries attempted
+  std::atomic<int> nTrustWarm{0};    // same-radius re-solves from the point just found
   std::atomic<int> nTrustNudge{0};   // nudge-cascade attempts
   std::atomic<int> nTrustFail{0};    // inner solves still non-converged after every retry
   // per-fit count of calcEtaHessian() calls that used the hessianMethod=
@@ -4531,6 +4532,16 @@ static inline int innerOpt1(int id, int likId) {
     };
 
     bool converged = trustSolveAt(false, 0.0);
+    if (!converged && pushDist >= 0.0 && pushDist <= curRmax) {
+      // The Newton step FITS in the current radius and trust_solve_c still
+      // stopped: it hit its own fterm/mterm step-size criterion, which is
+      // measured against the PREVIOUS iterate, not against the model's own
+      // remaining decrease.  A fresh solve from the point just found resets
+      // that history and can move again, and it keeps the good point -- the
+      // nudge cascade below throws it away and restarts from a fill.
+      op_focei.nTrustWarm.fetch_add(1, std::memory_order_relaxed);
+      converged = trustSolveAt(false, 0.0);
+    }
     if (!converged && pushDist > curRmax) {
       // Radius-escalation retry from the point just found (already the best
       // seen so far, via keepBest() above) before falling back to eta nudges.
@@ -8612,6 +8623,7 @@ NumericVector foceiSetup_(const RObject &obj,
   op_focei.nTrustSolverNoConv.store(0, std::memory_order_relaxed);
   op_focei.nTrustPush.store(0, std::memory_order_relaxed);
   op_focei.nTrustRetry.store(0, std::memory_order_relaxed);
+  op_focei.nTrustWarm.store(0, std::memory_order_relaxed);
   op_focei.nTrustNudge.store(0, std::memory_order_relaxed);
   op_focei.nTrustFail.store(0, std::memory_order_relaxed);
   op_focei.nHessianQN.store(0, std::memory_order_relaxed);
@@ -12170,6 +12182,7 @@ void foceiFinalizeTables(Environment e){
           // convergence the Newton-decrement gate withdrew to force a retry.
           _["solverFail"] = op_focei.nTrustSolverNoConv.load(std::memory_order_relaxed),
           _["newtonGate"] = op_focei.nTrustPush.load(std::memory_order_relaxed),
+          _["warmRetry"] = op_focei.nTrustWarm.load(std::memory_order_relaxed),
           _["radiusRetry"] = op_focei.nTrustRetry.load(std::memory_order_relaxed),
           _["nudge"] = op_focei.nTrustNudge.load(std::memory_order_relaxed),
           // Subjects whose whole cascade -- first solve, radius escalation and

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4442,6 +4442,14 @@ static inline int innerOpt1(int id, int likId) {
     // below to decide whether a wider-radius retry is worth attempting at
     // all before falling back to relocating the start point via nudges.
     double pushDist = -1.0; // -1: not computed / not usable this call
+    // trust_solve_c() allocates tres's argument/gradient/hessian arrays.  The
+    // arma work below (matrix copies, arma::solve) can throw std::bad_alloc,
+    // which the branch-level catch swallows -- so the free has to run on every
+    // exit from the lambda, not only the normal one.
+    struct TresGuard {
+      trust_result_t *r;
+      ~TresGuard() { trust_result_free_ptr(r); }
+    };
     auto trustSolveAt = [&](bool fill, double startVal) {
       if (fill) std::fill_n(fInd->x, npar, startVal);
       // Reset per attempt (mirrors n1qn1's cascade, which clears this before
@@ -4462,6 +4470,7 @@ static inline int innerOpt1(int id, int likId) {
       topts.rmax = curRmax;
       trust_result_t tres;
       trust_solve_c_ptr(npar, fInd->x, trustInnerObjfun, (void*)(&id), &topts, &tres);
+      TresGuard _tresGuard{&tres};
       op_focei.nTrustInner.fetch_add(1, std::memory_order_relaxed);
       bool conv = false;
       // trust_solve_c()'s OWN verdict, kept separate from `conv` because the
@@ -4536,7 +4545,6 @@ static inline int innerOpt1(int id, int likId) {
       // Attempts that did not end converged, however they got there:
       // error + solverFail + newtonGate.
       if (!conv) op_focei.nTrustNoConv.fetch_add(1, std::memory_order_relaxed);
-      trust_result_free_ptr(&tres);
       return conv;
     };
 

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4468,9 +4468,14 @@ static inline int innerOpt1(int id, int likId) {
       fInd->etaHasPrevQN = 0;
       pushDist = -1.0;
       topts.rmax = curRmax;
-      trust_result_t tres;
-      trust_solve_c_ptr(npar, fInd->x, trustInnerObjfun, (void*)(&id), &topts, &tres);
+      // Value-initialized so the guard below can free it even if the solve
+      // never allocates: trust_result_free() frees every member unconditionally
+      // and free(NULL) is a no-op, but free() on an indeterminate pointer is
+      // not.  The guard is armed BEFORE the call so an exception thrown out of
+      // trustInnerObjfun mid-solve still frees whatever was allocated.
+      trust_result_t tres = {};
       TresGuard _tresGuard{&tres};
+      trust_solve_c_ptr(npar, fInd->x, trustInnerObjfun, (void*)(&id), &topts, &tres);
       op_focei.nTrustInner.fetch_add(1, std::memory_order_relaxed);
       bool conv = false;
       // trust_solve_c()'s OWN verdict, kept separate from `conv` because the
@@ -4691,6 +4696,11 @@ static inline int innerOpt1(int id, int likId) {
   // LikInner2() writes lik[likId] for whichever candidate it is called on, and
   // the final call at the winner overwrites it, exactly as for likId == 0.
   if (!candEta.empty()) {
+    // keepCand() grows the three candidate vectors one after another, so a
+    // std::bad_alloc between them (swallowed by the trust arm's own catch)
+    // could leave candOk short.  Pad rather than index past it; an unknown
+    // verdict is treated as eligible, which is the behavior before this rule.
+    if (candOk.size() != candEta.size()) candOk.resize(candEta.size(), (char)1);
     // A candidate the optimizer FAILED on is a fallback, not a choice.  Both
     // the inner-objective winner and the marginal re-rank below therefore look
     // only at candidates whose attempt succeeded whenever there is at least

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -727,6 +727,10 @@ struct focei_options {
   // converged on -- every candidate was a failed attempt, so the selection had
   // nothing good to choose from (#1044).
   std::atomic<int> nInnerNoGood{0};
+  // Inner solves where a failed attempt's candidate was dropped from the
+  // selection because a succeeded one was available.  This is the count that
+  // shows the rule is doing something, rather than that it merely exists.
+  std::atomic<int> nInnerDropped{0};
   std::atomic<int> didEtaReset{0};
   double resetThetaSize = std::numeric_limits<double>::infinity();
   double resetThetaFinalSize = std::numeric_limits<double>::infinity();
@@ -4668,11 +4672,15 @@ static inline int innerOpt1(int id, int likId) {
     // measured at a point the inner objective never descended to) and win.
     // "Failed" is the optimizer's own verdict plus a latched bad solve, NOT a
     // heuristic staleness gate -- see the trust arm's solveOk.
-    bool anyOk = false;
+    bool anyOk = false, anyBad = false;
     for (size_t k = 0; k < candOk.size(); ++k) {
-      if (candOk[k]) { anyOk = true; break; }
+      if (candOk[k]) anyOk = true; else anyBad = true;
     }
-    if (!anyOk) op_focei.nInnerNoGood.fetch_add(1, std::memory_order_relaxed);
+    if (!anyOk) {
+      op_focei.nInnerNoGood.fetch_add(1, std::memory_order_relaxed);
+    } else if (anyBad) {
+      op_focei.nInnerDropped.fetch_add(1, std::memory_order_relaxed);
+    }
     int nElig = 0;
     int bestInnerK = -1;
     for (size_t k = 0; k < candEta.size(); ++k) {
@@ -8176,6 +8184,7 @@ NumericVector foceiSetup_(const RObject &obj,
   op_focei.nInnerRanked.store(0, std::memory_order_relaxed);
   op_focei.nInnerReranked.store(0, std::memory_order_relaxed);
   op_focei.nInnerNoGood.store(0, std::memory_order_relaxed);
+  op_focei.nInnerDropped.store(0, std::memory_order_relaxed);
   op_focei.warm = foceiO.containsElementNamed("warm") ? as<int>(foceiO["warm"]) : 0;
   op_focei.maxOdeRecalc = as<int>(foceiO["maxOdeRecalc"]);
   op_focei.objfRecalN=0;
@@ -9503,6 +9512,7 @@ Environment foceiOuter(Environment e){
   op_focei.nInnerRanked.store(0, std::memory_order_relaxed);
   op_focei.nInnerReranked.store(0, std::memory_order_relaxed);
   op_focei.nInnerNoGood.store(0, std::memory_order_relaxed);
+  op_focei.nInnerDropped.store(0, std::memory_order_relaxed);
   op_focei.nDeclineNewton=0;
   op_focei.nDeclineE0=0;
   op_focei.nDeclineOther=0;
@@ -12165,7 +12175,10 @@ void foceiFinalizeTables(Environment e){
         _["flipped"] = op_focei.nInnerReranked.load(std::memory_order_relaxed),
         // Inner solves that had nothing converged to choose from, so the fit
         // reports a failed attempt's eta for that subject (#1044).
-        _["noGood"] = op_focei.nInnerNoGood.load(std::memory_order_relaxed));
+        _["noGood"] = op_focei.nInnerNoGood.load(std::memory_order_relaxed),
+        // ... and solves where a failed attempt WAS dropped because a
+        // succeeded one was available.
+        _["dropped"] = op_focei.nInnerDropped.load(std::memory_order_relaxed));
       if (op_focei.innerOpt == 3) {
         // innerOpt="trust" outcomes.  "calls" is what .nTrustInner() reports;
         // the rest say whether those calls actually converged -- a fit whose

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4098,9 +4098,18 @@ static inline int innerOpt1(int id, int likId) {
   // computed at a point the objective never actually descended to and can come
   // out larger.  mceta>=1 is where a mixed candidate set is common (#1044).
   std::vector<char> candOk;
+  // The three vectors are read by index against each other, so they must never
+  // end up ragged.  Everything that can allocate -- the eta copy and all three
+  // reserves -- is done FIRST, so a std::bad_alloc (which the trust arm's own
+  // catch swallows, letting the selection below still run) leaves nothing
+  // pushed; the three push_backs that follow allocate nothing and cannot throw.
   auto keepCand = [&](bool ok) {
     if (!R_FINITE(f)) return;
-    candEta.push_back(std::vector<double>(fInd->x, fInd->x + fop->neta));
+    std::vector<double> eta(fInd->x, fInd->x + fop->neta);
+    candEta.reserve(candEta.size() + 1);
+    candF.reserve(candF.size() + 1);
+    candOk.reserve(candOk.size() + 1);
+    candEta.push_back(std::move(eta));
     candF.push_back(f);
     candOk.push_back(ok ? (char)1 : (char)0);
   };
@@ -4696,11 +4705,6 @@ static inline int innerOpt1(int id, int likId) {
   // LikInner2() writes lik[likId] for whichever candidate it is called on, and
   // the final call at the winner overwrites it, exactly as for likId == 0.
   if (!candEta.empty()) {
-    // keepCand() grows the three candidate vectors one after another, so a
-    // std::bad_alloc between them (swallowed by the trust arm's own catch)
-    // could leave candOk short.  Pad rather than index past it; an unknown
-    // verdict is treated as eligible, which is the behavior before this rule.
-    if (candOk.size() != candEta.size()) candOk.resize(candEta.size(), (char)1);
     // A candidate the optimizer FAILED on is a fallback, not a choice.  Both
     // the inner-objective winner and the marginal re-rank below therefore look
     // only at candidates whose attempt succeeded whenever there is at least

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -559,6 +559,15 @@ struct focei_options {
   double trustFterm;
   double trustMterm;
   std::atomic<int> nTrustInner{0}; // per-fit count of trust_solve_c calls (test evidence)
+  // innerOpt="trust" per-fit OUTCOME counts (#1044).  nTrustInner counts CALLS,
+  // so a fit whose inner solves all converged and one where every one of them
+  // failed look identical from the fit object; these separate the two.
+  std::atomic<int> nTrustError{0};   // tres.error < 0 -- no usable eta at all
+  std::atomic<int> nTrustNoConv{0};  // solved, but trust_solve_c said not converged
+  std::atomic<int> nTrustPush{0};    // converged flag withdrawn by the Newton-decrement gate
+  std::atomic<int> nTrustRetry{0};   // radius-escalation retries attempted
+  std::atomic<int> nTrustNudge{0};   // nudge-cascade attempts
+  std::atomic<int> nTrustFail{0};    // inner solves still non-converged after every retry
   // per-fit count of calcEtaHessian() calls that used the hessianMethod=
   // quasi-Newton update (as opposed to a fresh FD pass) -- test evidence the
   // mechanism actually ran, not just that the numbers happen to agree.
@@ -712,6 +721,10 @@ struct focei_options {
   // one that says the Laplace log|H| term actually changes the choice.
   std::atomic<int> nInnerRanked{0};
   std::atomic<int> nInnerReranked{0};
+  // Inner solves that had to report a candidate no optimizer arm actually
+  // converged on -- every candidate was a failed attempt, so the selection had
+  // nothing good to choose from (#1044).
+  std::atomic<int> nInnerNoGood{0};
   std::atomic<int> didEtaReset{0};
   double resetThetaSize = std::numeric_limits<double>::infinity();
   double resetThetaFinalSize = std::numeric_limits<double>::infinity();
@@ -4071,10 +4084,19 @@ static inline int innerOpt1(int id, int likId) {
   // objective (see the re-rank after the loop).
   std::vector< std::vector<double> > candEta;
   std::vector<double> candF;
-  auto keepCand = [&]() {
+  // Whether the attempt that produced each candidate actually SUCCEEDED (the
+  // optimizer reported convergence and no solve failure latched).  A candidate
+  // that did not is a fallback, never a choice: the marginal re-rank below could
+  // otherwise hand a failed attempt's eta to the fit even though a converged
+  // attempt was available, and with mceta>=1 that is exactly what happened
+  // (#1044) -- the failed candidate wins the marginal because its Laplace
+  // log|H| term is computed at a point the objective never actually descended.
+  std::vector<char> candOk;
+  auto keepCand = [&](bool ok) {
     if (!R_FINITE(f)) return;
     candEta.push_back(std::vector<double>(fInd->x, fInd->x + fop->neta));
     candF.push_back(f);
+    candOk.push_back(ok ? (char)1 : (char)0);
   };
   // Starting points this inner solve runs from.  mceta>=1 picks its start by the
   // objective AT that point, which does not order the points the optimization
@@ -4085,8 +4107,9 @@ static inline int innerOpt1(int id, int likId) {
   // branch of it, so it holds for whichever inner optimizer is configured, and a
   // new optimizer arm gets the floor pass without being told about it.  An arm
   // only has to leave the converged objective in `f` and call both keepBest()
-  // (this pass's running minimum) and keepCand() (the candidate the marginal
-  // re-rank below chooses from).  On a non-finite `f` it should hand the loop
+  // (this pass's running minimum) and keepCand(ok) (the candidate the marginal
+  // re-rank below chooses from, with `ok` saying whether that attempt actually
+  // converged -- see candOk).  On a non-finite `f` it should hand the loop
   // `_lastStart` (see the arms below) rather than returning, so a failed
   // sampled start still gets its eta=0 pass.
   int nInnerStart = mcetaSampleStart ? 2 : 1;
@@ -4131,7 +4154,7 @@ static inline int innerOpt1(int id, int likId) {
       if (_lastStart) return 0;
       continue;
     }
-    keepBest(); keepCand();
+    keepBest(); keepCand(fInd->badSolve == 0);
     nF = fInd->nInnerF-nF;
     // REprintf("innerCost id: %d, fInd->nInnerF: %d", id, fInd->nInnerF);
     // If stays at zero try another point?
@@ -4165,7 +4188,7 @@ static inline int innerOpt1(int id, int likId) {
                &mode, &maxInnerIterations, &nsim,
                &imp, fInd->zm,
                &izs, &rzs, &dzs, &id);
-        if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest(); keepCand();
+        if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else { keepBest(); keepCand(fInd->badSolve == 0); }
         // nF = fInd->nInnerF - nF;
         // if (nF > 3) tryAgain = false;
         // The re-check below used to be wrapped in `if (!tryAgain)`, which can
@@ -4193,7 +4216,7 @@ static inline int innerOpt1(int id, int likId) {
                  fInd->var, &epsilon,
                  &mode, &maxInnerIterations, &nsim,
                  &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-          if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest(); keepCand();
+          if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else { keepBest(); keepCand(fInd->badSolve == 0); }
           // nF = fInd->nInnerF - nF;
           // if (nF > 3) tryAgain = false;
           {
@@ -4217,7 +4240,7 @@ static inline int innerOpt1(int id, int likId) {
                    fInd->var, &epsilon,
                    &mode, &maxInnerIterations, &nsim,
                    &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-            if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest(); keepCand();
+            if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else { keepBest(); keepCand(fInd->badSolve == 0); }
             // nF = fInd->nInnerF - nF;
             // if (nF > 3) tryAgain = false;
             {
@@ -4241,7 +4264,7 @@ static inline int innerOpt1(int id, int likId) {
                      fInd->var, &epsilon,
                      &mode, &maxInnerIterations, &nsim,
                      &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-              if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest(); keepCand();
+              if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else { keepBest(); keepCand(fInd->badSolve == 0); }
               // nF = fInd->nInnerF - nF;
               // if (nF > 3) tryAgain = false;
               {
@@ -4263,7 +4286,7 @@ static inline int innerOpt1(int id, int likId) {
                        &mode, &maxInnerIterations, &nsim,
                        &imp, fInd->zm,
                        &izs, &rzs, &dzs, &id);
-                if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else keepBest(); keepCand();
+                if (ISNA(f)) { if (!haveBest) return 0; restoreBest(); } else { keepBest(); keepCand(fInd->badSolve == 0); }
                 //nF = fInd->nInnerF-nF;
                 // if (nF > 3) tryAgain = false;
                 {
@@ -4441,12 +4464,6 @@ static inline int innerOpt1(int id, int likId) {
         conv = (bool)tres.converged;
         if (R_FINITE(f) && !ISNA(f)) {
           keepBest();
-          // Record it for the marginal re-rank after the starting-point loop as
-          // well.  keepBest() is only the running minimum on the INNER objective
-          // (the recovery from a failed restart within this pass); the choice of
-          // which candidate the fit reports is made on LikInner2()'s marginal,
-          // which sees only what keepCand() recorded (#1040, #1044).
-          keepCand();
           if (tres.gradient != NULL) std::copy(tres.gradient, tres.gradient + npar, fInd->g);
           if (tres.gradient != NULL && tres.hessian != NULL) {
             arma::mat H(tres.hessian, npar, npar);
@@ -4463,12 +4480,28 @@ static inline int innerOpt1(int id, int likId) {
                 d2 += si * si;
               }
               pushDist = std::sqrt(d2);
-              if (conv && pushDist > pushTol) conv = false;
+              if (conv && pushDist > pushTol) {
+                conv = false;
+                op_focei.nTrustPush.fetch_add(1, std::memory_order_relaxed);
+              }
             }
             // Newton estimate unusable (singular/indefinite H, or not a
             // descent direction): leave conv at trust_solve_c()'s own flag
             // rather than fabricate a verdict from an untrustworthy estimate.
           }
+          // Record it for the marginal re-rank after the starting-point loop as
+          // well.  keepBest() is only the running minimum on the INNER objective
+          // (the recovery from a failed restart within this pass); the choice of
+          // which candidate the fit reports is made on LikInner2()'s marginal,
+          // which sees only what keepCand() recorded (#1040, #1044).  It is
+          // recorded here, AFTER the Newton-decrement gate above, so `conv` is
+          // this attempt's final verdict: a candidate marked converged on
+          // trust_solve_c()'s own flag and then withdrawn by the gate would
+          // otherwise still be eligible to win the re-rank.
+          keepCand(conv && fInd->badSolve == 0);
+          if (!conv) op_focei.nTrustNoConv.fetch_add(1, std::memory_order_relaxed);
+        } else {
+          op_focei.nTrustNoConv.fetch_add(1, std::memory_order_relaxed);
         }
       } else {
         // Hard error (e.g. tres.error==-3: the nudged starting point itself
@@ -4480,6 +4513,7 @@ static inline int innerOpt1(int id, int likId) {
         // actually held this failed nudge point. Force f to +Inf so that
         // guard always fires when this attempt didn't produce a usable eta.
         f = std::numeric_limits<double>::infinity();
+        op_focei.nTrustError.fetch_add(1, std::memory_order_relaxed);
       }
       trust_result_free_ptr(&tres);
       return conv;
@@ -4497,6 +4531,7 @@ static inline int innerOpt1(int id, int likId) {
       // poorly-conditioned subject can't blow the radius up without bound.
       double target = std::max(curRmax * 2.0, pushDist * 1.2);
       curRmax = std::min(target, op_focei.trustRmax * 8.0);
+      op_focei.nTrustRetry.fetch_add(1, std::memory_order_relaxed);
       converged = trustSolveAt(false, 0.0);
     }
     // Restart cascade on non-convergence, same nudge magnitudes n1qn1 uses; the
@@ -4507,9 +4542,14 @@ static inline int innerOpt1(int id, int likId) {
       double nudges[4] = {op_focei.etaNudge, -op_focei.etaNudge,
                            -op_focei.etaNudge2, op_focei.etaNudge2};
       for (int _n = 0; _n < 4 && !converged; _n++) {
+        op_focei.nTrustNudge.fetch_add(1, std::memory_order_relaxed);
         converged = trustSolveAt(true, nudges[_n]);
       }
     }
+    // Every attempt this subject got is spent and none of them converged --
+    // the count #1044 needed: without it a fit whose trust solves all failed
+    // is indistinguishable from one where they all converged.
+    if (!converged) op_focei.nTrustFail.fetch_add(1, std::memory_order_relaxed);
     if (!haveBest) return 0;
     } catch (const std::bad_alloc &) {
       // System out of memory mid-solve -- see the branch-level comment above.
@@ -4544,7 +4584,7 @@ static inline int innerOpt1(int id, int likId) {
       if (_lastStart) return 0;
       continue;
     }
-    keepBest(); keepCand();
+    keepBest(); keepCand(fInd->badSolve == 0);
     // if (fail != 6 && fail != 7 && fail != 8 && fail != 27){
     //   // did not converge
     //   if (fInd->doEtaNudge == 1 && op_focei.etaNudge != 0.0){
@@ -4596,12 +4636,29 @@ static inline int innerOpt1(int id, int likId) {
   // LikInner2() writes lik[likId] for whichever candidate it is called on, and
   // the final call at the winner overwrites it, exactly as for likId == 0.
   if (!candEta.empty()) {
-    int bestInnerK = 0;
-    for (size_t k = 0; k < candEta.size(); ++k) {
-      if (candF[k] < candF[(size_t)bestInnerK]) bestInnerK = (int)k;
+    // A candidate whose attempt did not converge is a FALLBACK, not a choice.
+    // Both the inner-objective winner and the marginal re-rank below therefore
+    // look only at converged candidates whenever there is at least one; a
+    // failed attempt is considered only when nothing else survived (#1044).
+    // This matters most under mceta>=1, where the extra starting points make a
+    // mixed set of converged and failed candidates the common case: a failed
+    // attempt's eta can carry a larger marginal (its Laplace log|H| is measured
+    // at a point the inner objective never descended to) and would then win.
+    bool anyOk = false;
+    for (size_t k = 0; k < candOk.size(); ++k) {
+      if (candOk[k]) { anyOk = true; break; }
     }
+    if (!anyOk) op_focei.nInnerNoGood.fetch_add(1, std::memory_order_relaxed);
+    int nElig = 0;
+    int bestInnerK = -1;
+    for (size_t k = 0; k < candEta.size(); ++k) {
+      if (anyOk && !candOk[k]) continue;
+      nElig++;
+      if (bestInnerK < 0 || candF[k] < candF[(size_t)bestInnerK]) bestInnerK = (int)k;
+    }
+    if (bestInnerK < 0) bestInnerK = 0; // unreachable; keeps the indexing below total
     int bestK = -1;
-    if (candEta.size() > 1) {
+    if (nElig > 1) {
       op_focei.nInnerRanked.fetch_add(1, std::memory_order_relaxed);
       // calcEtaHessian(), reached through LikInner2(), FREEZES the shi21 finite
       // difference steps on first use.  Snapshot them so the ranking leaves
@@ -4613,6 +4670,7 @@ static inline int innerOpt1(int id, int likId) {
       if (fInd->etahh != NULL) shh.assign(fInd->etahh, fInd->etahh + fop->neta);
       double bestMarg = 0.0;
       for (size_t k = 0; k < candEta.size(); ++k) {
+        if (anyOk && !candOk[k]) continue;
         // Each candidate is measured with ITS OWN step search, which is what
         // the fit would have computed had that candidate been the only one.
         // Without the zeroing the candidate evaluated first freezes the steps
@@ -8093,6 +8151,7 @@ NumericVector foceiSetup_(const RObject &obj,
   op_focei.nMcetaSample.store(0, std::memory_order_relaxed);
   op_focei.nInnerRanked.store(0, std::memory_order_relaxed);
   op_focei.nInnerReranked.store(0, std::memory_order_relaxed);
+  op_focei.nInnerNoGood.store(0, std::memory_order_relaxed);
   op_focei.warm = foceiO.containsElementNamed("warm") ? as<int>(foceiO["warm"]) : 0;
   op_focei.maxOdeRecalc = as<int>(foceiO["maxOdeRecalc"]);
   op_focei.objfRecalN=0;
@@ -8535,6 +8594,12 @@ NumericVector foceiSetup_(const RObject &obj,
     op_focei.trustMterm = as<double>(foceiO["trustMterm"]);
   }
   op_focei.nTrustInner.store(0, std::memory_order_relaxed);
+  op_focei.nTrustError.store(0, std::memory_order_relaxed);
+  op_focei.nTrustNoConv.store(0, std::memory_order_relaxed);
+  op_focei.nTrustPush.store(0, std::memory_order_relaxed);
+  op_focei.nTrustRetry.store(0, std::memory_order_relaxed);
+  op_focei.nTrustNudge.store(0, std::memory_order_relaxed);
+  op_focei.nTrustFail.store(0, std::memory_order_relaxed);
   op_focei.nHessianQN.store(0, std::memory_order_relaxed);
   op_focei.nsim=as<int>(foceiO["n1qn1nsim"]);
   op_focei.imp=0;
@@ -9411,6 +9476,7 @@ Environment foceiOuter(Environment e){
   op_focei.nMcetaSample.store(0, std::memory_order_relaxed);
   op_focei.nInnerRanked.store(0, std::memory_order_relaxed);
   op_focei.nInnerReranked.store(0, std::memory_order_relaxed);
+  op_focei.nInnerNoGood.store(0, std::memory_order_relaxed);
   op_focei.nDeclineNewton=0;
   op_focei.nDeclineE0=0;
   op_focei.nDeclineOther=0;
@@ -12070,7 +12136,30 @@ void foceiFinalizeTables(Environment e){
       // the nudge cascade produces multiple candidates too.
       e["nInnerRerank"] = IntegerVector::create(
         _["ranked"] = op_focei.nInnerRanked.load(std::memory_order_relaxed),
-        _["flipped"] = op_focei.nInnerReranked.load(std::memory_order_relaxed));
+        _["flipped"] = op_focei.nInnerReranked.load(std::memory_order_relaxed),
+        // Inner solves that had nothing converged to choose from, so the fit
+        // reports a failed attempt's eta for that subject (#1044).
+        _["noGood"] = op_focei.nInnerNoGood.load(std::memory_order_relaxed));
+      if (op_focei.innerOpt == 3) {
+        // innerOpt="trust" outcomes.  "calls" is what .nTrustInner() reports;
+        // the rest say whether those calls actually converged -- a fit whose
+        // inner solves all failed used to look exactly like one where they all
+        // succeeded (#1044).
+        e["nTrustInner"] = IntegerVector::create(
+          _["calls"] = op_focei.nTrustInner.load(std::memory_order_relaxed),
+          // trust_solve_c() returned no usable eta at all (tres.error < 0).
+          _["error"] = op_focei.nTrustError.load(std::memory_order_relaxed),
+          // Attempts that ended non-converged (includes the "error" ones).
+          _["notConverged"] = op_focei.nTrustNoConv.load(std::memory_order_relaxed),
+          // Convergence trust_solve_c() claimed and the Newton-decrement gate
+          // withdrew.
+          _["newtonGate"] = op_focei.nTrustPush.load(std::memory_order_relaxed),
+          _["radiusRetry"] = op_focei.nTrustRetry.load(std::memory_order_relaxed),
+          _["nudge"] = op_focei.nTrustNudge.load(std::memory_order_relaxed),
+          // Subjects whose whole cascade -- first solve, radius escalation and
+          // all four nudges -- ended without a converged attempt.
+          _["failed"] = op_focei.nTrustFail.load(std::memory_order_relaxed));
+      }
       if (op_focei.mceta >= 1) {
         // Which mceta candidate each inner solve started from.  Not gated on
         // `fast`: mceta>=1 is independent of the analytic gradient.

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4589,7 +4589,15 @@ static inline int innerOpt1(int id, int likId) {
     // the count #1044 needed: without it a fit whose trust solves all failed
     // is indistinguishable from one where they all converged.
     if (!converged) op_focei.nTrustFail.fetch_add(1, std::memory_order_relaxed);
-    if (!haveBest) return 0;
+    // haveBest is PASS-LOCAL, so "this pass produced nothing" is not "this
+    // subject produced nothing": under mceta>=1 an earlier pass may already
+    // have a converged candidate, and returning 0 here would throw it away and
+    // fail the subject.  Same three-way exit the n1qn1 arm takes (#1044).
+    if (!haveBest) {
+      if (!candEta.empty()) break;
+      if (_lastStart) return 0;
+      continue;
+    }
     } catch (const std::bad_alloc &) {
       // System out of memory mid-solve -- see the branch-level comment above.
       // Every other exit from this branch marks a failed attempt via
@@ -4597,13 +4605,21 @@ static inline int innerOpt1(int id, int likId) {
       // this subject) -- match that here even though the caller's own
       // innerOpt1() return value already signals the failure on its own.
       fInd->badSolve = 1;
-      if (!haveBest) return 0;
+      if (!haveBest) {
+        if (!candEta.empty()) break;
+        if (_lastStart) return 0;
+        continue;
+      }
     } catch (...) {
       // Defense in depth, matching trust_solve_c()'s own catch(...) fallback:
       // any other C++ exception escaping this branch is equally fatal if it
       // crosses the OpenMP boundary uncaught.
       fInd->badSolve = 1;
-      if (!haveBest) return 0;
+      if (!haveBest) {
+        if (!candEta.empty()) break;
+        if (_lastStart) return 0;
+        continue;
+      }
     }
   } else {
     int fail=0, fncount=0, grcount=0;

--- a/tests/testthat/test-focei-trust-inner.R
+++ b/tests/testthat/test-focei-trust-inner.R
@@ -280,6 +280,113 @@ nmTest({
     expect_equal(.ok$env$nInnerRerank[["noGood"]], 0L)
   })
 
+  # A model with curvature the inner problem can get lost in -- two etas with a
+  # FIXED unit omega entering through an inverse CDF, alongside an estimated
+  # block (the #1040 model).  Displacing every theta by `d` walks the inner
+  # solves from "all converge" into "most trip the Newton-decrement gate", which
+  # is the regime #1044 is about and the only one the retry counts fire in.
+  .gateBase <- function() {
+    ini({
+      tcl <- log(4)
+      tv1 <- log(30)
+      tq <- log(4)
+      tv2 <- log(40)
+      rxz.eta.cl ~ fix(1)
+      rxz.eta.v1 ~ fix(1)
+      eta.q + eta.v2 ~ c(0.0305,
+                         0.0107, 0.0285)
+      prop.sd <- 0.1
+    })
+    model({
+      cl <- exp(tcl + 0.3 * logit(pnorm(rxz.eta.cl)))
+      v1 <- exp(tv1 + 0.3 * logit(pnorm(rxz.eta.v1)))
+      q <- exp(tq + eta.q)
+      v2 <- exp(tv2 + eta.v2)
+      linCmt() ~ prop(prop.sd)
+    })
+  }
+
+  .gateMod <- function(d) {
+    suppressWarnings(suppressMessages(
+      rxode2::ini(.gateBase, tcl = log(4) + d, tv1 = log(30) - d,
+                  tq = log(4) + 1.5 * d, tv2 = log(40) + d)))
+  }
+
+  .gateData <- function() {
+    withr::with_seed(42, {
+      .ev <- rxode2::et(amt = 200, ii = 24, addl = 2)
+      .ev <- rxode2::et(.ev, seq(0.5, 96, length.out = 12))
+      .ev <- rxode2::et(.ev, id = 1:60)
+      .d <- suppressWarnings(suppressMessages(
+        as.data.frame(rxode2::rxSolve(.gateBase, .ev, addDosing = TRUE))))
+    })
+    .dat <- data.frame(ID = .d$id, TIME = .d$time, DV = .d$sim, EVID = .d$evid,
+                       AMT = ifelse(is.na(.d$amt), 0, .d$amt))
+    .dat$DV[.dat$EVID != 0] <- NA
+    .dat
+  }
+
+  test_that("the trust retry cascade's stages are each reachable (#1044)", {
+    skip_on_cran()
+    .dat <- .gateData()
+    .gateFit <- function(d) {
+      suppressWarnings(suppressMessages(
+        nlmixr2(.gateMod(d), .dat, "focei",
+                foceiControl(print = 0L, covMethod = "", maxOuterIterations = 0L,
+                             maxInnerIterations = 5000L, calcTables = FALSE,
+                             innerOpt = "trust"))))
+    }
+
+    # Each retry stage needs its own count > 0 or it could be dead code and
+    # every other assertion here would still pass.  Only ">0" is asserted: the
+    # exact numbers move with rxode2's solver.
+    .g3 <- .gateFit(3)
+    .c3 <- .g3$env$nTrustInner
+    # trust_solve_c() reports convergence and the Newton decrement says
+    # otherwise -- this is what drives the retries, not solverFail.
+    expect_gt(.c3[["newtonGate"]], 0L)
+    # The in-place re-solve, taken when the Newton step still fits the radius.
+    expect_gt(.c3[["warmRetry"]], 0L)
+    expect_gt(.c3[["nudge"]], 0L)
+    # ... and subjects where none of it worked, which is the count that says a
+    # fit is in trouble.
+    expect_gt(.c3[["failed"]], 0L)
+    expect_true(is.finite(.g3$objf))
+
+    # Displaced further, the Newton step outgrows the radius often enough to
+    # exercise the escalation branch instead.
+    .c4 <- .gateFit(4)$env$nTrustInner
+    expect_gt(.c4[["radiusRetry"]], 0L)
+  })
+
+  test_that("mceta's mixed candidate set drops the failed attempts (#1044)", {
+    skip_on_cran()
+    # The re-rank only has something to choose between when the restarts
+    # produce several candidates, and mceta >= 1 is what makes that ordinary.
+    # maxInnerIterations=2 makes some of those attempts genuinely fail, so the
+    # candidate set is mixed -- which is the case the rule exists for.
+    .mc <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmt, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(innerOpt = "trust", maxOuterIterations = 5,
+                                     maxInnerIterations = 2, mceta = 5L,
+                                     covMethod = "", calcTables = FALSE,
+                                     print = 0))))
+    expect_gt(.mc$env$nTrustInner[["solverFail"]], 0L)
+    expect_gt(.mc$env$nInnerRerank[["dropped"]], 0L)
+    expect_gt(.mc$env$nInnerRerank[["ranked"]], 0L)
+    expect_true(is.finite(.mc$objf))
+
+    # The same fit with converging inner solves drops nothing, so mceta does not
+    # pay for the rule when there is nothing to drop.
+    .ok <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmt, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(innerOpt = "trust", maxOuterIterations = 5,
+                                     mceta = 5L, covMethod = "",
+                                     calcTables = FALSE, print = 0))))
+    expect_gt(.ok$env$nInnerRerank[["ranked"]], 0L)
+    expect_equal(.ok$env$nInnerRerank[["dropped"]], 0L)
+  })
+
   test_that("innerOpt='trust' is thread-safe (cores>=2 matches serial)", {
     skip_on_cran()
     .old <- rxode2::getRxThreads()

--- a/tests/testthat/test-focei-trust-inner.R
+++ b/tests/testthat/test-focei-trust-inner.R
@@ -210,6 +210,73 @@ nmTest({
     expect_true(.n2 > 0L)
   })
 
+  test_that("a fit reports whether its trust inner solves converged (#1044)", {
+    skip_on_cran()
+    # op_focei.nTrustInner counted trust_solve_c() CALLS, so a fit whose inner
+    # solves all failed was indistinguishable, from the fit object, from one
+    # where they all converged -- which is what made #1040's set B impossible to
+    # diagnose.  The outcome breakdown is what answers that.
+    .ok <- .fitTrustCmp("trust")
+    .cnt <- .ok$env$nTrustInner
+    expect_true(is.integer(.cnt))
+    expect_equal(sort(names(.cnt)),
+                 sort(c("calls", "error", "notConverged", "solverFail",
+                        "newtonGate", "warmRetry", "radiusRetry", "nudge",
+                        "failed")))
+    expect_gt(.cnt[["calls"]], 0L)
+    # This fit converges cleanly, so nothing below "calls" fires.  That is the
+    # half of the diagnostic that has to stay quiet or it says nothing.
+    expect_equal(.cnt[["failed"]], 0L)
+    expect_equal(.cnt[["notConverged"]], 0L)
+    expect_equal(.cnt[["nudge"]], 0L)
+
+    # n1qn1 has no trust solves at all, so the entry is absent rather than zero.
+    expect_null(.fitTrustCmp("n1qn1")$env$nTrustInner)
+
+    # maxInnerIterations=2 makes trust_solve_c() hit iterlim, so it reports the
+    # non-convergence itself (solverFail) rather than the Newton-decrement gate
+    # withdrawing it, and some subjects exhaust the whole cascade.
+    .bad <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmt, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(innerOpt = "trust", maxOuterIterations = 5,
+                                     maxInnerIterations = 2, covMethod = "",
+                                     calcTables = FALSE, print = 0))))
+    .bc <- .bad$env$nTrustInner
+    expect_gt(.bc[["solverFail"]], 0L)
+    expect_equal(.bc[["notConverged"]], .bc[["solverFail"]] + .bc[["newtonGate"]])
+    expect_gt(.bc[["failed"]], 0L)
+    expect_true(is.finite(.bad$objf))
+  })
+
+  test_that("a failed inner attempt cannot win the marginal re-rank (#1044)", {
+    skip_on_cran()
+    # The restart candidates the marginal re-rank chooses from carried no record
+    # of whether the attempt that produced them succeeded, so a failed attempt's
+    # eta could be selected over a converged one -- its Laplace log|H| is
+    # measured at a point the inner objective never descended to.  "dropped" is
+    # the count that shows the rule fires; equivalence of objectives cannot
+    # distinguish "dropped a bad candidate" from "never had one".
+    .bad <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmt, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(innerOpt = "trust", maxOuterIterations = 5,
+                                     maxInnerIterations = 2, covMethod = "",
+                                     calcTables = FALSE, print = 0))))
+    .rr <- .bad$env$nInnerRerank
+    expect_equal(sort(names(.rr)),
+                 sort(c("ranked", "flipped", "noGood", "dropped")))
+    expect_gt(.rr[["dropped"]], 0L)
+    # Solves where EVERY candidate failed still have to report something, so the
+    # rule falls back to them rather than returning nothing.
+    expect_gt(.rr[["noGood"]], 0L)
+    expect_true(is.finite(.bad$objf))
+
+    # A fit whose inner solves all converge drops nothing, so the rule costs the
+    # ordinary path neither a candidate nor an extra evaluation.
+    .ok <- .fitTrustCmp("trust")
+    expect_equal(.ok$env$nInnerRerank[["dropped"]], 0L)
+    expect_equal(.ok$env$nInnerRerank[["noGood"]], 0L)
+  })
+
   test_that("innerOpt='trust' is thread-safe (cores>=2 matches serial)", {
     skip_on_cran()
     .old <- rxode2::getRxThreads()

--- a/tests/testthat/test-focei-trust-inner.R
+++ b/tests/testthat/test-focei-trust-inner.R
@@ -243,7 +243,10 @@ nmTest({
                                      calcTables = FALSE, print = 0))))
     .bc <- .bad$env$nTrustInner
     expect_gt(.bc[["solverFail"]], 0L)
-    expect_equal(.bc[["notConverged"]], .bc[["solverFail"]] + .bc[["newtonGate"]])
+    # An attempt ends non-converged in exactly one of three ways, so the
+    # breakdown has to add up or it is not a breakdown.
+    expect_equal(.bc[["notConverged"]],
+                 .bc[["error"]] + .bc[["solverFail"]] + .bc[["newtonGate"]])
     expect_gt(.bc[["failed"]], 0L)
     expect_true(is.finite(.bad$objf))
   })

--- a/tests/testthat/test-focei-trust-inner.R
+++ b/tests/testthat/test-focei-trust-inner.R
@@ -359,6 +359,45 @@ nmTest({
     expect_gt(.c4[["radiusRetry"]], 0L)
   })
 
+  test_that("a hard trust solve error is counted and recovered from (#1044)", {
+    skip_on_cran()
+    # A volume that goes NEGATIVE for part of the eta range makes linCmt()
+    # undefined there, so a nudged starting point can be infeasible and
+    # trust_solve_c() returns an error rather than a result.  That is the one
+    # attempt outcome the retry-stage fit above never produces, and it is also
+    # the path that forces f to +Inf so the shared restore fires.
+    .negV <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 4
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v) - 30
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .fe <- suppressWarnings(suppressMessages(
+      nlmixr2(.negV, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(innerOpt = "trust", maxOuterIterations = 0L,
+                                     covMethod = "", calcTables = FALSE,
+                                     print = 0))))
+    .ce <- .fe$env$nTrustInner
+    expect_gt(.ce[["error"]], 0L)
+    expect_equal(.ce[["notConverged"]],
+                 .ce[["error"]] + .ce[["solverFail"]] + .ce[["newtonGate"]])
+    # The failed attempt is recovered from rather than reported: no subject ends
+    # the cascade unconverged, and the objective is a number.
+    expect_equal(.ce[["failed"]], 0L)
+    expect_true(is.finite(.fe$objf))
+  })
+
   test_that("mceta's mixed candidate set drops the failed attempts (#1044)", {
     skip_on_cran()
     # The re-rank only has something to choose between when the restarts


### PR DESCRIPTION
Closes #1044.

#1044 asked for one thing first: a per-fit diagnostic that says whether the
`innerOpt="trust"` inner solves converged, because `op_focei.nTrustInner`
counted `trust_solve_c()` **calls** and a fit whose inner solves were all
failing looked identical, from the fit object, to one where they all
converged. That diagnostic is here, and building it turned up four real
defects in the candidate handling and the retry cascade.

## What the diagnostic says

`fit$env$nTrustInner` now breaks the attempts down by outcome, and
`fit$env$nInnerRerank` gains two entries:

```
nTrustInner: calls, error, notConverged, solverFail, newtonGate,
             warmRetry, radiusRetry, nudge, failed
nInnerRerank: ranked, flipped, noGood, dropped
```

`notConverged == error + solverFail + newtonGate` by construction (pinned by
a test). On the #1040 model at 300 subjects, `maxOuterIterations = 0`, walking
the parameter set away from the truth (`d` = how far each theta is displaced):

| case | failed / 300 | notConverged | solverFail | newtonGate |
|---|---|---|---|---|
| d=1 | 1 | 24 | 0 | 24 |
| d=2 | 12 | 298 | 0 | 298 |
| d=3 | 55 | 482 | 0 | 482 |
| d=4 | 195 | 1450 | 0 | 1450 |

That is the answer to the issue's question, and it is not the one the issue
guessed at: `trust_solve_c()` never reports failure on this model
(`solverFail = 0` in every run measured). Every retry is driven by our own
Newton-decrement gate, and at a poor parameter set two thirds of the subjects
can end with the whole cascade spent.

## Bad candidates are no longer selectable

The restart candidates the marginal re-rank chooses from carried no record of
whether the attempt that produced them succeeded, so a failed attempt's eta
could win -- its Laplace `log|H|` is measured at a point the inner objective
never descended to. `mceta >= 1` is where a mixed candidate set is common,
since the extra starting points are what produce one. `keepCand()` now takes
that verdict; the selection uses a failed attempt only when nothing else
survived, and `nInnerRerank[["dropped"]]` counts when it fires.

**"Failed" is the optimizer's own verdict, not the Newton gate.** A first cut
used the gate and it was measurably wrong -- the gate is deliberately eager
because its job is to trigger retries. Measured against n1qn1 on the same fit:

| mceta | n1qn1 | trust, gate = failure | trust, optimizer's own verdict |
|---|---|---|---|
| 0 | 34004.40 | 41821.79 | 35097.24 |
| 10 | 33548.35 | 38192.62 | 34248.75 |
| 100 | 33525.64 | 37498.38 | 33799.14 |

## Fewer solves fail, and fewer solves run

When the gate withdraws convergence and the Newton step still **fits** inside
the radius, `trust_solve_c()` stopped on its own step-size criterion, measured
against the previous iterate rather than the model's remaining decrease. The
cascade went straight to the eta nudges, which throw that point away and
restart from a fill. It now re-solves once in place first:

| case | failed | calls | objective |
|---|---|---|---|
| d=1 mceta=0 | 1 -> 1 | 318 -> 323 | 3032.9855 -> 3032.9864 |
| d=2 mceta=0 | 13 -> 12 | 527 -> 586 | 35097.2404 -> 35097.2144 |
| d=3 mceta=0 | 96 -> 55 | 814 -> 727 | 434969.7132 -> 434742.5472 |
| d=3 mceta=10 | 185 -> 92 | 1580 -> 1353 | 229954.0707 -> 229954.0559 |
| d=4 mceta=10 | 351 -> 278 | 2566 -> 2398 | 2010047.2519 -> 2010041.0607 |

Converting a gate withdrawal early is cheaper than the four nudges it
replaces, so the total number of solves falls with the failures. A parameter
set where nothing trips the gate is unchanged (300/300/550/596 calls before
and after).

## Other defects fixed along the way

- **A failed pass discarded an earlier pass's candidate.** `haveBest` is
  reset at the top of every `mceta` starting-point pass, but both the trust
  arm and the n1qn1 restart cascade read it as "this subject produced
  nothing" and returned a failed inner solve. Reachable with `mceta >= 1`
  whenever a later pass fails outright. Both now take the same three-way exit
  the first call in a pass already did.
- **A NaN trust result was treated as a success.** Only `trust_solve_c()`'s
  error code forced `f` to `+Inf`; a call that returned normally with a
  NaN/Inf objective kept the solver's converged flag, so an unusable attempt
  ended the retry cascade.
- **Exception safety.** The result arrays were freed only on the lambda's
  normal exit while the Armadillo work between can throw `bad_alloc` (which
  the branch catch swallows); an RAII guard armed before the solve takes it.
  `keepCand()` does every allocation before any push, so the three candidate
  vectors cannot end up ragged and be indexed against each other.

## Review

Seven rounds of `agy` (Gemini) review; the last is clean. Its findings drove
the pass-local, NaN, exception-safety and per-stage-coverage commits above.
One finding was rejected on inspection (it read `haveBest` as global; it is
reset per pass at `src/inner.cpp:4130`). One is acknowledged and **not**
fixed here: a `std::bad_alloc` out of the n1qn1/lbfgsb3C arms or the re-rank
snapshot escapes the OpenMP region, since only the trust arm carries a catch.
That is pre-existing and a correct fix changes the whole function's error
contract, so it does not belong in this PR.

## Tests

`tests/testthat/test-focei-trust-inner.R` gains coverage for the counter
breakdown, the candidate rule (`dropped`/`noGood`), each retry stage
(`newtonGate`, `warmRetry`, `radiusRetry`, `nudge`, `failed`) on a fit that
reaches it, the hard-error outcome, and the `mceta >= 1` mixed candidate set.
Every count is asserted `> 0` rather than pinned to a value, since the exact
numbers move with rxode2's solver.
