### PR TITLE
fix(focei): refresh the parameter table after the FD-full covariance swap

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # nlmixr2est 7.0.3
 
+## Bug fixes
+
+- A focei fit reports standard errors that match its own covariance again.
+  `.foceiInstallFdFullCov()` replaces `$cov` with the full theta+omega matrix
+  after the C++ step has already derived `popDf$SE` from the native theta-only
+  covariance it discards, so `parFixedDf$SE` described a matrix the fit no
+  longer held and a `setCov()` round trip silently changed the reported SEs.
+  The parameter table is now refreshed from the covariance actually installed
+  (nlmixr2extra#125).
+
 ## New features
 
 - `impmapControl(proposal=)` selects the importance-sampling proposal family for

--- a/R/focei.R
+++ b/R/focei.R
@@ -4366,8 +4366,16 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       assign("control", .control, envir = .ret)
     }
     .foceiInstallAnalyticCov(.ret)
-    .foceiInstallFdFullCov(.ret)
+    # Installing the FD-full covariance replaces $cov with a matrix spanning
+    # theta AND omega, but the C++ step has already derived popDf$SE from the
+    # native theta-only covariance it discards.  Left alone the fit reports SEs
+    # that are not sqrt(diag(fit$cov)), and a setCov() round trip then silently
+    # changes them (nlmixr2extra#125).
+    .fdFullInstalled <- .foceiInstallFdFullCov(.ret)
     .updateParFixed(.ret)
+    if (isTRUE(.fdFullInstalled)) {
+      .updateParFixedRefreshSeFromCov(.ret, .ret$cov)
+    }
     if (!exists("table", .ret)) {
       .ret$table <- tableControl()
     }

--- a/R/foceiCovFdFull.R
+++ b/R/foceiCovFdFull.R
@@ -42,7 +42,7 @@
 #' @param .ret focei fit environment
 #' @noRd
 .foceiInstallFdFullCov <- function(.ret) {
-  if (!exists(".fdFullCov", envir = .ret, inherits = FALSE)) return(invisible())
+  if (!exists(".fdFullCov", envir = .ret, inherits = FALSE)) return(invisible(FALSE))
   # The fit env's covMethod records what the NATIVE theta-only step produced, not what was
   # asked for -- C++ downgrades it to "s" when that step's "r" fails.  The full R/S pieces
   # used below are computed independently of that step, so route on the REQUESTED control;
@@ -64,20 +64,20 @@
   .type <- if (grepl("^(r\\+?|\\|r\\|),(s\\+?|\\|s\\|)$", .cm)) "r,s"
     else if (grepl("^(r\\+?|\\|r\\|)$", .cm)) "r"
     else if (grepl("^(s\\+?|\\|s\\|)$", .cm)) "s"
-    else return(invisible())   # analytic / failed / "" / boundary -> keep the native cov
+    else return(invisible(FALSE))   # analytic / failed / "" / boundary -> keep the native cov
   .Rinv <- get(".fdFullCov", envir = .ret)
-  if (!is.matrix(.Rinv) || !all(is.finite(.Rinv))) return(invisible())
+  if (!is.matrix(.Rinv) || !all(is.finite(.Rinv))) return(invisible(FALSE))
   .S <- if (exists(".fdFullS", envir = .ret, inherits = FALSE)) get(".fdFullS", envir = .ret) else NULL
-  if (.type != "r" && (!is.matrix(.S) || !all(is.finite(.S)))) return(invisible())
+  if (.type != "r" && (!is.matrix(.S) || !all(is.finite(.S)))) return(invisible(FALSE))
   .covS <- if (is.null(.S)) NULL else tryCatch(solve(.S), error = function(e) NULL)
-  if (.type != "r" && is.null(.covS)) return(invisible())
+  if (.type != "r" && is.null(.covS)) return(invisible(FALSE))
   .covRS <- if (is.null(.S)) NULL else .Rinv %*% .S %*% .Rinv
   .cov <- switch(.type, "r" = .Rinv, "s" = .covS, "r,s" = .covRS)
-  if (is.null(.cov) || !is.matrix(.cov) || !all(is.finite(.cov))) return(invisible())
+  if (is.null(.cov) || !is.matrix(.cov) || !all(is.finite(.cov))) return(invisible(FALSE))
   dimnames(.cov) <- dimnames(.Rinv)
   # PD guard: reject an indefinite cov (negative variances -> NaN SEs), keep the native cov.
   .ev <- suppressWarnings(eigen(.cov, symmetric = TRUE, only.values = TRUE)$values)
-  if (any(diag(.cov) <= 0) || !all(is.finite(.ev)) || min(.ev) <= 0) return(invisible())
+  if (any(diag(.cov) <= 0) || !all(is.finite(.ev)) || min(.ev) <= 0) return(invisible(FALSE))
   .ret$cov <- .cov
   # Keep the reported covMethod consistent with what was installed: routing on the
   # requested control can install a sandwich where the env still says "s".  Only rewrite
@@ -96,5 +96,8 @@
     .ret$covRS <- .covRS
   }
   .foceiCovCondition(.ret, .cov, .ev)
-  invisible()
+  # Report the swap: the SEs the C++ step derived from the native theta-only
+  # covariance describe a matrix that is no longer $cov, so the caller must
+  # refresh the parameter table.
+  invisible(TRUE)
 }

--- a/tests/testthat/test-cov-focei.R
+++ b/tests/testthat/test-cov-focei.R
@@ -62,9 +62,16 @@ nmTest({
         linCmt() ~ add(add.sd)
       })
     }
