### PR TITLE
fix(focei): keep the posthoc fast= gradient from moving the fit's ETAs (#1057)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -132,6 +132,16 @@
 
 ## Bug fixes
 
+- `foceiControl(fast=)` no longer moves a `maxOuterIterations = 0` fit's ETAs.
+  That fit evaluates the analytic outer gradient once so `.foceiGradDirect()`
+  has something to report, and the evaluation ran an extra inner optimization
+  pass per subject before the final one; under the default warm start
+  (`mceta < 0` keeps the last eta) the inner solve converges only to its own
+  tolerance, so the extra pass shifted the reported ETAs and everything derived
+  from them.  On `theo_sd` at `sigdig = 4` the `covMethod = "analytic"`
+  standard errors differed by 1.8e-4 relative between `fast = TRUE` and
+  `fast = FALSE`; they now agree to 2.7e-12.
+
 - A `focei`-family fit now reports whether its inner solves actually
   converged.  `fit$env$nTrustInner` breaks the `innerOpt="trust"` per-subject
   Newton solves down by outcome (`calls`, `error`, `notConverged`,

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -9750,12 +9750,13 @@ Environment foceiOuter(Environment e){
         }
         rx_solve *_rxSave = rx;
         analyticOuterGrad(x.begin(), _g.data());   // stashes firstDirectGrad on success
-        // analyticOuterGradDirect() assigns the GLOBAL rx and leaves it NULL when
-        // getRxSolve_() hands back nothing (declineHere(102)).  ~FdInnerStateGuard runs
-        // next and resolves its subject through getRxId(), i.e. cid % getRxNsub(rx) --
-        // a NULL dereference before any of its own NULL checks.  Put the live pointer
-        // back; prefer whatever the gradient left when it is usable, since it re-reads
-        // the same solve the pool was built on.
+        // analyticOuterGradDirect() assigns the GLOBAL rx, and declines (declineHere(102))
+        // if getRxSolve_() hands back nothing -- which would leave every later
+        // getRxId(cid) (cid % getRxNsub(rx)) dereferencing NULL, ~FdInnerStateGuard's
+        // included.  rxode2's getRxSolve_() actually returns &rx_global, a file-scope
+        // static it never frees, so this cannot fire today and _rxSave cannot dangle;
+        // it is here so the guards keep a usable pointer if that ever changes, matching
+        // the NULL check analyticOuterGradDirect already makes.
         if (rx == NULL) rx = _rxSave;
       }
       // The guards put fInd->setup and oldEta back, which is exactly the state in which

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -9740,7 +9740,8 @@ Environment foceiOuter(Environment e){
         rx = getRxSolve_();
         // nIndsFocei, not getRxNsub(): a mixture fit carries one focei_ind per
         // subject PER mixture component, and foceiOfv0() moves all of them.
-        const int _ns = (rx == NULL || inds_focei == NULL) ? 0 : nIndsFocei;
+        const int _ns = (rx == NULL || inds_focei == NULL || getRxNsub(rx) <= 0) ?
+          0 : nIndsFocei;
         FdPhaseStateGuard _phaseGuard;
         std::vector< std::unique_ptr<FdInnerStateGuard> > _inGuards;
         _inGuards.reserve((size_t)_ns);

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -9736,19 +9736,31 @@ Environment foceiOuter(Environment e){
       op_foceiUseAnalyticGrad = true;
       loadGradPooledSetup(e);
       std::vector<double> _g((size_t)op_focei.npars, 0.0);
+      rx = getRxSolve_();
+      // nIndsFocei, not getRxNsub(): a mixture fit carries one focei_ind per
+      // subject PER mixture component, and foceiOfv0() moves all of them.
+      const int _nsGuarded = (rx == NULL || inds_focei == NULL || getRxNsub(rx) <= 0) ?
+        0 : nIndsFocei;
       {
-        rx = getRxSolve_();
-        // nIndsFocei, not getRxNsub(): a mixture fit carries one focei_ind per
-        // subject PER mixture component, and foceiOfv0() moves all of them.
-        const int _ns = (rx == NULL || inds_focei == NULL || getRxNsub(rx) <= 0) ?
-          0 : nIndsFocei;
         FdPhaseStateGuard _phaseGuard;
         std::vector< std::unique_ptr<FdInnerStateGuard> > _inGuards;
-        _inGuards.reserve((size_t)_ns);
-        for (int _i = 0; _i < _ns; ++_i) {
+        _inGuards.reserve((size_t)_nsGuarded);
+        for (int _i = 0; _i < _nsGuarded; ++_i) {
           _inGuards.push_back(std::unique_ptr<FdInnerStateGuard>(new FdInnerStateGuard(_i)));
         }
         analyticOuterGrad(x.begin(), _g.data());   // stashes firstDirectGrad on success
+      }
+      // The guards put fInd->setup and oldEta back, which is exactly the state in which
+      // likInner0() answers from the CACHE instead of solving -- and ind->solve still holds
+      // the AUGMENTED model's solution, because restoring the inner state deliberately does
+      // not restore the solve.  Force the re-solve so foceiOuterFinal() cannot read it;
+      // fdPinRefEtaForce() pairs setIndSolve(-1) with an invalidated cache for the same
+      // reason on the differencing legs.  The eta is unchanged, so this costs one solve
+      // per subject and changes no result.
+      for (int _i = 0; _i < _nsGuarded; ++_i) {
+        inds_focei[_i].setup = 0;
+        rx_solving_options_ind *_ind = getSolvingOptionsInd(rx, getRxId(_i));
+        if (_ind != NULL) setIndSolve(_ind, -1);
       }
       op_foceiUseAnalyticGrad = false;
       op_focei.calcGrad = 0;

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -9719,13 +9719,36 @@ Environment foceiOuter(Environment e){
     // This branch sets scaleObjective = 0 and does no parameter scaling, so
     // dUnscaleParDx is the identity and the stashed gradient is on the NATURAL scale --
     // the same scale .foceiGradDirect() reports.
+    //
+    // The evaluation is DIAGNOSTIC, so it must not move the fit's own state.
+    // analyticOuterGrad() opens with foceiOfv0(), i.e. one more inner optimization pass
+    // per subject, and foceiOuterFinal() then starts from wherever that left each eta.
+    // With the default warm start (mceta<0 keeps the last eta) the inner solve converges
+    // only to its own tolerance, so that extra pass shifted the reported ETAs -- and with
+    // them the objective, the tables and the analytic covariance -- by ~1e-4 at sigdig=4
+    // relative to the same fit with fast=FALSE (#1057).  The guards below put the
+    // per-subject inner state and the fit-wide eta statistics back, so `fast=` selects the
+    // gradient and nothing else.  The SOLVE is deliberately left alone: the augmented
+    // model must stay in the pool for foceiOuterFinal to re-solve over.
     if (op_focei.fast) {
       op_foceiFitEnv = e;
       op_foceiFitEnvSet = true;
       op_foceiUseAnalyticGrad = true;
       loadGradPooledSetup(e);
       std::vector<double> _g((size_t)op_focei.npars, 0.0);
-      analyticOuterGrad(x.begin(), _g.data());   // stashes firstDirectGrad on success
+      {
+        rx = getRxSolve_();
+        // nIndsFocei, not getRxNsub(): a mixture fit carries one focei_ind per
+        // subject PER mixture component, and foceiOfv0() moves all of them.
+        const int _ns = (rx == NULL || inds_focei == NULL) ? 0 : nIndsFocei;
+        FdPhaseStateGuard _phaseGuard;
+        std::vector< std::unique_ptr<FdInnerStateGuard> > _inGuards;
+        _inGuards.reserve((size_t)_ns);
+        for (int _i = 0; _i < _ns; ++_i) {
+          _inGuards.push_back(std::unique_ptr<FdInnerStateGuard>(new FdInnerStateGuard(_i)));
+        }
+        analyticOuterGrad(x.begin(), _g.data());   // stashes firstDirectGrad on success
+      }
       op_foceiUseAnalyticGrad = false;
       op_focei.calcGrad = 0;
     }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -9748,7 +9748,15 @@ Environment foceiOuter(Environment e){
         for (int _i = 0; _i < _nsGuarded; ++_i) {
           _inGuards.push_back(std::unique_ptr<FdInnerStateGuard>(new FdInnerStateGuard(_i)));
         }
+        rx_solve *_rxSave = rx;
         analyticOuterGrad(x.begin(), _g.data());   // stashes firstDirectGrad on success
+        // analyticOuterGradDirect() assigns the GLOBAL rx and leaves it NULL when
+        // getRxSolve_() hands back nothing (declineHere(102)).  ~FdInnerStateGuard runs
+        // next and resolves its subject through getRxId(), i.e. cid % getRxNsub(rx) --
+        // a NULL dereference before any of its own NULL checks.  Put the live pointer
+        // back; prefer whatever the gradient left when it is usable, since it re-reads
+        // the same solve the pool was built on.
+        if (rx == NULL) rx = _rxSave;
       }
       // The guards put fInd->setup and oldEta back, which is exactly the state in which
       // likInner0() answers from the CACHE instead of solving -- and ind->solve still holds

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1192,12 +1192,20 @@ nmTest({
     # pool is only available with fast=TRUE, `fast=` moved the standard errors.  Both
     # routes now solve at solveTol.
     #
-    # On THIS model at sigdig = 4 the defect is 1.16e-5 relative and what is left after
-    # the fix is 5.6e-8 (two different code paths integrating the same quantity at the
-    # same tolerance), so 1e-6 below has ~18x margin under it and ~12x over it.  Do not
-    # loosen it without re-measuring: the gap TRACKS the fit tolerance, and at sigdig = 3
-    # the defect is only 1.9e-4, so a tolerance chosen off the 1.7e-2 seen on a 5-ETA
-    # 2-compartment model would pass with the bug still in.
+    # On THIS model at sigdig = 4 that defect is 1.16e-5 relative; at sigdig = 3 it is only
+    # 1.9e-4, so a tolerance chosen off the 1.7e-2 seen on a 5-ETA 2-compartment model
+    # would pass with the bug still in.  Do not loosen 1e-8 below without re-measuring.
+    #
+    # #1057: a SECOND way `fast=` moved the SEs, unrelated to the tolerance.  With
+    # maxOuterIterations = 0, fast=TRUE evaluates the analytic gradient once (so
+    # .foceiGradDirect() has something to report), and that evaluation ran one more inner
+    # optimization pass per subject before foceiOuterFinal re-solved the inner problem.
+    # Under the default warm start (mceta < 0 keeps the last eta) the inner solve converges
+    # only to its own tolerance, so the extra pass left different ETAs and the SEs followed:
+    # 1.8e-4 relative on om.eta.ka.  With the diagnostic evaluation guarded, the two routes
+    # agree to 2.7e-12 -- so 1e-8 sits ~3700x above what is left and ~100x below what a
+    # tolerance regression costs (measured: solving the augmented model at the fit's 1e-4
+    # instead of its own moves the SEs 1.4e-6).
     .m <- function() {
       ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- 0.7
             eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1 })
@@ -1218,7 +1226,8 @@ nmTest({
       expect_equal(.f$covMethod, "analytic")   # a fallback would compare the wrong thing
       .i <- .odeSwapInfo()
       list(se = sqrt(diag(.f$cov)), pooled = .i$pooledSolveN - .n0,
-           bailed = .foceiOuterFlagged$n - .b0, cores = .i$pooledSolveCores)
+           bailed = .foceiOuterFlagged$n - .b0, cores = .i$pooledSolveCores,
+           eta = as.matrix(.f$eta[, -1, drop = FALSE]), objf = .f$objf)
     }
     .rT <- .se(TRUE); .rF <- .se(FALSE)
     # Without this the comparison is vacuous: if fast=TRUE stopped reaching the pool the
@@ -1234,8 +1243,13 @@ nmTest({
     # threads -> min2(cores, getOpCores(op)) -> doParallel.  Measured 11 with the fix and
     # 1 without, on a host reporting 11 threads.
     if (rxode2::getRxThreads() > 1L) expect_gt(.rT$cores, 1L)
+    # The SEs are a function of the EBEs, so compare the INPUT before the output: this is
+    # what #1057 actually broke, and it fails first and says so, instead of leaving a
+    # tolerance on the SEs to be blamed.  0.0003 apart with the bug in.
+    expect_equal(unname(.rT$eta), unname(.rF$eta), tolerance = 1e-8)
+    expect_equal(.rT$objf, .rF$objf, tolerance = 1e-8)
     .n <- intersect(names(.rT$se), names(.rF$se))
     expect_gt(length(.n), 0L)
-    expect_equal(unname(.rT$se[.n]), unname(.rF$se[.n]), tolerance = 1e-6)
+    expect_equal(unname(.rT$se[.n]), unname(.rF$se[.n]), tolerance = 1e-8)
   })
 })


### PR DESCRIPTION
Fixes #1057.

## What was happening

`test_that("covMethod='analytic' SEs do not depend on foceiControl(fast=)")` failed
with one SE (`om.eta.ka`) 1.8e-4 relative apart between `fast = TRUE` and
`fast = FALSE` -- two orders of magnitude above the spread of the other six.

**It is not the covariance route.** Pinning both runs to a starting eta that does not
depend on the path (`mceta = 0`) made the two agree to 2.7e-12 with the pooled route
still provably in use, so the pooled and non-pooled assembly are identical. What
differed was the *input*: the reported ETAs were 3.3e-4 apart and the objective
5.9e-4 apart.

Why: with `maxOuterIterations = 0` and `fast = TRUE`, `foceiOuter()` evaluates the
analytic outer gradient once purely so `.foceiGradDirect()` has something to report.
`analyticOuterGrad()` opens with `foceiOfv0()` -- one more inner (EBE) optimization
pass per subject -- and `foceiOuterFinal()` then starts each eta from wherever that
pass left it. Under the default warm start (`mceta < 0` keeps the last eta) the inner
solve converges only to its own tolerance, so the extra pass moved the reported ETAs
and, with them, the objective, the tables and the covariance. The gap tracked the
inner tolerance (3.3e-4 at `sigdig = 4`, 4.1e-6 at `sigdig = 6`), which is what a
convergence-tolerance effect looks like rather than noise.

## The fix

Wrap the diagnostic evaluation in the guards that already exist for exactly this
purpose -- `FdInnerStateGuard` per subject and `FdPhaseStateGuard` fit-wide -- so it
restores the inner state it moved, then invalidate the per-subject solve cache so
`foceiOuterFinal()` cannot answer from a cache whose `ind->solve` still holds the
augmented model's solution. The solve itself is deliberately left in the pool: the
augmented model has to stay there for `foceiOuterFinal` to re-solve over.

## Measured, on `theo_sd` at `sigdig = 4`, `maxOuterIterations = 0`

| quantity | before | after |
|---|---|---|
| max abs ETA difference | 3.3e-4 | 1.2e-11 |
| objective difference | 5.9e-4 | 1.2e-10 |
| max relative SE difference | 1.8e-4 | 2.7e-12 |

`pooledSolveN` is 14 for `fast = TRUE` and 0 for `fast = FALSE` in both cases, so the
two runs still take different routes. The whole fitted data frame now agrees to
~1e-11 as well, including the solved state columns (`depot`, `center`) and
`CWRES`/`CPRED` -- so nothing reads a stale solve.

## Test

The invariance test now compares the ETAs and the objective **before** the SEs,
because that is the input #1057 actually broke, and tightens the SE tolerance from
1e-6 to 1e-8: ~3700x above what is left, and ~100x below the 1.4e-6 that a regression
of the earlier `covSolveTol` defect costs on this model (measured by re-running the
covariance at the fit's 1e-4 instead of its own tolerance).

## Review

Reviewed independently with Antigravity (Gemini). It found one real defect, fixed
here: `analyticOuterGradDirect()` assigns the *global* `rx` and can decline with it
left `NULL`, after which `~FdInnerStateGuard` resolves its subject through
`getRxId(cid)` = `cid % getRxNsub(rx)` -- a dereference before any of the guard's own
NULL checks, and a window this change created by being the first site to destroy
those guards after a gradient evaluation.

Two further findings were checked and rejected:

- *"tolFactor is restored to the wrong solver."* There is one global `rx_solve* rx`
  (`src/inner.cpp:1459`); the odeSwap pool exists precisely so the models share one
  solve, so `getSolvingOptionsInd(rx, id)` returns the same `ind` before and after.
- *"restoring the saved `rx` resurrects a freed struct."* `getRxSolve_()` returns
  `&rx_global`, a file-scope static (rxode2 `par_solve.cpp:84`, returned at `:1439`),
  so it never yields NULL and `rxSolveFree()` frees its contents, not the struct.

## Test runs

`test-focei-fast-grad.R` (62), `test-odeswap-fit.R` (24), `test-odeswap.R` (116),
`test-agq-fast-grad.R` (33), `test-mix.R` (47) and `test-cov-analytic-defaults.R` (39)
all pass with zero failures. `test-cov-analytic.R` is 194 passed with the two failures
already filed as #1055 (block-Omega covariance indefinite) and #1056 (foce+ vs FOCEI
R) -- both bit-identical on `origin/main` and both running with `fast = FALSE`, so
neither can reach this change.

## Known coverage gap

The mixture branch of the guard's loop bound (`nIndsFocei`, which is
`getRxNsubAndMix()` when mixture components are allocated, rather than
`getRxNsub()`) is not covered by a test. I built one and then discarded it as
vacuous: with `maxOuterIterations = 0` from the *initial* estimates both routes take
their first inner solve from eta = 0, so nothing can differ, and deliberately breaking
the bound to `getRxNsub(rx)` produced bit-identical results. Reproducing the effect
needs *converged* thetas, and a mixture fit cannot be re-entered through `finalUi`
because `p1` comes back on the mlogit scale (`mix()` rejects it: "the probabilities in
a mixture must sum to a number between 0 and 1, they sum to: -0.847297860387204",
which is exactly `mlogit(0.3)`). The bound itself is safe by construction --
`nIndsFocei` is assigned the `R_Calloc` size at both allocation sites
(`src/inner.cpp:7683`, `:7739`).
