### PR TITLE
fix(saem): mixture proportion now matches its own responsibilities and the data (#1058)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -132,6 +132,22 @@
 
 ## Bug fixes
 
+- `est="saem"` now reports a mixture proportion that agrees with the fit's own
+  posterior responsibilities (`sum_i (r_i - p) == 0`) and with what the data
+  identifies.  Three things were wrong: the shared parameter-table hook mlogit
+  back-transformed `saem`'s proportions, which are already on the natural
+  scale, so the reported value was `expit(p)` and could not equal the
+  responsibilities it was averaged from; `mixProbMethod="regress"` classified
+  each subject at that subject's `phiM` draw, whose fixed-effect-only columns
+  carry a search variance of 1 rather than a real BSV, so the draw swamped the
+  between-component signal and misclassified a fifth of the subjects even with
+  8-fold separated components; and an eta shared by every mixture component was
+  marked as owned by whichever component mentioned it last, sending shared-eta
+  mixtures down the split-ETA code paths.  Every `mixProbMethod` now reports
+  the proportion at the score-zero point: one exact M-step at the final
+  responsibilities, rather than a value still carrying the annealing or
+  Dirichlet-style shrinkage that stabilizes the trajectory.
+
 - A `focei`-family fit now reports whether its inner solves actually
   converged.  `fit$env$nTrustInner` breaks the `innerOpt="trust"` per-subject
   Newton solves down by outcome (`calls`, `error`, `notConverged`,

--- a/R/mix.R
+++ b/R/mix.R
@@ -217,7 +217,9 @@
   .bestMix <- apply(.mixWeights, 1L, which.max)
 
   # Final mixture probabilities (full simplex, nMix elements)
-  .mixProb <- .saem$mixProb
+  # .saem$mixProb comes back from armadillo as an n x 1 matrix; keep
+  # env$mixProbabilities a plain vector, as the focei side already is.
+  .mixProb <- as.vector(.saem$mixProb)
   if (length(.mixProb) == .nMix - 1L) {
     .mixProbabilities <- c(.mixProb, 1.0 - sum(.mixProb))
   } else if (length(.mixProb) == .nMix) {
@@ -409,6 +411,10 @@
   .mixIdx <- try(get("mixIdx", envir=env), silent=TRUE)
   if (inherits(.mixIdx, "try-error")) return(invisible(NULL))
   if (length(.mixIdx) == 0L) return(invisible(NULL))
+  # saem reports the proportions already on the natural scale (env$mixProbNatural,
+  # set by .getSaemTheta()); mexpit()-ing them again silently reports
+  # expit(p) instead of p and breaks the p == mean_i r_i identity (#1058).
+  if (isTRUE(env$mixProbNatural)) return(invisible(NULL))
 
   .thetaDf <- env$theta
   if (is.null(.thetaDf) || !is.data.frame(.thetaDf)) return(invisible(NULL))

--- a/R/mix.R
+++ b/R/mix.R
@@ -88,7 +88,7 @@
     }
     return(unique(unlist(lapply(as.list(expr)[-1], .extractEtasOutsideMix, etas = etas))))
   }
-  return(NULL)
+  NULL
 }
 
 #' Process mixture model information after a focei fit

--- a/R/mix.R
+++ b/R/mix.R
@@ -64,6 +64,33 @@
   return(NULL)
 }
 
