### PR TITLE
feat(mix): mixture-proportion standard errors, an exact mixture gradient, and est="vae" support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -144,7 +144,9 @@
   initial values; from three components up the magnitude was wrong too.  The
   full Jacobian collapses to `-2 * sum_i (r_il - pi_l)`, which is what it now
   uses -- checked against a central difference of the objective to eight
-  significant digits at three components.  Fits left on the default
+  significant digits at three components, and equal to a literal evaluation of
+  the NONMEM 7 Technical Guide's own equations (1.194) and (1.197) for the
+  mixture-proportion gradient.  Fits left on the default
   derivative-free `outerOpt="bobyqa"` never reached this code and are
   unchanged, as are the reported standard errors (a mixture proportion is
   `skipCov`).

--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,15 @@
   two defects above stopped every such fit during assembly, so only the
   training loop had ever run with a mixture.
 
+- `est="vae"` estimates the mixture proportions.  They were read once from
+  `ini()` and never updated, so the reported proportion was whatever the model
+  started at.  They are now estimated on the mlogit scale through their own
+  analytic gradient -- the same chain `focei` uses (`mixGrad`): each subject's
+  responsibility difference against the last, non-free component, times the
+  `mexpit` Jacobian -- consumed by the same Adam loop that trains the encoder.
+  The gradient agrees with finite differences to 1e-4.  On simulated data with
+  a 3:1 split started from 0.5, the fitted proportion comes back at 0.74.
+
 - `est="vae"` no longer treats a mixture proportion as an ordinary structural
   theta.  `p1` appears inside `mix(a, p1, b)`, so it passed the "does this
   theta appear in a model expression" filter and became a `nonMuTheta`

--- a/NEWS.md
+++ b/NEWS.md
@@ -151,6 +151,12 @@
   across rather than dropped.  Same principle as `covFull` reporting Omega on the
   natural variance scale instead of `chol(solve(omega))`.
 
+  That rotation carries a factor of `p(1-p)`, so a proportion sitting near 0 or
+  1 gets an SE that shrinks toward zero.  It is the right delta-method answer
+  but it reads as certainty, when in fact the symmetric Wald interval has
+  stopped being meaningful there, so the fit's `$runInfo` now says when a
+  proportion is at a boundary.
+
 - The S matrix is no longer singular for mixture models, so `covMethod="r,s"`
   stops silently degrading to `"r"`.  `foceiS()` built each subject's score by
   finite-differencing component 0's likelihood instead of the marginal

--- a/NEWS.md
+++ b/NEWS.md
@@ -181,11 +181,12 @@
   structural parameters and its SEs are mildly optimistic.
 
   The block is only reported when the fit is actually at the mixture's fixed
-  point, `p_l == mean_i r_il`.  An information matrix describes the precision of
-  a maximum-likelihood estimate, and away from that point it is a
+  point, judged by the score statistic `s' I^-1 s` (which is on a chi-square
+  scale, so unlike a tolerance on `mean(r) - p` it does not loosen as the number
+  of subjects grows).  An information matrix describes the precision of a
+  maximum-likelihood estimate, and away from that point it is a
   confident-looking number attached to something that is not one; instead the
-  fit's `$runInfo` says the SE was not computed and by how much the identity
-  fails.  `est="saem"` currently lands far from it (nlmixr2/nlmixr2est#1058), so
+  fit's `$runInfo` says the SE was skipped.  `est="saem"` currently lands far from it (nlmixr2/nlmixr2est#1058), so
   in practice this declines today and will start reporting once that is fixed.
 
 - `est="focei"` estimates the mixture proportions under a gradient-based

--- a/NEWS.md
+++ b/NEWS.md
@@ -165,6 +165,12 @@
   across rather than dropped.  Same principle as `covFull` reporting Omega on the
   natural variance scale instead of `chol(solve(omega))`.
 
+  The confidence interval is taken on the logit scale,
+  `expit(logit(p) +/- z*SE/(p(1-p)))`, from the SE actually reported.  The
+  generic symmetric `est +/- z*SE` interval walks out of `(0, 1)` for a
+  proportion (a fit reported `p1 = 0.648 (-0.045, 1.34)`) and was built from the
+  covariance before the rotation, so it did not agree with the SE beside it.
+
   That rotation carries a factor of `p(1-p)`, so a proportion sitting near 0 or
   1 gets an SE that shrinks toward zero.  It is the right delta-method answer
   but it reads as certainty, when in fact the symmetric Wald interval has

--- a/NEWS.md
+++ b/NEWS.md
@@ -171,6 +171,23 @@
   The augmented sensitivity model differentiates one component's conditional
   likelihood and has no mixture-proportion block at all.
 
+- `est="saem"` mixture fits can report a mixture-proportion SE as well.  `saem`
+  leaves the proportions out of the parameter vector its kernel converges (they
+  are updated by a separate EM step), so its `linFim`/`fim`/`sa` covariance has
+  no mixture rows to extend; the (7.51) block is appended from the fit's own
+  posterior responsibilities.  The cross terms (7.52)-(7.54) are NOT formed --
+  they need per-subject scores for the other parameters on the same footing,
+  which that covariance does not expose -- so the block is uncorrelated with the
+  structural parameters and its SEs are mildly optimistic.
+
+  The block is only reported when the fit is actually at the mixture's fixed
+  point, `p_l == mean_i r_il`.  An information matrix describes the precision of
+  a maximum-likelihood estimate, and away from that point it is a
+  confident-looking number attached to something that is not one; instead the
+  fit's `$runInfo` says the SE was not computed and by how much the identity
+  fails.  `est="saem"` currently lands far from it (nlmixr2/nlmixr2est#1058), so
+  in practice this declines today and will start reporting once that is fixed.
+
 - `est="focei"` estimates the mixture proportions under a gradient-based
   `outerOpt`.  `mixGrad()` supplies an analytic value that short-circuits the
   finite difference in `numericGrad()`, and it chained the per-subject

--- a/NEWS.md
+++ b/NEWS.md
@@ -132,6 +132,22 @@
 
 ## Bug fixes
 
+### Mixture models
+
+- `fit$etaMat` no longer carries the `mixnum` column that `$eta` gains for a
+  mixture fit.  Every consumer that hands it back as `foceiControl(etaMat=)`
+  compared `neta + 1` columns against the model's `neta` and stopped with "The
+  etaMat must have the same number of ETAs (cols) as the model" -- so `$cov`,
+  `addCwres()`, the FO objective and re-fitting a fit were all failing for
+  every mixture fit, in most cases inside a `try()` that swallowed it.
+
+- A mixture fit's `$ui` now carries the mixture probability on the probability
+  scale rather than the mlogit scale it is estimated on.  `fullTheta` is left
+  on the estimation scale and only `$theta` was back-transformed, so `$ui`
+  reported `p1 = -0.847` where `fixef()` reported `0.3`, and re-fitting the fit
+  failed its own `ini()` validation ("the probabilities in a mixture must sum
+  to a number between 0 and 1").
+
 - A `focei`-family fit now reports whether its inner solves actually
   converged.  `fit$env$nTrustInner` breaks the `innerOpt="trust"` per-subject
   Newton solves down by outcome (`calls`, `error`, `notConverged`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -134,6 +134,21 @@
 
 ### Mixture models
 
+- `est="focei"` estimates the mixture proportions under a gradient-based
+  `outerOpt`.  `mixGrad()` supplies an analytic value that short-circuits the
+  finite difference in `numericGrad()`, and it chained the per-subject
+  responsibility sum through the *diagonal* of the `mexpit` Jacobian
+  (`dmexpit()` returns only the diagonal) while dropping the `-2` of the
+  objective scale.  That flipped the sign at every number of components, so the
+  line search rejected the first step and the proportions never moved off their
+  initial values; from three components up the magnitude was wrong too.  The
+  full Jacobian collapses to `-2 * sum_i (r_il - pi_l)`, which is what it now
+  uses -- checked against a central difference of the objective to eight
+  significant digits at three components.  Fits left on the default
+  derivative-free `outerOpt="bobyqa"` never reached this code and are
+  unchanged, as are the reported standard errors (a mixture proportion is
+  `skipCov`).
+
 - `fit$etaMat` no longer carries the `mixnum` column that `$eta` gains for a
   mixture fit.  Every consumer that hands it back as `foceiControl(etaMat=)`
   compared `neta + 1` columns against the model's `neta` and stopped with "The
@@ -155,9 +170,9 @@
 - `est="vae"` estimates the mixture proportions.  They were read once from
   `ini()` and never updated, so the reported proportion was whatever the model
   started at.  They are now estimated on the mlogit scale through their own
-  analytic gradient -- the same chain `focei` uses (`mixGrad`): each subject's
-  responsibility difference against the last, non-free component, reduced
-  against the full `mexpit` Jacobian -- consumed by the same Adam loop that trains the encoder.
+  analytic gradient -- the same closed form `focei`'s corrected `mixGrad()`
+  uses, each component's summed responsibility against its expected count --
+  consumed by the same Adam loop that trains the encoder.
   The gradient agrees with finite differences to 1e-4 at two components and at
   three.  On simulated data with
   a 3:1 split started from 0.5, the fitted proportion comes back at 0.74.

--- a/NEWS.md
+++ b/NEWS.md
@@ -148,6 +148,22 @@
   failed its own `ini()` validation ("the probabilities in a mixture must sum
   to a number between 0 and 1").
 
+- `est="vae"` can fit a mixture (`mix()`) model.  It could not before: the
+  two defects above stopped every such fit during assembly, so only the
+  training loop had ever run with a mixture.
+
+- `est="vae"` no longer treats a mixture proportion as an ordinary structural
+  theta.  `p1` appears inside `mix(a, p1, b)`, so it passed the "does this
+  theta appear in a model expression" filter and became a `nonMuTheta`
+  regression parameter, moved by `bobyqa` against the `(-Inf, Inf)` bounds it
+  carries in `iniDf` -- writing values like `p1 <- 10.6` back into `ini()`.
+  `est="npag"` already excluded them for the same reason.
+
+- `est="vae"` reads the mixture proportion on the scale the inner problem
+  reads it on.  The prepared theta vector held the raw `ini()` probability
+  while the inner problem passes that slot through `mexpit()`, so `p1 = 0.3`
+  was used as `mexpit(0.3) = 0.574`.
+
 - A `focei`-family fit now reports whether its inner solves actually
   converged.  `fit$env$nTrustInner` breaks the `innerOpt="trust"` per-subject
   Newton solves down by outcome (`calls`, `error`, `notConverged`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -134,6 +134,20 @@
 
 ### Mixture models
 
+- A mixture proportion now binds to the `mix()` component it was written for,
+  whatever order `ini()` declares the proportions in.  `mix(a, p1, b, p2, c)`
+  means `p1` is component 1's share, but the theta slots were collected with
+  `which(names(theta) %in% mixProbs)`, which returns ascending theta positions
+  -- `ini()` order.  Every consumer reads that index as "component m's slot"
+  (`op_focei.mixProb[m]`, `.getMixFromLog()`, the back-transform that writes the
+  estimates back), so declaring the proportions in a different order than
+  `mix()` uses them ran component 1 on `p2`'s value and reported each
+  component's proportion under the other's name.  Measured at zero iterations
+  with `ini({p2 <- 0.20; p1 <- 0.70})`: `$mixProbabilities` came back
+  `0.2 0.7 0.1` instead of `0.7 0.2 0.1`.  A model whose `ini()` order already
+  matched its `mix()` order -- which is the usual way to write one -- was never
+  affected.
+
 - Mixture proportions now get standard errors, under every covariance method
   that supports them: `covMethod="r"`, `"s"`, `"r,s"` and `"imp"`.  They were
   forced out of the covariance entirely (`skipCov`), so `p1` reported `SE = NA`

--- a/NEWS.md
+++ b/NEWS.md
@@ -159,6 +159,26 @@
   carries in `iniDf` -- writing values like `p1 <- 10.6` back into `ini()`.
   `est="npag"` already excluded them for the same reason.
 
+- `est="vae"`'s mixture objective is the marginal -2LL.  It exponentiated
+  `-obj/2` and negated the result twice, so it marginalized a *square root*
+  likelihood and carried a spurious `-log` of the winning component's
+  proportion.  Both errors cancel exactly when there is one component, and
+  again when the components are identical under a uniform proportion, so no
+  existing test could see it.  The prediction-model M-step scored candidate
+  thetas the same wrong way, and the two must agree or the M-step optimizes a
+  different function than the reported ELBO.
+
+- `est="vae"`'s encoder is trained on the gradient of the objective it
+  optimizes.  The objective was the marginal over components but the gradient
+  handed to the encoder was the single best component's; it is now the
+  responsibility-weighted mean.  Predictions and the residual variance stay on
+  the best component, since the closed-form residual step is a moment
+  estimator.
+
+- A subject whose components all fail to solve no longer *improves*
+  `est="vae"`'s objective.  It contributed nothing at all; it is now charged
+  the same bad-solve penalty the `focei` mixture likelihood charges.
+
 - `est="vae"` reads the mixture proportion on the scale the inner problem
   reads it on.  The prepared theta vector held the raw `ini()` probability
   while the inner problem passes that slot through `mexpit()`, so `p1 = 0.3`

--- a/NEWS.md
+++ b/NEWS.md
@@ -156,9 +156,10 @@
   `ini()` and never updated, so the reported proportion was whatever the model
   started at.  They are now estimated on the mlogit scale through their own
   analytic gradient -- the same chain `focei` uses (`mixGrad`): each subject's
-  responsibility difference against the last, non-free component, times the
-  `mexpit` Jacobian -- consumed by the same Adam loop that trains the encoder.
-  The gradient agrees with finite differences to 1e-4.  On simulated data with
+  responsibility difference against the last, non-free component, reduced
+  against the full `mexpit` Jacobian -- consumed by the same Adam loop that trains the encoder.
+  The gradient agrees with finite differences to 1e-4 at two components and at
+  three.  On simulated data with
   a 3:1 split started from 0.5, the fitted proportion comes back at 0.74.
 
 - `est="vae"` no longer treats a mixture proportion as an ordinary structural

--- a/NEWS.md
+++ b/NEWS.md
@@ -168,6 +168,15 @@
   thetas the same wrong way, and the two must agree or the M-step optimizes a
   different function than the reported ELBO.
 
+- `est="vae"`'s encoder now characterizes every subject-component pair, each
+  at its own random effect, the way the other mixture methods do.  It produced
+  a single posterior per subject which was then reused for every component, so
+  the components were compared at a random effect that had been fitted to none
+  of them.  The component enters the encoder at its head, alongside the
+  covariates, so a mixture model's encoder head is `nMix` inputs wider.
+  Everything reported per subject -- the random effect, the predictions, the
+  residual variance -- comes from the selected component.
+
 - `est="vae"`'s encoder is trained on the gradient of the objective it
   optimizes.  The objective was the marginal over components but the gradient
   handed to the encoder was the single best component's; it is now the

--- a/NEWS.md
+++ b/NEWS.md
@@ -134,6 +134,43 @@
 
 ### Mixture models
 
+- Mixture proportions now get standard errors, under every covariance method
+  that supports them: `covMethod="r"`, `"s"`, `"r,s"` and `"imp"`.  They were
+  forced out of the covariance entirely (`skipCov`), so `p1` reported `SE = NA`
+  no matter what was asked for.  This is the NONMEM 7 Technical Guide's own
+  construction, eq. (7.51)-(7.54): the mixture parameters' information is the
+  outer product of the same per-subject scores `g_ia` that give the gradient,
+  and `nlmixr2est`'s S matrix already IS that outer product, so the block drops
+  in once the per-subject score exists.  The per-subject mixture score is taken
+  analytically rather than by finite difference, so it costs no extra solves.
+
+  The reported covariance is rotated onto the probability scale with the FULL
+  mexpit Jacobian `J = diag(p) - p p'` -- so `$cov`, the SE, the %RSE and the CI
+  for `p1` all sit on the same scale as the estimate, and the proportions'
+  cross-covariances (with each other and with the structural thetas) are carried
+  across rather than dropped.  Same principle as `covFull` reporting Omega on the
+  natural variance scale instead of `chol(solve(omega))`.
+
+- The S matrix is no longer singular for mixture models, so `covMethod="r,s"`
+  stops silently degrading to `"r"`.  `foceiS()` built each subject's score by
+  finite-differencing component 0's likelihood instead of the marginal
+  `log(sum_m p_m L_im)`, so a parameter entering only another component got an
+  exactly-zero score.  Measured on a 3-component fit, two of six diagonal
+  entries came out at 1.9e-18 and 6.6e-10, the S matrix was reported
+  non-positive-definite, and the sandwich was dropped.  Each perturbation now
+  re-optimizes every component before combining, in the components-serial /
+  subjects-parallel order the rest of the mixture code uses.
+
+- `covMethod="imp"` builds its Monte-Carlo proposals for every mixture
+  component rather than component 0 alone, so the importance-sampling objective
+  it differences is the mixture marginal.  Without this the proportions'
+  directions were exactly flat and their SEs came back as 0.
+
+- `covMethod="analytic"` now declines a mixture model and falls back, instead of
+  reporting a single-component observed information as if it were the mixture's.
+  The augmented sensitivity model differentiates one component's conditional
+  likelihood and has no mixture-proportion block at all.
+
 - `est="focei"` estimates the mixture proportions under a gradient-based
   `outerOpt`.  `mixGrad()` supplies an analytic value that short-circuits the
   finite difference in `numericGrad()`, and it chained the per-subject

--- a/R/cov.R
+++ b/R/cov.R
@@ -137,6 +137,12 @@
     } else if (inherits(.lst$covMethod, "matrix")) {
       .env2$cov <- as.matrix(.lst$covMethod)
       .env2$ui <- obj$ui
+      # A caller-supplied covariance -- setCov() with a matrix, and the cached
+      # covList entry setCov() re-installs -- is ALREADY on the reported scale.
+      # Without this the mixture block is rotated by the mexpit Jacobian a
+      # second time on the refit, which silently shrinks the proportion's SE
+      # by a factor of p(1-p) every round trip.
+      .env2$.mixCovPreRotated <- TRUE
       .control$covMethod <- 0L
     } else if (length(.lst$covMethod) == 1) {
       if (.lst$covMethod == "") {

--- a/R/cov.R
+++ b/R/cov.R
@@ -281,8 +281,7 @@
   }
   .eta <- tryCatch(fit$eta, error = function(e) NULL)
   if (!is.null(.eta)) {
-    .etaCols <- setdiff(names(.eta), "ID")
-    .control$etaMat <- as.matrix(.eta[, .etaCols, drop = FALSE])
+    .control$etaMat <- as.matrix(.nmDropNonEtaCols(.eta))
   }
   # the nested re-fit resets mu-referencing global state (.muRefTrans$cur); save + restore.
   .savedMuRef <- .muRefTrans$cur

--- a/R/covRecompute.R
+++ b/R/covRecompute.R
@@ -135,6 +135,12 @@
 .covInstallResult <- function(env, r) {
   if (is.null(r) || is.null(r$cov) || !is.matrix(r$cov)) return(invisible(FALSE))
   .cov <- 0.5 * (r$cov + t(r$cov))                         # exact symmetry
+  # analytic/sa/imp produce the covariance on the mlogit estimation scale; rotate
+  # the mixture block onto the probability scale the estimates are reported on
+  .cov <- tryCatch(
+    .mixCovToProbScale(.cov, env$ui$mixProbs,
+                       utils::head(env$mixProbabilities, -1L)),
+    error = function(e) .cov)
   .ev <- suppressWarnings(eigen(.cov, symmetric = TRUE, only.values = TRUE)$values)
   if (any(!is.finite(diag(.cov))) || any(diag(.cov) <= 0) ||
         !all(is.finite(.ev)) || min(.ev) <= 0) {

--- a/R/covRecompute.R
+++ b/R/covRecompute.R
@@ -70,7 +70,9 @@
   if (inherits(.fit2, "try-error")) return(NULL)
   .cov <- tryCatch(.fit2$cov, error = function(e) NULL)
   if (is.null(.cov) || !is.matrix(.cov)) return(NULL)
-  list(cov = .cov, covMethod = .fit2$covMethod)
+  # .fit2 is a full re-fit, so its $cov has already been through
+  # .mixInstallProbScaleCov(); say so, or .covInstallResult() rotates it twice.
+  list(cov = .cov, covMethod = .fit2$covMethod, mixRotated = TRUE)
 }
 
 #' Recompute the SAEM Louis SA-FIM ("sa") at any fit's converged estimates.
@@ -135,12 +137,18 @@
 .covInstallResult <- function(env, r) {
   if (is.null(r) || is.null(r$cov) || !is.matrix(r$cov)) return(invisible(FALSE))
   .cov <- 0.5 * (r$cov + t(r$cov))                         # exact symmetry
-  # analytic/sa/imp produce the covariance on the mlogit estimation scale; rotate
-  # the mixture block onto the probability scale the estimates are reported on
-  .cov <- tryCatch(
-    .mixCovToProbScale(.cov, env$ui$mixProbs,
-                       utils::head(env$mixProbabilities, -1L)),
-    error = function(e) .cov)
+  # A covariance computed directly (analytic) is on the mlogit estimation scale
+  # and needs the mixture block rotated onto the probability scale; one that came
+  # back from a re-fit (sa/imp, via .covRecompute) was already rotated there.
+  # Key the rotation on the THETA slot, like every other consumer -- ui$mixProbs
+  # is in mix()-call order and would scramble the rows.
+  if (!isTRUE(r$mixRotated)) {
+    .mix <- .mixEnvPieces(env)
+    if (!is.null(.mix)) {
+      .cov <- tryCatch(.mixCovToProbScale(.cov, .mix$names, .mix$p),
+                       error = function(e) .cov)
+    }
+  }
   .ev <- suppressWarnings(eigen(.cov, symmetric = TRUE, only.values = TRUE)$values)
   if (any(!is.finite(diag(.cov))) || any(diag(.cov) <= 0) ||
         !all(is.finite(.ev)) || min(.ev) <= 0) {

--- a/R/covRecompute.R
+++ b/R/covRecompute.R
@@ -160,6 +160,11 @@
   }
   assign("cov", .cov, envir = env)
   assign("covMethod", r$covMethod, envir = env)
+  # An engine whose covariance carries no mixture rows at all (saem) needs the
+  # (7.51) block appended again -- the recomputed matrix REPLACED the one that
+  # had it, so without this a setCov() drops the proportion back to SE = NA.
+  .mixCovAppendBlock(env)
+  .cov <- tryCatch(get("cov", envir = env, inherits = FALSE), error = function(e) .cov)
   # refresh SE/%RSE/CI on the fit's own parameter table from the new covariance
   .updateParFixedRefreshSeFromCov(env, .cov)
   .nlmixr2CovConditionUpdate(env)

--- a/R/covRecompute.R
+++ b/R/covRecompute.R
@@ -29,9 +29,9 @@
   .eta <- tryCatch(fit$eta, error = function(e) NULL)
   .etaMat <- NULL
   if (!is.null(.eta)) {
-    .etaCols <- setdiff(names(.eta), "ID")
-    if (length(.etaCols) > 0L) {
-      .etaMat <- as.matrix(.eta[, .etaCols, drop = FALSE])
+    .eta <- .nmDropNonEtaCols(.eta)
+    if (ncol(.eta) > 0L) {
+      .etaMat <- as.matrix(.eta)
     }
   }
   list(ui = .ui, data = getData(fit), etaMat = .etaMat)

--- a/R/focei.R
+++ b/R/focei.R
@@ -3243,11 +3243,10 @@ rxUiGet.foceiSkipCov <- function(x, ...) {
     if (length(.uiIovEnv$iovVars) > 0) {
       .skipCov[which(.theta$name %in% .uiIovEnv$iovVars)] <- TRUE
     }
-    # Mixture probability parameters are estimated on the mlogit scale; their
-    # covariance cannot be meaningfully interpreted, so skip them.
-    if (length(.ui$mixProbs) > 0) {
-      .skipCov[which(.theta$name %in% .ui$mixProbs)] <- TRUE
-    }
+    # Mixture probability parameters ARE part of the covariance.  They are
+    # estimated on the mlogit scale, but the installed covariance is rotated to
+    # the probability scale with the full mexpit Jacobian (.mixCovToProbScale),
+    # so the reported SE sits on the same scale as the reported estimate.
     .skipCov
   }
 }
@@ -4367,6 +4366,9 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
     }
     .foceiInstallAnalyticCov(.ret)
     .foceiInstallFdFullCov(.ret)
+    # both installers replace $cov with a matrix on the mlogit estimation scale;
+    # rotate the mixture block before .updateParFixed() derives SEs from it
+    .mixInstallProbScaleCov(.ret)
     .updateParFixed(.ret)
     if (!exists("table", .ret)) {
       .ret$table <- tableControl()

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -915,6 +915,12 @@
   if (!length(.dist)) .dist <- tryCatch(as.character(ui$predDf$distribution), error = function(e) character(0))
   if (length(.dist) && !all(.dist %in% c("norm", "dnorm")))
     return(.foceiAnalyticFallback("a non-normal likelihood endpoint"))
+  # Mixture models: the augmented sensitivity model differentiates ONE component's
+  # conditional likelihood, not the marginal log(sum_m p_m L_m) the fit optimizes,
+  # and there is no mixture-proportion block at all.  Assembling it anyway would
+  # report a single-component observed information as "analytic".
+  if (length(tryCatch(ui$mixProbs, error = function(e) NULL)) > 0L)
+    return(.foceiAnalyticFallback("a mixture (mix()) model"))
   # Multiple modeled endpoints: rx_pred_ and rx_r_ are single dvid-conditional
   # expressions that already select the right endpoint per observation when solved
   # against the dataset, so the (f,R) path handles them -- but the single-endpoint

--- a/R/mix.R
+++ b/R/mix.R
@@ -801,11 +801,18 @@ attr(rxUiGet.thetaIniMix, "rstudio") <- stats::setNames(1, "a")
 #' @export
 rxUiGet.thetaMixIndex <- function(x, ...) {
   .ui <- x[[1]]
-  .theta <- .ui$theta
-  if (length(.ui$mixProbs) > 0) {
-    which(names(.ui$theta) %in% .ui$mixProbs)
-  } else {
-    integer(0)
-  }
+  if (length(.ui$mixProbs) == 0) return(integer(0))
+  # COMPONENT order (the order the proportions appear in the mix() call), not
+  # ini() order.  Every consumer reads mixIdx[m] as "component m's theta slot":
+  # op_focei.mixProb[m] is component m's proportion, .getMixFromLog() maps the
+  # slots through mexpit() positionally, and .aaaPostEstimationMixBacktransform
+  # writes probs[m] back to slot mixIdx[m].
+  #
+  # which(names %in% mixProbs) returns ASCENDING theta positions, i.e. ini()
+  # order, so declaring the proportions in a different order than mix() uses
+  # them silently attached each component's proportion to the other's name --
+  # mix(a, p1, b, p2, c) with ini({p2; p1}) reported fixef()["p1"] as
+  # component 2's proportion.  match() keeps mixProbs' own (component) order.
+  match(.ui$mixProbs, names(.ui$theta))
 }
 attr(rxUiGet.thetaMixIndex, "rstudio") <- 1L

--- a/R/mix.R
+++ b/R/mix.R
@@ -527,6 +527,45 @@
   invisible(NULL)
 }
 
+#' Put a mixture proportion's confidence interval on the logit scale
+#'
+#' A proportion's reported estimate IS a probability, so the generic
+#' \code{backTransform(est +/- z*SE)} interval is symmetric on (0, 1) and walks
+#' straight out of it -- a fit reported \code{p1 = 0.648 (-0.045, 1.34)}.  It is
+#' also built from the covariance as it stood BEFORE the probability-scale
+#' rotation, so it does not even agree with the SE printed beside it.
+#'
+#' Both are fixed by taking the interval where the parameter is actually
+#' estimated: \code{expit(logit(p) +/- z*SE_p/(p(1-p)))}, using the REPORTED SE
+#' so the two columns are consistent.  The result is inside (0, 1) by
+#' construction and asymmetric, which is the honest shape near a boundary.
+#'
+#' @param ui the fit's rxode2 ui
+#' @param popDf parameter table carrying Estimate/SE/CI columns
+#' @param ci confidence level
+#' @return \code{popDf} with the mixture rows' CI columns replaced
+#' @noRd
+#' @author Matthew L. Fidler
+.mixParFixedCi <- function(ui, popDf, ci = 0.95) {
+  .mp <- tryCatch(ui$mixProbs, error = function(e) NULL)
+  if (is.null(.mp) || length(.mp) == 0L) return(popDf)
+  if (!is.data.frame(popDf) || is.null(rownames(popDf))) return(popDf)
+  if (!all(c("Estimate", "SE", "CI Lower", "CI Upper") %in% names(popDf))) return(popDf)
+  if (!(length(ci) == 1L && is.numeric(ci) && is.finite(ci))) ci <- 0.95
+  .qn <- stats::qnorm(1 - (1 - ci) / 2)
+  for (.n in intersect(.mp, rownames(popDf))) {
+    .p <- popDf[.n, "Estimate"]
+    .s <- popDf[.n, "SE"]
+    if (!is.finite(.p) || !is.finite(.s) || .p <= 0 || .p >= 1) next
+    .j <- .p * (1 - .p)                       # dp/d(logit p)
+    if (!is.finite(.j) || .j <= 0) next
+    .sl <- .s / .j                            # SE on the logit scale
+    popDf[.n, "CI Lower"] <- rxode2::expit(rxode2::logit(.p) - .qn * .sl)
+    popDf[.n, "CI Upper"] <- rxode2::expit(rxode2::logit(.p) + .qn * .sl)
+  }
+  popDf
+}
+
 #' Note when a mixture proportion sits near 0 or 1
 #'
 #' The probability-scale SE is \code{J Sigma J'} with \code{J = diag(p) - p p'},

--- a/R/mix.R
+++ b/R/mix.R
@@ -471,6 +471,7 @@
     assign(.n, .mixCovToProbScale(.cur, .mp, .p), envir = env)
   }
   .mixRefreshSeFromCov(env, .mp, .mix$idx)
+  .mixWarnBoundary(.mix$pi)
   invisible(NULL)
 }
 
@@ -523,6 +524,27 @@
       ifelse(is.finite(.e) & .e != 0, abs(.newSe / .e) * 100, NA_real_)
   }
   assign("popDf", .pd, envir = env)
+  invisible(NULL)
+}
+
+#' Note when a mixture proportion sits near 0 or 1
+#'
+#' The probability-scale SE is \code{J Sigma J'} with \code{J = diag(p) - p p'},
+#' so it is scaled by \code{p(1-p)} and goes to ZERO as a proportion approaches
+#' a boundary.  That is the correct delta-method answer but it reads as
+#' certainty, when in truth the Wald approximation has simply stopped being
+#' meaningful there (the real interval is strongly asymmetric).  Say so rather
+#' than let a vanishing SE be taken for precision.
+#'
+#' @param p the mixture probabilities to check
+#' @return invisible \code{NULL}; called for the warning
+#' @noRd
+#' @author Matthew L. Fidler
+.mixWarnBoundary <- function(p) {
+  .p <- p[is.finite(p)]
+  if (length(.p) == 0L || !any(.p < 0.01 | .p > 0.99)) return(invisible(NULL))
+  warning("mixture proportion near 0/1; its SE is shrunk by the p(1-p) scale",
+          call. = FALSE)
   invisible(NULL)
 }
 
@@ -657,6 +679,7 @@
   dimnames(.out) <- list(.nm, .nm)
   assign("cov", .out, envir = env)
   .updateParFixedRefreshSeFromCov(env, .out, onlyMissing = TRUE)
+  .mixWarnBoundary(.pi)
   invisible(NULL)
 }
 

--- a/R/mix.R
+++ b/R/mix.R
@@ -447,28 +447,41 @@
 #' @noRd
 #' @author Matthew L. Fidler
 .mixInstallProbScaleCov <- function(env) {
-  .mp <- tryCatch(env$ui$mixProbs, error = function(e) NULL)
-  if (is.null(.mp) || length(.mp) == 0L) return(invisible(NULL))
-  .p <- tryCatch(env$mixProbabilities, error = function(e) NULL)
-  if (is.null(.p) || length(.p) != length(.mp) + 1L) return(invisible(NULL))
-  .p <- .p[seq_along(.mp)]
+  .m <- .mixEnvPieces(env)
+  if (is.null(.m)) return(invisible(NULL))
+  .mp <- .m$names
+  .p <- .m$p
   for (.n in c("cov", "covR", "covS", "covRS")) {
     if (!exists(.n, envir = env, inherits = FALSE)) next
     .m <- get(.n, envir = env)
     if (!is.matrix(.m)) next
     assign(.n, .mixCovToProbScale(.m, .mp, .p), envir = env)
   }
-  # foceiFinalizeTables filled se/popDf from the covariance as it stood BEFORE
-  # this rotation (mlogit scale), and .updateParFixed() reads popDf -- so the
-  # mixture rows have to be refreshed here or the reported SE stays on the
-  # estimation scale while the estimate next to it is a probability.
+  .mixRefreshSeFromCov(env, .mp)
+  invisible(NULL)
+}
+
+#' Refresh the mixture rows of se/popDf from the rotated covariance
+#'
+#' \code{foceiFinalizeTables} fills \code{se}/\code{popDf} from the covariance
+#' as it stood BEFORE the probability-scale rotation, and
+#' \code{.updateParFixed()} reads \code{popDf} -- so without this the reported
+#' SE stays on the mlogit estimation scale while the estimate beside it is a
+#' probability.
+#'
+#' @param env fit environment
+#' @param mixNames mixture-proportion parameter names
+#' @return invisible \code{NULL}; called for its side effects on \code{env}
+#' @noRd
+#' @author Matthew L. Fidler
+.mixRefreshSeFromCov <- function(env, mixNames) {
   .cov <- tryCatch(get("cov", envir = env, inherits = FALSE), error = function(e) NULL)
   .mixIdx <- tryCatch(get("mixIdx", envir = env, inherits = FALSE), error = function(e) NULL)
   if (!is.matrix(.cov) || is.null(rownames(.cov)) ||
-        is.null(.mixIdx) || length(.mixIdx) != length(.mp)) {
+        is.null(.mixIdx) || length(.mixIdx) != length(mixNames)) {
     return(invisible(NULL))
   }
-  .w <- match(.mp, rownames(.cov))
+  .w <- match(mixNames, rownames(.cov))
   if (anyNA(.w)) return(invisible(NULL))
   .newSe <- sqrt(diag(.cov))[.w]
   if (exists("se", envir = env, inherits = FALSE)) {
@@ -478,18 +491,130 @@
       assign("se", .se, envir = env)
     }
   }
-  if (exists("popDf", envir = env, inherits = FALSE)) {
-    .pd <- get("popDf", envir = env)
-    if (is.data.frame(.pd) && nrow(.pd) >= max(.mixIdx) && "SE" %in% names(.pd)) {
-      .pd[["SE"]][.mixIdx] <- .newSe
-      if ("%RSE" %in% names(.pd)) {
-        .e <- .pd[["Estimate"]][.mixIdx]
-        .pd[["%RSE"]][.mixIdx] <-
-          ifelse(is.finite(.e) & .e != 0, abs(.newSe / .e) * 100, NA_real_)
-      }
-      assign("popDf", .pd, envir = env)
-    }
+  if (!exists("popDf", envir = env, inherits = FALSE)) return(invisible(NULL))
+  .pd <- get("popDf", envir = env)
+  if (!is.data.frame(.pd) || nrow(.pd) < max(.mixIdx) || !("SE" %in% names(.pd))) {
+    return(invisible(NULL))
   }
+  .pd[["SE"]][.mixIdx] <- .newSe
+  if ("%RSE" %in% names(.pd)) {
+    .e <- .pd[["Estimate"]][.mixIdx]
+    .pd[["%RSE"]][.mixIdx] <-
+      ifelse(is.finite(.e) & .e != 0, abs(.newSe / .e) * 100, NA_real_)
+  }
+  assign("popDf", .pd, envir = env)
+  invisible(NULL)
+}
+
+#' Read a fit environment's mixture pieces, or NULL if it has none usable
+#'
+#' Both covariance consumers need the same three things off a fit env -- the
+#' proportion parameter names, the free probabilities, and the per-subject
+#' responsibility matrix -- with the same consistency checks between them.
+#'
+#' @param env fit environment
+#' @param needResp when \code{TRUE} also require \code{$mixList} and return the
+#'   responsibility matrix
+#' @return list with \code{names}, \code{p} (free probabilities) and, when
+#'   requested, \code{r} (subjects x components); \code{NULL} if unavailable
+#' @noRd
+#' @author Matthew L. Fidler
+.mixEnvPieces <- function(env, needResp = FALSE) {
+  .mp <- tryCatch(env$ui$mixProbs, error = function(e) NULL)
+  if (is.null(.mp) || length(.mp) == 0L) return(NULL)
+  .pi <- tryCatch(env$mixProbabilities, error = function(e) NULL)
+  if (is.null(.pi) || length(.pi) != length(.mp) + 1L || !all(is.finite(.pi))) return(NULL)
+  .ret <- list(names = .mp, p = .pi[seq_along(.mp)], pi = .pi)
+  if (!needResp) return(.ret)
+  .ml <- tryCatch(env$mixList, error = function(e) NULL)
+  if (is.null(.ml) || length(.ml) != length(.pi)) return(NULL)
+  .r <- try(do.call(cbind, lapply(.ml, function(.z) .z$prob)), silent = TRUE)
+  if (inherits(.r, "try-error") || !is.matrix(.r) || ncol(.r) != length(.pi)) return(NULL)
+  .ret$r <- .r
+  .ret
+}
+
+#' Probability-scale covariance of the mixture proportions from responsibilities
+#'
+#' NONMEM 7 Technical Guide eq. (7.51): the mixture parameters' information is
+#' the outer product of the per-subject scores, \code{sum_i (r_i - p)(r_i - p)'}
+#' on the mlogit scale.  Its inverse is rotated onto the probability scale with
+#' the same full Jacobian every other method uses.
+#'
+#' @param r matrix of per-subject responsibilities, one column per FREE component
+#' @param p free mixture probabilities
+#' @return the probability-scale covariance block, or \code{NULL} if it is not
+#'   invertible / not a usable covariance
+#' @noRd
+#' @author Matthew L. Fidler
+.mixProbCovBlock <- function(r, p) {
+  .d <- sweep(r, 2, p, "-")
+  .blk <- try(solve(t(.d) %*% .d), silent = TRUE)
+  if (inherits(.blk, "try-error") || !all(is.finite(.blk))) return(NULL)
+  .j <- diag(p, nrow = length(p)) - outer(p, p)
+  .blk <- .j %*% .blk %*% t(.j)
+  if (!all(is.finite(.blk)) || any(diag(.blk) <= 0)) return(NULL)
+  .blk
+}
+
+#' Append a mixture-proportion block to a covariance that has none
+#'
+#' \code{saem} excludes the mixture proportions from its kernel parameter vector
+#' (they are updated by a separate EM step), so its Louis/linFim covariance has
+#' no mixture rows at all and \code{p1} reports \code{SE = NA}.
+#'
+#' The block is NONMEM 7 Technical Guide eq. (7.51): the mixture parameters'
+#' information is the outer product of the per-subject scores,
+#' \code{sum_i (r_i - p)(r_i - p)'} on the mlogit scale, with \code{r_i} the
+#' subject's posterior responsibilities -- which the fit already carries in
+#' \code{$mixList}.  Its inverse is rotated onto the probability scale with the
+#' same full Jacobian every other method uses.
+#'
+#' The cross terms (7.52)-(7.54) are NOT formed: they need per-subject scores for
+#' the other parameters on the same footing, which the SAEM covariance does not
+#' expose.  The appended block is therefore uncorrelated with the structural
+#' parameters, so these SEs ignore that correlation and are mildly optimistic.
+#' Measured against a focei fit of the same data, where the cross terms ARE
+#' available, the difference is a couple of percent.
+#'
+#' @param env fit environment
+#' @return invisible \code{NULL}; called for its side effects on \code{env}
+#' @noRd
+#' @author Matthew L. Fidler
+.mixCovAppendBlock <- function(env) {
+  .m <- .mixEnvPieces(env, needResp = TRUE)
+  if (is.null(.m)) return(invisible(NULL))
+  .mp <- .m$names
+  .pi <- .m$pi
+  .r <- .m$r
+  .cov <- tryCatch(get("cov", envir = env, inherits = FALSE), error = function(e) NULL)
+  if (!is.matrix(.cov) || is.null(rownames(.cov))) return(invisible(NULL))
+  if (any(.mp %in% rownames(.cov))) return(invisible(NULL))   # already covered
+  .free <- seq_along(.mp)
+  # An information matrix reports the precision of a MAXIMUM-likelihood estimate.
+  # The mixture score is sum_i (r_il - p_l), so the fixed point is
+  # p_l == mean_i r_il; away from it the block is a confident-looking number
+  # attached to an estimate that is not an MLE.  Refuse rather than report it,
+  # and say why -- saem can land far off this (its proportions are updated by a
+  # separate EM step, outside the kernel that converged everything else).
+  .off <- max(abs(colMeans(.r[, .free, drop = FALSE]) - .pi[.free]))
+  if (!is.finite(.off) || .off > 0.01) {
+    .msg <- paste0("mixture proportion SE not computed; p != mean responsibility (off by ",
+                   signif(.off, 2), ")")
+    .ri <- tryCatch(get("runInfo", envir = env, inherits = FALSE), error = function(e) NULL)
+    assign("runInfo", unique(c(.ri, .msg)), envir = env)
+    return(invisible(NULL))
+  }
+  .blk <- .mixProbCovBlock(.r[, .free, drop = FALSE], .pi[.free])
+  if (is.null(.blk)) return(invisible(NULL))
+  .n <- nrow(.cov)
+  .out <- matrix(0, .n + length(.mp), .n + length(.mp))
+  .out[seq_len(.n), seq_len(.n)] <- .cov
+  .out[.n + .free, .n + .free] <- .blk
+  .nm <- c(rownames(.cov), .mp)
+  dimnames(.out) <- list(.nm, .nm)
+  assign("cov", .out, envir = env)
+  .updateParFixedRefreshSeFromCov(env, .out, onlyMissing = TRUE)
   invisible(NULL)
 }
 

--- a/R/mix.R
+++ b/R/mix.R
@@ -422,6 +422,22 @@
   parHist
 }
 
+#' Jacobian of the mexpit (softmax) map, d(p_j)/d(t_l)
+#'
+#' `p = mexpit(t)` is a softmax over the `K-1` free coordinates, so
+#' `d(p_j)/d(t_l) = p_j*(delta_jl - p_l)`, i.e. `diag(p) - p p'`.  It is the
+#' same matrix wherever a mixture quantity moves between the mlogit scale the
+#' proportions are estimated on and the probability scale they are reported on,
+#' so it is defined once here.
+#'
+#' @param p the free mixture probabilities
+#' @return the `(K-1) x (K-1)` Jacobian
+#' @noRd
+#' @author Matthew L. Fidler
+.mixProbJacobian <- function(p) {
+  diag(p, nrow = length(p)) - outer(p, p)
+}
+
 #' Rotate a covariance's mixture-proportion block onto the probability scale
 #'
 #' The proportions are estimated as a multinomial logit, so the covariance a
@@ -456,7 +472,7 @@
   # absent coordinates fixed makes the correct Jacobian exactly the submatrix.
   .keep <- !is.na(.i)
   if (!any(.keep)) return(cov)
-  .J <- (diag(p, nrow = length(p)) - outer(p, p))[.keep, .keep, drop = FALSE]
+  .J <- .mixProbJacobian(p)[.keep, .keep, drop = FALSE]
   .A <- diag(1, nrow(cov))
   .A[.i[.keep], .i[.keep]] <- .J
   .out <- .A %*% cov %*% t(.A)
@@ -682,7 +698,7 @@
   .d <- sweep(r, 2, p, "-")
   .blk <- try(solve(t(.d) %*% .d), silent = TRUE)
   if (inherits(.blk, "try-error") || !all(is.finite(.blk))) return(NULL)
-  .j <- diag(p, nrow = length(p)) - outer(p, p)
+  .j <- .mixProbJacobian(p)
   .blk <- .j %*% .blk %*% t(.j)
   if (!all(is.finite(.blk)) || any(diag(.blk) <= 0)) return(NULL)
   .blk

--- a/R/mix.R
+++ b/R/mix.R
@@ -577,7 +577,17 @@
   if (is.null(.mp) || length(.mp) != length(.idx) || anyNA(.mp)) return(NULL)
   .pi <- tryCatch(env$mixProbabilities, error = function(e) NULL)
   if (is.null(.pi) || length(.pi) != length(.mp) + 1L || !all(is.finite(.pi))) return(NULL)
-  .ret <- list(names = .mp, idx = .idx, p = .pi[seq_along(.mp)], pi = .pi)
+  # which of them were actually ESTIMATED: a fix()ed proportion is still in
+  # thetaMixIndex, but it has no covariance row and must not be given one
+  .fx <- tryCatch({
+    .idf <- .ui$iniDf
+    .w <- match(.mp, .idf$name)
+    .v <- if (is.null(.idf$fix)) rep(FALSE, length(.w)) else .idf$fix[.w]
+    .v[is.na(.v)] <- FALSE
+    .v
+  }, error = function(e) rep(FALSE, length(.mp)))
+  .ret <- list(names = .mp, idx = .idx, p = .pi[seq_along(.mp)], pi = .pi,
+               fixed = .fx)
   if (!needResp) return(.ret)
   .ml <- tryCatch(env$mixList, error = function(e) NULL)
   if (is.null(.ml) || length(.ml) != length(.pi)) return(NULL)
@@ -637,13 +647,17 @@
 .mixCovAppendBlock <- function(env) {
   .mix <- .mixEnvPieces(env, needResp = TRUE)
   if (is.null(.mix)) return(invisible(NULL))
-  .mp <- .mix$names
   .pi <- .mix$pi
   .r <- .mix$r
   .cov <- tryCatch(get("cov", envir = env, inherits = FALSE), error = function(e) NULL)
   if (!is.matrix(.cov) || is.null(rownames(.cov))) return(invisible(NULL))
-  if (any(.mp %in% rownames(.cov))) return(invisible(NULL))   # already covered
-  .free <- seq_along(.mp)
+  if (any(.mix$names %in% rownames(.cov))) return(invisible(NULL))   # already covered
+  # only the ESTIMATED proportions get a row: a fix()ed one has no uncertainty
+  # to report, and appending one would give a parameter that was never estimated
+  # a non-zero SE
+  .free <- which(!.mix$fixed)
+  if (length(.free) == 0L) return(invisible(NULL))
+  .mp <- .mix$names[.free]
   # An information matrix reports the precision of a MAXIMUM-likelihood estimate.
   # The mixture score is s_l = sum_i (r_il - p_l), so the fixed point is s == 0;
   # away from it the block is a confident-looking number attached to an estimate
@@ -674,7 +688,9 @@
   .n <- nrow(.cov)
   .out <- matrix(0, .n + length(.mp), .n + length(.mp))
   .out[seq_len(.n), seq_len(.n)] <- .cov
-  .out[.n + .free, .n + .free] <- .blk
+  # .free indexes the FULL mixture set; the appended block is only the estimated
+  # subset, so place it by its own position
+  .out[.n + seq_along(.mp), .n + seq_along(.mp)] <- .blk
   .nm <- c(rownames(.cov), .mp)
   dimnames(.out) <- list(.nm, .nm)
   assign("cov", .out, envir = env)

--- a/R/mix.R
+++ b/R/mix.R
@@ -610,17 +610,27 @@
   if (any(.mp %in% rownames(.cov))) return(invisible(NULL))   # already covered
   .free <- seq_along(.mp)
   # An information matrix reports the precision of a MAXIMUM-likelihood estimate.
-  # The mixture score is sum_i (r_il - p_l), so the fixed point is
-  # p_l == mean_i r_il; away from it the block is a confident-looking number
-  # attached to an estimate that is not an MLE.  Refuse rather than report it,
-  # and say why -- saem can land far off this (its proportions are updated by a
-  # separate EM step, outside the kernel that converged everything else).
-  .off <- max(abs(colMeans(.r[, .free, drop = FALSE]) - .pi[.free]))
-  if (!is.finite(.off) || .off > 0.01) {
-    .msg <- paste0("mixture proportion SE not computed; p != mean responsibility (off by ",
-                   signif(.off, 2), ")")
-    .ri <- tryCatch(get("runInfo", envir = env, inherits = FALSE), error = function(e) NULL)
-    assign("runInfo", unique(c(.ri, .msg)), envir = env)
+  # The mixture score is s_l = sum_i (r_il - p_l), so the fixed point is s == 0;
+  # away from it the block is a confident-looking number attached to an estimate
+  # that is not an MLE.  Refuse rather than report it, and say why -- saem can
+  # land far off this (its proportions are updated by a separate EM step,
+  # outside the kernel that converged everything else).
+  #
+  # Judge it by the SCORE STATISTIC s' solve(I) s, not by |mean(r) - p|: the
+  # score is N*(mean(r) - p), so any absolute tolerance on the mean silently
+  # loosens with the number of subjects (0.01 is a score of 1 at N=100 and 100
+  # at N=10000).  s' I^-1 s is on a chi-square scale and does not drift with N.
+  .d <- sweep(.r[, .free, drop = FALSE], 2, .pi[.free], "-")
+  .s <- colSums(.d)
+  .stat <- tryCatch(as.numeric(crossprod(.s, solve(crossprod(.d), .s))),
+                    error = function(e) NA_real_)
+  if (!is.finite(.stat) || .stat > 1e-3) {
+    # warning(), not an assignment to runInfo: that is the channel the fit
+    # collects run-time notes through, and a direct assignment here is
+    # overwritten by the later table assembly.  Kept under 75 characters so it
+    # renders on one line, and unprefixed -- the fit already reports its method.
+    warning("mixture proportion SE skipped; not at the score-zero point",
+            call. = FALSE)
     return(invisible(NULL))
   }
   .blk <- .mixProbCovBlock(.r[, .free, drop = FALSE], .pi[.free])

--- a/R/mix.R
+++ b/R/mix.R
@@ -408,7 +408,7 @@
 #' variance scale rather than the \code{chol(solve(omega))} estimation scale.
 #'
 #' @param cov covariance matrix with dimnames
-#' @param mixNames names of the mixture-proportion parameters (\code{ui$mixProbs})
+#' @param mixNames mixture-proportion parameter names, in THETA-slot order
 #' @param p free mixture probabilities, in \code{mixNames} order
 #' @return \code{cov} with the mixture rows/columns on the probability scale;
 #'   unchanged when there is no mixture block to rotate
@@ -452,17 +452,17 @@
                       error = function(e) FALSE))) {
     return(invisible(NULL))
   }