-    fit_r  <- .nlmixr(one.cmt, theo_sd, "focei", foceiControl(covMethod = "r",   print = 0))
-    fit_s  <- .nlmixr(one.cmt, theo_sd, "focei", foceiControl(covMethod = "s",   print = 0))
-    fit_rs <- .nlmixr(one.cmt, theo_sd, "focei", foceiControl(covMethod = "r,s", print = 0))
+    # covFull = FALSE pins this to the NATIVE theta-only covariance, which is the
+    # thing the ratios below are about.  With the FD-full covariance installed the
+    # theta SEs come from inverting the JOINT theta+omega matrix instead, a
+    # different quantity (it carries the omega estimation uncertainty), and
+    # se_s/se_rs runs ~5 -- into the range this test reads as the old constant
+    # factor returning.  Keep the guard on the estimator it was written for; the
+    # SE/cov invariant under covFull is asserted separately below.
+    fit_r  <- .nlmixr(one.cmt, theo_sd, "focei", foceiControl(covMethod = "r",   print = 0, covFull = FALSE))
+    fit_s  <- .nlmixr(one.cmt, theo_sd, "focei", foceiControl(covMethod = "s",   print = 0, covFull = FALSE))
+    fit_rs <- .nlmixr(one.cmt, theo_sd, "focei", foceiControl(covMethod = "r,s", print = 0, covFull = FALSE))
 
     p <- c("tka", "tcl", "tv")
     se_r  <- fit_r$parFixedDf[p,  "SE"]
@@ -89,6 +96,33 @@ nmTest({
     # ~1 this test says to expect.  3.5 still leaves clear room under the ~4.5 a
     # return of the constant factor would produce, which is what this guards.
     expect_true(all(se_s  / se_rs < 3.5), label = "covMethod='s' SE not inflated by the old 2x constant factor")
+  })
+
+  test_that("reported SE matches sqrt(diag(fit$cov)) (nlmixr2extra#125)", {
+    # .foceiInstallFdFullCov() replaces $cov after the C++ step has already
+    # derived popDf$SE from the covariance it discards.  Without a refresh the
+    # fit reports SEs describing a matrix it no longer holds, and a setCov()
+    # round trip silently changes them.
+    one.cmt <- function() {
+      ini({
+        tka <- log(1.5); tcl <- log(2.7); tv <- log(31.5)
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    for (.full in c(TRUE, FALSE)) {
+      .fit <- .nlmixr(one.cmt, theo_sd, "focei",
+                      foceiControl(print = 0, covFull = .full))
+      .p <- intersect(rownames(.fit$parFixedDf), rownames(.fit$cov))
+      expect_true(length(.p) > 0)
+      expect_equal(unname(.fit$parFixedDf[.p, "SE"]),
+                   unname(sqrt(diag(.fit$cov))[.p]),
+                   label = paste0("covFull=", .full, " SE == sqrt(diag(cov))"))
+    }
   })
 
   test_that("covariance with many omegas fixed will not crash focei", {


### PR DESCRIPTION
Fixes nlmixr2/nlmixr2extra#125.

## The bug

`.foceiInstallFdFullCov()` replaces `$cov` with the FD-full matrix, which spans
theta **and** omega. By that point the C++ step has already built `popDf$SE`
from `sqrt(cov.diag())` of the **native theta-only** covariance -- the one being
discarded -- and nothing refreshes it. The fit then reports standard errors
describing a matrix it no longer holds:

```
covFull=TRUE    dim(cov) 7x7   SE               0.2319  0.1690  0.0405  0.0730
                               sqrt(diag(cov))  0.1927  0.0269  0.0468  0.0911   <- mismatch
covFull=FALSE   dim(cov) 4x4   both             0.2319  0.1690  0.0405  0.0730   <- match
```

Because `setCov()` rebuilds the parameter table from `$cov`, a round trip
through it silently changed the reported SEs even though the covariance matrix
itself came back identical. That is how it surfaced downstream.

## The fix

`.foceiInstallFdFullCov()` now reports whether it actually swapped, and focei
refreshes the table with the existing `.updateParFixedRefreshSeFromCov()` -- the
helper written for precisely this case (its doc: "leaving the displayed table
stale"), already used on the `covRecompute` and `saem` paths.

## This changes reported SEs -- please sanity-check the call

For `covFull = TRUE` fits the theta SEs now come from inverting the **joint**
theta+omega matrix, which carries the omega estimation uncertainty, rather than
from the theta-only inverse. They are generally larger. That is the visible
consequence of making the table agree with `$cov`, and it is the part worth a
second opinion: the alternative reading is that the FD-full matrix should not be
installed as `$cov` at all, and should be exposed separately instead. I went
with "the table follows `$cov`" because that restores the invariant users and
downstream code assume.

## About `test-cov-focei.R`

That test's `se_s / se_rs < 3.5` leg guards against the old #666 constant factor
(`covS = 4*Sinv`) in the **native** estimator. With the joint inverse the ratio
runs ~5.2-5.7, which would read as that bug returning even though the mechanism
is different. Rather than loosen the bound -- which would blunt the guard -- the
test is pinned to `covFull = FALSE` so it keeps testing the estimator it was
written for, at its existing threshold, with a comment explaining why.

A new test then covers what the fix actually restores:

```r
expect_equal(unname(fit$parFixedDf[p, "SE"]),
             unname(sqrt(diag(fit$cov))[p]))
```

for both `covFull = TRUE` and `FALSE`.

## Testing

`test-cov-focei`, `test-cov-fdfull-install`, `test-cov-condition` and
`test-fix-cov` pass. The four `test-cov-analytic.R` failures on this branch
(`:93`, `:94`, `:343`, `:1239`) are present on unmodified `main` -- I verified by
installing main and running the same filter -- and are untouched by this change.