+#' Extract ETA names referenced outside any mix() component expression
+#'
+#' The component expressions of a `mix()` call are skipped (they are scanned
+#' per-component elsewhere); everything else, including a `mix()` call's
+#' probability arguments, counts as outside.  An ETA found here applies to every
+#' mixture component, so it is shared no matter which component also uses it.
+#'
+#' @param expr A parsed expression (or sub-expression) from `ui$lstExpr`
+#' @param etas Character vector of all known ETA names to match against
+#' @return Character vector of ETA names found outside a component (deduplicated)
+#' @noRd
+#' @author Matthew L. Fidler
+.extractEtasOutsideMix <- function(expr, etas) {
+  if (is.name(expr)) {
+    .n <- as.character(expr)
+    if (.n %in% etas) return(.n)
+  } else if (is.call(expr)) {
+    if (identical(expr[[1]], quote(mix))) {
+      .args <- as.list(expr)[-1]
+      .probs <- .args[seq_along(.args) %% 2L == 0L]
+      return(unique(unlist(lapply(.probs, .extractEtasOutsideMix, etas = etas))))
+    }
+    return(unique(unlist(lapply(as.list(expr)[-1], .extractEtasOutsideMix, etas = etas))))
+  }
+  return(NULL)
+}
+
 #' Process mixture model information after a focei fit
 #'
 #' After the C++ focei fit, strips the MIXEST column from ranef, computes

--- a/R/saem.R
+++ b/R/saem.R
@@ -496,6 +496,13 @@
       .theta[paste(.tmp$name[.w])] <- .saem$arCor[i]
     }
   }