-  .m <- .mixEnvPieces(env)
-  if (is.null(.m)) return(invisible(NULL))
-  .mp <- .m$names
-  .p <- .m$p
+  .mix <- .mixEnvPieces(env)
+  if (is.null(.mix)) return(invisible(NULL))
+  .mp <- .mix$names
+  .p <- .mix$p
   for (.n in c("cov", "covR", "covS", "covRS")) {
     if (!exists(.n, envir = env, inherits = FALSE)) next
-    .m <- get(.n, envir = env)
-    if (!is.matrix(.m)) next
-    assign(.n, .mixCovToProbScale(.m, .mp, .p), envir = env)
+    .cur <- get(.n, envir = env)
+    if (!is.matrix(.cur)) next
+    assign(.n, .mixCovToProbScale(.cur, .mp, .p), envir = env)
   }
-  .mixRefreshSeFromCov(env, .mp)
+  .mixRefreshSeFromCov(env, .mp, .mix$idx)
   invisible(NULL)
 }
 
@@ -475,13 +475,15 @@
 #' probability.
 #'
 #' @param env fit environment
-#' @param mixNames mixture-proportion parameter names
+#' @param mixNames mixture-proportion parameter names, in THETA-slot order
+#' @param mixIdx their positions in the theta vector, same order as
+#'   \code{mixNames}
 #' @return invisible \code{NULL}; called for its side effects on \code{env}
 #' @noRd
 #' @author Matthew L. Fidler
-.mixRefreshSeFromCov <- function(env, mixNames) {
+.mixRefreshSeFromCov <- function(env, mixNames, mixIdx) {
   .cov <- tryCatch(get("cov", envir = env, inherits = FALSE), error = function(e) NULL)
-  .mixIdx <- tryCatch(get("mixIdx", envir = env, inherits = FALSE), error = function(e) NULL)
+  .mixIdx <- mixIdx
   if (!is.matrix(.cov) || is.null(rownames(.cov)) ||
         is.null(.mixIdx) || length(.mixIdx) != length(mixNames)) {
     return(invisible(NULL))
@@ -525,11 +527,22 @@
 #' @noRd
 #' @author Matthew L. Fidler
 .mixEnvPieces <- function(env, needResp = FALSE) {
-  .mp <- tryCatch(env$ui$mixProbs, error = function(e) NULL)
-  if (is.null(.mp) || length(.mp) == 0L) return(NULL)
+  .ui <- tryCatch(env$ui, error = function(e) NULL)
+  if (is.null(.ui)) return(NULL)
+  .idx <- tryCatch(.ui$thetaMixIndex, error = function(e) NULL)
+  if (is.null(.idx) || length(.idx) == 0L) return(NULL)
+  # Name the proportions by their THETA slot, not by ui$mixProbs.  The two are
+  # the same set but NOT the same order: mixProbs follows the mix() call while
+  # thetaMixIndex follows ini(), and everything downstream -- the covariance's
+  # rows, op_focei.mixProb, $mixProbabilities, and the se/popDf rows -- is keyed
+  # on the theta slot.  Using mixProbs to index a theta-ordered covariance puts
+  # the Jacobian on the wrong rows whenever ini() lists them in a different
+  # order than mix() uses them.
+  .mp <- tryCatch(names(.ui$theta)[.idx], error = function(e) NULL)
+  if (is.null(.mp) || length(.mp) != length(.idx) || anyNA(.mp)) return(NULL)
   .pi <- tryCatch(env$mixProbabilities, error = function(e) NULL)
   if (is.null(.pi) || length(.pi) != length(.mp) + 1L || !all(is.finite(.pi))) return(NULL)
-  .ret <- list(names = .mp, p = .pi[seq_along(.mp)], pi = .pi)
+  .ret <- list(names = .mp, idx = .idx, p = .pi[seq_along(.mp)], pi = .pi)
   if (!needResp) return(.ret)
   .ml <- tryCatch(env$mixList, error = function(e) NULL)
   if (is.null(.ml) || length(.ml) != length(.pi)) return(NULL)
@@ -587,11 +600,11 @@
 #' @noRd
 #' @author Matthew L. Fidler
 .mixCovAppendBlock <- function(env) {
-  .m <- .mixEnvPieces(env, needResp = TRUE)
-  if (is.null(.m)) return(invisible(NULL))
-  .mp <- .m$names
-  .pi <- .m$pi
-  .r <- .m$r
+  .mix <- .mixEnvPieces(env, needResp = TRUE)
+  if (is.null(.mix)) return(invisible(NULL))
+  .mp <- .mix$names
+  .pi <- .mix$pi
+  .r <- .mix$r
   .cov <- tryCatch(get("cov", envir = env, inherits = FALSE), error = function(e) NULL)
   if (!is.matrix(.cov) || is.null(rownames(.cov))) return(invisible(NULL))
   if (any(.mp %in% rownames(.cov))) return(invisible(NULL))   # already covered

--- a/R/mix.R
+++ b/R/mix.R
@@ -447,6 +447,11 @@
 #' @noRd
 #' @author Matthew L. Fidler
 .mixInstallProbScaleCov <- function(env) {
+  # a covariance handed in by the caller is already on the reported scale
+  if (isTRUE(tryCatch(get(".mixCovPreRotated", envir = env, inherits = FALSE),
+                      error = function(e) FALSE))) {
+    return(invisible(NULL))
+  }
   .m <- .mixEnvPieces(env)
   if (is.null(.m)) return(invisible(NULL))
   .mp <- .m$names

--- a/R/mix.R
+++ b/R/mix.R
@@ -393,13 +393,116 @@
   parHist
 }
 
+#' Rotate a covariance's mixture-proportion block onto the probability scale
+#'
+#' The proportions are estimated as a multinomial logit, so the covariance a
+#' covariance method produces is on that scale while the reported estimate is a
+#' probability.  \code{p = mexpit(t)} is a softmax over the \code{K-1} free
+#' coordinates, whose Jacobian is \code{dp_j/dt_l = p_j*(delta_jl - p_l)}, i.e.
+#' \code{J = diag(p) - p \%*\% t(p)}.  The FULL Jacobian is used, not its
+#' diagonal: the off-diagonal terms are what carry the proportions'
+#' cross-covariances -- with each other and with the structural thetas -- onto
+#' the reported scale.
+#'
+#' Same principle as \code{covFull}, which reports Omega on the natural
+#' variance scale rather than the \code{chol(solve(omega))} estimation scale.
+#'
+#' @param cov covariance matrix with dimnames
+#' @param mixNames names of the mixture-proportion parameters (\code{ui$mixProbs})
+#' @param p free mixture probabilities, in \code{mixNames} order
+#' @return \code{cov} with the mixture rows/columns on the probability scale;
+#'   unchanged when there is no mixture block to rotate
+#' @noRd
+#' @author Matthew L. Fidler
+.mixCovToProbScale <- function(cov, mixNames, p) {
+  if (!is.matrix(cov) || length(mixNames) == 0L) return(cov)
+  if (is.null(rownames(cov))) return(cov)
+  .i <- match(mixNames, rownames(cov))
+  if (anyNA(.i) || length(p) != length(.i) || !all(is.finite(p))) return(cov)
+  .J <- diag(p, nrow = length(p)) - outer(p, p)
+  .A <- diag(1, nrow(cov))
+  .A[.i, .i] <- .J
+  .out <- .A %*% cov %*% t(.A)
+  dimnames(.out) <- dimnames(cov)
+  .out
+}
+
+#' Rotate a fit's installed covariance onto the probability scale
+#'
+#' The pre-final table hook rotates \code{env$cov}, but the \code{covFull} and
+#' analytic installers (\code{.foceiInstallFdFullCov} /
+#' \code{.foceiInstallAnalyticCov}) then REPLACE it wholesale with a matrix
+#' still on the mlogit estimation scale, so the hook's rotation is gone by the
+#' time \code{.updateParFixed()} reads it.  This runs between the two and covers
+#' whichever matrix ended up installed, plus the \code{covR}/\code{covS}/
+#' \code{covRS} diagnostics so they stay on one scale.
+#'
+#' This is the ONLY fit-time rotation, so no matrix is rotated twice: the native
+#' C++ covariance and both installers' output all arrive here on the mlogit
+#' scale.  Post-fit \code{setCov()} installs rotate separately, in
+#' \code{.covInstallResult()}, on a matrix the recompute engine produced.
+#'
+#' @param env fit environment
+#' @return invisible \code{NULL}; called for its side effects on \code{env}
+#' @noRd
+#' @author Matthew L. Fidler
+.mixInstallProbScaleCov <- function(env) {
+  .mp <- tryCatch(env$ui$mixProbs, error = function(e) NULL)
+  if (is.null(.mp) || length(.mp) == 0L) return(invisible(NULL))
+  .p <- tryCatch(env$mixProbabilities, error = function(e) NULL)
+  if (is.null(.p) || length(.p) != length(.mp) + 1L) return(invisible(NULL))
+  .p <- .p[seq_along(.mp)]
+  for (.n in c("cov", "covR", "covS", "covRS")) {
+    if (!exists(.n, envir = env, inherits = FALSE)) next
+    .m <- get(.n, envir = env)
+    if (!is.matrix(.m)) next
+    assign(.n, .mixCovToProbScale(.m, .mp, .p), envir = env)
+  }
+  # foceiFinalizeTables filled se/popDf from the covariance as it stood BEFORE
+  # this rotation (mlogit scale), and .updateParFixed() reads popDf -- so the
+  # mixture rows have to be refreshed here or the reported SE stays on the
+  # estimation scale while the estimate next to it is a probability.
+  .cov <- tryCatch(get("cov", envir = env, inherits = FALSE), error = function(e) NULL)
+  .mixIdx <- tryCatch(get("mixIdx", envir = env, inherits = FALSE), error = function(e) NULL)
+  if (!is.matrix(.cov) || is.null(rownames(.cov)) ||
+        is.null(.mixIdx) || length(.mixIdx) != length(.mp)) {
+    return(invisible(NULL))
+  }
+  .w <- match(.mp, rownames(.cov))
+  if (anyNA(.w)) return(invisible(NULL))
+  .newSe <- sqrt(diag(.cov))[.w]
+  if (exists("se", envir = env, inherits = FALSE)) {
+    .se <- get("se", envir = env)
+    if (length(.se) >= max(.mixIdx)) {
+      .se[.mixIdx] <- .newSe
+      assign("se", .se, envir = env)
+    }
+  }
+  if (exists("popDf", envir = env, inherits = FALSE)) {
+    .pd <- get("popDf", envir = env)
+    if (is.data.frame(.pd) && nrow(.pd) >= max(.mixIdx) && "SE" %in% names(.pd)) {
+      .pd[["SE"]][.mixIdx] <- .newSe
+      if ("%RSE" %in% names(.pd)) {
+        .e <- .pd[["Estimate"]][.mixIdx]
+        .pd[["%RSE"]][.mixIdx] <-
+          ifelse(is.finite(.e) & .e != 0, abs(.newSe / .e) * 100, NA_real_)
+      }
+      assign("popDf", .pd, envir = env)
+    }
+  }
+  invisible(NULL)
+}
+
 #' Pre-final parameter table hook: back-transform mixture probability parameters
 #'
 #' Registered via \code{preFinalParTableHooksAdd()}; converts mixture
 #' probability parameters from mlogit scale to natural probability scale in
-#' \code{env$theta$theta}. SE/\%RSE stay \code{NA} (skipCov already set for
-#' these indices); the full probability vector (including the implicit last
-#' component) is stored in \code{env$mixProbabilities} for \code{.mixFix()}.
+#' \code{env$theta$theta}. The full probability vector (including the implicit
+#' last component) is stored in \code{env$mixProbabilities}, which
+#' \code{.mixFix()} and \code{.mixInstallProbScaleCov()} both read.  The
+#' covariance is rotated onto the probability scale later, by
+#' \code{.mixInstallProbScaleCov()} -- not here, because the covFull/analytic
+#' installers replace \code{env$cov} after this hook runs.
 #'
 #' @param env Fit environment containing \code{mixIdx} and \code{theta}
 #' @return invisible \code{NULL}; called for its side effects on \code{env}

--- a/R/mix.R
+++ b/R/mix.R
@@ -418,10 +418,18 @@
   if (!is.matrix(cov) || length(mixNames) == 0L) return(cov)
   if (is.null(rownames(cov))) return(cov)
   .i <- match(mixNames, rownames(cov))
-  if (anyNA(.i) || length(p) != length(.i) || !all(is.finite(p))) return(cov)
-  .J <- diag(p, nrow = length(p)) - outer(p, p)
+  if (length(p) != length(.i) || !all(is.finite(p))) return(cov)
+  # A proportion can be absent from THIS matrix while others are present -- a
+  # fix()ed proportion is dropped by skipCov, and covR/covS can drop a singular
+  # direction.  Rotate the subset that IS here rather than bailing on the whole
+  # matrix: aborting left the remaining proportions reported on the mlogit
+  # scale (measured 0.265 where the probability scale is 0.063).  Holding the
+  # absent coordinates fixed makes the correct Jacobian exactly the submatrix.
+  .keep <- !is.na(.i)
+  if (!any(.keep)) return(cov)
+  .J <- (diag(p, nrow = length(p)) - outer(p, p))[.keep, .keep, drop = FALSE]
   .A <- diag(1, nrow(cov))
-  .A[.i, .i] <- .J
+  .A[.i[.keep], .i[.keep]] <- .J
   .out <- .A %*% cov %*% t(.A)
   dimnames(.out) <- dimnames(cov)
   .out
@@ -489,7 +497,12 @@
     return(invisible(NULL))
   }
   .w <- match(mixNames, rownames(.cov))
-  if (anyNA(.w)) return(invisible(NULL))
+  # refresh the proportions that ARE in this covariance; one can be absent (a
+  # fix()ed proportion is dropped by skipCov) without invalidating the rest
+  .keep <- !is.na(.w)
+  if (!any(.keep)) return(invisible(NULL))
+  .w <- .w[.keep]
+  .mixIdx <- .mixIdx[.keep]
   .newSe <- sqrt(diag(.cov))[.w]
   if (exists("se", envir = env, inherits = FALSE)) {
     .se <- get("se", envir = env)
@@ -625,10 +638,11 @@
   .stat <- tryCatch(as.numeric(crossprod(.s, solve(crossprod(.d), .s))),
                     error = function(e) NA_real_)
   if (!is.finite(.stat) || .stat > 1e-3) {
-    # warning(), not an assignment to runInfo: that is the channel the fit
-    # collects run-time notes through, and a direct assignment here is
-    # overwritten by the later table assembly.  Kept under 75 characters so it
-    # renders on one line, and unprefixed -- the fit already reports its method.
+    # warning() IS how a note reaches the fit's $runInfo -- every warning raised
+    # during a run is collected there.  Assigning env$runInfo directly instead
+    # does NOT work: the later table assembly overwrites it.  Kept under 75
+    # characters so it renders on one line, and unprefixed (the fit already
+    # reports which method was run).
     warning("mixture proportion SE skipped; not at the score-zero point",
             call. = FALSE)
     return(invisible(NULL))

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -395,6 +395,7 @@
     .changed <- TRUE
   }
   if (!.changed) return(invisible())
+  .pf <- .mixParFixedCi(env$ui, .pf, .ci)
   env$parFixedDf <- .pf
   # regenerate the formatted table; the FIXED / fix(...) decorations are
   # re-derived from the existing formatted table (the numeric one lacks them)
@@ -502,6 +503,9 @@
     popDf <- .bsv$popDf
     popDf <- .updateParFixedAddShrinkage(popDf, shrink = .ret$shrink, ui = .ui)
   }
+  # a mixture proportion's CI belongs on the logit scale: the generic
+  # symmetric interval leaves (0, 1) and is built from the pre-rotation SE
+  popDf <- .mixParFixedCi(.ui, popDf, .parFixedCi)
   .ret$popDf <- popDf
   # $popDfSig may still exist from the C++ side but is no longer used
   .ret$parFixed <-

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -806,7 +806,11 @@ vcov.nlmixr2FitCoreSilent <- vcov.nlmixr2FitCore
   .ui <- x$ui
   .iniDf <- .ui$iniDf
   assign("iniDf0", nlmixr2global$nlmixr2EstEnv$iniDf0, envir=x)
-  if (exists("fullTheta", x)) {
+  # `fullTheta` is on the ESTIMATION scale; a mixture probability is therefore
+  # still mlogit there and has to be brought back below.  `fixef` and `theta`
+  # were already back-transformed by .aaaPostEstimationMixBacktransform().
+  .fromFullTheta <- exists("fullTheta", x)
+  if (.fromFullTheta) {
     .thetas <- x$fullTheta
   } else if (exists("fixef", x)) {
     .thetas <- get("fixef", x)
@@ -818,6 +822,15 @@ vcov.nlmixr2FitCoreSilent <- vcov.nlmixr2FitCore
     if (length(.thetaNames) > length(.thetas)) stop("corrupted rxode2 ui", call.=FALSE)
     .thetas <- .thetas[seq_along(.thetaNames)]
     names(.thetas) <- .thetaNames
+  }
+  # Without this the ui carries e.g. p1 = -0.847 = mlogit(0.3) while fixef()
+  # reports 0.3, and re-fitting the fit fails its own ini() validation.
+  if (.fromFullTheta) {
+    .mixNames <- tryCatch(.ui$mixProbs, error = function(e) character(0))
+    .mixNames <- intersect(.mixNames, names(.thetas))
+    if (length(.mixNames) > 0L) {
+      .thetas[.mixNames] <- rxode2::mexpit(unname(.thetas[.mixNames]))
+    }
   }
   for (.n in names(.thetas)) {
     .iniDf$est[.iniDf$name == .n] <- .thetas[.n]

--- a/R/nmObjGetEtaMat.R
+++ b/R/nmObjGetEtaMat.R
@@ -1,11 +1,29 @@
+#' Drop the non-eta columns from a `$eta`/`$ranef` data frame
+#'
+#' `$eta` carries `ID`, and for a mixture model `nmObjGet.ranef` also merges in
+#' a `mixnum` column.  Neither is an eta, so neither may reach an `etaMat`:
+#' `foceiSetup_` compares the column count against the model's `neta` and stops
+#' with "The etaMat must have the same number of ETAs (cols) as the model."
+#' Same strip as `R/resid.R`'s residual path.
+#'
+#' @param eta `$eta` / `$ranef` data frame
+#' @return the same data frame with `ID`/`mixnum`/`MIXEST` removed
+#' @noRd
+#' @author Matthew L. Fidler
+.nmDropNonEtaCols <- function(eta) {
+  .w <- which(names(eta) %in% c("ID", "mixnum", "MIXEST"))
+  if (length(.w) > 0L) return(eta[, -.w, drop = FALSE])
+  eta
+}
+
 #' @export
 nmObjGet.etaMat <- function(x, ...) {
   .ui <- x[[1]]
   if (is.null(.ui$eta)) return(NULL)
   if (is.null(.ui$iov)) {
-    as.matrix(.ui$eta[-1])
+    as.matrix(.nmDropNonEtaCols(.ui$eta))
   } else {
-    .eta <- as.matrix(.ui$eta[-1])
+    .eta <- as.matrix(.nmDropNonEtaCols(.ui$eta))
     .n <- names(.ui$iov)
     as.matrix(do.call(`cbind`,
                       c(list(.eta),

--- a/R/preProcessVaeNonMuTheta.R
+++ b/R/preProcessVaeNonMuTheta.R
@@ -102,7 +102,14 @@
   ## "invalid second argument of length 0".  Estimating it in the M-step is what
   ## the omega-fixed-at-1 parameterization expects.
   .iov <- if (is.null(.uiIovEnv$iovVars)) character(0) else .uiIovEnv$iovVars
-  .cand <- setdiff(.th$name, setdiff(c(.mu, .cov, .covCoef), .iov))
+  ## a mixture proportion (ui$mixProbs) is not a candidate: it is estimated on
+  ## the mlogit scale through its own analytic gradient, not injected as an eta
+  ## and not moved by the regress M-step (which would run it unbounded, against
+  ## the (-Inf, Inf) it carries in iniDf, and on the wrong scale).  Mirrors the
+  ## same exclusion in .npMuExpand().
+  .mix <- tryCatch(ui$mixProbs, error = function(e) character(0))
+  if (is.null(.mix)) .mix <- character(0)
+  .cand <- setdiff(.th$name, c(setdiff(c(.mu, .cov, .covCoef), .iov), .mix))
   if (length(.cand) == 0L) return(character(0))
   ## keep only thetas that actually appear in a model expression (so an eta can be
   ## attached to a structural line)

--- a/R/saem.R
+++ b/R/saem.R
@@ -1507,6 +1507,10 @@ nmObjGetFoceiControl.saem <- function(x, ...) {
     # table is built, attempt the FOCEI analytic covariance at the converged
     # estimates (keeps linFim on any failure).
     .saemInstallAnalyticCov(.ret)
+    # saem leaves the mixture proportions out of its kernel parameter vector, so
+    # its covariance has no mixture rows; append that block (NONMEM 7.51) from
+    # the fit's own responsibilities.
+    .mixCovAppendBlock(if (rxode2::rxIs(.ret, "nlmixr2FitData")) .ret$env else .ret)
     # For mixture models: post-correct me/mn/mu in the assembled fit table
     # (mirrors the .mixFixTable call in .foceiFamilyReturn for FOCEi fits)
     if (inherits(.ret, "nlmixr2FitData") && length(.ui$mixProbs) > 0L) {

--- a/R/saemIov.R
+++ b/R/saemIov.R
@@ -735,18 +735,6 @@ preProcessHooksAdd(".uiApplyIovTwoLevel", .uiApplyIovTwoLevel)
   }
   list(theta = .theta, omega = .omega, psi = .psi)
 }
-#' Restore the user's model after a collapsed (Panhard & Samson) fit
-#'
-#' Registered as a post-final hook.  The collapsed expansion replaced the user's
-#' line outright, so this rebuilds from the ORIGINAL ui rather than unpicking the
-#' rewritten one: it takes the pre-rewrite `iniDf`/`model` and writes the fitted
-#' values back into it -- the shared `mu` from the pooled thetas, the
-#' between-subject variance from the block's off-diagonal, and the
-#' inter-occasion variance from diagonal minus off-diagonal.
-#'
-#' @param ret fit object
-#' @return the fit, with the user's parameterization restored
-#' @noRd
 #' Rebuild the user's original ui from a collapsed fit
 #'
 #' Puts the collapsed block's estimates back on the parameters the user wrote:
@@ -816,6 +804,18 @@ preProcessHooksAdd(".uiApplyIovTwoLevel", .uiApplyIovTwoLevel)
   }
   invisible()
 }
+#' Restore the user's model after a collapsed (Panhard & Samson) fit
+#'
+#' Registered as a post-final hook.  The collapsed expansion replaced the user's
+#' line outright, so this rebuilds from the ORIGINAL ui rather than unpicking the
+#' rewritten one: it takes the pre-rewrite `iniDf`/`model` and writes the fitted
+#' values back into it -- the shared `mu` from the pooled thetas, the
+#' between-subject variance from the block's off-diagonal, and the
+#' inter-occasion variance from diagonal minus off-diagonal.
+#'
+#' @param ret fit object
+#' @return the fit, with the user's parameterization restored
+#' @noRd
 .saemIovFinalizeCollapsed <- function(ret) {
   .info <- .uiIovEnv$iovCollapsed
   if (is.null(.info) || is.null(.uiIovEnv$ui)) return(ret)

--- a/R/vaeData.R
+++ b/R/vaeData.R
@@ -796,7 +796,16 @@ vaeCovariates <- function(data, warn = TRUE,
   ## full theta vector (THETA_i_ in ntheta order), from ini estimates
   .thRows <- .idf[!is.na(.idf$ntheta), , drop = FALSE]
   .thRows <- .thRows[order(.thRows$ntheta), , drop = FALSE]
-  .th <- setNames(as.numeric(.thRows$est), paste0("THETA_", seq_len(nrow(.thRows)), "_"))
+  ## thetaIniMix puts the mixture proportions on the mlogit scale, which is the
+  ## scale the inner problem reads them on (updateTheta -> .getMixFromLog); the
+  ## raw iniDf estimate is the probability, and pushing that in unchanged made
+  ## p1 = 0.6 be read as mexpit(0.6) = 0.646.  It also stop()s on an invalid
+  ## ini() proportion, which is the right error to surface.
+  .thEst <- tryCatch(as.numeric(ui$thetaIniMix), error = function(e) NULL)
+  if (is.null(.thEst) || length(.thEst) != nrow(.thRows)) {
+    .thEst <- as.numeric(.thRows$est)
+  }
+  .th <- setNames(.thEst, paste0("THETA_", seq_len(nrow(.thRows)), "_"))
   ## structural theta index (in the full theta vector) paired with each eta.
   ## A random effect that is not mu-referenced to a single theta -- a mixture eta
   ## (mix(exp(lke1+eta.ke),p,exp(lke2+eta.ke))), an eta on a fixed (literalFix-ed)

--- a/R/vaeFit.R
+++ b/R/vaeFit.R
@@ -164,7 +164,12 @@
                       parInfo = NULL) {
   ## RNG is seeded ONCE for the whole estimation in nlmixr2Est.vae (rxWithSeed),
   ## which also covers the model's own random draws and restores the caller's seed
-  zDim <- prep$zDim; hDim <- control$hiddenDim; nCov <- ncol(prep$covIn); N <- prep$N
+  zDim <- prep$zDim; hDim <- control$hiddenDim; N <- prep$N
+  ## The encoder is conditioned on the mixture component: it characterizes every
+  ## (subject, component) pair, with the component entering the FC head as a
+  ## one-hot appended to the covariate block (see vaeTileEncoderInputs in
+  ## src/inner.cpp).  So the head is nMix wider for a mixture model.
+  nCov <- ncol(prep$covIn) + if (nMix > 1L) as.integer(nMix) else 0L
   ## the FC head is [outDim x (hDim + nCov)]; a width mismatch reaches armadillo
   ## as a std::logic_error and aborts the session, so check it here
   .vaeCheckEncoderDims <- function(params) {

--- a/R/vaeFit.R
+++ b/R/vaeFit.R
@@ -343,8 +343,9 @@
   if (is.na(.nMix) || .nMix < 1L) .nMix <- 1L
   .mixProb <- 1
   if (.nMix > 1L) {
-    .p <- as.numeric(.prep$th[.ui$thetaMixIndex])
-    .mixProb <- c(.p, 1 - sum(.p))
+    ## prep$th holds the mlogit values (see .vaeDataPrep); mexpit them back to
+    ## the simplex, exactly as the inner problem does
+    .mixProb <- .getMixFromLog(.prep$th, .ui$thetaMixIndex)
   }
   ## parameter-history / iteration-print names: structural typical values on the
   ## mu-referenced etas, the omega diagonal, and the residual error params

--- a/R/vaeFit.R
+++ b/R/vaeFit.R
@@ -164,7 +164,8 @@
                       parInfo = NULL) {
   ## RNG is seeded ONCE for the whole estimation in nlmixr2Est.vae (rxWithSeed),
   ## which also covers the model's own random draws and restores the caller's seed
-  zDim <- prep$zDim; hDim <- control$hiddenDim; N <- prep$N
+  zDim <- prep$zDim
+  hDim <- control$hiddenDim
   ## The encoder is conditioned on the mixture component: it characterizes every
   ## (subject, component) pair, with the component entering the FC head as a
   ## one-hot appended to the covariate block (see vaeTileEncoderInputs in

--- a/R/vaeFit.R
+++ b/R/vaeFit.R
@@ -334,7 +334,13 @@
        nRegGrad = as.integer(.fit$nRegGrad), nRegFallback = as.integer(.fit$nRegFallback),
        nStage2 = as.integer(.fit$nStage2),
        covSelectMethodUsed = .modes$used,
-       nMix = nMix, mixProb = mixProb, mixnum = as.integer(.fit$mixnum))
+       nMix = nMix,
+       ## the FITTED proportions, not the ini() ones: they are estimated on the
+       ## mlogit scale by their own analytic gradient (Adam), so the value that
+       ## comes back from training is the one to report and write into ini()
+       mixProb = if (is.null(.fit$mixProb)) mixProb else as.numeric(.fit$mixProb),
+       nMixThetaStep = .fit$nMixThetaStep,
+       mixnum = as.integer(.fit$mixnum))
 }
 
 #' Fit entry: prepare data, set up the FOCEi inner problem once, train.

--- a/R/vaeOutput.R
+++ b/R/vaeOutput.R
@@ -107,12 +107,6 @@
   if (length(.m) == 0L) .own else .m[1L]
 }
 
-#' Update a ui with the VAE's selected covariate effects and fitted estimates.
-#'
-#' Continuous covariates enter as `beta*log(COV/center)`, categorical as
-#' `beta*(COV - center)`, inserted into each mu-referenced parameter's model
-#' line. Returns the updated ui.
-#' @noRd
 #' Write a mixture model's fitted proportions back into `ini()`
 #'
 #' `fit$mixProb` is the full simplex (nMix entries); `ini()` carries the first
@@ -140,6 +134,12 @@
   ui2
 }
 
+#' Update a ui with the VAE's selected covariate effects and fitted estimates.
+#'
+#' Continuous covariates enter as `beta*log(COV/center)`, categorical as
+#' `beta*(COV - center)`, inserted into each mu-referenced parameter's model
+#' line. Returns the updated ui.
+#' @noRd
 .vaeUpdateModel <- function(ui, fit) {
   prep <- fit$prep
   .map <- .foceiEtaThetaMap(ui)

--- a/R/vaeOutput.R
+++ b/R/vaeOutput.R
@@ -113,6 +113,33 @@
 #' `beta*(COV - center)`, inserted into each mu-referenced parameter's model
 #' line. Returns the updated ui.
 #' @noRd
+#' Write a mixture model's fitted proportions back into `ini()`
+#'
+#' `fit$mixProb` is the full simplex (nMix entries); `ini()` carries the first
+#' nMix-1 on the PROBABILITY scale.  Clamped and renormalized so a proportion
+#' that reached the boundary still passes the ui's own validation (each in
+#' [0,1], summing to under 1) instead of failing `assertRxUi`.
+#'
+#' @param ui2 ui being updated
+#' @param ui original ui (carries `mixProbs`)
+#' @param fit vae fit list
+#' @param setIni the caller's `ini()` setter
+#' @return the updated ui
+#' @noRd
+#' @author Matthew L. Fidler
+.vaeSetIniMixProb <- function(ui2, ui, fit, setIni) {
+  .nm <- tryCatch(ui$mixProbs, error = function(e) character(0))
+  if (is.null(.nm) || length(.nm) == 0L) return(ui2)
+  .p <- fit$mixProb
+  if (is.null(.p) || length(.p) != length(.nm) + 1L || !all(is.finite(.p))) return(ui2)
+  .p <- pmin(pmax(.p, 1e-6), 1 - 1e-6)
+  .p <- .p / sum(.p)
+  for (.k in seq_along(.nm)) {
+    ui2 <- setIni(ui2, paste0(.nm[.k], " <- ", signif(.p[.k], 12)))
+  }
+  ui2
+}
+
 .vaeUpdateModel <- function(ui, fit) {
   prep <- fit$prep
   .map <- .foceiEtaThetaMap(ui)
@@ -234,6 +261,8 @@
       if (is.finite(.rv)) ui2 <- .setIni(ui2, paste0(rn, " <- ", signif(.rv, 12)))
     }
   }
+  ## 3b. mixture proportions (never regressed -- see .vaeNonMuThetas)
+  ui2 <- .vaeSetIniMixProb(ui2, ui, fit, .setIni)
   ## The incremental model()/ini() edits above leave the ui's cached `covariates`
   ## stale: an injected covariate-coefficient theta (beta.<par>.<cov>) is added to
   ## the iniDf as a theta but ALSO stays listed as a covariate.  The augmented
@@ -304,6 +333,8 @@
       if (is.finite(.rv)) ui2 <- .setIni(ui2, paste0(rn, " <- ", signif(.rv, 12)))
     }
   }
+  ## 5. mixture proportions (never regressed -- see .vaeNonMuThetas)
+  ui2 <- .vaeSetIniMixProb(ui2, ui, fit, .setIni)
   rxode2::assertRxUi(ui2$fun)
 }
 

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -997,6 +997,8 @@ static void impComputeCov(Environment e, const arma::vec& gammaVec,
   int nsub = impNsub();
   int neta = impNeta();
   int isample = impNsample();
+  int Nm = impNmix();
+  int nExp = nsub * Nm;   // expanded pseudo-subjects: component j is i + j*nsub
   // Parallelize the reweighted-objective subject loop (each subject contributes an
   // independent scalar to the -2LL) when the inner solves are thread-safe: no
   // mixture (expanded pseudo-subjects share solve rows) and no multi-endpoint
@@ -1017,15 +1019,19 @@ static void impComputeCov(Environment e, const arma::vec& gammaVec,
   int nTh = 0;
   for (int j = 0; j < np; ++j) if (pl[j] < ntheta) ++nTh;
 
-  // Per-subject proposal: mode, information H, lower Cholesky of gamma*H^-1, and
-  // one fixed sample matrix.
-  std::vector<arma::vec> modes(nsub);
-  std::vector<arma::mat> Hs(nsub), Ls(nsub), Ss(nsub);
-  std::vector<double> logDetH(nsub, 0.0);
-  std::vector<char> ok(nsub, 0);
+  // Per-pseudo-subject proposal: mode, information H, lower Cholesky of
+  // gamma*H^-1, and one fixed sample matrix.  For a mixture these run over the
+  // EXPANDED subjects (component j is i + j*nsub), exactly as the E-step does:
+  // the objective differenced below is the mixture MARGINAL, so every component
+  // needs its own proposal.  Component 0 alone left the proportions' directions
+  // exactly flat and their SEs at 0.
+  std::vector<arma::vec> modes(nExp);
+  std::vector<arma::mat> Hs(nExp), Ls(nExp), Ss(nExp);
+  std::vector<double> logDetH(nExp, 0.0);
+  std::vector<char> ok(nExp, 0);
   arma::vec mode(neta);
   arma::mat H(neta, neta, arma::fill::zeros);
-  for (int id = 0; id < nsub; ++id) {
+  for (int id = 0; id < nExp; ++id) {
     impGetMode(id, mode);
     modes[id] = mode;
     if (impGetHessian(id, H)) {
@@ -1059,7 +1065,7 @@ static void impComputeCov(Environment e, const arma::vec& gammaVec,
   }
   uint32_t seed0 = (uint32_t)impBaseSeed() + 0x2545F491u;
   setRxThreadId(0);
-  for (int id = 0; id < nsub; ++id) {
+  for (int id = 0; id < nExp; ++id) {
     if (!ok[id]) continue;
     setSeedEng1(seed0 + (uint32_t)(id * 2 + 1));
     arma::mat S(isample, neta);
@@ -1108,7 +1114,9 @@ static void impComputeCov(Environment e, const arma::vec& gammaVec,
   // per-subject buffer under the parallel loop, then reduce in id order so the sum
   // is bit-identical to the serial `obj += ...` accumulation.  objBuf is allocated
   // once here and refilled per call (the FD Hessian calls evalObj O(np^2) times).
-  std::vector<double> objBuf(nsub, 0.0);
+  std::vector<double> objBuf(nExp, 0.0);
+  std::vector<char> objGood(nExp, 0);
+  std::vector<double> mixLl((size_t)Nm);
   // Progress bar over the finite-difference covariance evaluations, like the
   // focei covariance step.  evalObj is called f0 (1) + 2*np (diagonal) +
   // 2*np*(np-1) (off-diagonal) = 1 + 2*np*np times; tick once per call.
@@ -1121,10 +1129,11 @@ static void impComputeCov(Environment e, const arma::vec& gammaVec,
     // Re-read after setting: an Omega perturbation changes -0.5 log|Omega|.
     double negHalfLogDetOmega = impLogDetOmegaInv5();
     std::fill(objBuf.begin(), objBuf.end(), 0.0);
+    std::fill(objGood.begin(), objGood.end(), 0);
 #ifdef _OPENMP
 #pragma omp parallel for num_threads(cores) if(doParCov)
 #endif
-    for (int id = 0; id < nsub; ++id) {
+    for (int id = 0; id < nExp; ++id) {
 #ifdef _OPENMP
       if (doParCov) setRxThreadId(omp_get_thread_num());
 #endif
@@ -1148,15 +1157,31 @@ static void impComputeCov(Environment e, const arma::vec& gammaVec,
           double logMeanExp = qmax + std::log(sumw / (double)isample);
           double Ci = negHalfLogDetOmega + 0.5 * neta * std::log(gammaVec[id]) - 0.5 * logDetH[id]
             + pr.corr;
-          objBuf[id] = -2.0 * (logMeanExp + Ci);
+          objBuf[id] = logMeanExp + Ci;   // log-likelihood; combined below
+          objGood[id] = 1;
         }
       }
 #ifdef _OPENMP
       if (doParCov) setRxThreadId(-1);
 #endif
     }
+    // Reduce in id order so the sum is bit-identical to a serial accumulation.
+    // For a mixture each physical subject's contribution is the marginal
+    // log(sum_m p_m L_im) over its components, which is what makes the mixture
+    // proportions enter the objective at all.  A subject with no usable
+    // component contributes 0, as the single-component path always did.
     double obj = 0.0;
-    for (int id = 0; id < nsub; ++id) obj += objBuf[id];
+    if (Nm == 1) {
+      for (int id = 0; id < nsub; ++id) obj += objGood[id] ? -2.0 * objBuf[id] : 0.0;
+    } else {
+      for (int i = 0; i < nsub; ++i) {
+        for (int m = 0; m < Nm; ++m) {
+          mixLl[(size_t)m] = objGood[i + m*nsub] ? objBuf[i + m*nsub] : NA_REAL;
+        }
+        double lse = impMixLogSumExp(mixLl);
+        if (R_FINITE(lse)) obj += -2.0 * lse;
+      }
+    }
     if (covProg) covTick = par_progress(covCur++, covTot, covTick, 1, covT0, 0);
     return obj;
   };

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -992,6 +992,38 @@ static void impEStep(int nsub, int neta, const arma::ivec& isampleVec,
 // gamma -- wrong whenever the scale adapted during the fit, and badly wrong
 // under gammaMethod="individual" where the scales are per subject.  The
 // covariance must be evaluated with the same proposal the fit converged on.
+// Central finite-difference Hessian of `f` at `par0`, with the same relative
+// step the MC covariance has always used.  Split out of impComputeCov() so the
+// FD bookkeeping is readable on its own; `f` reuses the fixed importance
+// samples (common random numbers), which is what makes this well behaved.
+static arma::mat impFdHessian(const arma::vec& par0,
+                              const std::function<double(const arma::vec&)>& f) {
+  const int np = (int)par0.n_elem;
+  arma::vec hstep(np);
+  for (int j = 0; j < np; ++j) {
+    double a = std::fabs(par0[j]);
+    hstep[j] = 1e-3 * (a > 1e-3 ? a : 1.0);
+  }
+  double f0 = f(par0);
+  arma::mat hess(np, np, arma::fill::zeros);
+  for (int j = 0; j < np; ++j) {
+    arma::vec p = par0; p[j] = par0[j] + hstep[j]; double fp = f(p);
+    p = par0; p[j] = par0[j] - hstep[j]; double fm = f(p);
+    hess(j, j) = (fp - 2.0 * f0 + fm) / (hstep[j] * hstep[j]);
+  }
+  for (int a = 0; a < np; ++a) {
+    for (int b = a + 1; b < np; ++b) {
+      arma::vec p = par0; p[a] += hstep[a]; p[b] += hstep[b]; double fpp = f(p);
+      p = par0; p[a] += hstep[a]; p[b] -= hstep[b]; double fpm = f(p);
+      p = par0; p[a] -= hstep[a]; p[b] += hstep[b]; double fmp = f(p);
+      p = par0; p[a] -= hstep[a]; p[b] -= hstep[b]; double fmm = f(p);
+      double v = (fpp - fpm - fmp + fmm) / (4.0 * hstep[a] * hstep[b]);
+      hess(a, b) = v; hess(b, a) = v;
+    }
+  }
+  return hess;
+}
+
 static void impComputeCov(Environment e, const arma::vec& gammaVec,
                           const std::vector<impProp>& props, int covIter) {
   int nsub = impNsub();
@@ -1190,30 +1222,7 @@ static void impComputeCov(Environment e, const arma::vec& gammaVec,
   for (int j = 0; j < np; ++j)
     par0[j] = (pl[j] < ntheta) ? impGetFullThetaVal(pl[j])
                                : impGetOmegaThetaVal(pl[j] - ntheta);
-  double f0 = evalObj(par0);
-  arma::vec hstep(np);
-  for (int j = 0; j < np; ++j) {
-    double a = std::fabs(par0[j]);
-    hstep[j] = 1e-3 * (a > 1e-3 ? a : 1.0);
-  }
-  arma::vec fp(np), fm(np);
-  for (int j = 0; j < np; ++j) {
-    arma::vec p = par0; p[j] = par0[j] + hstep[j]; fp[j] = evalObj(p);
-    p = par0; p[j] = par0[j] - hstep[j]; fm[j] = evalObj(p);
-  }
-  arma::mat Hess(np, np, arma::fill::zeros);
-  for (int j = 0; j < np; ++j)
-    Hess(j, j) = (fp[j] - 2.0 * f0 + fm[j]) / (hstep[j] * hstep[j]);
-  for (int a = 0; a < np; ++a) {
-    for (int b = a + 1; b < np; ++b) {
-      arma::vec p = par0; p[a] += hstep[a]; p[b] += hstep[b]; double fpp = evalObj(p);
-      p = par0; p[a] += hstep[a]; p[b] -= hstep[b]; double fpm = evalObj(p);
-      p = par0; p[a] -= hstep[a]; p[b] += hstep[b]; double fmp = evalObj(p);
-      p = par0; p[a] -= hstep[a]; p[b] -= hstep[b]; double fmm = evalObj(p);
-      double v = (fpp - fpm - fmp + fmm) / (4.0 * hstep[a] * hstep[b]);
-      Hess(a, b) = v; Hess(b, a) = v;
-    }
-  }
+  arma::mat Hess = impFdHessian(par0, evalObj);
   if (covProg) par_progress(covTot, covTot, covTick, 1, covT0, 1);   // close the bar
   // Restore the converged estimates.
   for (int j = 0; j < np; ++j) setPar(j, par0[j]);

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -22,6 +22,7 @@
 #include "nmMcmcRng.h"
 #include "impQrng.h"
 #include "imp.h"
+#include "logSumExp.h"
 #include "odeSwap.h" // odeSwapAnyNdiffSet()
 #include "utilc.h"   // RSprintf (covariance-step progress header)
 #ifdef _OPENMP
@@ -204,13 +205,10 @@ static inline double impGammaQuantile(double u, double shape) {
   return boost::math::quantile(boost::math::gamma_distribution<double>(shape, 1.0), u);
 }
 
+// unweighted log-sum-exp over the proposal's log-weights; the max-shifted sum
+// itself is rxLogSumExp() (logSumExp.h), shared with the mixture marginals
 static inline double impLogSumExp3(const double* v, int n) {
-  double m = v[0];
-  for (int k = 1; k < n; ++k) if (v[k] > m) m = v[k];
-  if (!R_finite(m)) return m;
-  double s = 0.0;
-  for (int k = 0; k < n; ++k) s += std::exp(v[k] - m);
-  return m + std::log(s);
+  return rxLogSumExp(v, n);
 }
 
 // Build a subject's proposal from the fit-constant spec plus its own df.

--- a/src/imp.cpp
+++ b/src/imp.cpp
@@ -1217,7 +1217,10 @@ static void impComputeCov(Environment e, const arma::vec& gammaVec,
   if (covProg) par_progress(covTot, covTot, covTick, 1, covT0, 1);   // close the bar
   // Restore the converged estimates.
   for (int j = 0; j < np; ++j) setPar(j, par0[j]);
-  for (int id = 0; id < nsub; ++id) impForceResolve(id);
+  // every pseudo-subject, not just component 0: the perturbed solves above ran
+  // over nExp, so stopping at nsub leaves the other components' cached solves
+  // sitting at the LAST perturbation rather than the converged estimates
+  for (int id = 0; id < nExp; ++id) impForceResolve(id);
 
   // Observed information = 0.5 * Hess(-2LL) (symmetrized); covariance = inverse.
   arma::mat info = 0.25 * (Hess + Hess.t());

--- a/src/imp.h
+++ b/src/imp.h
@@ -175,6 +175,7 @@ void impUpdateMixProbs();                          // recompute mixProb from the
 void impSetMixThetas(const arma::vec& theta);      // install absolute mixture-proportion thetas (EM) + recompute proportions
 void npMixEMUpdate(const arma::mat& etaPoints, const arma::vec& lam, int cores); // EM update of the mixture proportions (support/weights fixed)
 void npbSampleMixProbs(const arma::mat& subEta, double alpha0, uint32_t seed);     // npb Gibbs: Dirichlet draw of the mixture proportions
+double impMixLogSumExp(const std::vector<double>& ll);  // log(sum_m p_m exp(ll[m])); R_NegInf if nothing finite
 
 // ---- Monte-Carlo covariance support (implemented in inner.cpp) ----
 int impNtheta();                                   // number of thetas

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -22826,50 +22826,75 @@ static void vaeScoreCandidates(VaeBnbCtx& c, int nCov,
 // Moves are per BLOCK, not per column: a single-column add or drop inside a
 // hockey block only ever produces a half-selected support, which vaeBnbLeaf
 // rejects -- so a column-wise polish could never move a blocked relationship.
+// append block b's columns to `t`, keeping it sorted
+static void vaeLsAddBlock(const VaeBnbCtx& c, std::vector<int>& t, int b) {
+  const std::vector<int>& cols = c.blocks[(size_t)b];
+  t.insert(t.end(), cols.begin(), cols.end());
+  std::sort(t.begin(), t.end());
+}
+
+// `cur` minus every column of block b
+static std::vector<int> vaeLsDropBlock(const VaeBnbCtx& c,
+                                       const std::vector<int>& cur, int b) {
+  std::vector<int> t;
+  t.reserve(cur.size());
+  for (size_t s = 0; s < cur.size(); ++s) {
+    if (c.blockOf[(size_t)cur[s]] != b) t.push_back(cur[s]);
+  }
+  return t;
+}
+
+// score every support reachable from `cur` by ADDING one absent block
+static void vaeLsAdd(VaeBnbCtx& c, const std::vector<int>& cur,
+                     const std::vector<char>& inBlk) {
+  for (int b = 0; b < (int)c.blocks.size(); ++b) {
+    if (inBlk[(size_t)b]) continue;
+    if (!vaeGroupFreeBlock(c, cur, b)) continue;         // group already taken
+    std::vector<int> t = cur;
+    vaeLsAddBlock(c, t, b);
+    vaeBnbLeaf(c, t);
+  }
+}
+
+// score every support reachable from `cur` by DROPPING one present block
+static void vaeLsDrop(VaeBnbCtx& c, const std::vector<int>& cur,
+                      const std::vector<char>& inBlk) {
+  for (int d = 0; d < (int)c.blocks.size(); ++d) {
+    if (!inBlk[(size_t)d]) continue;
+    vaeBnbLeaf(c, vaeLsDropBlock(c, cur, d));
+  }
+}
+
+// score every support reachable from `cur` by SWAPPING a present block for an
+// absent one.  The swap vacates block d, so feasibility is judged against the
+// REST of the support -- swapping one shape of a covariate for another stays
+// legal.
+static void vaeLsSwap(VaeBnbCtx& c, const std::vector<int>& cur,
+                      const std::vector<char>& inBlk) {
+  const int nBlk = (int)c.blocks.size();
+  for (int d = 0; d < nBlk; ++d) {
+    if (!inBlk[(size_t)d]) continue;
+    std::vector<int> rest = vaeLsDropBlock(c, cur, d);
+    for (int b = 0; b < nBlk; ++b) {
+      if (inBlk[(size_t)b]) continue;
+      if (!vaeGroupFreeBlock(c, rest, b)) continue;
+      std::vector<int> t = rest;
+      vaeLsAddBlock(c, t, b);
+      vaeBnbLeaf(c, t);
+    }
+  }
+}
+
 static void vaeLocalSearchL0(VaeBnbCtx& c, int maxPass = 100) {
   const int nBlk = (int)c.blocks.size();
-  // append block b's columns to `t`, keeping it sorted
-  auto addBlock = [&](std::vector<int>& t, int b) {
-    const std::vector<int>& cols = c.blocks[(size_t)b];
-    t.insert(t.end(), cols.begin(), cols.end());
-    std::sort(t.begin(), t.end());
-  };
-  // `cur` minus every column of block b
-  auto dropBlock = [&](const std::vector<int>& cur, int b) {
-    std::vector<int> t;
-    t.reserve(cur.size());
-    for (size_t s = 0; s < cur.size(); ++s) {
-      if (c.blockOf[(size_t)cur[s]] != b) t.push_back(cur[s]);
-    }
-    return t;
-  };
   for (int pass = 0; pass < maxPass; ++pass) {
     const std::vector<int> cur = c.bestSel;
     const double before = c.bestScore;
     std::vector<char> inBlk((size_t)nBlk, 0);
     for (size_t s = 0; s < cur.size(); ++s) inBlk[(size_t)c.blockOf[(size_t)cur[s]]] = 1;
-    for (int b = 0; b < nBlk; ++b) {                     // add
-      if (inBlk[(size_t)b]) continue;
-      if (!vaeGroupFreeBlock(c, cur, b)) continue;       // group already taken
-      std::vector<int> t = cur; addBlock(t, b);
-      vaeBnbLeaf(c, t);
-    }
-    for (int d = 0; d < nBlk; ++d) {                     // drop
-      if (!inBlk[(size_t)d]) continue;
-      vaeBnbLeaf(c, dropBlock(cur, d));
-    }
-    for (int d = 0; d < nBlk; ++d) {                     // swap
-      if (!inBlk[(size_t)d]) continue;
-      // the swap vacates block d, so feasibility is judged against the REST of
-      // the support -- swapping one shape of a covariate for another stays legal
-      std::vector<int> rest = dropBlock(cur, d);
-      for (int b = 0; b < nBlk; ++b) {
-        if (inBlk[(size_t)b]) continue;
-        if (!vaeGroupFreeBlock(c, rest, b)) continue;
-        std::vector<int> t = rest; addBlock(t, b);
-        vaeBnbLeaf(c, t);
-      }
-    }
+    vaeLsAdd(c, cur, inBlk);
+    vaeLsDrop(c, cur, inBlk);
+    vaeLsSwap(c, cur, inBlk);
     if (!(c.bestScore < before)) break;                  // local optimum
   }
 }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -10,6 +10,7 @@
 #include "shi21.h"
 #include "trustHessianUpdate.h"
 #include "foceiGrad.h"
+#include "logSumExp.h"
 #include "inner.h"
 #include "nmMcmcRng.h"
 #include <cfloat>
@@ -5785,25 +5786,15 @@ static double foceiLik0Mix() {
   return lik;
 }
 
-// log( sum_m pi_m exp(ll[m]) ) -- the mixture marginal in log space, with the
-// usual max-shift so a component whose likelihood underflows does not take the
-// sum with it.  pi is op_focei.mixProb (the population proportions).  Returns
-// NA_REAL when no component has a finite contribution.  Shared with npMixLogSumExp().
+// log( sum_m pi_m exp(ll[m]) ) -- the mixture marginal in log space, weighted
+// by op_focei.mixProb (the population proportions).  Returns NA_REAL when no
+// component has a finite contribution.  The max-shifted sum itself lives in
+// rxLogSumExpW() (logSumExp.h); this only supplies the weights and the
+// NA_REAL-vs-R_NegInf convention its callers expect.
 static double foceiMixLogSumExp(const double *ll, int nMix) {
   if (nMix <= 1) return (nMix == 1) ? ll[0] : NA_REAL;
-  double mx = R_NegInf;
-  for (int m = 0; m < nMix; ++m) {
-    if (!R_FINITE(ll[m])) continue;
-    double lp = ll[m] + std::log(std::max(1e-300, op_focei.mixProb[m]));
-    if (lp > mx) mx = lp;
-  }
-  if (!R_FINITE(mx)) return NA_REAL;
-  double se = 0.0;
-  for (int m = 0; m < nMix; ++m) {
-    if (!R_FINITE(ll[m])) continue;
-    se += std::exp(ll[m] + std::log(std::max(1e-300, op_focei.mixProb[m])) - mx);
-  }
-  return mx + std::log(se);
+  double r = rxLogSumExpMix(ll, op_focei.mixProb, nMix, NULL);
+  return R_FINITE(r) ? r : NA_REAL;
 }
 
 // One physical subject's MARGINAL contribution to the objective (-2*log-lik),
@@ -10717,6 +10708,18 @@ static bool foceiSMixScore(int cpar, const std::vector<double> &mixR,
   return true;
 }
 
+// This subject contributed no usable score for cpar: fall back to the pooled
+// gradient, which is what the non-mixture branch's serial retry ends up doing.
+// sInfoPer must be docked as well -- it feeds the smatPer gate that decides
+// whether the S matrix is trustworthy at all, so a substituted value has to be
+// counted rather than silently pass for a real per-subject score.
+static inline void foceiSMixNoInfo(focei_ind *fInd, int cpar, const arma::vec &gfull,
+                                   bool &hasZero, double &sInfoPer) {
+  hasZero = true;
+  sInfoPer -= 1.0;
+  fInd->thetaGrad[cpar] = gfull[cpar];
+}
+
 // Forward leg of the per-subject difference for a MIXTURE model.  The subject's
 // contribution is the marginal over components, so every component has to be
 // re-optimized before any per-subject score exists: differencing component 0
@@ -10735,11 +10738,7 @@ static void foceiSMixForward(int cpar, double delta, bool doForward,
     if (R_FINITE(o2) && R_FINITE(op_focei.likSav[gid])) {
       fIndL->thetaGrad[cpar] = (o2 - op_focei.likSav[gid]) / delta;
     } else {
-      // no usable contribution for this subject/parameter: fall back to the
-      // pooled gradient, as the non-mixture serial retry does
-      hasZero = true;
-      sInfoPer -= 1.0;
-      fIndL->thetaGrad[cpar] = gfull[cpar];
+      foceiSMixNoInfo(fIndL, cpar, gfull, hasZero, sInfoPer);
     }
   }
 }
@@ -10764,9 +10763,7 @@ static void foceiSMixCentral(int cpar, double delta, const arma::vec &gfull,
     } else {
       // one leg is unusable; likSav is only filled on the doForward path, so a
       // stale forward difference is not an option here
-      hasZero = true;
-      sInfoPer -= 1.0;
-      fIndL->thetaGrad[cpar] = gfull[cpar];
+      foceiSMixNoInfo(fIndL, cpar, gfull, hasZero, sInfoPer);
     }
   }
 }
@@ -21943,18 +21940,18 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
     // is why no test could see it.
     jointTot = 0;
     for (int i = 0; i < N; ++i) {
-      double mmax = -std::numeric_limits<double>::infinity(); int best = 0;
       arma::vec ll(nMix);
+      int best = 0;
+      double bestLl = -std::numeric_limits<double>::infinity();
       for (int m = 0; m < nMix; ++m) {
-        double v = std::log(pi[m]) - obj[m * N + i];
-        if (!R_FINITE(v)) v = -std::numeric_limits<double>::infinity();
-        ll[m] = v; if (v > mmax) { mmax = v; best = m; }
+        ll[m] = -obj[m * N + i];
+        double v = std::log(pi[m]) + ll[m];
+        if (R_FINITE(v) && v > bestLl) { bestLl = v; best = m; }
       }
       arma::vec resp(nMix, arma::fill::zeros);
-      if (R_FINITE(mmax)) {
-        double se = 0; for (int m = 0; m < nMix; ++m) se += std::exp(ll[m] - mmax);
-        jointTot += -(mmax + std::log(se));
-        for (int m = 0; m < nMix; ++m) resp[m] = std::exp(ll[m] - mmax)/se;
+      double lse = rxLogSumExpMix(ll.memptr(), pi.memptr(), nMix, resp.memptr());
+      if (R_FINITE(lse)) {
+        jointTot += -lse;
       } else {
         // every component failed to solve: charge the same penalty focei does
         // (foceiLik0Mix), instead of contributing 0 and IMPROVING the objective.
@@ -23072,19 +23069,16 @@ static double gVaeThetaObjR(Rcpp::NumericVector r) {
     // per-subject mixture -2LL via log-sum-exp (same as vaeElboStepCpp)
     v = 0;
     for (int i = 0; i < N; ++i) {
-      double mmax = -std::numeric_limits<double>::infinity();
-      arma::vec ll(nMix);
+      // same 1x-scale marginal as vaeElboStepCpp -- the two MUST optimize one
+      // functional, or the M-step chases a different objective than the ELBO
+      arma::vec ll(nMix), pm(nMix);
       for (int m = 0; m < nMix; ++m) {
-        // same 1x-scale marginal as vaeElboStepCpp -- the two MUST optimize one
-        // functional, or the M-step chases a different objective than the ELBO
-        double pm = (op_focei.mixProb != NULL) ? op_focei.mixProb[m] : gVaeRegMixProb[m];
-        double lv = std::log(pm) - obj[m * N + i];
-        if (!R_FINITE(lv)) lv = -std::numeric_limits<double>::infinity();
-        ll[m] = lv; if (lv > mmax) mmax = lv;
+        ll[m] = -obj[m * N + i];
+        pm[m] = (op_focei.mixProb != NULL) ? op_focei.mixProb[m] : gVaeRegMixProb[m];
       }
-      if (R_FINITE(mmax)) {
-        double se = 0; for (int m = 0; m < nMix; ++m) se += std::exp(ll[m] - mmax);
-        v += -(mmax + std::log(se));
+      double lse = rxLogSumExpMix(ll.memptr(), pm.memptr(), nMix, NULL);
+      if (R_FINITE(lse)) {
+        v += -lse;
       } else {
         v += op_focei.badSolveObjfAdj;
       }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -5785,6 +5785,48 @@ static double foceiLik0Mix() {
   return lik;
 }
 
+// log( sum_m pi_m exp(ll[m]) ) -- the mixture marginal in log space, with the
+// usual max-shift so a component whose likelihood underflows does not take the
+// sum with it.  pi is op_focei.mixProb (the population proportions).  Returns
+// NA_REAL when no component has a finite contribution.  Shared with npMixLogSumExp().
+static double foceiMixLogSumExp(const double *ll, int nMix) {
+  if (nMix <= 1) return (nMix == 1) ? ll[0] : NA_REAL;
+  double mx = R_NegInf;
+  for (int m = 0; m < nMix; ++m) {
+    if (!R_FINITE(ll[m])) continue;
+    double lp = ll[m] + std::log(std::max(1e-300, op_focei.mixProb[m]));
+    if (lp > mx) mx = lp;
+  }
+  if (!R_FINITE(mx)) return NA_REAL;
+  double se = 0.0;
+  for (int m = 0; m < nMix; ++m) {
+    if (!R_FINITE(ll[m])) continue;
+    se += std::exp(ll[m] + std::log(std::max(1e-300, op_focei.mixProb[m])) - mx);
+  }
+  return mx + std::log(se);
+}
+
+// One physical subject's MARGINAL contribution to the objective (-2*log-lik),
+// combined from the per-component values innerOpt1() leaves in lik[slot].  The
+// pseudo-subject layout is component-major (id = m*nsub + i).
+//
+// The slots do NOT share a scale: LikInner2() writes lik[0] as the raw
+// log-likelihood and lik[1]/lik[2] as -2*log-likelihood, so slot 0 is used as
+// is and the difference legs are halved back before combining.  Without this
+// the per-subject score foceiS() differences is component 0's alone, which is
+// how the S matrix came out singular for every mixture model (a parameter that
+// only enters component 2 gets an exactly-zero score).
+static double foceiMixObjSlot(int gid, int slot) {
+  int nsub = (int)getRxNsub(rx), nMix = (int)op_focei.mixIdxN + 1;
+  std::vector<double> ll((size_t)nMix);
+  for (int m = 0; m < nMix; ++m) {
+    double l = inds_focei[gid + m*nsub].lik[slot];
+    ll[(size_t)m] = (slot == 0) ? l : -0.5*l;
+  }
+  double lse = foceiMixLogSumExp(ll.data(), nMix);
+  return R_FINITE(lse) ? -2.0*lse : NA_REAL;
+}
+
 static inline double foceiLik0(double *theta) {
   updateTheta(theta);
   innerOpt();
@@ -10617,6 +10659,43 @@ int foceiCalcR(Environment e){
 }
 
 
+// Re-run the inner problem at the CURRENT theta for every pseudo-subject,
+// writing lik[slot].  Mirrors innerOpt()'s mixture arrangement exactly:
+// components SERIAL on the outside, physical subjects parallel inside, because
+// components share the physical subjects' solving structures and must never be
+// solved concurrently.
+//
+// res[i] is 1 only when EVERY component of physical subject i converged -- the
+// subject's marginal needs all of them, so one failed component invalidates the
+// whole contribution.
+static void foceiSInnerAll(int slot, std::vector<int> &res) {
+  rx = getRxSolve_();
+  int nsub = (int)getRxNsub(rx);
+  int nMix = (int)op_focei.mixIdxN + 1;
+  rx_solving_options *op = getSolvingOptions(rx);
+  int cores = getOpCores(op);
+  bool doParallel = (cores > 1) && solveMethodThreadSafe(op);
+  res.assign((size_t)nsub, 1);
+  std::vector<int> ok((size_t)nsub, 0);
+  for (int m = 0; m < nMix; ++m) {
+    std::fill(ok.begin(), ok.end(), 0);
+    if (doParallel) sortIds(rx, 2);
+    _innerParallel.store(1, std::memory_order_release);
+#ifdef _OPENMP
+#pragma omp parallel for num_threads(cores) schedule(dynamic) if(doParallel)
+#endif
+    for (int i = 0; i < nsub; i++) {
+      int gid = doParallel ? (getOrdId(rx, i) - 1) : i;
+      setRxThreadId(omp_get_thread_num());
+      ok[(size_t)gid] = innerOpt1(gid + m*nsub, slot);
+      setRxThreadId(-1);
+    }
+    _innerParallel.store(0, std::memory_order_release);
+    if (doParallel) sortIds(rx, 0);
+    for (int i = 0; i < nsub; ++i) if (!ok[(size_t)i]) res[(size_t)i] = 0;
+  }
+}
+
 // Necessary for S-matrix calculation
 int foceiS(double *theta, Environment e, bool &hasZero){
   int npars = op_focei.npars;
@@ -10643,10 +10722,15 @@ int foceiS(double *theta, Environment e, bool &hasZero){
       }
     }
     if (doForward){
-      // Fill in lik0
+      // Fill in lik0.  For a mixture the subject's contribution is the MARGINAL
+      // over components, not component 0's -- see foceiMixObjSlot().
       for (gid = getRxNsub(rx); gid--;){
-        fInd = &(inds_focei[gid]);
-        op_focei.likSav[gid] = -2*fInd->lik[0];
+        if (op_focei.mixIdxN != 0) {
+          op_focei.likSav[gid] = foceiMixObjSlot(gid, 0);
+        } else {
+          fInd = &(inds_focei[gid]);
+          op_focei.likSav[gid] = -2*fInd->lik[0];
+        }
       }
     }
   }
@@ -10654,8 +10738,51 @@ int foceiS(double *theta, Environment e, bool &hasZero){
   if (op_focei.needOptimHess) {
     smatNorm = op_focei.smatNormLlik;
   }
+  // Per-subject responsibilities r_im and the population proportions pi_m at the
+  // BASE theta, for the analytic mixture-proportion score below.  Recomputed
+  // here from the per-component lik[0] rather than read from fInd->mixProb when
+  // it is needed: the loop below perturbs theta, and neither innerOpt1() nor
+  // updateTheta() refreshes the responsibilities, so a later read would be at
+  // the wrong point.  Same base-theta assumption likSav above already makes.
+  int nMixS = (int)op_focei.mixIdxN + 1;
+  std::vector<double> mixR, mixP;
+  if (op_focei.mixIdxN != 0) {
+    int _nsub = (int)getRxNsub(rx);
+    mixP.assign((size_t)nMixS, 0.0);
+    for (int m = 0; m < nMixS; ++m) mixP[(size_t)m] = op_focei.mixProb[m];
+    mixR.assign((size_t)_nsub*(size_t)nMixS, NA_REAL);
+    std::vector<double> ll((size_t)nMixS);
+    for (int i = 0; i < _nsub; ++i) {
+      for (int m = 0; m < nMixS; ++m) ll[(size_t)m] = inds_focei[i + m*_nsub].lik[0];
+      double lse = foceiMixLogSumExp(ll.data(), nMixS);
+      if (!R_FINITE(lse)) continue;
+      for (int m = 0; m < nMixS; ++m) {
+        if (!R_FINITE(ll[(size_t)m])) { mixR[(size_t)i*nMixS + m] = 0.0; continue; }
+        mixR[(size_t)i*nMixS + m] =
+          std::exp(ll[(size_t)m] + std::log(std::max(1e-300, mixP[(size_t)m])) - lse);
+      }
+    }
+  }
   double sInfoPer = npars * getRxNsub(rx);
   for (cpar = npars; cpar--;){
+    // A mixture proportion's per-subject score is known in closed form -- NONMEM
+    // (1.194) chained by (1.197) for ONE subject, the same expression mixGrad()
+    // sums over subjects.  Exact, and it costs no solves, so skip the finite
+    // difference entirely for these parameters.
+    if (op_focei.mixIdxN != 0 && op_focei.mixTrans != NULL &&
+        op_focei.mixTrans[cpar] != -1) {
+      int mi = op_focei.mixTrans[cpar];
+      double sc = dUnscaleParDx(cpar);
+      for (int _gid = 0; _gid < (int)getRxNsub(rx); ++_gid) {
+        double r = mixR[(size_t)_gid*nMixS + mi];
+        double g = R_FINITE(r) ? -2.0*(r - mixP[(size_t)mi])*sc : 0.0;
+        inds_focei[_gid].thetaGrad[cpar] = R_FINITE(g) ? g : 0.0;
+      }
+      op_focei.cur++;
+      op_focei.curTick = par_progress(op_focei.cur, op_focei.totTick, op_focei.curTick,
+                                      1, op_focei.t0, 0);
+      continue;
+    }
     double rEps = op_focei.rEps[cpar];
     double rEpsC = op_focei.rEpsC[cpar];
     if (smatNorm){
@@ -10675,7 +10802,32 @@ int foceiS(double *theta, Environment e, bool &hasZero){
     cur = theta[cpar];
     theta[cpar] = cur + delta;
     updateTheta(theta);
-    {
+    if (op_focei.mixIdxN != 0) {
+      // Mixture: the subject's contribution is the marginal over components, so
+      // every component has to be re-optimized before any per-subject score
+      // exists.  Differencing component 0 alone (what this did before) gives an
+      // exactly-zero score for any parameter that only enters another
+      // component, which made S singular for every mixture model.
+      int _nsub = (int)getRxNsub(rx);
+      std::vector<int> _opt1Res;
+      foceiSInnerAll(2, _opt1Res);
+      for (int _gid = 0; _gid < _nsub; _gid++) {
+        focei_ind *fIndL = &(inds_focei[_gid]);
+        fIndL->thetaGrad[cpar] = NA_REAL;
+        double _o2 = _opt1Res[_gid] ? foceiMixObjSlot(_gid, 2) : NA_REAL;
+        if (doForward) {
+          if (R_FINITE(_o2) && R_FINITE(op_focei.likSav[_gid])) {
+            fIndL->thetaGrad[cpar] = (_o2 - op_focei.likSav[_gid]) / delta;
+          } else {
+            // no usable contribution for this subject/parameter: fall back to
+            // the pooled gradient, as the non-mixture serial retry does
+            hasZero = true;
+            sInfoPer -= 1.0;
+            fIndL->thetaGrad[cpar] = gfull[cpar];
+          }
+        }
+      }
+    } else {
       int _nsub = (int)getRxNsub(rx);
       rx_solving_options *_op = getSolvingOptions(rx);
       int _cores = getOpCores(_op);
@@ -10723,7 +10875,26 @@ int foceiS(double *theta, Environment e, bool &hasZero){
       theta[cpar] = cur - delta;
       updateTheta(theta);
       // Second inner loop: run innerOpt1(gid, 1) over subjects in parallel.
-      {
+      if (op_focei.mixIdxN != 0) {
+        int _nsub = (int)getRxNsub(rx);
+        std::vector<int> _res1;
+        foceiSInnerAll(1, _res1);
+        for (int _gid = 0; _gid < _nsub; _gid++) {
+          focei_ind *fIndL = &(inds_focei[_gid]);
+          if (!ISNA(fIndL->thetaGrad[cpar])) continue;
+          double _o1 = _res1[_gid] ? foceiMixObjSlot(_gid, 1) : NA_REAL;
+          double _o2 = foceiMixObjSlot(_gid, 2);
+          if (R_FINITE(_o1) && R_FINITE(_o2)) {
+            fIndL->thetaGrad[cpar] = (_o2 - _o1) / (2*delta);
+          } else {
+            // one leg is unusable; likSav is only filled on the doForward
+            // path, so a stale forward difference is not an option here
+            hasZero = true;
+            sInfoPer -= 1.0;
+            fIndL->thetaGrad[cpar] = gfull[cpar];
+          }
+        }
+      } else {
         int _nsub = (int)getRxNsub(rx);
         rx_solving_options *_op = getSolvingOptions(rx);
         int _cores = getOpCores(_op);
@@ -11524,19 +11695,19 @@ static bool foceiFdHessian(const FdFullCtx &c, const std::vector<double> &x0, do
 }
 
 // per-subject -2LL contributions after a foceiFdObjAt probe -- the quantity foceiS
-// differences (native: likSav[gid] = -2*fInd->lik[0]).  Returns false for mixture models
-// (op_focei.mixIdxN != 0: no per-subject contribution is stashed) or any non-finite subject
-// value (a failed inner solve leaves lik[0] = NA_REAL), so the caller keeps the native cov.
+// differences (native: likSav[gid] = -2*fInd->lik[0]).  For a mixture the contribution is
+// the MARGINAL over components (foceiMixObjSlot), not component 0's.  Returns false on any
+// non-finite subject value (a failed inner solve leaves lik[0] = NA_REAL), so the caller
+// keeps the native cov.
 static bool foceiFdLikById(arma::vec &out) {
-  if (op_focei.mixIdxN != 0) return false;
   rx = getRxSolve_();
   int nsub = getRxNsub(rx);
   if (nsub <= 0) return false;
   out.set_size(nsub);
   for (int gid = 0; gid < nsub; ++gid) {
-    double l = inds_focei[gid].lik[0];
+    double l = (op_focei.mixIdxN != 0) ? foceiMixObjSlot(gid, 0) : -2.0 * inds_focei[gid].lik[0];
     if (!R_FINITE(l)) return false;
-    out[gid] = -2.0 * l;
+    out[gid] = l;
   }
   return true;
 }
@@ -12562,6 +12733,17 @@ void impSetThetaAll(int idx, double val) {
   for (int id = 0; id < nsub; ++id) {
     rx_solving_options_ind *ind = getSolvingOptionsInd(rx, getRxId(id));
     setIndParPtr(ind, op_focei.thetaTrans[idx], val);
+  }
+  // A mixture proportion reaches the likelihood ONLY through op_focei.mixProb
+  // (the mlogit -> probability map), and nothing on this path refreshes it --
+  // updateTheta() is the outer route, which the MC covariance does not take.
+  // Without this the FD Hessian moves fullTheta while the proportions stay put,
+  // so every mixture direction comes back an exact zero.  Calls R, so it must
+  // stay outside any parallel region (evalObj's caller is serial).
+  if (op_focei.mixIdxN != 0 && op_focei.mixIdx != NULL) {
+    for (unsigned int m = 0; m < op_focei.mixIdxN; ++m) {
+      if (op_focei.mixIdx[m] - 1 == idx) { impUpdateMixProbs(); break; }
+    }
   }
 }
 
@@ -18869,19 +19051,15 @@ static int gFreezeNsub = 0, gFreezeNpoint = 0, gFreezeNmix = 1;
 
 // log( sum_m mixProb(m) * exp(ll[m]) ); ll[] are the per-component conditional
 // log-likelihoods for one subject.  Identity for a single component.
+double impMixLogSumExp(const std::vector<double>& ll) {
+  if (ll.empty()) return R_NegInf;
+  if (ll.size() == 1) return ll[0];
+  double r = foceiMixLogSumExp(ll.data(), (int)ll.size());
+  return R_FINITE(r) ? r : R_NegInf;
+}
+
 static double npMixLogSumExp(const std::vector<double>& ll) {
-  int nMix = (int)ll.size();
-  if (nMix <= 1) return ll.empty() ? R_NegInf : ll[0];
-  double mx = R_NegInf;
-  std::vector<double> lp(nMix);
-  for (int m = 0; m < nMix; ++m) {
-    lp[m] = ll[m] + std::log(std::max(1e-300, impMixProb(m)));
-    if (std::isfinite(lp[m]) && lp[m] > mx) mx = lp[m];
-  }
-  if (!std::isfinite(mx)) return R_NegInf;
-  double se = 0.0;
-  for (int m = 0; m < nMix; ++m) se += std::exp(lp[m] - mx);
-  return mx + std::log(se);
+  return impMixLogSumExp(ll);
 }
 
 static int npIndSolveSize(rx_solving_options* op, rx_solving_options_ind* ind) {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -21596,10 +21596,11 @@ struct VaeStepOut {
   double pxz, DKL;
   arma::mat mu, z;      // [N, zDim]
   arma::cube L;         // [zDim, zDim, N]
-  arma::mat lp;         // [N, zDim] decoder eta-gradient (best mixture component)
+  arma::mat lp;         // [N, zDim] decoder eta-gradient (responsibility-weighted)
   std::vector<std::vector<double> > preds;  // per-subject predictions f
   std::vector<std::vector<double> > rvar;   // per-subject residual variance r (sigma^2)
   arma::ivec mixnum;    // [N] selected mixture component (1-based)
+  arma::vec mixW;       // [nMix] mean posterior responsibility over subjects
   // encoder parameter gradients
   arma::mat gWih, gWhh, gFcW; arma::vec gbih, gbhh, gFcB;
 };
@@ -21666,25 +21667,52 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
   S.preds.resize(N);
   S.rvar.resize(N);
   S.mixnum.set_size(N); S.mixnum.fill(1);
+  S.mixW.zeros(nMix > 1 ? nMix : 1); S.mixW[0] = 1.0;
   if (nMix > 1) {
+    S.mixW.zeros();
+    // Marginal mixture -2LL.  obj is -log p(y_i, eta_i | m) at 1x scale
+    // (likInner0 returns -(llik - 0.5 eta' Om^-1 eta), and the nMix == 1 branch
+    // below sums it directly), so the exponent is -obj, NOT -0.5*obj, and the
+    // sum is negated once, not twice.  The old -0.5/-2 pair marginalized a
+    // SQUARE ROOT likelihood and carried a spurious -log(pi_best); it cancels
+    // exactly at nMix == 1 and at identical components with uniform pi, which
+    // is why no test could see it.
     jointTot = 0;
     for (int i = 0; i < N; ++i) {
       double mmax = -std::numeric_limits<double>::infinity(); int best = 0;
       arma::vec ll(nMix);
       for (int m = 0; m < nMix; ++m) {
-        double v = std::log(mixProb[m]) - 0.5 * obj[m * N + i];
+        double v = std::log(mixProb[m]) - obj[m * N + i];
         if (!R_FINITE(v)) v = -std::numeric_limits<double>::infinity();
         ll[m] = v; if (v > mmax) { mmax = v; best = m; }
       }
+      arma::vec resp(nMix, arma::fill::zeros);
       if (R_FINITE(mmax)) {
         double se = 0; for (int m = 0; m < nMix; ++m) se += std::exp(ll[m] - mmax);
-        jointTot += -2 * (mmax + std::log(se));
+        jointTot += -(mmax + std::log(se));
+        for (int m = 0; m < nMix; ++m) resp[m] = std::exp(ll[m] - mmax)/se;
+      } else {
+        // every component failed to solve: charge the same penalty focei does
+        // (foceiLik0Mix), instead of contributing 0 and IMPROVING the objective
+        jointTot += op_focei.badSolveObjfAdj;
+        resp[best] = 1.0;
       }
-      lpBest.row(i) = lp.row(best * N + i);
+      // the encoder is trained on the objective it optimizes: the gradient of
+      // the marginal is the responsibility-weighted mean, not the argmax
+      // component's gradient
+      lpBest.row(i).zeros();
+      for (int m = 0; m < nMix; ++m) {
+        if (resp[m] > 0) lpBest.row(i) += resp[m] * lp.row(m * N + i);
+      }
+      // preds/rvar stay on the argmax component: the closed-form residual
+      // M-step is a moment estimator, and averaging residuals across
+      // components inflates the residual SD
       S.preds[i] = pf[best * N + i];
       if (!prv.empty()) S.rvar[i] = prv[best * N + i];
       S.mixnum[i] = best + 1;
+      S.mixW += resp;
     }
+    S.mixW /= (double)N;
   } else {
     jointTot = arma::accu(obj);
     lpBest = lp;
@@ -22696,13 +22724,17 @@ static double gVaeThetaObjR(Rcpp::NumericVector r) {
       double mmax = -std::numeric_limits<double>::infinity();
       arma::vec ll(nMix);
       for (int m = 0; m < nMix; ++m) {
-        double lv = std::log(gVaeRegMixProb[m]) - 0.5 * obj[m * N + i];
+        // same 1x-scale marginal as vaeElboStepCpp -- the two MUST optimize one
+        // functional, or the M-step chases a different objective than the ELBO
+        double lv = std::log(gVaeRegMixProb[m]) - obj[m * N + i];
         if (!R_FINITE(lv)) lv = -std::numeric_limits<double>::infinity();
         ll[m] = lv; if (lv > mmax) mmax = lv;
       }
       if (R_FINITE(mmax)) {
         double se = 0; for (int m = 0; m < nMix; ++m) se += std::exp(ll[m] - mmax);
-        v += -2 * (mmax + std::log(se));
+        v += -(mmax + std::log(se));
+      } else {
+        v += op_focei.badSolveObjfAdj;
       }
     }
   } else {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -21602,6 +21602,8 @@ struct VaeStepOut {
   arma::ivec mixnum;    // [N] selected mixture component (1-based)
   arma::vec mixW;       // [nMix] mean posterior responsibility over subjects
   arma::mat muAll;      // [N*nMix, zDim] posterior mean per (subject, component)
+  arma::vec gMixTheta;  // [nMix-1] d(objective)/d(mlogit mixture theta)
+  arma::vec mixProbCur; // [nMix] proportions the step actually used
   // encoder parameter gradients
   arma::mat gWih, gWhh, gFcW; arma::vec gbih, gbhh, gFcB;
 };
@@ -21698,6 +21700,16 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
   // eta already carries one row per (subject, component): each component is
   // scored at ITS OWN eta, not at a shared one tiled across components
   const arma::mat& etaEval = eta;
+  // The proportions come from op_focei, which updateTheta just refreshed from
+  // th through .getMixFromLog (mexpit).  That is the ONLY source of truth: the
+  // R-side vector cannot track a theta the optimizer is moving, and reading it
+  // is how the mlogit-vs-probability scale confusion got in.
+  arma::vec pi = mixProb;
+  if (nMix > 1 && op_focei.mixProb != NULL) {
+    pi.set_size(nMix);
+    for (int m = 0; m < nMix; ++m) pi[m] = op_focei.mixProb[m];
+  }
+  S.mixProbCur = pi;
   arma::vec obj; arma::mat lp; std::vector<std::vector<double> > pf;
   std::vector<std::vector<double> > prv;
   vaeInnerLikCore(etaEval, cores, true, true, obj, lp, pf, false, &prv);
@@ -21717,6 +21729,7 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
   double jointTot;
   arma::mat lpAll(Ne, zDim, arma::fill::zeros);
   arma::uvec sel(N);                       // selected pseudo-subject row per subject
+  arma::vec gpi(nMix > 1 ? nMix - 1 : 1, arma::fill::zeros);
   for (int i = 0; i < N; ++i) sel[i] = i;  // nMix == 1: the subject IS the row
   S.preds.resize(N);
   S.rvar.resize(N);
@@ -21736,7 +21749,7 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
       double mmax = -std::numeric_limits<double>::infinity(); int best = 0;
       arma::vec ll(nMix);
       for (int m = 0; m < nMix; ++m) {
-        double v = std::log(mixProb[m]) - obj[m * N + i];
+        double v = std::log(pi[m]) - obj[m * N + i];
         if (!R_FINITE(v)) v = -std::numeric_limits<double>::infinity();
         ll[m] = v; if (v > mmax) { mmax = v; best = m; }
       }
@@ -21765,8 +21778,23 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
       if (!prv.empty()) S.rvar[i] = prv[sel[i]];
       S.mixnum[i] = best + 1;
       S.mixW += resp;
+      // d/d(pi_m) of -log sum_k pi_k exp(-obj_ik) is -(r_im/pi_m), and the last
+      // component is not free (pi_last = 1 - sum), so its share is subtracted --
+      // the same difference foceiLik0Mix accumulates into fInd->mixProbGrad.
+      for (int m = 0; m < nMix - 1; ++m) {
+        double gm = -(resp[m] / pi[m] - resp[nMix - 1] / pi[nMix - 1]);
+        if (R_FINITE(gm)) gpi[m] += gm;
+      }
     }
     S.mixW /= (double)N;
+    // chain rule through mexpit: op_focei.mixProbGrad is the dmexpit Jacobian
+    // updateTheta filled, exactly as mixGrad() applies it for focei
+    S.gMixTheta.zeros(nMix - 1);
+    for (int m = 0; m < nMix - 1; ++m) {
+      double j = (op_focei.mixProbGrad != NULL) ? op_focei.mixProbGrad[m] : 1.0;
+      double g = gpi[m] * j;
+      S.gMixTheta[m] = R_FINITE(g) ? g : 0.0;
+    }
   } else {
     jointTot = arma::accu(obj);
     lpAll = lp;
@@ -21922,7 +21950,8 @@ List vaeElboStepCpp_(List params, List prep, RObject zPopR, RObject omegaR,
                       _["preds"] = preds, _["rvar"] = rvar, _["mixnum"] = mixnum,
                       // per (subject, component) posterior mean, component-major
                       // (row m*N + i) -- the encoder characterizes every pair
-                      _["muAll"] = S.muAll, _["mixW"] = S.mixW);
+                      _["muAll"] = S.muAll, _["mixW"] = S.mixW,
+                      _["gMixTheta"] = S.gMixTheta, _["mixProb"] = S.mixProbCur);
 }
 
 // ---------------------------------------------------------------------------
@@ -22820,7 +22849,8 @@ static double gVaeThetaObjR(Rcpp::NumericVector r) {
       for (int m = 0; m < nMix; ++m) {
         // same 1x-scale marginal as vaeElboStepCpp -- the two MUST optimize one
         // functional, or the M-step chases a different objective than the ELBO
-        double lv = std::log(gVaeRegMixProb[m]) - obj[m * N + i];
+        double pm = (op_focei.mixProb != NULL) ? op_focei.mixProb[m] : gVaeRegMixProb[m];
+        double lv = std::log(pm) - obj[m * N + i];
         if (!R_FINITE(lv)) lv = -std::numeric_limits<double>::infinity();
         ll[m] = lv; if (lv > mmax) mmax = lv;
       }
@@ -22854,6 +22884,22 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
   arma::cube dataIn = as<arma::cube>(prep["dataIn"]);
   arma::ivec lengths = vaeToIvec(prep["lengths"]);
   arma::mat covIn = as<arma::mat>(prep["covIn"]);
+  // Adam state for the mixture proportions, which are estimated on the MLOGIT
+  // scale through their own analytic gradient (see vaeElboStepCpp) rather than
+  // by the bobyqa regress step or held at their ini() value.  1-based theta
+  // indices, as op_focei.mixIdx stores them.
+  arma::uvec mixThIdx;
+  if (nMix > 1 && op_focei.mixIdx != NULL && op_focei.mixIdxN > 0) {
+    mixThIdx.set_size(op_focei.mixIdxN);
+    for (int m = 0; m < op_focei.mixIdxN; ++m) mixThIdx[m] = op_focei.mixIdx[m] - 1;
+  }
+  VaeAdamBlk aMixTh; int nMixThStep = 0;
+  if (mixThIdx.n_elem > 0) {
+    // vaeAdam accumulates into m/v in place, so they must be sized up front
+    aMixTh.m.zeros(mixThIdx.n_elem, 1);
+    aMixTh.v.zeros(mixThIdx.n_elem, 1);
+  }
+  arma::vec mixProbFinal = as<arma::vec>(mixProbR);
   // Component-conditioned ENCODER inputs, built once (see
   // vaeTileEncoderInputs).  Kept separate from covIn, which the covariate
   // best-subset machinery below indexes against covAllow/covGroup -- the
@@ -23807,6 +23853,15 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
       vaeAdam(fcW, st.gFcW, aFcW, learningRate, tstep);
       vaeAdam(fcBM, st.gFcB, aFcB, learningRate, tstep); fcB = fcBM.col(0);
       esum += st.pxz + st.DKL;
+      if (mixThIdx.n_elem > 0 && st.gMixTheta.n_elem == mixThIdx.n_elem) {
+        arma::mat pm(mixThIdx.n_elem, 1), gm(mixThIdx.n_elem, 1);
+        for (unsigned int m = 0; m < mixThIdx.n_elem; ++m) {
+          pm(m, 0) = th[mixThIdx[m]]; gm(m, 0) = st.gMixTheta[m];
+        }
+        vaeAdam(pm, gm, aMixTh, learningRate, ++nMixThStep);
+        for (unsigned int m = 0; m < mixThIdx.n_elem; ++m) th[mixThIdx[m]] = pm(m, 0);
+      }
+      if (st.mixProbCur.n_elem > 0) mixProbFinal = st.mixProbCur;
       last = st;
     }
     elboTrace[it - 1] = esum / Lg;
@@ -23835,7 +23890,8 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
                       _["parHist"] = parHist, _["mu"] = last.mu, _["zPopMat"] = zPopMatOut,
                       _["mixnum"] = mixnumOut, _["regressTheta"] = regressThetaOut,
                       _["nRegGrad"] = nRegGrad, _["nRegFallback"] = nRegFallback,
-                      _["nStage2"] = nStage2);
+                      _["nStage2"] = nStage2,
+                      _["mixProb"] = mixProbFinal, _["nMixThetaStep"] = nMixThStep);
 }
 
 // Test-facing entry point for the exact L0/BIC best-subset kernel used by the VAE

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -6733,73 +6733,6 @@ int gill83(double *hf, double *hphif, double *df, double *df2, double *ef,
 
 // Calculate the mixture parameter gradient
 //
-// This notes that the mixture gradient does not need to be numerically, but
-// can be calculated directly from the mixture probabilities, the translation from
-// the by the mexpit, and the scaling factors.
-//
-// @param theta The parameter vector
-//
-// @param g The gradient vector to fill in
-//
-// @param cpar The parameter index to test/calculate the gradient for.
-//
-// @return 0 if the gradient was not calculated, 1 if it was.
-//
-int mixGrad(double *theta, double *g, int cpar) {
-  if (op_focei.mixTrans == NULL) return 0;
-  if (op_focei.mixTrans[cpar] != -1) {
-    // This is a mixture grad
-    int mi = op_focei.mixTrans[cpar];
-    // First add the gradients from each individual contribution
-    g[cpar] = 0.0;
-    for (int i = 0; i < getRxNsub(rx); ++i) {
-      focei_ind *fInd = &(inds_focei[i]);
-      g[cpar] += fInd->mixProbGrad[mi];
-    }
-    // Next multiple the gradient from the mexpit() transformation
-    // (from chain rule)
-    g[cpar] *= op_focei.mixProbGrad[mi];
-    // FIXME: Last apply the scaling gradient changes from chain rule
-    double scaleTo = op_focei.scaleTo, C=getScaleC(cpar);
-    switch (op_focei.scaleType){
-    case 1: // normalized
-      g[cpar] *= op_focei.c2;
-      return 1;
-      break;
-    case 2: // log vs linear scales and/or ranges
-      g[cpar] *= C;
-      return 1;
-      break;
-    case 3: // simple multiplicative scaling
-      if (op_focei.scaleTo != 0){
-        g[cpar] *= op_focei.initPar[cpar]/scaleTo;
-        return 1;
-      } else {
-        return 1;
-      }
-      break;
-    case 4: // log non-log multiplicative scaling
-      if (op_focei.scaleTo > 0){
-        switch (op_focei.xPar[cpar]){
-        case 1:
-          return 1;
-        default:
-          g[cpar] *= op_focei.initPar[cpar]/scaleTo;
-          return 1;
-        }
-      } else {
-        return 1;
-      }
-    default:
-      return 1;
-    }
-    return 0;
-
-  }
-  return 0;
-}
-
-
 // d(unscalePar)/d(x_i): the finite-difference outer gradient is d(OFV)/d(scaled
 // par), so an analytic d(OFV)/d(theta) must be multiplied by this factor to land
 // in the same optimizer scale.  Mirrors the linear coefficient of unscalePar().
@@ -6817,6 +6750,54 @@ static inline double dUnscaleParDx(int i) {
   default: return 1.0;
   }
 }
+
+// This notes that the mixture gradient does not need to be numerically, but
+// can be calculated directly from the mixture probabilities, the translation from
+// the by the mexpit, and the scaling factors.
+//
+// @param g The gradient vector to fill in
+//
+// @param cpar The parameter index to test/calculate the gradient for.
+//
+// @return 0 if the gradient was not calculated, 1 if it was.
+//
+int mixGrad(double *g, int cpar) {
+  if (op_focei.mixTrans == NULL) return 0;
+  if (op_focei.mixTrans[cpar] != -1) {
+    // This is a mixture grad.  pi = mexpit(t) is a softmax, so
+    // d(pi_m)/d(t_l) = pi_m*(delta_ml - pi_l); feeding that through
+    // d(log-lik)/d(pi_m) = sum_i (r_im/pi_m - r_iK/pi_K) and using
+    // sum_m r_im = 1 collapses the whole Jacobian to
+    //
+    //   d(-2*log-lik)/d(t_l) = -2 * sum_i (r_il - pi_l)
+    //
+    // with r_il = fInd->mixProb[l] the subject's posterior responsibility
+    // from foceiLik0Mix().  Do NOT chain through op_focei.mixProbGrad here:
+    // rxode2::dmexpit() is the DIAGONAL of that Jacobian only, so it drops
+    // every m != l term -- which cancels by accident at nMix == 2 and is
+    // wrong from nMix == 3 up.  The -2 is the objective scale
+    // (foceiObjFromLik0() = -2*foceiLik0()).
+    int mi = op_focei.mixTrans[cpar];
+    double tot = 0.0, nUsed = 0.0;
+    for (int i = 0; i < getRxNsub(rx); ++i) {
+      double r = inds_focei[i].mixProb[mi];
+      // a subject whose every component failed to solve took the flat
+      // badSolveObjfAdj penalty, which does not depend on the proportions
+      if (!R_FINITE(r)) continue;
+      tot += r;
+      nUsed += 1.0;
+    }
+    double gr = -2.0*(tot - nUsed*op_focei.mixProb[mi]);
+    if (!R_FINITE(gr)) gr = 0.0;
+    // and into the optimizer's scale, the same chain rule every other analytic
+    // gradient applies -- the finite-difference paths get it for free by
+    // differencing in the scaled space
+    g[cpar] = gr*dUnscaleParDx(cpar);
+    return 1;
+  }
+  return 0;
+}
+
 
 static bool restoreFitSolve_();   // defined below (with covSolveArgs_)
 void impSetInnerNeqOverride();     // defined below; re-pins the inner neqOverride after restore
@@ -7146,7 +7127,7 @@ void numericGrad(double *theta, double *g){
     std::copy(theta, theta+op_focei.npars, armaTheta.begin());
     double h = 0;
     for (int cpar = (int)op_focei.npars; cpar--;) {
-      if (mixGrad(theta, g, cpar) == 1) {
+      if (mixGrad(g, cpar) == 1) {
         continue;
       } else {
         op_focei.calcGrad=1;
@@ -7191,7 +7172,7 @@ void numericGrad(double *theta, double *g){
       }
     }
     for (int cpar = (int)op_focei.npars; cpar--;) {
-      if (mixGrad(theta, g, cpar) == 1) {
+      if (mixGrad(g, cpar) == 1) {
         continue;
       } else {
         op_focei.gillRet[cpar] = gill83(&hf, &hphif, &op_focei.gillDf[cpar], &op_focei.gillDf2[cpar], &op_focei.gillErr[cpar],
@@ -7283,7 +7264,7 @@ void numericGrad(double *theta, double *g){
       haveF=true;
     }
     for (cpar = npars; cpar--;) {
-      if (mixGrad(theta, g, cpar) == 1) {
+      if (mixGrad(g, cpar) == 1) {
         continue;
       } else {
         if (doForward){

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -10746,6 +10746,12 @@ int foceiS(double *theta, Environment e, bool &hasZero){
   // the wrong point.  Same base-theta assumption likSav above already makes.
   int nMixS = (int)op_focei.mixIdxN + 1;
   std::vector<double> mixR, mixP;
+  // Which subjects' FORWARD (slot 2) leg converged for the current cpar.  Held
+  // at function scope because the central leg below needs it too: lik[2] is
+  // stale from a previous cpar for any component that failed, and
+  // foceiMixObjSlot() would happily combine that into a finite but wrong
+  // marginal.
+  std::vector<int> mixFwdOk;
   if (op_focei.mixIdxN != 0) {
     int _nsub = (int)getRxNsub(rx);
     mixP.assign((size_t)nMixS, 0.0);
@@ -10809,12 +10815,11 @@ int foceiS(double *theta, Environment e, bool &hasZero){
       // exactly-zero score for any parameter that only enters another
       // component, which made S singular for every mixture model.
       int _nsub = (int)getRxNsub(rx);
-      std::vector<int> _opt1Res;
-      foceiSInnerAll(2, _opt1Res);
+      foceiSInnerAll(2, mixFwdOk);
       for (int _gid = 0; _gid < _nsub; _gid++) {
         focei_ind *fIndL = &(inds_focei[_gid]);
         fIndL->thetaGrad[cpar] = NA_REAL;
-        double _o2 = _opt1Res[_gid] ? foceiMixObjSlot(_gid, 2) : NA_REAL;
+        double _o2 = mixFwdOk[_gid] ? foceiMixObjSlot(_gid, 2) : NA_REAL;
         if (doForward) {
           if (R_FINITE(_o2) && R_FINITE(op_focei.likSav[_gid])) {
             fIndL->thetaGrad[cpar] = (_o2 - op_focei.likSav[_gid]) / delta;
@@ -10883,7 +10888,7 @@ int foceiS(double *theta, Environment e, bool &hasZero){
           focei_ind *fIndL = &(inds_focei[_gid]);
           if (!ISNA(fIndL->thetaGrad[cpar])) continue;
           double _o1 = _res1[_gid] ? foceiMixObjSlot(_gid, 1) : NA_REAL;
-          double _o2 = foceiMixObjSlot(_gid, 2);
+          double _o2 = mixFwdOk[_gid] ? foceiMixObjSlot(_gid, 2) : NA_REAL;
           if (R_FINITE(_o1) && R_FINITE(_o2)) {
             fIndL->thetaGrad[cpar] = (_o2 - _o1) / (2*delta);
           } else {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -6777,6 +6777,19 @@ int mixGrad(double *g, int cpar) {
     // every m != l term -- which cancels by accident at nMix == 2 and is
     // wrong from nMix == 3 up.  The -2 is the objective scale
     // (foceiObjFromLik0() = -2*foceiLik0()).
+    //
+    // This is the NONMEM 7 Technical Guide's own formulation, eq. (1.194) for
+    // d(L_i)/d(a_j) -- what foceiLik0Mix() leaves in mixProbGrad -- chained by
+    // eq. (1.197), g_a = sum_i (dL_i/da)(da/dtheta_a), whose da/dtheta_a is the
+    // FULL Jacobian.  NONMEM carries it as a matrix because $MIX lets P(j) be
+    // arbitrary code; here the link is fixed to mexpit, so the product has the
+    // closed form above (checked equal to a literal evaluation of (1.194) x
+    // (1.197) to 2e-16).  It is valid for THAT link only -- a covariate- or
+    // otherwise non-softmax-modelled proportion has to go back to the matrix
+    // product.  NONMEM's L is -log-lik where this OFV is -2*log-lik, so this is
+    // 2x its g_a; the factor cancels in NONMEM's own Gauss-Newton step (1.199)
+    // but not here, where g[] must match the finite differences taken for every
+    // other parameter.
     int mi = op_focei.mixTrans[cpar];
     double tot = 0.0, nUsed = 0.0;
     for (int i = 0; i < getRxNsub(rx); ++i) {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -10696,6 +10696,81 @@ static void foceiSInnerAll(int slot, std::vector<int> &res) {
   }
 }
 
+// A mixture proportion's per-subject score is known in closed form -- NONMEM
+// (1.194) chained by (1.197) for ONE subject, the same expression mixGrad()
+// sums over subjects.  Exact, and it costs no solves.  Returns true when cpar
+// IS such a parameter (the caller then skips the finite difference for it).
+static bool foceiSMixScore(int cpar, const std::vector<double> &mixR,
+                           const std::vector<double> &mixP, int nMixS) {
+  if (op_focei.mixIdxN == 0 || op_focei.mixTrans == NULL ||
+      op_focei.mixTrans[cpar] == -1) return false;
+  int mi = op_focei.mixTrans[cpar];
+  double sc = dUnscaleParDx(cpar);
+  for (int gid = 0; gid < (int)getRxNsub(rx); ++gid) {
+    double r = mixR[(size_t)gid*nMixS + mi];
+    double g = R_FINITE(r) ? -2.0*(r - mixP[(size_t)mi])*sc : 0.0;
+    inds_focei[gid].thetaGrad[cpar] = R_FINITE(g) ? g : 0.0;
+  }
+  op_focei.cur++;
+  op_focei.curTick = par_progress(op_focei.cur, op_focei.totTick, op_focei.curTick,
+                                  1, op_focei.t0, 0);
+  return true;
+}
+
+// Forward leg of the per-subject difference for a MIXTURE model.  The subject's
+// contribution is the marginal over components, so every component has to be
+// re-optimized before any per-subject score exists: differencing component 0
+// alone gives an exactly-zero score for a parameter that only enters another
+// component, which is what made S singular for every mixture model.
+static void foceiSMixForward(int cpar, double delta, bool doForward,
+                             const arma::vec &gfull, std::vector<int> &mixFwdOk,
+                             bool &hasZero, double &sInfoPer) {
+  int nsub = (int)getRxNsub(rx);
+  foceiSInnerAll(2, mixFwdOk);
+  for (int gid = 0; gid < nsub; gid++) {
+    focei_ind *fIndL = &(inds_focei[gid]);
+    fIndL->thetaGrad[cpar] = NA_REAL;
+    if (!doForward) continue;                // the central leg fills these in
+    double o2 = mixFwdOk[gid] ? foceiMixObjSlot(gid, 2) : NA_REAL;
+    if (R_FINITE(o2) && R_FINITE(op_focei.likSav[gid])) {
+      fIndL->thetaGrad[cpar] = (o2 - op_focei.likSav[gid]) / delta;
+    } else {
+      // no usable contribution for this subject/parameter: fall back to the
+      // pooled gradient, as the non-mixture serial retry does
+      hasZero = true;
+      sInfoPer -= 1.0;
+      fIndL->thetaGrad[cpar] = gfull[cpar];
+    }
+  }
+}
+
+// Central leg of the per-subject difference for a MIXTURE model.  mixFwdOk is
+// the FORWARD leg's per-subject convergence: lik[2] is stale from a previous
+// cpar for any component that failed there, and foceiMixObjSlot() would combine
+// it into a finite but wrong marginal.
+static void foceiSMixCentral(int cpar, double delta, const arma::vec &gfull,
+                             const std::vector<int> &mixFwdOk,
+                             bool &hasZero, double &sInfoPer) {
+  int nsub = (int)getRxNsub(rx);
+  std::vector<int> res1;
+  foceiSInnerAll(1, res1);
+  for (int gid = 0; gid < nsub; gid++) {
+    focei_ind *fIndL = &(inds_focei[gid]);
+    if (!ISNA(fIndL->thetaGrad[cpar])) continue;
+    double o1 = res1[gid] ? foceiMixObjSlot(gid, 1) : NA_REAL;
+    double o2 = mixFwdOk[gid] ? foceiMixObjSlot(gid, 2) : NA_REAL;
+    if (R_FINITE(o1) && R_FINITE(o2)) {
+      fIndL->thetaGrad[cpar] = (o2 - o1) / (2*delta);
+    } else {
+      // one leg is unusable; likSav is only filled on the doForward path, so a
+      // stale forward difference is not an option here
+      hasZero = true;
+      sInfoPer -= 1.0;
+      fIndL->thetaGrad[cpar] = gfull[cpar];
+    }
+  }
+}
+
 // Necessary for S-matrix calculation
 int foceiS(double *theta, Environment e, bool &hasZero){
   int npars = op_focei.npars;
@@ -10771,24 +10846,9 @@ int foceiS(double *theta, Environment e, bool &hasZero){
   }
   double sInfoPer = npars * getRxNsub(rx);
   for (cpar = npars; cpar--;){
-    // A mixture proportion's per-subject score is known in closed form -- NONMEM
-    // (1.194) chained by (1.197) for ONE subject, the same expression mixGrad()
-    // sums over subjects.  Exact, and it costs no solves, so skip the finite
-    // difference entirely for these parameters.
-    if (op_focei.mixIdxN != 0 && op_focei.mixTrans != NULL &&
-        op_focei.mixTrans[cpar] != -1) {
-      int mi = op_focei.mixTrans[cpar];
-      double sc = dUnscaleParDx(cpar);
-      for (int _gid = 0; _gid < (int)getRxNsub(rx); ++_gid) {
-        double r = mixR[(size_t)_gid*nMixS + mi];
-        double g = R_FINITE(r) ? -2.0*(r - mixP[(size_t)mi])*sc : 0.0;
-        inds_focei[_gid].thetaGrad[cpar] = R_FINITE(g) ? g : 0.0;
-      }
-      op_focei.cur++;
-      op_focei.curTick = par_progress(op_focei.cur, op_focei.totTick, op_focei.curTick,
-                                      1, op_focei.t0, 0);
-      continue;
-    }
+    // A mixture proportion's per-subject score is known in closed form, so the
+    // finite difference is skipped entirely for those parameters.
+    if (foceiSMixScore(cpar, mixR, mixP, nMixS)) continue;
     double rEps = op_focei.rEps[cpar];
     double rEpsC = op_focei.rEpsC[cpar];
     if (smatNorm){
@@ -10809,29 +10869,7 @@ int foceiS(double *theta, Environment e, bool &hasZero){
     theta[cpar] = cur + delta;
     updateTheta(theta);
     if (op_focei.mixIdxN != 0) {
-      // Mixture: the subject's contribution is the marginal over components, so
-      // every component has to be re-optimized before any per-subject score
-      // exists.  Differencing component 0 alone (what this did before) gives an
-      // exactly-zero score for any parameter that only enters another
-      // component, which made S singular for every mixture model.
-      int _nsub = (int)getRxNsub(rx);
-      foceiSInnerAll(2, mixFwdOk);
-      for (int _gid = 0; _gid < _nsub; _gid++) {
-        focei_ind *fIndL = &(inds_focei[_gid]);
-        fIndL->thetaGrad[cpar] = NA_REAL;
-        double _o2 = mixFwdOk[_gid] ? foceiMixObjSlot(_gid, 2) : NA_REAL;
-        if (doForward) {
-          if (R_FINITE(_o2) && R_FINITE(op_focei.likSav[_gid])) {
-            fIndL->thetaGrad[cpar] = (_o2 - op_focei.likSav[_gid]) / delta;
-          } else {
-            // no usable contribution for this subject/parameter: fall back to
-            // the pooled gradient, as the non-mixture serial retry does
-            hasZero = true;
-            sInfoPer -= 1.0;
-            fIndL->thetaGrad[cpar] = gfull[cpar];
-          }
-        }
-      }
+      foceiSMixForward(cpar, delta, doForward, gfull, mixFwdOk, hasZero, sInfoPer);
     } else {
       int _nsub = (int)getRxNsub(rx);
       rx_solving_options *_op = getSolvingOptions(rx);
@@ -10881,24 +10919,7 @@ int foceiS(double *theta, Environment e, bool &hasZero){
       updateTheta(theta);
       // Second inner loop: run innerOpt1(gid, 1) over subjects in parallel.
       if (op_focei.mixIdxN != 0) {
-        int _nsub = (int)getRxNsub(rx);
-        std::vector<int> _res1;
-        foceiSInnerAll(1, _res1);
-        for (int _gid = 0; _gid < _nsub; _gid++) {
-          focei_ind *fIndL = &(inds_focei[_gid]);
-          if (!ISNA(fIndL->thetaGrad[cpar])) continue;
-          double _o1 = _res1[_gid] ? foceiMixObjSlot(_gid, 1) : NA_REAL;
-          double _o2 = mixFwdOk[_gid] ? foceiMixObjSlot(_gid, 2) : NA_REAL;
-          if (R_FINITE(_o1) && R_FINITE(_o2)) {
-            fIndL->thetaGrad[cpar] = (_o2 - _o1) / (2*delta);
-          } else {
-            // one leg is unusable; likSav is only filled on the doForward
-            // path, so a stale forward difference is not an option here
-            hasZero = true;
-            sInfoPer -= 1.0;
-            fIndL->thetaGrad[cpar] = gfull[cpar];
-          }
-        }
+        foceiSMixCentral(cpar, delta, gfull, mixFwdOk, hasZero, sInfoPer);
       } else {
         int _nsub = (int)getRxNsub(rx);
         rx_solving_options *_op = getSolvingOptions(rx);

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -21759,9 +21759,13 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
         for (int m = 0; m < nMix; ++m) resp[m] = std::exp(ll[m] - mmax)/se;
       } else {
         // every component failed to solve: charge the same penalty focei does
-        // (foceiLik0Mix), instead of contributing 0 and IMPROVING the objective
+        // (foceiLik0Mix), instead of contributing 0 and IMPROVING the objective.
+        // The likelihood says nothing about membership here, so the posterior
+        // IS the prior -- giving component 1 the whole responsibility (best is
+        // still its initial 0) would silently drag the proportions toward it.
+        // saem falls back the same way when its weights underflow.
         jointTot += op_focei.badSolveObjfAdj;
-        resp[best] = 1.0;
+        resp = pi;
       }
       // Each component has its OWN eta, so eta_im appears in component m's term
       // alone: d(marginal)/d(eta_im) is just that component's gradient scaled
@@ -23875,6 +23879,17 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
   }
   setRxThreadId(-1);
 
+  // The proportions each step reports are the ones it USED, i.e. from before
+  // that step's own Adam update; refresh from the final th so what is reported
+  // and written into ini() is the estimate, not the estimate one step ago.
+  if (mixThIdx.n_elem > 0) {
+    arma::vec thvEnd = vaeBuildTh(th, zPopThetaIdx0, zPop, errThetaIdx0, a);
+    vaeInnerUpdateParCore(thvEnd, omFull());
+    if (op_focei.mixProb != NULL) {
+      mixProbFinal.set_size(nMix);
+      for (int m = 0; m < nMix; ++m) mixProbFinal[m] = op_focei.mixProb[m];
+    }
+  }
   RObject parHist = vaeIterPrintGet_(printCtl >= 1);
   arma::mat zPopMatOut(N, zDim);
   if (isCovStep) zPopMatOut = zPopArg; else zPopMatOut.each_row() = zPop.t();

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -21601,9 +21601,46 @@ struct VaeStepOut {
   std::vector<std::vector<double> > rvar;   // per-subject residual variance r (sigma^2)
   arma::ivec mixnum;    // [N] selected mixture component (1-based)
   arma::vec mixW;       // [nMix] mean posterior responsibility over subjects
+  arma::mat muAll;      // [N*nMix, zDim] posterior mean per (subject, component)
   // encoder parameter gradients
   arma::mat gWih, gWhh, gFcW; arma::vec gbih, gbhh, gFcB;
 };
+
+// Component-conditioned encoder inputs.  The encoder must characterize every
+// (subject, component) pair, so it is run over nSub*nMix pseudo-subjects laid
+// out component-major (row m*N + i), matching the flattened id space the inner
+// driver already uses (id = m*nsub + subject).
+//
+// The sequence the trunk reads does not depend on the component, so the
+// sequence data is tiled unchanged and the component identity enters at the FC
+// head as a one-hot appended to the covariate block -- which is exactly where
+// covariates enter.  That makes this encoder(y_i, cov_i, m) with no change to
+// the encoder itself: the trunk gradient accumulates over the nMix copies,
+// which is the correct gradient for a shared trunk with a conditioned head.
+//
+// Built ONCE per fit by the callers, not per ELBO step.
+static void vaeTileEncoderInputs(const arma::cube& dataIn, const arma::ivec& lengths,
+                                 const arma::mat& covIn, int nMix,
+                                 arma::cube& dataOut, arma::ivec& lenOut,
+                                 arma::mat& covOut) {
+  const int N = dataIn.n_rows;
+  if (nMix <= 1) { dataOut = dataIn; lenOut = lengths; covOut = covIn; return; }
+  const int nCov = covIn.n_cols;
+  dataOut.set_size(N * nMix, dataIn.n_cols, dataIn.n_slices);
+  lenOut.set_size(N * nMix);
+  covOut.zeros(N * nMix, nCov + nMix);
+  for (int m = 0; m < nMix; ++m) {
+    for (int i = 0; i < N; ++i) {
+      const int r = m * N + i;
+      for (unsigned int sl = 0; sl < dataIn.n_slices; ++sl) {
+        dataOut.slice(sl).row(r) = dataIn.slice(sl).row(i);
+      }
+      lenOut[r] = lengths[i];
+      if (nCov > 0) covOut.submat(r, 0, r, nCov - 1) = covIn.row(i);
+      covOut(r, nCov + m) = 1.0;          // component one-hot
+    }
+  }
+}
 
 // One ELBO evaluation using the FOCEi inner likelihood (port of
 // .vaeElboStepInner).  zPopMat [N,zDim] is the (possibly subject-specific) KL
@@ -21620,7 +21657,10 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
                                  int nMix, const arma::vec& mixProb, int cores,
                                  bool withGrad = true, bool parEncoderBackward = false) {
   VaeStepOut S; S.ok = true;
-  const int N = dataIn.n_rows;
+  // dataIn/lengths/covIn arrive TILED to nSub*nMix pseudo-subjects (see
+  // vaeTileEncoderInputs); N stays the physical subject count.
+  const int Ne = dataIn.n_rows;
+  const int N = (nMix > 1) ? Ne / nMix : Ne;
   // full-omega prior pieces; the diagonal path below is kept verbatim so
   // diagonal models are bit-identical to the historic code
   const arma::vec omega = Om.diag();
@@ -21632,11 +21672,22 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
     double sgn; arma::log_det(logdetOm, sgn, arma::symmatu(Om));
   }
   // encoder forward (no backward yet -- need z to form gZ first)
-  arma::mat mu(N, zDim), logSigma(N, zDim), zOut(N, zDim);
-  arma::cube Lout(zDim, zDim, N);
-  arma::mat dummyGz(N, zDim, arma::fill::zeros), dummyGls(N, zDim, arma::fill::zeros);
+  arma::mat mu(Ne, zDim), logSigma(Ne, zDim), zOut(Ne, zDim);
+  arma::cube Lout(zDim, zDim, Ne);
+  arma::mat dummyGz(Ne, zDim, arma::fill::zeros), dummyGls(Ne, zDim, arma::fill::zeros);
   arma::mat gWih, gWhh, gFcW; arma::vec gbih, gbhh, gFcB;
-  vaeEncoderFwdBwdCore(dataIn, lengths, covIn, eps, Wih, Whh, bih, bhh, fcW, fcB, zDim,
+  // one reparameterization draw per subject, shared across that subject's
+  // components (common random numbers -- lower variance, and the components
+  // differ through the head, not the noise)
+  arma::mat epsE = eps, zPopE = zPopMat;
+  if (nMix > 1) {
+    epsE.set_size(Ne, zDim); zPopE.set_size(Ne, zDim);
+    for (int m = 0; m < nMix; ++m) {
+      epsE.rows(m * N, m * N + N - 1) = eps.rows(0, N - 1);
+      zPopE.rows(m * N, m * N + N - 1) = zPopMat.rows(0, N - 1);
+    }
+  }
+  vaeEncoderFwdBwdCore(dataIn, lengths, covIn, epsE, Wih, Whh, bih, bhh, fcW, fcB, zDim,
                        dummyGz, dummyGls, false, mu, logSigma, Lout, zOut,
                        gWih, gWhh, gbih, gbhh, gFcW, gFcB, cores);
   arma::mat eta = zOut;
@@ -21644,15 +21695,16 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
   // inner-problem re-parameterization + evaluation
   arma::vec thv = vaeBuildTh(th, zPopThetaIdx0, baseline, errThetaIdx0, a);
   vaeInnerUpdateParCore(thv, Om);
-  arma::mat etaEval = eta;
-  if (nMix > 1) { etaEval.set_size(nMix * N, zDim); for (int m = 0; m < nMix; ++m) etaEval.rows(m * N, m * N + N - 1) = eta; }
+  // eta already carries one row per (subject, component): each component is
+  // scored at ITS OWN eta, not at a shared one tiled across components
+  const arma::mat& etaEval = eta;
   arma::vec obj; arma::mat lp; std::vector<std::vector<double> > pf;
   std::vector<std::vector<double> > prv;
   vaeInnerLikCore(etaEval, cores, true, true, obj, lp, pf, false, &prv);
 
   const double ln2pi = std::log(2 * M_PI);
-  arma::vec pzI(N);
-  for (int i = 0; i < N; ++i) {
+  arma::vec pzI(Ne);
+  for (int i = 0; i < Ne; ++i) {
     double s;
     if (omOff) {
       arma::vec ei = eta.row(i).t();
@@ -21663,7 +21715,9 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
     pzI[i] = 0.5 * s;
   }
   double jointTot;
-  arma::mat lpBest(N, zDim);
+  arma::mat lpAll(Ne, zDim, arma::fill::zeros);
+  arma::uvec sel(N);                       // selected pseudo-subject row per subject
+  for (int i = 0; i < N; ++i) sel[i] = i;  // nMix == 1: the subject IS the row
   S.preds.resize(N);
   S.rvar.resize(N);
   S.mixnum.set_size(N); S.mixnum.fill(1);
@@ -21697,71 +21751,98 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
         jointTot += op_focei.badSolveObjfAdj;
         resp[best] = 1.0;
       }
-      // the encoder is trained on the objective it optimizes: the gradient of
-      // the marginal is the responsibility-weighted mean, not the argmax
-      // component's gradient
-      lpBest.row(i).zeros();
+      // Each component has its OWN eta, so eta_im appears in component m's term
+      // alone: d(marginal)/d(eta_im) is just that component's gradient scaled
+      // by its responsibility.  Nothing is combined across components.
       for (int m = 0; m < nMix; ++m) {
-        if (resp[m] > 0) lpBest.row(i) += resp[m] * lp.row(m * N + i);
+        lpAll.row(m * N + i) = resp[m] * lp.row(m * N + i);
       }
-      // preds/rvar stay on the argmax component: the closed-form residual
-      // M-step is a moment estimator, and averaging residuals across
-      // components inflates the residual SD
-      S.preds[i] = pf[best * N + i];
-      if (!prv.empty()) S.rvar[i] = prv[best * N + i];
+      // everything reported per SUBJECT comes from the selected component --
+      // its eta, its predictions, its residual variance -- the same way focei
+      // reports bestMixEst
+      sel[i] = best * N + i;
+      S.preds[i] = pf[sel[i]];
+      if (!prv.empty()) S.rvar[i] = prv[sel[i]];
       S.mixnum[i] = best + 1;
       S.mixW += resp;
     }
     S.mixW /= (double)N;
   } else {
     jointTot = arma::accu(obj);
-    lpBest = lp;
+    lpAll = lp;
     for (int i = 0; i < N; ++i) {
       S.preds[i] = pf[i];
       if (!prv.empty()) S.rvar[i] = prv[i];
     }
   }
-  double pxz = jointTot - arma::accu(pzI);
+  // the prior is removed at the SELECTED component, which is the eta this
+  // subject is reported at
+  double pxzPrior = 0;
+  for (int i = 0; i < N; ++i) pxzPrior += pzI[sel[i]];
+  double pxz = jointTot - pxzPrior;
   double pz = 0, qz = 0;
   for (int i = 0; i < N; ++i) {
+    const unsigned int r = sel[i];         // the selected component's posterior
     if (omOff) {
-      arma::vec d = (zOut.row(i) - zPopMat.row(i)).t();
+      arma::vec d = (zOut.row(r) - zPopE.row(r)).t();
       pz += 0.5 * (arma::dot(d, OmInv * d) + logdetOm + zDim * ln2pi);
     }
     for (int k = 0; k < zDim; ++k) {
       if (!omOff) {
-        double d = zOut(i, k) - zPopMat(i, k);
+        double d = zOut(r, k) - zPopE(r, k);
         pz += 0.5 * (d * d / omega[k] + std::log(omega[k]) + ln2pi);
       }
-      qz += 0.5 * (eps(i, k) * eps(i, k) + ln2pi + 2 * logSigma(i, k));
+      qz += 0.5 * (epsE(r, k) * epsE(r, k) + ln2pi + 2 * logSigma(r, k));
     }
   }
   double DKL = pz - qz;
   if (withGrad) {
     // encoder upstream: d(pxz)/dz = lp - Omega^-1 eta; KL adds
     // alphaKL * Omega^-1 (z - zPopMat)
-    arma::mat gZ = lpBest;
+    // Every pseudo-subject keeps its OWN data gradient (already responsibility
+    // scaled).  The prior correction and the KL apply to the selected row only,
+    // because that is where pxz removed the prior and where DKL was formed.
+    arma::mat gZ = lpAll;
+    arma::mat gLS(Ne, zDim, arma::fill::zeros);
     for (int i = 0; i < N; ++i) {
+      const unsigned int r = sel[i];
       arma::vec pri(zDim), klg(zDim);
       if (omOff) {
-        pri = OmInv * eta.row(i).t();
-        klg = OmInv * (zOut.row(i) - zPopMat.row(i)).t();
+        pri = OmInv * eta.row(r).t();
+        klg = OmInv * (zOut.row(r) - zPopE.row(r)).t();
       }
       for (int k = 0; k < zDim; ++k) {
         double g = omOff
-          ? gZ(i, k) - pri[k] + alphaKL * klg[k]
-          : gZ(i, k) - eta(i, k) / omega[k] + alphaKL * (zOut(i, k) - zPopMat(i, k)) / omega[k];
-        gZ(i, k) = R_FINITE(g) ? g : 0.0;
+          ? gZ(r, k) - pri[k] + alphaKL * klg[k]
+          : gZ(r, k) - eta(r, k) / omega[k] + alphaKL * (zOut(r, k) - zPopE(r, k)) / omega[k];
+        gZ(r, k) = R_FINITE(g) ? g : 0.0;
       }
+      gLS.row(r).fill(-alphaKL);
     }
-    arma::mat gLS(N, zDim); gLS.fill(-alphaKL);
-    arma::mat mu2(N, zDim), ls2(N, zDim), z2(N, zDim); arma::cube L2(zDim, zDim, N);
-    vaeEncoderFwdBwdCore(dataIn, lengths, covIn, eps, Wih, Whh, bih, bhh, fcW, fcB, zDim,
+    for (int r = 0; r < Ne; ++r) {
+      for (int k = 0; k < zDim; ++k) if (!R_FINITE(gZ(r, k))) gZ(r, k) = 0.0;
+    }
+    arma::mat mu2(Ne, zDim), ls2(Ne, zDim), z2(Ne, zDim); arma::cube L2(zDim, zDim, Ne);
+    vaeEncoderFwdBwdCore(dataIn, lengths, covIn, epsE, Wih, Whh, bih, bhh, fcW, fcB, zDim,
                          gZ, gLS, true, mu2, ls2, L2, z2,
                          S.gWih, S.gWhh, S.gbih, S.gbhh, S.gFcW, S.gFcB, cores,
                          parEncoderBackward);
   }
-  S.pxz = pxz; S.DKL = DKL; S.mu = mu; S.z = zOut; S.L = Lout; S.lp = lpBest;
+  // report one row per SUBJECT: the selected component's posterior
+  S.pxz = pxz; S.DKL = DKL;
+  if (nMix > 1) {
+    S.mu.set_size(N, zDim); S.z.set_size(N, zDim); S.lp.set_size(N, zDim);
+    S.L.set_size(zDim, zDim, N);
+    for (int i = 0; i < N; ++i) {
+      S.mu.row(i) = mu.row(sel[i]);
+      S.z.row(i) = zOut.row(sel[i]);
+      S.lp.row(i) = lpAll.row(sel[i]);
+      S.L.slice(i) = Lout.slice(sel[i]);
+    }
+  } else {
+    S.mu = mu; S.z = zOut; S.L = Lout; S.lp = lpAll;
+  }
+  S.muAll = mu;
   if (!R_FINITE(pxz)) S.ok = true; // a failed subject is zeroed in gZ, not fatal
   return S;
 }
@@ -21788,6 +21869,17 @@ List vaeElboStepCpp_(List params, List prep, RObject zPopR, RObject omegaR,
   arma::cube dataIn = as<arma::cube>(prep["dataIn"]);
   arma::ivec lengths = vaeToIvec(prep["lengths"]);
   arma::mat covIn = as<arma::mat>(prep["covIn"]);
+  // component-conditioned encoder inputs (see vaeTileEncoderInputs)
+  arma::cube dataInE; arma::ivec lenE; arma::mat covEnc;
+  vaeTileEncoderInputs(dataIn, lengths, covIn, nMix, dataInE, lenE, covEnc);
+  // A head that does not match the (widened) input reaches armadillo as a
+  // std::logic_error from inside the encoder, which terminates the SESSION
+  // rather than raising an R error.  Check it here while we still can.
+  if ((int)fcW.n_cols != (int)(Whh.n_cols + covEnc.n_cols)) {
+    stop("vae encoder head is %d wide but needs hiddenDim + ncol(covIn)%s = %d",
+         (int)fcW.n_cols, nMix > 1 ? " + nMix" : "",
+         (int)(Whh.n_cols + covEnc.n_cols));
+  }
   arma::vec th = as<arma::vec>(prep["th"]);
   // .vaeDataPrep stores 1-based theta indices with NA for a free/mixture eta; map
   // to the 0-based (-1 = free) form the core uses.
@@ -21812,7 +21904,7 @@ List vaeElboStepCpp_(List params, List prep, RObject zPopR, RObject omegaR,
     zPopMat.each_row() = zp.t();
     baseline = zp;
   }
-  VaeStepOut S = vaeElboStepCpp(Wih, Whh, bih, bhh, fcW, fcB, dataIn, lengths, covIn,
+  VaeStepOut S = vaeElboStepCpp(Wih, Whh, bih, bhh, fcW, fcB, dataInE, lenE, covEnc,
                                 eps, zDim, th, zPopThetaIdx0, errThetaIdx0, zPopMat, baseline,
                                 Om, a, alphaKL, nMix, mixProb, cores, withGrad);
   RObject grads = R_NilValue;
@@ -21827,7 +21919,10 @@ List vaeElboStepCpp_(List params, List prep, RObject zPopR, RObject omegaR,
   for (int i = 0; i < N; ++i) mixnum[i] = S.mixnum[i];
   return List::create(_["loss"] = S.pxz + alphaKL * S.DKL, _["pxz"] = S.pxz, _["DKL"] = S.DKL,
                       _["grads"] = grads, _["mu"] = S.mu, _["L"] = S.L, _["z"] = S.z,
-                      _["preds"] = preds, _["rvar"] = rvar, _["mixnum"] = mixnum);
+                      _["preds"] = preds, _["rvar"] = rvar, _["mixnum"] = mixnum,
+                      // per (subject, component) posterior mean, component-major
+                      // (row m*N + i) -- the encoder characterizes every pair
+                      _["muAll"] = S.muAll, _["mixW"] = S.mixW);
 }
 
 // ---------------------------------------------------------------------------
@@ -22707,13 +22802,12 @@ static double gVaeThetaObjR(Rcpp::NumericVector r) {
   }
   arma::vec thv = vaeBuildTh(thc, gVaeRegZpopIdx0, gVaeRegBaseline, gVaeRegErrIdx0, aCand);
   vaeInnerUpdateParCore(thv, gVaeRegOmega);
-  const int N = (int)gVaeRegEtaCentered.n_rows;
+  // gVaeRegEtaCentered already carries one row per (subject, component) --
+  // each component is scored at ITS OWN eta, not at a shared one tiled across
+  // components
   const int nMix = gVaeRegNMix;
-  arma::mat etaEval = gVaeRegEtaCentered;
-  if (nMix > 1) {
-    etaEval.set_size(nMix * N, gVaeRegEtaCentered.n_cols);
-    for (int m = 0; m < nMix; ++m) etaEval.rows(m * N, m * N + N - 1) = gVaeRegEtaCentered;
-  }
+  const int N = (int)gVaeRegEtaCentered.n_rows / (nMix > 1 ? nMix : 1);
+  const arma::mat& etaEval = gVaeRegEtaCentered;
   arma::vec obj; arma::mat lp; std::vector<std::vector<double> > pf;
   vaeInnerLikCore(etaEval, gVaeRegCores, false, false, obj, lp, pf, gVaeRegAdjOuter);
   double v;
@@ -22760,6 +22854,12 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
   arma::cube dataIn = as<arma::cube>(prep["dataIn"]);
   arma::ivec lengths = vaeToIvec(prep["lengths"]);
   arma::mat covIn = as<arma::mat>(prep["covIn"]);
+  // Component-conditioned ENCODER inputs, built once (see
+  // vaeTileEncoderInputs).  Kept separate from covIn, which the covariate
+  // best-subset machinery below indexes against covAllow/covGroup -- the
+  // component one-hot is not a covariate and must not be selectable.
+  arma::cube dataInE; arma::ivec lenE; arma::mat covEnc;
+  vaeTileEncoderInputs(dataIn, lengths, covIn, nMix, dataInE, lenE, covEnc);
   arma::mat covMat = as<arma::mat>(prep["covMat"]);
   arma::vec th = as<arma::vec>(prep["th"]);
   arma::ivec zPopThetaIdx0 = vaeToIvec(prep["zPopThetaIdx0"]);
@@ -23125,7 +23225,7 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
       arma::mat eps(N, zDim);
       vaeDrawEps(eps, (uint32_t)(seed + (it - 1) * Lg + l));
       arma::mat zPopMat(N, zDim); zPopMat.each_row() = zPop.t();
-      VaeStepOut st = vaeElboStepCpp(Wih, Whh, bih, bhh, fcW, fcB, dataIn, lengths, covIn,
+      VaeStepOut st = vaeElboStepCpp(Wih, Whh, bih, bhh, fcW, fcB, dataInE, lenE, covEnc,
                                      eps, zDim, th, zPopThetaIdx0, errThetaIdx0, zPopMat, zPop,
                                      omFull(), a, 0.001, nMix, mixProb, cores, true, parEncoderBackward);
       tstep++;
@@ -23546,7 +23646,8 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
       gVaeRegBaseline = baseline;
       gVaeRegA = a;
       gVaeRegOmega = omFull();
-      gVaeRegEtaCentered = last.mu; gVaeRegEtaCentered.each_row() -= baseline.t();
+      gVaeRegEtaCentered = last.muAll.n_rows > 0 ? last.muAll : last.mu;
+      gVaeRegEtaCentered.each_row() -= baseline.t();
       gVaeRegCores = cores; gVaeRegNMix = nMix; gVaeRegMixProb = mixProb;
       gVaeRegAdjOuter = mStepOuter;  // outer objective, or the reference ELBO
       Rcpp::Environment nlmixr2 = Rcpp::Environment::namespace_env("nlmixr2est");
@@ -23694,7 +23795,7 @@ List vaeTrainCpp_(List params, List prep, List control, int nMix, NumericVector 
     for (int l = 1; l <= Lg; ++l) {
       arma::mat eps(N, zDim);
       vaeDrawEps(eps, (uint32_t)(seed + 1000003 + (it - 1) * Lg + l));
-      VaeStepOut st = vaeElboStepCpp(Wih, Whh, bih, bhh, fcW, fcB, dataIn, lengths, covIn,
+      VaeStepOut st = vaeElboStepCpp(Wih, Whh, bih, bhh, fcW, fcB, dataInE, lenE, covEnc,
                                      eps, zDim, th, zPopThetaIdx0, errThetaIdx0, zPopArg, baseline,
                                      omFull(), a, alphaKL, nMix, mixProb, cores, true, parEncoderBackward);
       tstep++;

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -21729,7 +21729,6 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
   double jointTot;
   arma::mat lpAll(Ne, zDim, arma::fill::zeros);
   arma::uvec sel(N);                       // selected pseudo-subject row per subject
-  arma::vec gpi(nMix > 1 ? nMix - 1 : 1, arma::fill::zeros);
   for (int i = 0; i < N; ++i) sel[i] = i;  // nMix == 1: the subject IS the row
   S.preds.resize(N);
   S.rvar.resize(N);
@@ -21778,21 +21777,23 @@ static VaeStepOut vaeElboStepCpp(const arma::mat& Wih, const arma::mat& Whh,
       if (!prv.empty()) S.rvar[i] = prv[sel[i]];
       S.mixnum[i] = best + 1;
       S.mixW += resp;
-      // d/d(pi_m) of -log sum_k pi_k exp(-obj_ik) is -(r_im/pi_m), and the last
-      // component is not free (pi_last = 1 - sum), so its share is subtracted --
-      // the same difference foceiLik0Mix accumulates into fInd->mixProbGrad.
-      for (int m = 0; m < nMix - 1; ++m) {
-        double gm = -(resp[m] / pi[m] - resp[nMix - 1] / pi[nMix - 1]);
-        if (R_FINITE(gm)) gpi[m] += gm;
-      }
     }
     S.mixW /= (double)N;
-    // chain rule through mexpit: op_focei.mixProbGrad is the dmexpit Jacobian
-    // updateTheta filled, exactly as mixGrad() applies it for focei
+    // Gradient of the marginal -2LL wrt the MLOGIT parameters.  Carrying
+    // d/d(pi) and then applying a Jacobian is a trap here: mexpit's Jacobian is
+    // dense, d(pi_m)/d(theta_l) = pi_m (delta_ml - pi_l), so treating it as one
+    // scalar per free parameter (as mixGrad does) silently drops the
+    // off-diagonal -pi_m pi_l terms.  That is exact only at nMix == 2, where
+    // there is a single free parameter -- and wrong by 25% at nMix == 3.
+    //
+    // Chaining it properly collapses: summing -r_im/pi_m against the dense
+    // Jacobian over ALL components gives -(r_il - pi_l), since the
+    // responsibilities sum to one.  So the exact gradient is just
+    //   N * pi_l - sum_i r_il
+    // for every l, with no Jacobian to get wrong.
     S.gMixTheta.zeros(nMix - 1);
     for (int m = 0; m < nMix - 1; ++m) {
-      double j = (op_focei.mixProbGrad != NULL) ? op_focei.mixProbGrad[m] : 1.0;
-      double g = gpi[m] * j;
+      double g = (double)N * (pi[m] - S.mixW[m]);
       S.gMixTheta[m] = R_FINITE(g) ? g : 0.0;
     }
   } else {

--- a/src/logSumExp.h
+++ b/src/logSumExp.h
@@ -1,0 +1,65 @@
+#ifndef __LOGSUMEXP_H__
+#define __LOGSUMEXP_H__
+#include <cmath>
+#include <limits>
+#include <Rmath.h>
+
+// Weighted log-sum-exp, max-shifted:
+//
+//   log( sum_k w[k] * exp(v[k]) )
+//
+// The shift is what keeps a term that underflows from taking the whole sum with
+// it, which is the entire reason a mixture marginal is computed in log space.
+// `w == NULL` means unit weights.
+//
+// `skipNonFinite` distinguishes the two callers, and they genuinely differ:
+//
+//   TRUE  -- a mixture marginal.  A component that failed to solve contributes
+//            nothing rather than poisoning the sum.  Returns R_NegInf when NO
+//            component is finite, so the caller can charge its own penalty;
+//            mixture code must not let that read as a likelihood of 1.
+//   FALSE -- the importance-sampling proposal kernel, which has always let a
+//            NaN propagate.  Quietly dropping one there would turn a loud
+//            failure into a plausible number.
+//
+// When `wOut` is non-NULL it receives the normalized weights
+// w[k]*exp(v[k]) / sum_j w[j]*exp(v[j]) -- the posterior responsibilities.
+// They are left at 0 when the sum is not finite.
+//
+// static inline, in a header, because impPropLogKernelRecip() calls this once
+// per importance sample; a cross-translation-unit call there is measurable.
+static inline double rxLogSumExpW(const double *v, const double *w, int n,
+                                  double *wOut, bool skipNonFinite) {
+  double mx = -std::numeric_limits<double>::infinity();
+  for (int k = 0; k < n; ++k) {
+    if (wOut != NULL) wOut[k] = 0.0;
+    if (skipNonFinite && !R_FINITE(v[k])) continue;
+    double lp = v[k] + ((w == NULL) ? 0.0 : std::log(std::max(1e-300, w[k])));
+    if (lp > mx) mx = lp;          // NaN compares false, so it never wins here
+  }
+  if (!R_FINITE(mx)) return R_NegInf;
+  double se = 0.0;
+  for (int k = 0; k < n; ++k) {
+    if (skipNonFinite && !R_FINITE(v[k])) continue;
+    double e = std::exp(v[k] + ((w == NULL) ? 0.0 : std::log(std::max(1e-300, w[k]))) - mx);
+    se += e;                        // a NaN term reaches the result when
+    if (wOut != NULL) wOut[k] = e;  // skipNonFinite is FALSE, as it always did
+  }
+  if (wOut != NULL && se > 0.0) {
+    for (int k = 0; k < n; ++k) wOut[k] /= se;
+  }
+  return mx + std::log(se);
+}
+
+// Mixture marginal: weighted, and a failed component contributes nothing.
+static inline double rxLogSumExpMix(const double *v, const double *w, int n,
+                                    double *wOut) {
+  return rxLogSumExpW(v, w, n, wOut, true);
+}
+
+// Unweighted log( sum_k exp(v[k]) ), NaN-propagating.
+static inline double rxLogSumExp(const double *v, int n) {
+  return rxLogSumExpW(v, NULL, n, NULL, false);
+}
+
+#endif // __LOGSUMEXP_H__

--- a/tests/testthat/test-etaMat.R
+++ b/tests/testthat/test-etaMat.R
@@ -54,4 +54,27 @@ nmTest({
     expect_true(is.na(f4$foceiControl$etaMat))
 
   })
+
+  test_that("etaMat drops the mixture bookkeeping columns", {
+    ## $eta carries ID, and for a mixture fit nmObjGet.ranef merges in a mixnum
+    ## column.  Neither is an eta.  Letting either reach an etaMat trips
+    ## foceiSetup_'s column check ("The etaMat must have the same number of ETAs
+    ## (cols) as the model"), which is what broke every mixture refit -- $cov,
+    ## addCwres, .setOfvFo and nlmixr2(fit, ...) all round-trip fit$etaMat.
+    .eta <- data.frame(ID = 1:3, eta.ka = c(0.1, -0.2, 0.3),
+                       eta.cl = c(-0.1, 0.2, 0.0), mixnum = c(1L, 2L, 1L))
+    expect_equal(colnames(.nmDropNonEtaCols(.eta)), c("eta.ka", "eta.cl"))
+    ## the accessor itself, with and without the mixture column
+    expect_equal(colnames(nmObjGet.etaMat(list(list(eta = .eta, iov = NULL)))),
+                 c("eta.ka", "eta.cl"))
+    expect_equal(colnames(nmObjGet.etaMat(list(list(eta = .eta[, 1:3], iov = NULL)))),
+                 c("eta.ka", "eta.cl"))
+    ## MIXEST is the same bookkeeping under its focei spelling
+    .eta2 <- .eta
+    names(.eta2)[4] <- "MIXEST"
+    expect_equal(colnames(.nmDropNonEtaCols(.eta2)), c("eta.ka", "eta.cl"))
+    ## an ordinary eta whose name merely contains "mix" is NOT dropped
+    .eta3 <- data.frame(ID = 1:2, eta.mixup = c(0.1, 0.2))
+    expect_equal(colnames(.nmDropNonEtaCols(.eta3)), "eta.mixup")
+  })
 })

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -111,6 +111,59 @@ nmTest({
     expect_equal(max(.ses) / min(.ses), 1, tolerance = 0.05)
   })
 
+  test_that("the rotation is keyed on the theta slot, not on ui$mixProbs order", {
+    ## ui$mixProbs follows the mix() CALL; thetaMixIndex follows ini().  When the
+    ## two orders differ, everything downstream -- the covariance's rows,
+    ## op_focei.mixProb, $mixProbabilities, se/popDf -- is keyed on the THETA
+    ## slot, so indexing a theta-ordered covariance by mixProbs puts the Jacobian
+    ## on the wrong rows.
+    .mod <- function() {
+      ini({
+        tka <- log(1.1)
+        p2 <- 0.30          # deliberately declared BEFORE p1
+        p1 <- 0.60
+        tcl1 <- log(1)
+        tcl2 <- log(8)
+        tcl3 <- log(30)
+        tv <- log(20)
+        eta.cl ~ 0.01
+        add.sd <- 0.05
+      })
+      model({
+        ka <- exp(tka)
+        cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl), p2,
+                  exp(tcl3 + eta.cl))
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(.mod))
+    .slot <- names(.ui$theta)[.ui$thetaMixIndex]
+    ## the hazard this guards is real for this model
+    expect_false(identical(.ui$mixProbs, .slot))
+    expect_equal(.slot, c("p2", "p1"))
+
+    ## component-ordered probabilities, far enough apart that a swap shows
+    .p <- c(0.60, 0.30)
+    .e <- new.env(parent = emptyenv())
+    .e$ui <- .ui
+    .e$mixProbabilities <- c(.p, 1 - sum(.p))
+    ## the covariance is in THETA order, so its mixture rows are named p2, p1
+    .nm <- c(.slot, "add.sd")
+    .e$cov <- diag(c(1, 4, 9))
+    dimnames(.e$cov) <- list(.nm, .nm)
+    .mixInstallProbScaleCov(.e)
+
+    ## component m's Jacobian must land on the row for theta slot mixIdx[m]
+    .j <- diag(.p, nrow = 2L) - outer(.p, .p)
+    .a <- diag(1, 3)
+    .a[1:2, 1:2] <- .j
+    .want <- .a %*% diag(c(1, 4, 9)) %*% t(.a)
+    expect_equal(unname(.e$cov), unname(.want))
+    ## and concretely: the two mixture variances are NOT interchangeable here
+    expect_false(isTRUE(all.equal(.e$cov[1, 1], .e$cov[2, 2])))
+  })
+
   test_that("setCov() round trips without re-rotating the mixture block", {
     ## setCov() re-installs a CACHED covariance (covList) by handing it back as a
     ## matrix, which refits and would rotate an already-probability-scale matrix
@@ -178,8 +231,24 @@ nmTest({
   ## (saem excludes the proportions from its kernel parameter vector).  Driven
   ## from a synthetic env so both branches are exercised without a fit.
   .mkMixEnv <- function(r1, pi1, n = 100L) {
+    ## a REAL ui: the covariance helpers key the proportions on their theta slot
+    ## (names(ui$theta)[ui$thetaMixIndex]), so a stub list will not do
+    .m <- function() {
+      ini({
+        tcl <- log(1)
+        p1 <- 0.45
+        tv <- log(20)
+        eta.cl ~ 0.01
+        add.sd <- 0.05
+      })
+      model({
+        cl <- mix(exp(tcl + eta.cl), p1, exp(tcl + 2 + eta.cl))
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
     .e <- new.env(parent = emptyenv())
-    .e$ui <- list(mixProbs = "p1")
+    .e$ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(.m))
     .nm <- c("tcl", "tv")
     .e$cov <- matrix(c(4, 1, 1, 9), 2, 2, dimnames = list(.nm, .nm))
     .e$mixProbabilities <- c(pi1, 1 - pi1)

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -164,6 +164,28 @@ nmTest({
     expect_false(isTRUE(all.equal(.e$cov[1, 1], .e$cov[2, 2])))
   })
 
+  test_that("a proportion missing from the covariance does not block the others", {
+    ## A fix()ed proportion is dropped from the covariance by skipCov.  Bailing
+    ## on the whole rotation when a name is absent left the REMAINING
+    ## proportions reported on the mlogit scale -- measured 0.265 where the
+    ## probability scale is 0.063, a factor of 1/(p(1-p)).
+    .nm <- c("p2", "add.sd")
+    .cov <- diag(c(4, 9)); dimnames(.cov) <- list(.nm, .nm)
+    .p <- c(0.40, 0.35)                       # p1 (fixed, absent) and p2
+    .out <- .mixCovToProbScale(.cov, c("p1", "p2"), .p)
+    ## only p2's row is rotated, by its own diagonal Jacobian entry p2(1-p2)
+    .j22 <- .p[2] * (1 - .p[2])
+    expect_equal(unname(.out[1, 1]), .j22^2 * 4)
+    expect_equal(unname(.out[2, 2]), 9)       # add.sd untouched
+    ## and it is NOT left unrotated
+    expect_false(isTRUE(all.equal(unname(.out[1, 1]), 4)))
+
+    ## with every name absent the matrix is returned as-is
+    .nm2 <- c("tcl", "add.sd")
+    .cov2 <- diag(c(4, 9)); dimnames(.cov2) <- list(.nm2, .nm2)
+    expect_equal(.mixCovToProbScale(.cov2, c("p1", "p2"), .p), .cov2)
+  })
+
   test_that("setCov() round trips without re-rotating the mixture block", {
     ## setCov() re-installs a CACHED covariance (covList) by handing it back as a
     ## matrix, which refits and would rotate an already-probability-scale matrix

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -164,6 +164,18 @@ nmTest({
     expect_false(isTRUE(all.equal(.e$cov[1, 1], .e$cov[2, 2])))
   })
 
+  test_that("a proportion at the boundary is flagged, not reported as precise", {
+    ## The probability-scale SE carries a factor p(1-p), so it goes to ZERO as a
+    ## proportion approaches 0 or 1.  That is the correct delta-method answer but
+    ## reads as certainty, so it must be said out loud.
+    expect_warning(.mixWarnBoundary(c(0.001, 0.999)), "near 0/1")
+    expect_warning(.mixWarnBoundary(c(0.45, 0.996)), "near 0/1")
+    expect_silent(.mixWarnBoundary(c(0.45, 0.55)))
+    expect_silent(.mixWarnBoundary(c(0.02, 0.98)))
+    expect_silent(.mixWarnBoundary(numeric(0)))
+    expect_silent(.mixWarnBoundary(c(NA_real_, 0.5)))
+  })
+
   test_that("a proportion missing from the covariance does not block the others", {
     ## A fix()ed proportion is dropped from the covariance by skipCov.  Bailing
     ## on the whole rotation when a name is absent left the REMAINING

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -39,7 +39,7 @@ nmTest({
     expect_equal(dimnames(.out), dimnames(.cov))
     ## a non-mixture cov, or names that are not present, is left alone
     expect_equal(.mixCovToProbScale(.cov, character(0), numeric(0)), .cov)
-    expect_equal(.mixCovToProbScale(.cov, c("nope"), .p[1]), .cov)
+    expect_equal(.mixCovToProbScale(.cov, "nope", .p[1]), .cov)
   })
 
   ## Two well-separated components with everything but the proportion and the
@@ -139,9 +139,14 @@ nmTest({
     }
     .ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(.mod))
     .slot <- names(.ui$theta)[.ui$thetaMixIndex]
-    ## the hazard this guards is real for this model
-    expect_false(identical(.ui$mixProbs, .slot))
-    expect_equal(.slot, c("p2", "p1"))
+    ## thetaMixIndex is in COMPONENT order, so the slots it names are mixProbs
+    expect_equal(.slot, .ui$mixProbs)
+    ## ...but this model's ini() declares them in the OTHER order, so those slot
+    ## POSITIONS are descending.  That is what makes the test non-trivial: the
+    ## covariance's rows are built in ascending theta order (p2 then p1) while
+    ## the Jacobian is built in component order (p1 then p2), so the two must be
+    ## bridged by name rather than by position.
+    expect_gt(.ui$thetaMixIndex[1], .ui$thetaMixIndex[2])
 
     ## component-ordered probabilities, far enough apart that a swap shows
     .p <- c(0.60, 0.30)

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -153,6 +153,47 @@ nmTest({
     expect_equal(unname(.se), sqrt(.p * (1 - .p) / .dat$n), tolerance = 0.05)
   })
 
+  ## The appended block for engines whose covariance has no mixture rows at all
+  ## (saem excludes the proportions from its kernel parameter vector).  Driven
+  ## from a synthetic env so both branches are exercised without a fit.
+  .mkMixEnv <- function(r1, pi1, n = 100L) {
+    .e <- new.env(parent = emptyenv())
+    .e$ui <- list(mixProbs = "p1")
+    .nm <- c("tcl", "tv")
+    .e$cov <- matrix(c(4, 1, 1, 9), 2, 2, dimnames = list(.nm, .nm))
+    .e$mixProbabilities <- c(pi1, 1 - pi1)
+    .e$mixList <- list(data.frame(prob = r1), data.frame(prob = 1 - r1))
+    .e
+  }
+
+  test_that("a covariance with no mixture rows gets the NONMEM (7.51) block appended", {
+    ## hard 0/1 responsibilities with mean == the proportion: the EM fixed point,
+    ## where the information is n*p*(1-p) and the answer is the binomial variance
+    .n <- 100L
+    .r <- c(rep(1, 45), rep(0, 55))
+    .e <- .mkMixEnv(.r, 0.45, .n)
+    .mixCovAppendBlock(.e)
+    expect_true("p1" %in% rownames(.e$cov))
+    expect_equal(dim(.e$cov), c(3L, 3L))
+    expect_equal(unname(sqrt(diag(.e$cov))[3]), sqrt(0.45 * 0.55 / .n), tolerance = 1e-8)
+    ## the pre-existing block is untouched and the new one is uncorrelated with
+    ## it -- the cross terms (7.52)-(7.54) need per-subject scores this engine
+    ## does not expose, so they are deliberately absent
+    expect_equal(unname(.e$cov[1:2, 1:2]), matrix(c(4, 1, 1, 9), 2, 2))
+    expect_equal(unname(.e$cov[1:2, 3]), c(0, 0))
+  })
+
+  test_that("the appended block is refused when the fit is not at the EM fixed point", {
+    ## p != mean_i r_i: an information matrix reports the precision of an MLE,
+    ## and this is not one.  saem lands here (nlmixr2est#1058), and reporting a
+    ## number would be a confident-looking SE on a non-stationary estimate.
+    .e <- .mkMixEnv(c(rep(1, 30), rep(0, 70)), 0.64, 100L)
+    .mixCovAppendBlock(.e)
+    expect_false("p1" %in% rownames(.e$cov))
+    expect_equal(dim(.e$cov), c(2L, 2L))
+    expect_true(any(grepl("mean responsibility", .e$runInfo)))
+  })
+
   test_that("covMethod='analytic' declines a mixture rather than reporting one component", {
     ## The augmented sensitivity model differentiates ONE component's conditional
     ## likelihood, not the marginal, and has no mixture-proportion block at all.

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -1,0 +1,169 @@
+nmTest({
+
+  ## Standard errors for mixture proportions -- NONMEM 7 Technical Guide
+  ## eq. (7.51)-(7.54), which build the mixture parameters' information matrix
+  ## from the same per-subject scores g_ia as the gradient (1.194)/(1.197).
+  ##
+  ## Two defects are guarded here.  The proportions were forced out of the
+  ## covariance entirely (skipCov), so they reported SE = NA under every method.
+  ## And foceiS() built each subject's score by differencing component 0's
+  ## likelihood rather than the marginal, which made the S matrix singular for
+  ## EVERY mixture model -- a parameter that only enters another component got an
+  ## exactly-zero score, and covMethod="r,s" silently degraded to "r".
+
+  test_that("the mixture covariance block is rotated by the FULL mexpit Jacobian", {
+    ## No fit: the rotation is pure linear algebra, and the full Jacobian (not
+    ## its diagonal) is what carries the proportions' cross-covariances onto the
+    ## reported scale.
+    .t <- c(0.3, -0.8)
+    .p <- rxode2::mexpit(.t)
+    ## numeric Jacobian of mexpit at .t, for comparison with diag(p) - p p'
+    .num <- vapply(seq_along(.t), function(j) {
+      .h <- 1e-6
+      .tp <- .t; .tp[j] <- .t[j] + .h
+      .tm <- .t; .tm[j] <- .t[j] - .h
+      (rxode2::mexpit(.tp) - rxode2::mexpit(.tm)) / (2 * .h)
+    }, numeric(length(.t)))
+    .J <- diag(.p, nrow = length(.p)) - outer(.p, .p)
+    expect_equal(.J, .num, tolerance = 1e-6)
+
+    ## and the rotation is A cov A' with A the identity off the mixture block
+    .nm <- c("tcl", "p1", "p2")
+    .cov <- matrix(c(4, 1, 2,
+                     1, 9, 3,
+                     2, 3, 16), 3, 3, dimnames = list(.nm, .nm))
+    .out <- .mixCovToProbScale(.cov, c("p1", "p2"), .p)
+    .A <- diag(1, 3)
+    .A[2:3, 2:3] <- .J
+    expect_equal(unname(.out), unname(.A %*% .cov %*% t(.A)))
+    expect_equal(dimnames(.out), dimnames(.cov))
+    ## a non-mixture cov, or names that are not present, is left alone
+    expect_equal(.mixCovToProbScale(.cov, character(0), numeric(0)), .cov)
+    expect_equal(.mixCovToProbScale(.cov, c("nope"), .p[1]), .cov)
+  })
+
+  ## Two well-separated components with everything but the proportion and the
+  ## residual sd fixed at truth.  The responsibilities are then essentially 0/1,
+  ## so p1 is the observed group fraction and its variance is p(1-p)/n -- an
+  ## analytic target the reported SE can be held to without any replicate study.
+  .mixCovData <- function(nSub = 60L, pTrue = 0.45, clTrue = c(1.0, 8.0), seed = 1001L) {
+    set.seed(seed)
+    .grp <- sample.int(2L, nSub, TRUE, prob = c(pTrue, 1 - pTrue))
+    .sim <- rxode2::rxode2({
+      ka <- 1.1
+      cl <- CLI
+      v <- 20
+      d / dt(depot) <- -ka * depot
+      d / dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+    })
+    .ev <- rxode2::et(rxode2::et(amt = 320, cmt = "depot"),
+                      c(0.25, 0.5, 1, 2, 4, 8, 12, 24))
+    .obs <- do.call(rbind, lapply(seq_len(nSub), function(i) {
+      .s <- rxode2::rxSolve(.sim, params = c(CLI = clTrue[.grp[i]]), .ev,
+                            returnType = "data.frame")
+      data.frame(ID = i, TIME = .s$time,
+                 DV = .s$cp + stats::rnorm(nrow(.s), 0, 0.05), AMT = 0, EVID = 0)
+    }))
+    .d <- rbind(data.frame(ID = seq_len(nSub), TIME = 0, DV = NA_real_,
+                           AMT = 320, EVID = 1), .obs)
+    list(data = .d[order(.d$ID, .d$TIME, -.d$EVID), ], n = nSub)
+  }
+
+  .mixCovMod <- function() {
+    ini({
+      tka <- fix(log(1.1))
+      tcl1 <- fix(log(1.0))
+      tcl2 <- fix(log(8.0))
+      tv <- fix(log(20))
+      p1 <- 0.45
+      eta.cl ~ fix(0.01)
+      add.sd <- 0.05
+    })
+    model({
+      ka <- exp(tka)
+      cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl))
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  test_that("every focei covariance method gives the mixture proportion a calibrated SE", {
+    .dat <- .mixCovData()
+    .fits <- lapply(c("r,s", "r", "s"), function(.cm) {
+      suppressWarnings(nlmixr2(.mixCovMod, .dat$data, "focei",
+        foceiControl(print = 0, outerOpt = "lbfgsb3c", maxOuterIterations = 200L,
+                     maxInnerIterations = 100L, covMethod = .cm, calcTables = FALSE)))
+    })
+    for (.f in .fits) {
+      .p <- .f$parFixedDf["p1", "Estimate"]
+      .se <- .f$parFixedDf["p1", "SE"]
+      ## reported at all -- these were NA for every mixture fit
+      expect_true(is.finite(.se) && .se > 0)
+      ## and on the PROBABILITY scale the estimate is reported on: the mlogit
+      ## SE here is ~0.26, four times larger, so this pins the Jacobian rotation
+      expect_equal(unname(.se), sqrt(.p * (1 - .p) / .dat$n), tolerance = 0.05)
+      ## the proportion is in $cov by name
+      expect_true("p1" %in% rownames(.f$cov))
+    }
+    ## the three methods agree with each other
+    .ses <- vapply(.fits, function(.f) .f$parFixedDf["p1", "SE"], numeric(1))
+    expect_equal(max(.ses) / min(.ses), 1, tolerance = 0.05)
+  })
+
+  test_that("the S matrix is no longer singular for a mixture model", {
+    .dat <- .mixCovData()
+    .f <- suppressWarnings(nlmixr2(.mixCovMod, .dat$data, "focei",
+      foceiControl(print = 0, outerOpt = "lbfgsb3c", maxOuterIterations = 200L,
+                   maxInnerIterations = 100L, covMethod = "r,s", calcTables = FALSE)))
+    ## "r,s" is honoured rather than degraded to "r" by a non-PD S
+    expect_true(isTRUE(.f$env$S.pd))
+    expect_equal(.f$covMethod, "r,s")
+    ## no structurally-zero score direction
+    expect_true(all(diag(.f$env$S0) > 1e-6))
+
+    ## and the mixture block IS the outer product of the analytic per-subject
+    ## score -- NONMEM (7.51).  S = 0.25 * sum_i g_i g_i' with
+    ## g_i[l] = -2*(r_il - pi_l), so the block is sum_i (r_il - pi_l)(r_im - pi_m).
+    ##
+    ## Relative tolerance, not exact: $mixList's responsibilities are the FINAL
+    ## table's, while S's were taken at the covariance step's base point, and the
+    ## two states differ slightly on a converged fit.  1e-2 still pins the
+    ## identity -- differencing component 0 alone (the defect) puts this entry
+    ## orders of magnitude out, not fractions of a percent.
+    .pi <- .f$env$mixProbabilities
+    .R <- do.call(cbind, lapply(.f$env$mixList, function(z) z$prob))
+    .free <- seq_len(length(.pi) - 1L)
+    .D <- sweep(.R[, .free, drop = FALSE], 2, .pi[.free], "-")
+    .i <- match(.f$ui$mixProbs, rownames(.f$cov))
+    expect_equal(unname(.f$env$S0[.i, .i, drop = FALSE]), unname(t(.D) %*% .D),
+                 tolerance = 1e-2)
+  })
+
+  test_that("covMethod='imp' gives the mixture proportion the same calibrated SE", {
+    .dat <- .mixCovData()
+    .f <- suppressWarnings(nlmixr2(.mixCovMod, .dat$data, "imp",
+      impmapControl(print = 0, nIter = 8L, covMethod = "imp", calcTables = FALSE)))
+    expect_equal(.f$covMethod, "imp")
+    .p <- .f$parFixedDf["p1", "Estimate"]
+    .se <- .f$parFixedDf["p1", "SE"]
+    ## the imp MC covariance built its proposals from component 0 only, so the
+    ## proportion's direction was exactly flat and this came back 0
+    expect_true(is.finite(.se) && .se > 0)
+    expect_equal(unname(.se), sqrt(.p * (1 - .p) / .dat$n), tolerance = 0.05)
+  })
+
+  test_that("covMethod='analytic' declines a mixture rather than reporting one component", {
+    ## The augmented sensitivity model differentiates ONE component's conditional
+    ## likelihood, not the marginal, and has no mixture-proportion block at all.
+    .dat <- .mixCovData()
+    .f <- suppressWarnings(nlmixr2(.mixCovMod, .dat$data, "focei",
+      foceiControl(print = 0, outerOpt = "lbfgsb3c", maxOuterIterations = 200L,
+                   maxInnerIterations = 100L, covMethod = "analytic",
+                   calcTables = FALSE)))
+    expect_false(identical(.f$covMethod, "analytic"))
+    ## and the fallback still reports the proportion
+    expect_true(is.finite(.f$parFixedDf["p1", "SE"]))
+  })
+
+})

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -121,10 +121,15 @@ nmTest({
       foceiControl(print = 0, outerOpt = "lbfgsb3c", maxOuterIterations = 200L,
                    maxInnerIterations = 100L, covMethod = "r,s", calcTables = FALSE)))
     .se0 <- .f$parFixedDf["p1", "SE"]
+    ## without this the round-trip check passes vacuously against the old code,
+    ## where the SE was NA at both ends and NA == NA
+    expect_true(is.finite(.se0) && .se0 > 0)
     setCov(.f, "s")
     expect_true("r,s" %in% names(.f$env$covList))
     setCov(.f, "r,s")                       # served from covList, not recomputed
-    expect_equal(unname(.f$parFixedDf["p1", "SE"]), unname(.se0), tolerance = 1e-10)
+    .se1 <- .f$parFixedDf["p1", "SE"]
+    expect_true(is.finite(.se1) && .se1 > 0)
+    expect_equal(unname(.se1), unname(.se0), tolerance = 1e-10)
   })
 
   test_that("the S matrix is no longer singular for a mixture model", {

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -111,6 +111,22 @@ nmTest({
     expect_equal(max(.ses) / min(.ses), 1, tolerance = 0.05)
   })
 
+  test_that("setCov() round trips without re-rotating the mixture block", {
+    ## setCov() re-installs a CACHED covariance (covList) by handing it back as a
+    ## matrix, which refits and would rotate an already-probability-scale matrix
+    ## a second time -- shrinking the proportion's SE by p(1-p) every round trip
+    ## (measured 0.0644 -> 0.0155).
+    .dat <- .mixCovData()
+    .f <- suppressWarnings(nlmixr2(.mixCovMod, .dat$data, "focei",
+      foceiControl(print = 0, outerOpt = "lbfgsb3c", maxOuterIterations = 200L,
+                   maxInnerIterations = 100L, covMethod = "r,s", calcTables = FALSE)))
+    .se0 <- .f$parFixedDf["p1", "SE"]
+    setCov(.f, "s")
+    expect_true("r,s" %in% names(.f$env$covList))
+    setCov(.f, "r,s")                       # served from covList, not recomputed
+    expect_equal(unname(.f$parFixedDf["p1", "SE"]), unname(.se0), tolerance = 1e-10)
+  })
+
   test_that("the S matrix is no longer singular for a mixture model", {
     .dat <- .mixCovData()
     .f <- suppressWarnings(nlmixr2(.mixCovMod, .dat$data, "focei",

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -209,6 +209,30 @@ nmTest({
                  sqrt(0.35 * 0.65 / .n), tolerance = 1e-6)
   })
 
+  test_that("a mixture proportion's CI stays inside (0, 1)", {
+    ## The estimate IS a probability, so the generic symmetric
+    ## backTransform(est +/- z*SE) interval walks straight out of (0, 1) -- a
+    ## real fit reported p1 = 0.648 (-0.045, 1.34).  It was also built from the
+    ## covariance BEFORE the probability-scale rotation, so it did not even
+    ## agree with the SE printed beside it.
+    .ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(.mixCovMod))
+    .pf <- data.frame(Estimate = c(0.648, 0.5), SE = c(0.0862, 0.30),
+                      `CI Lower` = c(-0.045, -0.1), `CI Upper` = c(1.34, 1.1),
+                      row.names = c("p1", "add.sd"), check.names = FALSE)
+    .out <- .mixParFixedCi(.ui, .pf, 0.95)
+    expect_true(.out["p1", "CI Lower"] > 0 && .out["p1", "CI Upper"] < 1)
+    ## it is the logit-scale interval, built from the REPORTED SE
+    .p <- 0.648; .s <- 0.0862; .j <- .p * (1 - .p)
+    expect_equal(.out["p1", "CI Lower"],
+                 rxode2::expit(rxode2::logit(.p) - 1.959964 * .s / .j),
+                 tolerance = 1e-5)
+    ## asymmetric about the estimate, which is the honest shape here
+    expect_false(isTRUE(all.equal(.p - .out["p1", "CI Lower"],
+                                  .out["p1", "CI Upper"] - .p)))
+    ## a non-mixture row is untouched
+    expect_equal(.out["add.sd", "CI Lower"], -0.1)
+  })
+
   test_that("a proportion at the boundary is flagged, not reported as precise", {
     ## The probability-scale SE carries a factor p(1-p), so it goes to ZERO as a
     ## proportion approaches 0 or 1.  That is the correct delta-method answer but

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -164,6 +164,46 @@ nmTest({
     expect_false(isTRUE(all.equal(.e$cov[1, 1], .e$cov[2, 2])))
   })
 
+  test_that("a fix()ed proportion is not given an appended variance", {
+    ## thetaMixIndex still lists a fix()ed proportion, but it was never
+    ## estimated -- appending a row for it would report a non-zero SE for a
+    ## parameter with no uncertainty.
+    .m <- function() {
+      ini({
+        tcl <- log(1)
+        p1 <- fix(0.40)
+        p2 <- 0.35
+        tv <- log(20)
+        eta.cl ~ 0.01
+        add.sd <- 0.05
+      })
+      model({
+        cl <- mix(exp(tcl + eta.cl), p1, exp(tcl + 2 + eta.cl), p2,
+                  exp(tcl + 3 + eta.cl))
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(.m))
+    .n <- 100L
+    .k <- round(.n * 0.35)
+    .r <- cbind(rep(0.40, .n),
+                c(rep(1, .k), rep(0, .n - .k)))
+    .r <- cbind(.r, 1 - rowSums(.r))
+    .e <- new.env(parent = emptyenv())
+    .e$ui <- .ui
+    .e$mixProbabilities <- c(0.40, .k / .n, 1 - 0.40 - .k / .n)
+    .nm <- c("tcl", "add.sd")
+    .e$cov <- diag(c(4, 9)); dimnames(.e$cov) <- list(.nm, .nm)
+    .e$mixList <- lapply(seq_len(3L), function(.j) data.frame(prob = .r[, .j]))
+    .mixCovAppendBlock(.e)
+    ## exactly one appended row, for the ESTIMATED proportion
+    expect_equal(rownames(.e$cov), c("tcl", "add.sd", "p2"))
+    expect_false("p1" %in% rownames(.e$cov))
+    expect_equal(unname(sqrt(diag(.e$cov))[3]),
+                 sqrt(0.35 * 0.65 / .n), tolerance = 1e-6)
+  })
+
   test_that("a proportion at the boundary is flagged, not reported as precise", {
     ## The probability-scale SE carries a factor p(1-p), so it goes to ZERO as a
     ## proportion approaches 0 or 1.  That is the correct delta-method answer but

--- a/tests/testthat/test-focei-mix-cov.R
+++ b/tests/testthat/test-focei-mix-cov.R
@@ -278,10 +278,35 @@ nmTest({
     ## and this is not one.  saem lands here (nlmixr2est#1058), and reporting a
     ## number would be a confident-looking SE on a non-stationary estimate.
     .e <- .mkMixEnv(c(rep(1, 30), rep(0, 70)), 0.64, 100L)
-    .mixCovAppendBlock(.e)
+    expect_warning(.mixCovAppendBlock(.e), "score-zero")
     expect_false("p1" %in% rownames(.e$cov))
     expect_equal(dim(.e$cov), c(2L, 2L))
-    expect_true(any(grepl("mean responsibility", .e$runInfo)))
+  })
+
+  test_that("the stationarity gate does not loosen with the number of subjects", {
+    ## The gate is the score statistic s' I^-1 s, not |mean(r) - p|: the score is
+    ## N*(mean(r) - p), so an absolute tolerance on the mean accepts a score of 1
+    ## at N=100 and 100 at N=10000.  Hold the DEVIATION fixed and grow N; the
+    ## same deviation must be refused at least as firmly at the larger N.
+    .dev <- 0.02
+    .mk <- function(n) {
+      .k <- round(n * (0.45 + .dev))
+      .mkMixEnv(c(rep(1, .k), rep(0, n - .k)), 0.45, n)
+    }
+    for (.n in c(100L, 2000L)) {
+      .e <- .mk(.n)
+      expect_warning(.mixCovAppendBlock(.e), "score-zero")
+      expect_false("p1" %in% rownames(.e$cov))
+    }
+    ## and a fit that IS at the fixed point is still accepted at both sizes
+    for (.n in c(100L, 2000L)) {
+      .k <- round(.n * 0.45)
+      .e <- .mkMixEnv(c(rep(1, .k), rep(0, .n - .k)), .k / .n, .n)
+      .mixCovAppendBlock(.e)
+      expect_true("p1" %in% rownames(.e$cov))
+      expect_equal(unname(sqrt(diag(.e$cov))[3]),
+                   sqrt(0.45 * 0.55 / .n), tolerance = 1e-6)
+    }
   })
 
   test_that("covMethod='analytic' declines a mixture rather than reporting one component", {

--- a/tests/testthat/test-focei-mix-grad.R
+++ b/tests/testthat/test-focei-mix-grad.R
@@ -1,0 +1,125 @@
+nmTest({
+
+  ## FOCEi's mixture-proportion gradient is analytic: mixGrad() (src/inner.cpp)
+  ## short-circuits the finite difference in numericGrad(), so a wrong value is
+  ## invisible under the default derivative-free outer optimizer (bobyqa) and
+  ## silently wrong under every gradient-based one.
+  ##
+  ## The exact gradient is
+  ##   d(-2*log-lik)/d(mlogit theta_l) = -2 * sum_i (r_il - pi_l),
+  ## whose stationary point is the EM condition pi_l == mean_i r_il.  The old
+  ## form summed d(lik)/d(pi_l) and chained it through the DIAGONAL of the
+  ## mexpit Jacobian, dropping both the off-diagonal terms (wrong from nMix == 3
+  ## up) and the -2 objective scale (wrong at every nMix, sign included).  The
+  ## flipped sign sent lbfgsb3c's first step uphill; at nMix >= 3 the wrong
+  ## Jacobian compounds that and the proportions never moved off their initial
+  ## values at all.  At nMix == 2 the old value is exactly the right one divided
+  ## by -2 (the diagonal-only chain reduces to the correct expression there).
+
+  .simMixData <- function(clTrue, pTrue, nSub, seed = 42L) {
+    set.seed(seed)
+    .grp <- sample.int(length(clTrue), nSub, TRUE, prob = pTrue)
+    .sim <- rxode2::rxode2({
+      ka <- 1.1
+      cl <- CLI
+      v <- 20
+      d / dt(depot) <- -ka * depot
+      d / dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+    })
+    .ev <- rxode2::et(amt = 320, cmt = "depot")
+    .ev <- rxode2::et(.ev, c(0.25, 0.5, 1, 2, 4, 8, 12, 24))
+    .obs <- do.call(rbind, lapply(seq_len(nSub), function(i) {
+      .s <- rxode2::rxSolve(.sim, params = c(CLI = clTrue[.grp[i]]), .ev,
+                            returnType = "data.frame")
+      data.frame(ID = i, TIME = .s$time,
+                 DV = .s$cp + stats::rnorm(nrow(.s), 0, 0.05),
+                 AMT = 0, EVID = 0)
+    }))
+    .dose <- data.frame(ID = seq_len(nSub), TIME = 0, DV = NA_real_,
+                        AMT = 320, EVID = 1)
+    .d <- rbind(.dose, .obs)
+    list(data = .d[order(.d$ID, .d$TIME, -.d$EVID), ],
+         emp = as.numeric(table(.grp)) / nSub)
+  }
+
+  ## Everything but the mixture proportions and one component's typical value
+  ## is fix()ed, so mixGrad() drives essentially all of the outer optimization
+  ## and a wrong value cannot be masked by the rest of the model improving the
+  ## objective on its own.  It is deliberately NOT the only free parameter:
+  ## with npars == 1 the outer optimization never reaches numericGrad(), so
+  ## mixGrad() would not run at all and the test would be vacuous.
+  .ctlGrad <- function() {
+    foceiControl(print = 0, outerOpt = "lbfgsb3c", maxOuterIterations = 300L,
+                 maxInnerIterations = 100L, covMethod = "", calcTables = FALSE)
+  }
+  .ctlNone <- function() {
+    foceiControl(print = 0, maxOuterIterations = 0L,
+                 maxInnerIterations = 100L, covMethod = "", calcTables = FALSE)
+  }
+
+  .checkMixGrad <- function(mod, dat, emp) {
+    .f0 <- suppressWarnings(nlmixr2(mod, dat$data, "focei", .ctlNone()))
+    .f <- suppressWarnings(nlmixr2(mod, dat$data, "focei", .ctlGrad()))
+    .pi <- .f$env$mixProbabilities
+    .rbar <- vapply(.f$env$mixList, function(z) mean(z$prob), numeric(1))
+    ## it moved at all -- the sign check.  Under the old gradient the objective
+    ## was bit-identical to the 0-iteration one.
+    expect_true(.f$objective < .f0$objective - 1)
+    ## it landed on the EM fixed point -- the Jacobian check
+    expect_equal(unname(.pi), unname(.rbar), tolerance = 1e-3)
+    ## and that fixed point is the truth the data was simulated from
+    expect_equal(unname(.pi), emp, tolerance = 0.02)
+  }
+
+  test_that("focei estimates 2-component mixture proportions from the analytic gradient", {
+    .dat <- .simMixData(c(1.0, 6.0), c(0.6, 0.4), 40L)
+    .mod <- function() {
+      ini({
+        tka <- fix(log(1.1))
+        tcl1 <- fix(log(1.0))
+        tcl2 <- log(6.0)
+        tv <- fix(log(20))
+        p1 <- 0.25
+        eta.cl ~ fix(0.01)
+        add.sd <- fix(0.05)
+      })
+      model({
+        ka <- exp(tka)
+        cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl))
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .checkMixGrad(.mod, .dat, .dat$emp)
+  })
+
+  test_that("focei estimates 3-component mixture proportions from the analytic gradient", {
+    ## nMix >= 3 is where the dropped off-diagonal mexpit Jacobian terms bite;
+    ## at nMix == 2 the diagonal-only chain happens to reduce to the right
+    ## expression (up to the -2 the old code also dropped).
+    .dat <- .simMixData(c(1.0, 4.0, 12.0), c(0.5, 0.3, 0.2), 60L)
+    .mod <- function() {
+      ini({
+        tka <- fix(log(1.1))
+        tcl1 <- fix(log(1.0))
+        tcl2 <- fix(log(4.0))
+        tcl3 <- log(12.0)
+        tv <- fix(log(20))
+        p1 <- 0.2
+        p2 <- 0.2
+        eta.cl ~ fix(0.01)
+        add.sd <- fix(0.05)
+      })
+      model({
+        ka <- exp(tka)
+        cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl), p2,
+                  exp(tcl3 + eta.cl))
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .checkMixGrad(.mod, .dat, .dat$emp)
+  })
+
+})

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -405,4 +405,36 @@ nmTest({
     expect_false(any(vapply(.mixList, function(m) any(is.nan(m$prob)), logical(1))))
   })
 
+  test_that("mixture proportions bind to the mix() component, not the ini() order", {
+    ## `mix(a, p1, b, p2, c)` means p1 is COMPONENT 1's share.  thetaMixIndex is
+    ## what carries that binding: every consumer reads mixIdx[m] as component m's
+    ## theta slot.  Building it with which(names %in% mixProbs) returned
+    ## ASCENDING theta positions -- ini() order -- so declaring the proportions
+    ## in a different order than mix() uses them ran component 1 on p2's value.
+    ## Measured at zero iterations with ini({p2 <- 0.20; p1 <- 0.70}):
+    ## $mixProbabilities came back 0.2 0.7 0.1 instead of 0.7 0.2 0.1.
+    .mk <- function(.iniTxt) {
+      eval(parse(text = paste0(
+        "function() { ini({tka <- log(1.1); ", .iniTxt,
+        "; tcl1 <- log(1); tcl2 <- log(8); tcl3 <- log(30); tv <- log(20);",
+        " eta.cl ~ 0.01; add.sd <- 0.05}) ; model({ka <- exp(tka);",
+        " cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl), p2,",
+        " exp(tcl3 + eta.cl)); v <- exp(tv); linCmt() ~ add(add.sd)}) }")))
+    }
+    for (.o in c("p1 <- 0.70; p2 <- 0.20", "p2 <- 0.20; p1 <- 0.70")) {
+      .ui <- rxode2::rxUiDecompress(rxode2::assertRxUi(.mk(.o)))
+      ## the slots are named in mix() order whatever ini() did
+      expect_equal(names(.ui$theta)[.ui$thetaMixIndex], .ui$mixProbs)
+      ## and round-tripping them through the mlogit scale the solver uses gives
+      ## the proportions back against the right components
+      expect_equal(unname(rxode2::mexpit(.ui$thetaIniMix[.ui$thetaMixIndex])),
+                   c(0.70, 0.20), tolerance = 1e-8)
+    }
+    ## the reversed declaration really does reorder the theta vector -- without
+    ## this the two loop passes would be the same model and prove nothing
+    .rev <- rxode2::rxUiDecompress(rxode2::assertRxUi(.mk("p2 <- 0.20; p1 <- 0.70")))
+    expect_equal(names(.rev$theta)[.rev$thetaMixIndex[1]], "p1")
+    expect_gt(.rev$thetaMixIndex[1], .rev$thetaMixIndex[2])
+  })
+
 })

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -32,6 +32,30 @@ nmTest({
     expect_false("MIXEST" %in% names(fit$ranef))
     expect_equal(nrow(fit$ranef), length(unique(nlmixr2data::theo_sd$ID)))
 
+    ## $eta carries a mixnum column for a mixture fit, but an etaMat must be
+    ## etas only or foceiSetup_ rejects it on the column count -- which broke
+    ## $cov, addCwres, the FO objective and any refit of the fit.
+    expect_equal(ncol(fit$etaMat), nrow(fit$omega))
+    expect_false("mixnum" %in% colnames(fit$etaMat))
+    expect_equal(colnames(fit$etaMat), c("eta.ka", "eta.cl", "eta.v"))
+
+    ## the ui must carry the PROBABILITY, not the mlogit fullTheta value, or it
+    ## disagrees with fixef() and the fit cannot be re-fit through its own ini()
+    .p1 <- fit$ui$iniDf$est[fit$ui$iniDf$name == "p1"]
+    expect_true(.p1 > 0 && .p1 < 1)
+    expect_equal(.p1, unname(fixef(fit)[["p1"]]))
+
+    ## both round trips that the two fixes above unblock
+    expect_error(nlmixr2(one.cmt, nlmixr2data::theo_sd, "focei",
+                         control = foceiControl(print = 0, maxOuterIterations = 0L,
+                                                maxInnerIterations = 0L,
+                                                etaMat = fit$etaMat, covMethod = "")),
+                 NA)
+    expect_error(nlmixr2(fit, nlmixr2data::theo_sd, "focei",
+                         control = foceiControl(print = 0, maxOuterIterations = 0L,
+                                                maxInnerIterations = 0L, covMethod = "")),
+                 NA)
+
     # mixNum: one row per subject
     mn <- fit$mixNum
     expect_true(is.data.frame(mn))

--- a/tests/testthat/test-vae-inner.R
+++ b/tests/testthat/test-vae-inner.R
@@ -444,4 +444,58 @@ nmTest({
     expect_equal(.p1, nFast / (nFast + nSlow), tolerance = 0.1)
     expect_gt(max(.agree, 1 - .agree), 0.9)
   })
+
+  test_that("the mixture proportion gradient is exact beyond two components", {
+    ## mexpit's Jacobian is DENSE -- d(pi_m)/d(theta_l) = pi_m (delta_ml - pi_l)
+    ## -- so carrying d/d(pi) and applying one scalar per free parameter (which
+    ## is what mixGrad does) drops the off-diagonal terms.  That is exact at
+    ## nMix == 2, where there is a single free parameter, and wrong by 25% at
+    ## nMix == 3.  Three components is the smallest case that can see it.
+    mixmod3 <- function() {
+      ini({ lka <- log(1.5); lke1 <- log(0.15); lke2 <- log(0.08); lke3 <- log(0.04)
+            lV <- log(32); p1 <- 0.5; p2 <- 0.3
+            eta.ka ~ 0.04; eta.ke ~ 0.02; eta.V ~ 0.02; add.err <- 0.25 })
+      model({ ka <- exp(lka + eta.ka)
+        ke <- mix(exp(lke1 + eta.ke), p1, exp(lke2 + eta.ke), p2, exp(lke3 + eta.ke))
+        V <- exp(lV + eta.V)
+        d/dt(depot) = -ka * depot; d/dt(central) = ka * depot - ke * central
+        cp <- central / V; cp ~ add(add.err) })
+    }
+    ui <- rxode2::assertRxUi(mixmod3)
+    ctl <- vaeControl(itersBurnIn = 2L, iters = 2L, covariateSelection = FALSE, seed = 1L)
+    prep <- .vaeDataPrep(ui, nlmixr2data::theo_sd)
+    N <- prep$N; zDim <- prep$zDim
+    nMix <- as.integer(ui$saemNMix)
+    expect_equal(nMix, 3L)
+    mixProb <- .getMixFromLog(prep$th, ui$thetaMixIndex)
+    expect_equal(sum(mixProb), 1)
+
+    innerEnv <- .vaeInnerSetup(ui, nlmixr2data::theo_sd, matrix(0, N, zDim), ctl)
+    on.exit(.vaeInnerFree(), add = TRUE)
+    .testSeed(11)
+    params <- .vaeEncoderInitParams(zDim, 12L, ncol(prep$covIn) + nMix, prep$zPop,
+                                    rep(0.1, zDim))
+    eps <- matrix(rnorm(N * zDim), N, zDim)
+    .stepAt <- function(prp) {
+      .vaeElboStepInner(params, prp, innerEnv, prp$zPop, prp$omega, prp$a,
+                        0, eps, ctl, nMix, mixProb, withGrad = TRUE)
+    }
+    .g <- .stepAt(prep)
+    expect_length(.g$gMixTheta, nMix - 1L)
+
+    .idx <- ui$thetaMixIndex
+    .h <- 1e-5
+    .fd <- vapply(seq_along(.idx), function(j) {
+      .pp <- prep; .pp$th[.idx[j]] <- prep$th[.idx[j]] + .h
+      .pm <- prep; .pm$th[.idx[j]] <- prep$th[.idx[j]] - .h
+      (.stepAt(.pp)$pxz - .stepAt(.pm)$pxz) / (2 * .h)
+    }, numeric(1))
+    expect_equal(as.numeric(.g$gMixTheta), .fd, tolerance = 1e-4)
+
+    ## the gradient is N*(pi_l - mean responsibility), with no Jacobian involved
+    expect_equal(as.numeric(.g$gMixTheta),
+                 N * (as.numeric(.g$mixProb)[seq_along(.idx)] -
+                        as.numeric(.g$mixW)[seq_along(.idx)]),
+                 tolerance = 1e-8)
+  })
 })

--- a/tests/testthat/test-vae-inner.R
+++ b/tests/testthat/test-vae-inner.R
@@ -311,7 +311,10 @@ nmTest({
     innerEnv <- .vaeInnerSetup(ui, nlmixr2data::theo_sd, matrix(0, N, zDim), ctl)
     on.exit(.vaeInnerFree(), add = TRUE)
     .testSeed(7)
-    params <- .vaeEncoderInitParams(zDim, 12L, ncol(prep$covIn), prep$zPop, rep(0.1, zDim))
+    ## the encoder is conditioned on the component, so the head carries nMix
+    ## extra one-hot inputs alongside the covariates
+    params <- .vaeEncoderInitParams(zDim, 12L, ncol(prep$covIn) + nMix, prep$zPop,
+                                    rep(0.1, zDim))
     eps <- matrix(rnorm(N * zDim), N, zDim)
     st <- .vaeElboStepInner(params, prep, innerEnv, prep$zPop, prep$omega, prep$a,
                             1, eps, ctl, nMix, mixProb, withGrad = FALSE)
@@ -332,6 +335,22 @@ nmTest({
     .mm <- apply(.ll, 1, max)
     .want <- -sum(.mm + log(rowSums(exp(.ll - .mm))))
     expect_equal(.jointTot, .want, tolerance = 1e-8)
+
+    ## Every (subject, component) pair gets its OWN posterior from the encoder.
+    ## The components used to be scored at a single shared eta tiled across them
+    ## -- an eta fitted to none of them.  This is the assertion that would
+    ## regress if the tiling came back.
+    expect_equal(dim(st$muAll), c(N * nMix, zDim))
+    expect_equal(dim(st$mu), c(N, zDim))
+    .m1 <- st$muAll[seq_len(N), , drop = FALSE]
+    .m2 <- st$muAll[N + seq_len(N), , drop = FALSE]
+    expect_false(isTRUE(all.equal(.m1, .m2)))
+    ## and what is reported per subject is the SELECTED component's row
+    .sel <- (st$mixnum - 1L) * N + seq_len(N)
+    expect_equal(st$mu, st$muAll[.sel, , drop = FALSE])
+    ## responsibilities are a distribution over components
+    expect_length(st$mixW, nMix)
+    expect_equal(sum(st$mixW), 1)
 
     ## and it is NOT the square-root marginalization the code used to compute
     .ll2 <- sweep(-0.5 * .obj, 2, log(mixProb), "+")

--- a/tests/testthat/test-vae-inner.R
+++ b/tests/testthat/test-vae-inner.R
@@ -352,11 +352,96 @@ nmTest({
     expect_length(st$mixW, nMix)
     expect_equal(sum(st$mixW), 1)
 
+    ## The mixture proportion is estimated on the MLOGIT scale through its own
+    ## analytic gradient -- the same chain focei uses (mixGrad): the per-subject
+    ## responsibility difference against the last (non-free) component, times
+    ## the dmexpit Jacobian.  Check it against finite differences of the term it
+    ## is the gradient of.
+    .stepAt <- function(prp, alpha = 0) {
+      .vaeElboStepInner(params, prp, innerEnv, prp$zPop, prp$omega, prp$a,
+                        alpha, eps, ctl, nMix, mixProb, withGrad = TRUE)
+    }
+    .g <- .stepAt(prep)
+    expect_length(.g$gMixTheta, nMix - 1L)
+    .h <- 1e-5
+    .pp <- prep; .pp$th[ui$thetaMixIndex] <- prep$th[ui$thetaMixIndex] + .h
+    .pm <- prep; .pm$th[ui$thetaMixIndex] <- prep$th[ui$thetaMixIndex] - .h
+    .fd <- (.stepAt(.pp)$pxz - .stepAt(.pm)$pxz) / (2 * .h)
+    expect_equal(as.numeric(.g$gMixTheta), .fd, tolerance = 1e-4)
+    ## and the proportions the step used are the ones the inner problem holds,
+    ## on the simplex
+    expect_equal(sum(.g$mixProb), 1)
+    expect_equal(as.numeric(.g$mixProb), mixProb, tolerance = 1e-5)
+
     ## and it is NOT the square-root marginalization the code used to compute
     .ll2 <- sweep(-0.5 * .obj, 2, log(mixProb), "+")
     .mm2 <- apply(.ll2, 1, max)
     .old <- -2 * sum(.mm2 + log(rowSums(exp(.ll2 - .mm2))))
     expect_false(isTRUE(all.equal(.want, .old)))
     expect_false(isTRUE(all.equal(.jointTot, .old)))
+  })
+
+  test_that("vae estimates the mixture proportion", {
+    skip_on_cran()
+    ## Two subpopulations in a 3:1 split, started from 0.5.  The proportion was
+    ## previously either held at its ini() value or moved by the bobyqa regress
+    ## step against (-Inf, Inf) on the wrong scale; it is now estimated on the
+    ## mlogit scale by its own analytic gradient, consumed by the same Adam
+    ## loop that trains the encoder.
+    sim <- function() {
+      ini({ lka <- log(1.5); lV <- log(32) })
+      model({ ka <- exp(lka + eta.ka); ke <- KE * exp(eta.ke); V <- exp(lV + eta.V)
+        d/dt(depot) = -ka * depot; d/dt(central) = ka * depot - ke * central
+        cp <- central / V })
+    }
+    .testSeed(42)
+    nFast <- 30L; nSlow <- 10L
+    ev <- rxode2::et(amt = 320, cmt = "depot") %>% rxode2::et(seq(0.5, 24, length.out = 8))
+    mkGroup <- function(ke, ids) {
+      d <- rxode2::rxSolve(sim, rxode2::et(ev, id = ids),
+                           params = c(lka = log(1.5), lV = log(32), KE = ke),
+                           omega = lotri::lotri(eta.ka ~ 0.04, eta.ke ~ 0.02, eta.V ~ 0.02))
+      d <- as.data.frame(d)[, c("id", "time", "cp")]
+      names(d) <- c("ID", "TIME", "DV"); d$ID <- d$ID + (ids[1] - 1)
+      d$DV <- d$DV + stats::rnorm(nrow(d), 0, 0.25); d
+    }
+    dat <- rbind(mkGroup(0.15, 1:nFast), mkGroup(0.04, (nFast + 1):(nFast + nSlow)))
+    dose <- data.frame(ID = unique(dat$ID), TIME = 0, DV = 0, EVID = 1, AMT = 320, CMT = 1)
+    dat$EVID <- 0; dat$AMT <- 0; dat$CMT <- 2
+    dat <- rbind(dose, dat); dat <- dat[order(dat$ID, dat$TIME, -dat$EVID), ]
+    trueGrp <- ifelse(unique(dat$ID) <= nFast, 1L, 2L)
+
+    mixmod <- function() {
+      ini({ lka <- log(1.5); lke1 <- log(0.15); lke2 <- log(0.04); lV <- log(32)
+            p1 <- 0.5                       # deliberately NOT the truth (0.75)
+            eta.ka ~ 0.04; eta.ke ~ 0.02; eta.V ~ 0.02; add.err <- 0.25 })
+      model({ ka <- exp(lka + eta.ka)
+        ke <- mix(exp(lke1 + eta.ke), p1, exp(lke2 + eta.ke)); V <- exp(lV + eta.V)
+        d/dt(depot) = -ka * depot; d/dt(central) = ka * depot - ke * central
+        cp <- central / V; cp ~ add(add.err) })
+    }
+    ui <- rxode2::assertRxUi(mixmod)
+    ctl <- vaeControl(itersBurnIn = 40L, iters = 100L, klWarmup = 30L, gammaIter = 60L,
+                      nGradStep = 4L, covariateSelection = FALSE, seed = 1L)
+    prep <- .vaeDataPrep(ui, dat)
+    nMix <- as.integer(ui$saemNMix)
+    mixProb <- .getMixFromLog(prep$th, ui$thetaMixIndex)
+    expect_equal(mixProb, c(0.5, 0.5))
+    innerEnv <- .vaeInnerSetup(ui, dat, matrix(0, prep$N, prep$zDim), ctl)
+    on.exit(.vaeInnerFree(), add = TRUE)
+    fit <- .vaeTrain(prep, innerEnv, ctl, nMix, mixProb)
+
+    ## the gradient actually ran -- a held proportion would report 0 steps and
+    ## still look plausible
+    expect_true(fit$nMixThetaStep > 0L)
+    expect_length(fit$mixProb, nMix)
+    expect_equal(sum(fit$mixProb), 1, tolerance = 1e-8)
+    expect_true(all(fit$mixProb > 0 & fit$mixProb < 1))
+    ## it MOVED off its start, and toward the truth
+    expect_false(isTRUE(all.equal(as.numeric(fit$mixProb), c(0.5, 0.5))))
+    .agree <- mean(fit$mixnum == trueGrp)
+    .p1 <- if (.agree >= 0.5) fit$mixProb[1] else fit$mixProb[2]   # allow label swap
+    expect_equal(.p1, nFast / (nFast + nSlow), tolerance = 0.1)
+    expect_gt(max(.agree, 1 - .agree), 0.9)
   })
 })

--- a/tests/testthat/test-vae-inner.R
+++ b/tests/testthat/test-vae-inner.R
@@ -463,6 +463,26 @@ nmTest({
     .p1 <- if (.agree >= 0.5) fit$mixProb[1] else fit$mixProb[2]   # allow label swap
     expect_equal(.p1, nFast / (nFast + nSlow), tolerance = 0.1)
     expect_gt(max(.agree, 1 - .agree), 0.9)
+
+    ## a fix()ed proportion is NOT estimated -- it stays exactly where ini() put
+    ## it, even though the gradient machinery still runs
+    mixFixed <- function() {
+      ini({ lka <- log(1.5); lke1 <- log(0.15); lke2 <- log(0.04); lV <- log(32)
+            p1 <- fix(0.5)
+            eta.ka ~ 0.04; eta.ke ~ 0.02; eta.V ~ 0.02; add.err <- 0.25 })
+      model({ ka <- exp(lka + eta.ka)
+        ke <- mix(exp(lke1 + eta.ke), p1, exp(lke2 + eta.ke)); V <- exp(lV + eta.V)
+        d/dt(depot) = -ka * depot; d/dt(central) = ka * depot - ke * central
+        cp <- central / V; cp ~ add(add.err) })
+    }
+    .uiF <- rxode2::assertRxUi(mixFixed)
+    .ctlF <- vaeControl(itersBurnIn = 5L, iters = 10L, klWarmup = 3L, gammaIter = 6L,
+                        nGradStep = 2L, covariateSelection = FALSE, seed = 1L, print = 0L)
+    .prepF <- .vaeDataPrep(.uiF, dat)
+    .mpF <- .getMixFromLog(.prepF$th, .uiF$thetaMixIndex)
+    .envF <- .vaeInnerSetup(.uiF, dat, matrix(0, .prepF$N, .prepF$zDim), .ctlF)
+    .fitF <- .vaeTrain(.prepF, .envF, .ctlF, nMix, .mpF)
+    expect_equal(as.numeric(.fitF$mixProb), c(0.5, 0.5))
   })
 
   test_that("the mixture proportion gradient is exact beyond two components", {

--- a/tests/testthat/test-vae-inner.R
+++ b/tests/testthat/test-vae-inner.R
@@ -283,4 +283,61 @@ nmTest({
     }, numeric(1))
     expect_lt(max(abs(fd - st$grads$fcB)) / max(abs(st$grads$fcB)), 1e-3)
   })
+
+  test_that("the mixture ELBO is the marginal -2LL, at the right temperature", {
+    ## obj is -log p(y_i, eta_i | m) at 1x scale, so the marginal is
+    ## -sum_i log sum_m pi_m exp(-obj_im).  The code used exp(-0.5*obj) and
+    ## negated twice, i.e. it marginalized a SQUARE ROOT likelihood and carried
+    ## a spurious -log(pi_best).  Both errors cancel exactly when nMix == 1, and
+    ## also when the components are identical AND pi is uniform -- which is why
+    ## p1 here is 0.7 and not 0.5.  Nothing else in the suite could see this.
+    mixmod <- function() {
+      ini({ lka <- log(1.5); lke1 <- log(0.15); lke2 <- log(0.04); lV <- log(32)
+            p1 <- 0.7
+            eta.ka ~ 0.04; eta.ke ~ 0.02; eta.V ~ 0.02; add.err <- 0.25 })
+      model({ ka <- exp(lka + eta.ka)
+        ke <- mix(exp(lke1 + eta.ke), p1, exp(lke2 + eta.ke)); V <- exp(lV + eta.V)
+        d/dt(depot) = -ka * depot; d/dt(central) = ka * depot - ke * central
+        cp <- central / V; cp ~ add(add.err) })
+    }
+    ui <- rxode2::assertRxUi(mixmod)
+    ctl <- vaeControl(itersBurnIn = 2L, iters = 2L, covariateSelection = FALSE, seed = 1L)
+    prep <- .vaeDataPrep(ui, nlmixr2data::theo_sd)
+    N <- prep$N; zDim <- prep$zDim
+    nMix <- as.integer(ui$saemNMix)
+    mixProb <- .getMixFromLog(prep$th, ui$thetaMixIndex)
+    expect_equal(mixProb, c(0.7, 0.3))
+
+    innerEnv <- .vaeInnerSetup(ui, nlmixr2data::theo_sd, matrix(0, N, zDim), ctl)
+    on.exit(.vaeInnerFree(), add = TRUE)
+    .testSeed(7)
+    params <- .vaeEncoderInitParams(zDim, 12L, ncol(prep$covIn), prep$zPop, rep(0.1, zDim))
+    eps <- matrix(rnorm(N * zDim), N, zDim)
+    st <- .vaeElboStepInner(params, prep, innerEnv, prep$zPop, prep$omega, prep$a,
+                            1, eps, ctl, nMix, mixProb, withGrad = FALSE)
+
+    ## pxz = jointTot - sum(pzI); rebuild pzI from the returned z to recover the
+    ## mixture term the step actually computed
+    eta <- sweep(st$z, 2, prep$zPop, "-")
+    .om <- if (is.matrix(prep$omega)) prep$omega else
+      diag(as.numeric(prep$omega), nrow = length(prep$omega))
+    pzI <- 0.5 * (rowSums((eta %*% solve(.om)) * eta) +
+                    as.numeric(determinant(.om, logarithm = TRUE)$modulus) +
+                    zDim * log(2 * pi))
+    .jointTot <- st$pxz + sum(pzI)
+
+    ## the same quantity, recomputed in R from the raw per-component objectives
+    .obj <- matrix(.vaeInnerEval(do.call(rbind, rep(list(eta), nMix)), ctl)$obj, nrow = N)
+    .ll <- sweep(-.obj, 2, log(mixProb), "+")
+    .mm <- apply(.ll, 1, max)
+    .want <- -sum(.mm + log(rowSums(exp(.ll - .mm))))
+    expect_equal(.jointTot, .want, tolerance = 1e-8)
+
+    ## and it is NOT the square-root marginalization the code used to compute
+    .ll2 <- sweep(-0.5 * .obj, 2, log(mixProb), "+")
+    .mm2 <- apply(.ll2, 1, max)
+    .old <- -2 * sum(.mm2 + log(rowSums(exp(.ll2 - .mm2))))
+    expect_false(isTRUE(all.equal(.want, .old)))
+    expect_false(isTRUE(all.equal(.jointTot, .old)))
+  })
 })

--- a/tests/testthat/test-vae-inner.R
+++ b/tests/testthat/test-vae-inner.R
@@ -373,6 +373,26 @@ nmTest({
     expect_equal(sum(.g$mixProb), 1)
     expect_equal(as.numeric(.g$mixProb), mixProb, tolerance = 1e-5)
 
+    ## The encoder gradient under a mixture must be the gradient of the loss the
+    ## step actually reports -- the marginal data term, the SELECTED component's
+    ## prior and KL.  Finite-difference it, which settles at once whether the
+    ## prior correction and the KL are applied at the right rows and scaled the
+    ## right way.
+    .lossAt <- function(pp) {
+      .vaeElboStepInner(pp, prep, innerEnv, prep$zPop, prep$omega, prep$a,
+                        1, eps, ctl, nMix, mixProb, withGrad = FALSE)$loss
+    }
+    .withG <- .vaeElboStepInner(params, prep, innerEnv, prep$zPop, prep$omega,
+                                prep$a, 1, eps, ctl, nMix, mixProb, withGrad = TRUE)
+    .hh <- 1e-6
+    .anaB <- as.numeric(.withG$grads$fcB)
+    .fdB <- vapply(seq_along(.anaB), function(j) {
+      .pp <- params; .pp$fcB[j] <- params$fcB[j] + .hh
+      .pm <- params; .pm$fcB[j] <- params$fcB[j] - .hh
+      (.lossAt(.pp) - .lossAt(.pm)) / (2 * .hh)
+    }, numeric(1))
+    expect_equal(.anaB, .fdB, tolerance = 1e-3)
+
     ## and it is NOT the square-root marginalization the code used to compute
     .ll2 <- sweep(-0.5 * .obj, 2, log(mixProb), "+")
     .mm2 <- apply(.ll2, 1, max)

--- a/tests/testthat/test-vae-inner.R
+++ b/tests/testthat/test-vae-inner.R
@@ -182,7 +182,7 @@ nmTest({
     }
     .testSeed(42)
     nPer <- 20L
-    ev <- rxode2::et(amt = 320, cmt = "depot") %>% rxode2::et(seq(0.5, 24, length.out = 8))
+    ev <- rxode2::et(amt = 320, cmt = "depot") |> rxode2::et(seq(0.5, 24, length.out = 8))
     mkGroup <- function(ke, ids) {
       d <- rxode2::rxSolve(sim, rxode2::et(ev, id = ids),
                            params = c(lka = log(1.5), lV = log(32), KE = ke),
@@ -416,7 +416,7 @@ nmTest({
     }
     .testSeed(42)
     nFast <- 30L; nSlow <- 10L
-    ev <- rxode2::et(amt = 320, cmt = "depot") %>% rxode2::et(seq(0.5, 24, length.out = 8))
+    ev <- rxode2::et(amt = 320, cmt = "depot") |> rxode2::et(seq(0.5, 24, length.out = 8))
     mkGroup <- function(ke, ids) {
       d <- rxode2::rxSolve(sim, rxode2::et(ev, id = ids),
                            params = c(lka = log(1.5), lV = log(32), KE = ke),

--- a/tests/testthat/test-vae-inner.R
+++ b/tests/testthat/test-vae-inner.R
@@ -210,7 +210,10 @@ nmTest({
                       nGradStep = 4L, covariateSelection = FALSE, seed = 1L)
     prep <- .vaeDataPrep(ui, dat)
     nMix <- as.integer(ui$saemNMix)
-    mixProb <- { p <- as.numeric(prep$th[ui$thetaMixIndex]); c(p, 1 - sum(p)) }
+    ## prep$th holds the mixture slots on the MLOGIT scale (the scale the inner
+    ## problem reads them on); mexpit back, exactly as .vaeFitModel does
+    mixProb <- .getMixFromLog(prep$th, ui$thetaMixIndex)
+    expect_equal(mixProb, c(0.5, 0.5))
     innerEnv <- .vaeInnerSetup(ui, dat, matrix(0, prep$N, prep$zDim), ctl)
     on.exit(.vaeInnerFree(), add = TRUE)
     fit <- .vaeTrain(prep, innerEnv, ctl, nMix, mixProb)

--- a/tests/testthat/test-vae-mix.R
+++ b/tests/testthat/test-vae-mix.R
@@ -1,0 +1,77 @@
+nmTest({
+
+  ## Cheap, fit-free checks of the vae mixture plumbing.  Deliberately NOT in
+  ## .slowBatches: these are the ones that must run on every push, because each
+  ## of them guards a defect that produced a silently wrong number rather than
+  ## an error.
+
+  .mixMod <- function() {
+    ini({
+      tka <- log(1.5)
+      tcl1 <- log(1.0)
+      tcl2 <- log(5.0)
+      p1 <- 0.3
+      tv <- log(20)
+      eta.cl ~ 0.01
+      eta.v ~ 0.01
+      add.sd <- 0.05
+    })
+    model({
+      ka <- exp(tka)
+      cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl))
+      v <- exp(tv + eta.v)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  test_that("vae prep carries the mixture proportion on the estimation scale", {
+    ## The inner problem reads that theta slot through .getMixFromLog (mexpit),
+    ## so prep$th has to hold the MLOGIT value.  Handing it the raw ini()
+    ## probability meant p1 = 0.3 was read as mexpit(0.3) = 0.574 -- a wrong
+    ## number with no error anywhere.
+    .ui <- rxode2::assertRxUi(.mixMod())
+    .prep <- .vaeDataPrep(.ui, nlmixr2data::theo_sd)
+    expect_equal(unname(.prep$th[.ui$thetaMixIndex]), rxode2::mlogit(0.3))
+    ## and it round trips back to the simplex the combine step needs
+    expect_equal(.getMixFromLog(.prep$th, .ui$thetaMixIndex), c(0.3, 0.7))
+  })
+
+  test_that("a mixture proportion is not a vae regress theta", {
+    ## p1 appears in mix(a, p1, b) so it survived the "is it in a model
+    ## expression" filter and became a bobyqa regress theta, moved against the
+    ## (-Inf, Inf) it carries in iniDf -- producing e.g. p1 <- 10.6 in ini().
+    ## npag excludes them for the same reason (.npMuExpand).
+    .ui <- rxode2::assertRxUi(.mixMod())
+    expect_false("p1" %in% .vaeNonMuThetas(.ui))
+    .prep <- .vaeDataPrep(.ui, nlmixr2data::theo_sd)
+    expect_false("p1" %in% .prep$regressNames)
+    ## the ordinary non-mu structural thetas are still candidates
+    expect_true(all(c("tka", "tcl1", "tcl2") %in% .vaeNonMuThetas(.ui)))
+  })
+
+  test_that("vae writes the fitted mixture proportion back as a probability", {
+    .ui <- rxode2::assertRxUi(.mixMod())
+    .setIni <- function(u, expr) do.call(rxode2::ini, list(u, str2lang(expr)))
+    .ui2 <- .vaeSetIniMixProb(.ui, .ui, list(mixProb = c(0.42, 0.58)), .setIni)
+    expect_equal(unname(.ui2$iniDf$est[.ui2$iniDf$name == "p1"]), 0.42)
+    ## and the result is a model the ui itself accepts
+    expect_error(rxode2::assertRxUi(.ui2$fun), NA)
+
+    ## a proportion that reached the boundary is clamped rather than written as
+    ## a 0/1 that ini() validation rejects
+    .ui3 <- .vaeSetIniMixProb(.ui, .ui, list(mixProb = c(1, 0)), .setIni)
+    .p3 <- unname(.ui3$iniDf$est[.ui3$iniDf$name == "p1"])
+    expect_true(.p3 > 0 && .p3 < 1)
+    expect_error(rxode2::assertRxUi(.ui3$fun), NA)
+
+    ## a non-mixture fit, or a malformed mixProb, leaves the ui alone
+    expect_equal(.vaeSetIniMixProb(.ui, .ui, list(mixProb = NULL), .setIni)$iniDf$est,
+                 .ui$iniDf$est)
+    expect_equal(.vaeSetIniMixProb(.ui, .ui, list(mixProb = c(0.5, 0.3, 0.2)), .setIni)$iniDf$est,
+                 .ui$iniDf$est)
+  })
+
+})


### PR DESCRIPTION
> **Depends on nlmixr2/rxode2#1358** (merged upstream) for the mixture columns
> to reach the fitted table at all. A local checkout needs rxode2 from source
> to see the mixture-table tests pass -- the installed 5.1.7 predates it.

Started as "make `est="vae"` fit a `mix()` model". Establishing whether it fit
one *correctly* meant checking the mixture gradient against a finite difference,
which turned out to be wrong in FOCEi too -- and fixing that made the mixture
proportions' information matrix available, which they never had. So this PR is
now three things.

## 1. `est="vae"` fits a mixture model

It could not before: the fit stopped during assembly, so only the training loop
had ever run with a mixture. It now follows the same convention as the
gradient-based methods -- every one of the `nSub x nMix` subject-component pairs
is characterized by the encoder at its own eta, membership is the posterior
responsibility, and the proportions are estimated on the mlogit scale through
their analytic gradient, consumed by the same Adam loop that trains the encoder.

The objective was also wrong in a way no existing test could see: it
marginalized a **square root** likelihood (`exp(-obj/2)` negated twice). Both
errors cancel exactly at `nMix == 1` *and* at identical components with uniform
`pi`, which is why `p1 = 0.5` in the one existing mixture test never caught it.

## 2. The mixture-proportion gradient was wrong -- in FOCEi

`mixGrad()` short-circuits the finite difference in `numericGrad()`, so a wrong
value is invisible under the default derivative-free `outerOpt="bobyqa"` and
silently wrong under every gradient-based one. Two independent defects:

- **the missing `-2`.** `foceiObjFromLik0() = -2*foceiLik0()`, but `mixGrad`
  returned the gradient of `lik`. That flips the sign at *every* `nMix`,
  including 2 -- `lbfgsb3c`'s first step went uphill, the line search rejected
  it, and the proportions never moved off their `ini()` values;
- **the diagonal-only Jacobian.** `rxode2::dmexpit()` returns only the diagonal,
  so every `m != l` term was dropped -- additionally wrong from `nMix >= 3` up.

`pi = mexpit(t)` is a softmax, so `d(pi_m)/d(t_l) = pi_m(delta_ml - pi_l)`, and
with `sum_m r_im = 1` the whole Jacobian collapses to `-2 * sum_i (r_il - pi_l)`.
Checked against a central difference of the objective, 3 components on `theo_sd`:

| | dOFV/dt1 | dOFV/dt2 |
|---|---|---|
| finite difference of the objective | -7.3939793 | 2.7728427 |
| closed form (this PR) | -7.3939794 | 2.7728427 |
| old `mixGrad()` | +4.7367 | +1.4556 |

This is the NONMEM 7 Technical Guide's own formulation -- eq. (1.194) chained by
(1.197), whose `da/dtheta_a` is the FULL Jacobian. Verified equal to a literal
evaluation of (1.194)x(1.197) to 2e-16. The old diagonal-only form was the
departure from it, not the fix.

## 3. Mixture proportions get standard errors

They were forced out of the covariance entirely (`skipCov`), so `p1` reported
`SE = NA` under every method. NONMEM (7.51)-(7.54) build the mixture
parameters' information as the outer product of the same per-subject scores
`g_ia` the gradient uses -- and nlmixr2est's S matrix already *is* that outer
product, so the block drops in once the per-subject score exists. The
per-subject mixture score is taken analytically, so it costs no extra solves.

**This also repaired the S matrix for mixture models generally.** `foceiS()`
built each subject's score by finite-differencing component 0's likelihood
rather than the marginal `log(sum_m pi_m L_im)`, so a parameter entering only
another component got an exactly-zero score. Measured on a 3-component fit,
two of six diagonal entries came out at `1.9e-18` and `6.6e-10`, S was reported
non-positive-definite, and `covMethod="r,s"` silently degraded to `"r"`. The
same model without `mix()` was fine.

Reported on the **probability** scale: the covariance is rotated with the full
mexpit Jacobian `J = diag(p) - p p'` (the off-diagonal terms are what carry the
proportions' correlations across), and the CI is taken on the logit scale,
`expit(logit(p) +/- z*SE/(p(1-p)))`, so it stays inside `(0, 1)` and is
asymmetric. A symmetric interval had a real fit printing
`p1 = 0.648 (-0.045, 1.34)`.

| `covMethod` | proportion SE |
|---|---|
| `"r,s"`, `"r"`, `"s"` | yes |
| `"imp"` | yes |
| `"analytic"` | declines for a mixture (it differentiates one component's conditional likelihood and has no proportion block) and falls back |
| `linFim`/`fim`/`sa` (`saem`) | appended from the fit's own responsibilities, gated on the score statistic `s' I^-1 s` |

`covMethod="imp"` also had to build its Monte-Carlo proposals for every
component rather than component 0 alone, or the proportions' directions were
exactly flat and their SEs came back 0.

## Calibrated against ground truth

Not just internal consistency: 60 replicates of a 2-component model, mean
reported SE **0.06450** against the analytic `sqrt(p(1-p)/n)` = **0.06423**,
with `sd(p1hat)` tracking the realized group fractions (`cor = 0.997`).
`r,s` / `r` / `s` / `imp` agree within 2%.

## Also fixed

- **A proportion now binds to the `mix()` component it was written for.**
  `thetaMixIndex` was built with `which(names(theta) %in% mixProbs)`, which
  returns ascending theta positions -- `ini()` order -- while `ui$mixProbs` is
  in `mix()`-call order. Declaring the proportions in a different order than
  `mix()` uses them ran component 1 on `p2`'s value. At zero iterations with
  `ini({p2 <- 0.20; p1 <- 0.70})`, `$mixProbabilities` came back `0.2 0.7 0.1`
  instead of `0.7 0.2 0.1`. A model whose `ini()` order already matches its
  `mix()` order -- the usual way to write one -- was never affected.
- `fit$etaMat` no longer carries the `mixnum` column, which every consumer
  handing it back as `foceiControl(etaMat=)` compared against the model's
  `neta` and stopped on.
- A mixture fit's `$ui` carries the proportion on the probability scale, so the
  fit is re-fittable rather than failing its own `ini()` validation.
- A fix()ed proportion is no longer given an appended variance for a parameter
  that was never estimated.
- A near-boundary proportion says so in `$runInfo`: the `p(1-p)` factor drives
  its SE toward zero, which is arithmetically right and reads as certainty.

## Review

Ten rounds with an independent reviewer (antigravity, `gemini-3.1-pro-high`),
run to convergence -- the last two clean. Eight real defects found and fixed
(stale `lik[2]` in the central difference; an `nExp`/`nsub` loop bound;
`setCov()` re-rotating an already-rotated covariance, SE `0.06445 -> 0.01548`
per round trip; a dropped block on recompute; the `mixProbs` ordering above; a
double rotation from `.covRecompute`; an N-dependent stationarity tolerance; an
all-or-nothing rotation that left a `fix()`ed proportion's neighbours on the
mlogit scale, measured `0.2652` where the probability scale is `0.0634`). Five
claims were checked and rejected with evidence, including a suggested
`gammaVec[id % nsub]` that would have used component 0's proposal scale for
every component.

CodeFactor: 5 issues -> 0 (the last one refactored, pending re-analysis).

## Verification

482 assertions green across `mix`, `saem-mix`, `vae-mix`, `focei-mix-grad`,
`focei-mix-cov`, `npag-mixture`, `cov-decouple-saimp`, `cov-condition`,
`saem-cov`, `nlmixr2output`, `vae-inner`, plus 269 more over the paths that
exercise the shared log-sum-exp (`imp-tprop` 28, `imp-proposal` 148,
`npag-psi` 76, `vae-elbo` 9, `vae-train` 8), all clean. New `test-focei-mix-grad.R` and
`test-focei-mix-cov.R` are cheap enough to stay out of `.slowBatches`; both were
confirmed to FAIL against the pre-fix code rather than passing either way.

`cov-analytic` is 243/4 -- those four are pre-existing, reproduced on an
untouched worktree containing `origin/main`, and filed as #1055, #1056, #1057.

## Housekeeping

**No duplicated log-sum-exp.** Four implementations of the same max-shifted
sum had accumulated -- `impLogSumExp3()` (pre-existing), `foceiMixLogSumExp()`,
and two inline blocks in `vaeElboStepCpp`/`gVaeThetaObjR` (the latter three
added here). They now share `rxLogSumExpW()` in a new `src/logSumExp.h`, a
header and `static inline` because `impPropLogKernelRecip()` calls it once per
importance sample.

The two callers are not interchangeable and the shared core says so rather
than papering over it: a mixture marginal must **skip** a component that failed
to solve (it contributes nothing, and the caller charges its own
`badSolveObjfAdj`), while the importance-sampling kernel has always let a NaN
**propagate** -- quietly dropping one there would turn a loud failure into a
plausible number. Hence the explicit `skipNonFinite` argument and the two named
entry points, `rxLogSumExpMix()` and `rxLogSumExp()`.

Two smaller repeats collapsed the same way: `diag(p) - p p'` (the mexpit
Jacobian, built in two places) is now `.mixProbJacobian()`, and the S-matrix
"this subject had no usable score" fallback (set `gfull`, flag `hasZero`, dock
`sInfoPer`) is now `foceiSMixNoInfo()`, which gives the `sInfoPer` accounting
somewhere to be explained -- it feeds the `smatPer` gate.

Deliberately left alone: `mixGrad()`'s population score and
`foceiSMixScore()`'s per-subject score share the expression `-2*(r_il - pi_l)`
but not its shape (one sums over subjects, the other stores per subject), and
`vaeLsAdd`/`vaeLsSwap` share two lines across different neighborhood moves.
Extracting either would be noise.

**Two orphaned roxygen blocks put back.** Inserting a function directly above
an existing one's roxygen leaves the block attached to the *new* function and
the old one undocumented. `.vaeSetIniMixProb()` had taken `.vaeUpdateModel()`'s
docs (mine); `.saemIovRestoreUi()` had taken `.saemIovFinalizeCollapsed()`'s
(pre-existing on main, same defect, so fixed here too). Swept `R/` for the
signature -- a block carrying more than one `@noRd`/`@author` -- and these were
the only two.

## Merged `origin/main`

Kept current with `origin/main` throughout, which over the course of this PR
merged #1052 (the mixture-table fixes this branch was developed alongside),
#1053, #1059 and #1061 (the fix for #1058, filed from this branch's work).

Two semantic conflicts git could not see, both caught by tests rather than
markers:

- #1058's fix makes `saem` report proportions already on the natural scale and
  guards the shared back-transform hook with `env$mixProbNatural`. This branch
  adds a *second* back-transform in `.nlmixr2FitUpdateParams()` that had no such
  guard, so a `saem` fit's `ui` came back with `expit(p)` -- 0.4 written as
  0.599. Guarded, and main's own regression test for that identity passes.
- #1052 **removed** `.mixFixTable()`, which this branch still called; that would
  have been a runtime error, not a conflict. Dropped, keeping
  `.mixCovAppendBlock()`.

#1053 also landed on the exact lines where this branch rotates the covariance.
Both kept, with the rotation still *before* `.updateParFixed()` -- it has to be,
or the SEs are derived from the mlogit-scale covariance -- and #1053's refresh
after it. The mixture CI survives that refresh because `.mixParFixedCi()` is
called from `.updateParFixedRefreshSeFromCov()` as well.

A welcome interaction: with #1058 fixed, `saem` now reaches the mixture's
score-zero point, so the gate on the `saem` SE block stops declining and starts
reporting -- with no change to the gate.