+  if (length(.ui$mixProbs) > 0) {
+    # saem estimates the proportions on the natural [0, 1] scale (the kernel's
+    # simplex SA/M-step), unlike focei's mlogit thetas; flag it so the shared
+    # pre-final-table hook does not mlogit back-transform an already-natural
+    # value (#1058).
+    env$mixProbNatural <- TRUE
+  }
   if (length(.ui$mixProbs) > 0 && !is.null(.saem$mixProb)) {
     .estMix <- .saem$mixProb[seq_along(.ui$mixProbs)]
     .estMixClamped <- pmax(1e-6, pmin(1 - 1e-6, .estMix))

--- a/R/saemRxUiGet.R
+++ b/R/saemRxUiGet.R
@@ -276,11 +276,14 @@ rxUiGet.saemOmegaShareSubpop <- function(x, ...) {
   if (length(.mixCalls) == 0L) return(.ret)
 
   # Collect, for each eta, every component index it is referenced from, across
-  # ALL of the model's mix() calls.  An eta seen from more than one component is
-  # SHARED, not owned: marking it as a component (the assignment below used to
-  # take whichever mix() call mentioned it last) sends a shared-eta mixture down
-  # the split-ETA code paths, which weight that eta's theta/omega update by a
-  # single component's responsibilities.
+  # ALL of the model's mix() calls.  An eta seen from more than one component --
+  # or used anywhere outside a component, where it applies to every component --
+  # is SHARED, not owned: marking it as a component (the assignment below used
+  # to take whichever mix() call mentioned it last) sends a shared-eta mixture
+  # down the split-ETA code paths, which weight that eta's theta/omega update by
+  # a single component's responsibilities.
+  .outside <- unique(unlist(lapply(.ui$lstExpr, .extractEtasOutsideMix,
+                                   etas = .allEtas)))
   .compsOf <- list()
   for (.mc in .mixCalls) {
     .args <- as.list(.mc)[-1]
@@ -292,7 +295,7 @@ rxUiGet.saemOmegaShareSubpop <- function(x, ...) {
     }
   }
   for (.eta in names(.compsOf)) {
-    if (length(.compsOf[[.eta]]) != 1L) next
+    if (length(.compsOf[[.eta]]) != 1L || .eta %in% .outside) next
     .w <- which(.eta == .etaNames)
     if (length(.w) == 1L) {
       .ret[.w] <- .compsOf[[.eta]]

--- a/R/saemRxUiGet.R
+++ b/R/saemRxUiGet.R
@@ -275,23 +275,27 @@ rxUiGet.saemOmegaShareSubpop <- function(x, ...) {
   .mixCalls <- do.call(c, lapply(.ui$lstExpr, .findMixCalls))
   if (length(.mixCalls) == 0L) return(.ret)
 
+  # Collect, for each eta, every component index it is referenced from, across
+  # ALL of the model's mix() calls.  An eta seen from more than one component is
+  # SHARED, not owned: marking it as a component (the assignment below used to
+  # take whichever mix() call mentioned it last) sends a shared-eta mixture down
+  # the split-ETA code paths, which weight that eta's theta/omega update by a
+  # single component's responsibilities.
+  .compsOf <- list()
   for (.mc in .mixCalls) {
     .args <- as.list(.mc)[-1]
     .comps <- .args[seq(1, length(.args), by = 2)]
-    .byComp <- lapply(.comps, .extractEtas, etas = .allEtas)
     for (.j in seq_along(.comps)) {
-      for (.eta in .byComp[[.j]]) {
-        # An eta referenced by more than one component of the same mix() is
-        # shared, not owned by a component.  Leaving it marked as component .j
-        # (whichever mentions it last) sends a shared-eta mixture down the
-        # split-ETA code paths, which weight that eta's theta/omega update by a
-        # single component's responsibilities.
-        if (sum(vapply(.byComp, function(.e) .eta %in% .e, logical(1))) > 1L) next
-        .w <- which(.eta == .etaNames)
-        if (length(.w) == 1L) {
-          .ret[.w] <- .j
-        }
+      for (.eta in .extractEtas(.comps[[.j]], etas = .allEtas)) {
+        .compsOf[[.eta]] <- unique(c(.compsOf[[.eta]], .j))
       }
+    }
+  }
+  for (.eta in names(.compsOf)) {
+    if (length(.compsOf[[.eta]]) != 1L) next
+    .w <- which(.eta == .etaNames)
+    if (length(.w) == 1L) {
+      .ret[.w] <- .compsOf[[.eta]]
     }
   }
   .ret

--- a/R/saemRxUiGet.R
+++ b/R/saemRxUiGet.R
@@ -278,9 +278,15 @@ rxUiGet.saemOmegaShareSubpop <- function(x, ...) {
   for (.mc in .mixCalls) {
     .args <- as.list(.mc)[-1]
     .comps <- .args[seq(1, length(.args), by = 2)]
+    .byComp <- lapply(.comps, .extractEtas, etas = .allEtas)
     for (.j in seq_along(.comps)) {
-      .grpEtas <- .extractEtas(.comps[[.j]], etas = .allEtas)
-      for (.eta in .grpEtas) {
+      for (.eta in .byComp[[.j]]) {
+        # An eta referenced by more than one component of the same mix() is
+        # shared, not owned by a component.  Leaving it marked as component .j
+        # (whichever mentions it last) sends a shared-eta mixture down the
+        # split-ETA code paths, which weight that eta's theta/omega update by a
+        # single component's responsibilities.
+        if (sum(vapply(.byComp, function(.e) .eta %in% .e, logical(1))) > 1L) next
         .w <- which(.eta == .etaNames)
         if (length(.w) == 1L) {
           .ret[.w] <- .j

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -2411,7 +2411,7 @@ public:
       // Fall back to soft-EM (regularized) when fixed membership cannot work:
       //  (a) SPLIT-ETA mixtures -- each component owns a distinct eta, so
       //      omegaShareSubpop has >= 2 distinct non-zero subpop values (a
-      //      shared-eta mixture has just one).  Components start identical and
+      //      shared-eta mixture has none).  Components start identical and
       //      must differentiate during the fit; a hard split at the symmetric
       //      init is arbitrary and never separates.
       //  (b) a degenerate classification that leaves a component empty (its
@@ -4326,6 +4326,12 @@ public:
       lambda = lres;
       if (nMix > 1) { mixProb = _savMixProb; mixWeights = _savMixWeights; }
     }
+    // Report the proportion at the score-zero point: one exact M-step at the final
+    // responsibilities, so sum_i (r_i - p) == 0 holds for every mixProbMethod.  The
+    // annealed step size and the Dirichlet-style regularization above stabilize the
+    // TRAJECTORY; leaving their shrinkage in the reported value makes the proportion
+    // disagree with the fit's own per-subject probabilities (#1058).
+    if (nMix > 1 && arma::accu(mixWeights) > 0.0) mixProb = mean(mixWeights, 0).t();
     phiFile.close();
   }
 
@@ -4907,16 +4913,24 @@ private:
     return result;
   }
 
-  // Model-aware naive classification for MSAEM's stratified init (run once before iteration 1):
-  // for each subject/hypothesis, shift phi1's owned columns toward/away from that hypothesis
-  // (pertSd BSV-SD) and evaluate the compiled model's actual fit. Returns the per-subject
-  // argmin-hypothesis classification (1-indexed).
+  // Model-aware naive classification, used for mixProbMethod="regress" membership and for
+  // MSAEM's stratified init (both run once before iteration 1): for each
+  // subject/hypothesis, shift phi1's owned columns toward/away from that hypothesis
+  // (pertSd BSV-SD) and evaluate the compiled model's actual fit.  Returns the
+  // per-subject argmin-hypothesis classification (1-indexed).
   uvec mixNaiveClassify(double pertSd) {
     double double_xmin = 1.0e-200;
     double xmax = 1e300;
     mat lossByHyp(N, nMix, fill::zeros);
+    // phi0 columns (fixed-effect-only parameters) carry a search variance of 1 in
+    // phiM, not a real BSV, so a subject's draw sits e-fold off the population value
+    // and swamps the between-component signal the classification is measuring.  Judge
+    // every hypothesis at the population value instead (#1058); the phi1 (eta) columns
+    // stay at their draws, which are genuine subject-level values.
+    mat basePhi = phiM;
+    if (nphi0 > 0) basePhi.cols(i0) = repmat(mprior_phi0, nmc, 1);
     for (int mHyp = 0; mHyp < nMix; mHyp++) {
-      mat cand = phiM;
+      mat cand = basePhi;
       if (omegaShareSubpop.n_elem == (unsigned int)nphi1) {
         for (unsigned int c = 0; c < (unsigned int)nphi1; c++) {
           unsigned int subpop = omegaShareSubpop(c);

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -381,4 +381,57 @@ nmTest({
     expect_false(any(vapply(.mixList, function(m) any(is.nan(m$prob)), logical(1))))
   })
 
+  test_that("saemOmegaShareSubpop only marks an eta owned by ONE mixture component (#1058)", {
+    # a SHARED eta belongs to no component: marking it (the loop used to keep
+    # whichever component mentioned it last) sends the fit down the split-ETA
+    # paths, which weight that eta's theta/omega update by one component's
+    # responsibilities
+    sharedEta <- function() {
+      ini({
+        tcl1 <- log(1); tcl2 <- log(8); tv <- log(20); tka <- log(1.1)
+        p1 <- 0.5; eta.cl ~ 0.1; add.sd <- 0.1
+      })
+      model({
+        ka <- exp(tka)
+        cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl))
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    expect_equal(rxode2::rxode2(sharedEta)$saemOmegaShareSubpop, 0L)
+
+    # a genuine split-ETA mixture still marks each eta with its own component
+    splitEta <- function() {
+      ini({
+        tcl1 <- log(1); tcl2 <- log(8); tv <- log(20); tka <- log(1.1)
+        p1 <- 0.5; eta.cl1 ~ 0.1; eta.cl2 ~ 0.1; add.sd <- 0.1
+      })
+      model({
+        ka <- exp(tka)
+        cl <- mix(exp(tcl1 + eta.cl1), p1, exp(tcl2 + eta.cl2))
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .split <- rxode2::rxode2(splitEta)
+    expect_equal(.split$saemOmegaShareSubpop[.split$saemEtaNames == "eta.cl1"], 1L)
+    expect_equal(.split$saemOmegaShareSubpop[.split$saemEtaNames == "eta.cl2"], 2L)
+
+    # sharing is judged across ALL mix() calls: eta.cl is shared by both
+    # components of cl, so v's second component must not claim it
+    twoMix <- function() {
+      ini({
+        tcl1 <- log(1); tcl2 <- log(8); tv1 <- log(20); tv2 <- log(30)
+        tka <- log(1.1); p1 <- 0.5; eta.cl ~ 0.1; add.sd <- 0.1
+      })
+      model({
+        ka <- exp(tka)
+        cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl))
+        v <- mix(exp(tv1), p1, exp(tv2 + eta.cl))
+        linCmt() ~ add(add.sd)
+      })
+    }
+    expect_equal(rxode2::rxode2(twoMix)$saemOmegaShareSubpop, 0L)
+  })
+
 })

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -432,6 +432,24 @@ nmTest({
       })
     }
     expect_equal(rxode2::rxode2(twoMix)$saemOmegaShareSubpop, 0L)
+
+    # an eta used inside one component AND outside the mix() applies to every
+    # component, so it is shared too
+    outsideEta <- function() {
+      ini({
+        tcl1 <- log(1); tcl2 <- log(8); tv <- log(20); tka <- log(1.1)
+        p1 <- 0.5; eta.cl1 ~ 0.1; eta.cl2 ~ 0.1; add.sd <- 0.1
+      })
+      model({
+        ka <- exp(tka)
+        cl <- mix(exp(tcl1 + eta.cl1), p1, exp(tcl2 + eta.cl2))
+        v <- exp(tv + eta.cl1)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .outside <- rxode2::rxode2(outsideEta)
+    expect_equal(.outside$saemOmegaShareSubpop[.outside$saemEtaNames == "eta.cl1"], 0L)
+    expect_equal(.outside$saemOmegaShareSubpop[.outside$saemEtaNames == "eta.cl2"], 2L)
   })
 
 })

--- a/tests/testthat/test-saem-mix-regress.R
+++ b/tests/testthat/test-saem-mix-regress.R
@@ -121,4 +121,15 @@ test_that("saem's mixture proportion equals its own responsibilities and the dat
   # variance of 1, not a real BSV -- misclassified a fifth of these subjects
   # even though the components are 8-fold apart.
   expect_equal(as.integer(fit$env$mixNum$mixnum), as.integer(grp))
+
+  # the identity has to survive the dedicated SA covariance phase too:
+  # covMethod="sa" runs nSaCov extra iterations and then restores the converged
+  # snapshot, and the reported proportion is taken after that restore
+  fitSa <- suppressWarnings(nlmixr2(mixmod, dat, est = "saem",
+                                    saemControl(print = 0, nBurn = 100L, nEm = 100L,
+                                                covMethod = "sa", nSaCov = 50L,
+                                                calcTables = FALSE)))
+  .pSa <- fitSa$env$mixProbabilities[1]
+  expect_equal(sum(fitSa$env$mixList[[1]]$prob - .pSa), 0, tolerance = 1e-6)
+  expect_equal(unname(.pSa), pTrue, tolerance = 0.05)
 })

--- a/tests/testthat/test-saem-mix-regress.R
+++ b/tests/testthat/test-saem-mix-regress.R
@@ -49,3 +49,76 @@ test_that("saemControl(mixProbMethod='regress') fixes membership and separates t
   # mechanism: fixed hard membership yields a per-subject classification
   expect_true(!is.null(fit$mixNum))
 })
+
+test_that("saem's mixture proportion equals its own responsibilities and the data's (#1058)", {
+  skip_on_cran()
+
+  # Two well-separated components (CL 1 vs 8, additive sd 0.05) so the realized
+  # group fraction is the answer any method should find; everything except the
+  # proportion and the BSV is fixed at truth.
+  .testSeed(1001)
+  nSub <- 60L
+  clTrue <- c(1.0, 8.0)
+  grp <- sample.int(2L, nSub, TRUE, prob = c(0.45, 0.55))
+  sim <- rxode2::rxode2({
+    ka <- 1.1
+    cl <- CLI
+    v <- 20
+    d/dt(depot) <- -ka * depot
+    d/dt(center) <- ka * depot - cl / v * center
+    cp <- center / v
+  })
+  ev <- rxode2::et(rxode2::et(amt = 320, cmt = "depot"),
+                   c(0.25, 0.5, 1, 2, 4, 8, 12, 24))
+  obs <- do.call(rbind, lapply(seq_len(nSub), function(i) {
+    s <- rxode2::rxSolve(sim, params = c(CLI = clTrue[grp[i]]), ev,
+                         returnType = "data.frame")
+    data.frame(ID = i, TIME = s$time, DV = s$cp + rnorm(nrow(s), 0, 0.05),
+               AMT = 0, EVID = 0)
+  }))
+  dat <- rbind(data.frame(ID = seq_len(nSub), TIME = 0, DV = NA_real_,
+                          AMT = 320, EVID = 1), obs)
+  dat <- dat[order(dat$ID, dat$TIME, -dat$EVID), ]
+  pTrue <- mean(grp == 1L)
+
+  mixmod <- function() {
+    ini({
+      tka <- fix(log(1.1)); tcl1 <- fix(log(1.0)); tcl2 <- fix(log(8.0))
+      tv <- fix(log(20)); p1 <- 0.45; eta.cl ~ 0.01; add.sd <- fix(0.05)
+    })
+    model({
+      ka <- exp(tka)
+      cl <- mix(exp(tcl1 + eta.cl), p1, exp(tcl2 + eta.cl))
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  fit <- suppressWarnings(nlmixr2(mixmod, dat, est = "saem",
+                                  saemControl(print = 0, nBurn = 100L, nEm = 100L,
+                                              covMethod = "", calcTables = FALSE)))
+  p1 <- fit$env$mixProbabilities[1]
+  r1 <- fit$env$mixList[[1]]$prob
+
+  # the proportion and the per-subject probabilities must describe ONE model:
+  # the mixture score sum_i (r_i - p) is 0 at the EM/ML fixed point.  This is
+  # data-free and is what caught the mlogit double back-transform.
+  expect_equal(sum(r1 - p1), 0, tolerance = 1e-6)
+  expect_equal(unname(p1), mean(r1), tolerance = 1e-8)
+  expect_equal(sum(fit$env$mixProbabilities), 1, tolerance = 1e-8)
+  # the reported theta is that same natural-scale proportion, not mexpit() of it
+  expect_equal(unname(fit$theta[["p1"]]), unname(p1), tolerance = 1e-8)
+
+  # ... and it is the proportion the data identifies (focei and imp both find
+  # it on this dataset); saem reported expit(expit(p)) instead.
+  expect_equal(unname(fit$env$mixProbabilities), c(pTrue, 1 - pTrue),
+               tolerance = 0.05)
+  expect_null(dim(fit$env$mixProbabilities))
+
+  # mechanism: the proportion is the fraction of a per-subject classification,
+  # so it is only right when that classification is.  Judging each component at
+  # a subject's phiM draw -- whose fixed-effect-only columns carry a search
+  # variance of 1, not a real BSV -- misclassified a fifth of these subjects
+  # even though the components are 8-fold apart.
+  expect_equal(as.integer(fit$env$mixNum$mixnum), as.integer(grp))
+})


### PR DESCRIPTION
Fixes #1058.

## What was wrong

On the issue's 60-subject, two-component dataset (CL 1 vs 8, additive sd 0.05, realized fraction in component 1 = 0.40), `saem` returned `p1 = 0.6398` regardless of the starting value or the iteration budget, while its own posterior responsibilities averaged 0.3000 -- a mixture score `sum_i (r_i - p)` of -20.4 where the EM/ML fixed point requires 0. `focei` (0.4005) and `imp` (0.4000) both recover the truth on the same data.

Three separate defects, each independently verified:

**1. The reported proportion was `expit()` of the estimate.** The
`preFinalParTable` hook `.aaaPostEstimationMixBacktransform()` is shared by every estimation method and mlogit back-transforms the mixture thetas -- correct for `focei`/`imp`/`npb`, which estimate on the mlogit scale, but `saem` estimates on the natural `[0, 1]` simplex. The reported value was `expit(p)`, and `expit(expit(p))` once the hook ran twice: `expit(expit(0.3)) = 0.639788`, exactly the number in the issue. `saem` now flags the scale (`env$mixProbNatural`) and the hook leaves those thetas alone.

**2. Membership was classified at the wrong parameter values.** `mixProbMethod="regress"` (the default) hard-classifies each subject by which component fits it better, evaluated at that subject's `phiM` draw. `phiM`'s phi0 (fixed-effect-only) columns carry a *search* variance of 1, not a real BSV, so a draw sits e-fold off the population value -- and `tcl1`/`tcl2` are perturbed independently, which tilts the very comparison being made. Measured: 12 of 60 subjects misclassified even though the components are 8-fold apart and everything is fixed at truth. Each hypothesis is now judged at the population phi0 value; the phi1 (eta) columns stay at their draws, which are genuine subject-level values.

**3. A shared eta was marked as owned by one component.** `rxUiGet.saemOmegaShareSubpop()` marked an eta as belonging to a component; for an eta referenced by *every* component it kept whichever component mentioned it last. That sends a shared-eta mixture (the common shape) down the split-ETA code paths, which weight that eta's theta/omega update by a single component's responsibilities. Ownership is now decided across all `mix()` calls, and an eta used anywhere outside a component -- where it applies to every component -- is shared too.

Finally, every `mixProbMethod` now reports the proportion at the score-zero point: one exact M-step at the final responsibilities, so `sum_i (r_i - p) == 0` holds. The annealed step size and the Dirichlet-style regularization stabilize the *trajectory*; leaving their shrinkage in the reported value is what made `"regularized"`/`"annealed"` disagree with their own per-subject probabilities.

`env$mixProbabilities` also comes back as a plain vector now, as the `focei` side already did, rather than an n x 1 matrix.

## Result on the issue's repro

| | before | after |
|---|---|---|
| `p1` | 0.6398 | **0.4000** |
| `mean(r)` | 0.3000 | 0.4000 |
| score `sum_i (r_i - p)` | -20.39 | -1.3e-15 |
| classification accuracy | 0.80 | **1.000** |
| truth (realized fraction) | 0.400 | 0.400 |

Identical from starts of 0.20 / 0.40 / 0.45 at both 100/100 and 400/400 iterations. `"regularized"` and `"annealed"` now also satisfy the identity exactly (their proportions remain higher on this shared-eta model -- the mixture-vs-BSV degeneracy in the soft-EM E-step is a separate problem, not touched here).

Once this is in, the `p == mean_i r_i` gate that #1054 added for the `saem` mixture SE block should start passing on its own.

## Tests

- `test-saem-mix-regress.R`: the score-zero identity (data-free -- this is what catches the double back-transform), the reported theta being the same natural-scale proportion, recovery of the realized fraction, an exact per-subject classification assertion (the mechanism behind the number), and the same identity again under `covMethod="sa"` so the SA covariance phase's restore path is covered.
- `test-mix.R`: unit tests for `rxUiGet.saemOmegaShareSubpop()` across the shared, split-ETA, two-`mix()`-call, and used-outside-the-mix shapes.

Run locally, all green: `saem-mix-regress` (13), `saem-mix` (46), `mix` (53), `npag-mixture` (20), `saem-aic` (21), `saem-mu` (4), `saem-drop` (11), `saem-cov-sa` (88) -- 256 assertions, 0 failures.

## Review

Four completed Antigravity (Gemini) review rounds. Two findings were real and are fixed in commits 2 and 4 (mixture-eta sharing judged per-`mix()`-call rather than across all of them; an eta used outside a component still counted as owned). Two were checked and rejected: `env$fullTheta` keeping the natural scale is correct and pre-existing -- `rxUiGet.thetaIniMix()` mlogit-transforms an `iniDf` proportion at fit setup, and a re-fit from the `finalUi` was measured to return the same 0.4; and the reported proportion no longer matching the parameter the covariance was evaluated at does not apply, since `saem` excludes mixture proportions from the covariance entirely (`R/saem.R:753`, `:817`, `:953`). The final round found no issues.

`habit-hooks --branch main` findings all pre-date this branch (every touched file was already over the size threshold on `main`; `mixNaiveClassify` was already 86 lines; the `src/saem.cpp` `parse-error` is the documented missing-`-I` tooling gap).