### PR TITLE
fix(focei): decline the analytic outer gradient for a likelihood contributor (#1051)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@
 
 ## Bug fixes
 
+- `foceiControl(fast=TRUE)` no longer converges to a non-stationary point when
+  an external likelihood contribution is registered (`nlmixrRegisterLikContrib`,
+  e.g. from `nlmixr2nn`).  The analytic outer gradient re-derives
+  d(objective)/d(theta) from the model sensitivities alone, so a contributor
+  that adds a theta-dependent log-likelihood term left the objective right and
+  the gradient wrong.  It now declines to the finite-difference gradient for a
+  contributor that writes back `llik` or `d(LL)/d(eta)`; a pure observer changes
+  nothing and stays on the fast path (#1051).
+
 - A focei fit reports standard errors that match its own covariance again.
   `.foceiInstallFdFullCov()` replaces `$cov` with the full theta+omega matrix
   after the C++ step has already derived `popDf$SE` from the native theta-only

--- a/inst/include/nlmixr2estLikContrib.h
+++ b/inst/include/nlmixr2estLikContrib.h
@@ -13,6 +13,15 @@
 // solve outputs and cotangents are READ-ONLY; the contributor MAY add an extra
 // log-likelihood term and extra d(LL)/d(eta) (both optional -- leave untouched
 // to only observe, e.g. to record d(LL)/d(f) for an adjoint sweep).
+//
+// Writing back costs the analytic outer gradient (#1051).  foceiControl(fast=TRUE)
+// re-derives d(objective)/d(theta) from the MODEL sensitivities alone, so it cannot
+// see a contributed term's own theta dependence; nlmixr2est detects a bundle that
+// writes llik or dLL_deta and falls back to the finite-difference gradient for the
+// rest of the session (correct, slower).  A bundle that only OBSERVES keeps the
+// fast path, where it is already exact.  Carrying the term instead would need
+// d(C)/d(f) and d(C)/d(r) back from the contributor, which this ABI does not
+// return.
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/init.c
+++ b/src/init.c
@@ -219,6 +219,7 @@ SEXP _nlmixr2est_registerTestContrib(void);
 SEXP _nlmixr2est_removeTestContrib(void);
 SEXP _nlmixr2est_getTestContrib(void);
 SEXP _nlmixr2est_setTestContribAddLL(SEXP);
+SEXP _nlmixr2est_setTestContribAddLLf(SEXP);
 SEXP _nlmixr2est_setNnOuterFn(SEXP);
 SEXP _nlmixr2est_likContribPtrs(void);
 SEXP _nlmixr2est_foceiPtrs(void);
@@ -236,6 +237,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_removeTestContrib", (DL_FUNC) &_nlmixr2est_removeTestContrib, 0},
   {"_nlmixr2est_getTestContrib", (DL_FUNC) &_nlmixr2est_getTestContrib, 0},
   {"_nlmixr2est_setTestContribAddLL", (DL_FUNC) &_nlmixr2est_setTestContribAddLL, 1},
+  {"_nlmixr2est_setTestContribAddLLf", (DL_FUNC) &_nlmixr2est_setTestContribAddLLf, 1},
   {"_nlmixr2est_setNnOuterFn", (DL_FUNC) &_nlmixr2est_setNnOuterFn, 1},
   {"_nlmixr2est_impPropKernel_", (DL_FUNC) &_nlmixr2est_impPropKernel_, 7},
   {"_nlmixr2est_impQrPoints_", (DL_FUNC) &_nlmixr2est_impQrPoints_, 5},

--- a/src/init.c
+++ b/src/init.c
@@ -220,6 +220,7 @@ SEXP _nlmixr2est_removeTestContrib(void);
 SEXP _nlmixr2est_getTestContrib(void);
 SEXP _nlmixr2est_setTestContribAddLL(SEXP);
 SEXP _nlmixr2est_setTestContribAddLLf(SEXP);
+SEXP _nlmixr2est_setTestContribAddDEta(SEXP);
 SEXP _nlmixr2est_setNnOuterFn(SEXP);
 SEXP _nlmixr2est_likContribPtrs(void);
 SEXP _nlmixr2est_foceiPtrs(void);
@@ -238,6 +239,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"_nlmixr2est_getTestContrib", (DL_FUNC) &_nlmixr2est_getTestContrib, 0},
   {"_nlmixr2est_setTestContribAddLL", (DL_FUNC) &_nlmixr2est_setTestContribAddLL, 1},
   {"_nlmixr2est_setTestContribAddLLf", (DL_FUNC) &_nlmixr2est_setTestContribAddLLf, 1},
+  {"_nlmixr2est_setTestContribAddDEta", (DL_FUNC) &_nlmixr2est_setTestContribAddDEta, 1},
   {"_nlmixr2est_setNnOuterFn", (DL_FUNC) &_nlmixr2est_setNnOuterFn, 1},
   {"_nlmixr2est_impPropKernel_", (DL_FUNC) &_nlmixr2est_impPropKernel_, 7},
   {"_nlmixr2est_impQrPoints_", (DL_FUNC) &_nlmixr2est_impQrPoints_, 5},

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -62,16 +62,26 @@ static const nlmixrLikContrib* _nlmixrContrib[NLMIXR_MAX_CONTRIB] = {NULL};
 static int _nlmixrNContrib = 0;
 static nlmixrEmLik_fn _nlmixrEmLik[NLMIXR_MAX_CONTRIB] = {NULL};
 static int _nlmixrNEmLik = 0;
+// What the registered bundles were observed to DO (#1051); see likContribUtil.h.
+std::atomic<int> _nlmixrContribSeen{0};
+std::atomic<int> _nlmixrContribChanged{0};
+static inline void nlmixrContribResetObserved(void) {
+  _nlmixrContribSeen.store(0, std::memory_order_relaxed);
+  _nlmixrContribChanged.store(0, std::memory_order_relaxed);
+}
 
 extern "C" void nlmixrRegisterLikContrib(const nlmixrLikContrib *c) {
   if (c == NULL || c->obs == NULL) return;
   for (int i = 0; i < _nlmixrNContrib; ++i) if (_nlmixrContrib[i] == c) return;
   if (_nlmixrNContrib < NLMIXR_MAX_CONTRIB) _nlmixrContrib[_nlmixrNContrib++] = c;
+  nlmixrContribResetObserved();
 }
 extern "C" void nlmixrRemoveLikContrib(const nlmixrLikContrib *c) {
   for (int i = 0; i < _nlmixrNContrib; ++i) if (_nlmixrContrib[i] == c) {
     for (int k = i; k < _nlmixrNContrib - 1; ++k) _nlmixrContrib[k] = _nlmixrContrib[k + 1];
-    _nlmixrContrib[--_nlmixrNContrib] = NULL; return;
+    _nlmixrContrib[--_nlmixrNContrib] = NULL;
+    nlmixrContribResetObserved();
+    return;
   }
 }
 extern "C" void nlmixrRegisterEmLik(nlmixrEmLik_fn fn) {
@@ -86,6 +96,18 @@ extern "C" void nlmixrRemoveEmLik(nlmixrEmLik_fn fn) {
   }
 }
 extern "C" int nlmixrHasLikContrib(void) { return _nlmixrNContrib; }
+
+// #1051: may the analytic outer gradient run?  It re-derives d(objective)/d(theta)
+// from model sensitivities only, so it is exact for a pure OBSERVER (records the
+// cotangents, writes nothing back -- e.g. nlmixr2nn's weight-gradient capture) and
+// wrong for a contributor that adds an llik term or a d(LL)/d(eta) term.  A
+// registered bundle whose obs hook has not run yet is treated as contributing:
+// declining costs speed, running it costs correctness.
+static inline bool nlmixrContribBreaksAnalyticGrad(void) {
+  if (_nlmixrNContrib == 0) return false;
+  if (_nlmixrContribSeen.load(std::memory_order_relaxed) == 0) return true;
+  return _nlmixrContribChanged.load(std::memory_order_relaxed) != 0;
+}
 
 // Cross-TU dispatch: drive the (static, inner.cpp-private) registry from another
 // translation unit (nlm.cpp's population objective).  Same series semantics as
@@ -125,7 +147,7 @@ extern "C" SEXP _nlmixr2est_likContribPtrs(void) {
 // test-only contributor (tests/testthat/test-lik-contrib.R): records per-obs
 // values to confirm the hook fires with correct f/dv/r and dLL/df.  Uses global
 // accumulators, so the test runs single-threaded.
-static double _testSumDLLdf, _testSumErr, _testSumF, _testAddLL;
+static double _testSumDLLdf, _testSumErr, _testSumF, _testAddLL, _testAddLLf;
 static int _testNObs, _testNBegin, _testNEnd;
 static void _testBegin(const nlmixrLikSubj *s) { (void)s; _testNBegin++; }
 static void _testEnd(const nlmixrLikSubj *s) { (void)s; _testNEnd++; }
@@ -135,14 +157,28 @@ static void _testObs(nlmixrLikObs *o) {
   _testSumErr += (o->f - o->dv);
   _testSumF += o->f;
   if (_testAddLL != 0.0) *o->llik += _testAddLL;   // constant LL shift per obs
+  // THETA-dependent contribution (#1051): c*f reaches theta through the prediction
+  // and supplies its own exact d(LL)/d(eta), so the inner mode stays exact and any
+  // outer difference is attributable to the outer gradient alone.  A constant shift
+  // (_testAddLL above) cannot move an optimum, so it cannot exercise that path.
+  if (_testAddLLf != 0.0) {
+    *o->llik += _testAddLLf * o->f;
+    if (o->df_deta != NULL) {
+      for (int q = 0; q < o->neta; ++q) o->dLL_deta[q] += _testAddLLf * o->df_deta[q];
+    }
+  }
 }
 extern "C" SEXP _nlmixr2est_setTestContribAddLL(SEXP v) {
   _testAddLL = Rf_asReal(v);
   return R_NilValue;
 }
+extern "C" SEXP _nlmixr2est_setTestContribAddLLf(SEXP v) {
+  _testAddLLf = Rf_asReal(v);
+  return R_NilValue;
+}
 static const nlmixrLikContrib _testContribBundle = { _testBegin, _testObs, _testEnd };
 extern "C" SEXP _nlmixr2est_registerTestContrib(void) {
-  _testSumDLLdf = _testSumErr = _testSumF = _testAddLL = 0.0;
+  _testSumDLLdf = _testSumErr = _testSumF = _testAddLL = _testAddLLf = 0.0;
   _testNObs = _testNBegin = _testNEnd = 0;
   nlmixrRegisterLikContrib(&_testContribBundle);
   return R_NilValue;
@@ -693,6 +729,7 @@ struct focei_options {
   int firstDirectGradSet = 0;
   int nFDGradFast = 0;      // # FD fallbacks while fast was requested
   int warnedAnalyticFallback = 0; // one-time FD-fallback warning latch
+  int warnedContribFallback = 0;  // one-time #1051 contributor FD-fallback latch
   double cholSEtol;
   double hessEps;
   // The FIT's ODE tolerances, captured the first time the analytic gradient runs.
@@ -7042,12 +7079,28 @@ bool foceiGradPooledSetupLoad_(List st) {
 // Defined after the augmented-solve machinery it needs (VaeOuterE, outerSolveFill,
 // OdeFitTolGuard, foceiOuterFdInd_); declared here so analyticOuterGrad can prefer it.
 static bool analyticOuterGradDirect(double *theta, double *g);
+// Records the refusal site (and prints it under NLMIXR2EST_GRAD_DECLINE); defined
+// with the rest of the kernel below.
+static inline bool declineHere(int site);
 
 static bool analyticOuterGrad(double *theta, double *g) {
   if (!op_foceiUseAnalyticGrad || !op_foceiFitEnvSet) return false;
   op_focei.calcGrad = 1;
   // Ensure the inner solutions (eta*) and omega are current at this theta.
   foceiOfv0(theta);
+  // #1051: an external likelihood contribution that changes the objective is
+  // invisible to the kernel below -- the objective is right, the theta direction
+  // is not, so the fit converges to a non-stationary point and reports success.
+  // Checked AFTER foceiOfv0() so the registry has actually been cycled at least
+  // once and a pure observer is correctly recognized as harmless.
+  if (nlmixrContribBreaksAnalyticGrad()) {
+    declineHere(119);
+    if (!op_focei.warnedContribFallback) {
+      op_focei.warnedContribFallback = 1;
+      Rf_warning("analytic gradient off: external likelihood contribution");
+    }
+    return false;
+  }
   // The all-C++ path.  Preferred because it touches R not at all: the R route below has
   // to build etaObf/omega/.gradTheta as R objects, call into R, have R re-derive the
   // setup and .Call back down, then read etaP back out of the fit env -- every gradient
@@ -9668,6 +9721,10 @@ Environment foceiOuter(Environment e){
   op_focei.firstDirectGradSet=0;
   op_focei.nFDGradFast=0;
   op_focei.warnedAnalyticFallback=0;
+  op_focei.warnedContribFallback=0;
+  // Re-observe what the registered contributors do on THIS fit (#1051): a bundle
+  // can be swapped between fits, and the flags are process globals.
+  nlmixrContribResetObserved();
   if (op_focei.maxOuterIterations > 0){
     for (unsigned int k = op_focei.npars; k--;){
       if (R_FINITE(op_focei.lower[k])){
@@ -17836,6 +17893,10 @@ RObject foceiGradPooledDirect_(NumericVector thVals, NumericMatrix ebes,
                                int cores) {
   const FoceiGradPooledSetup &G = _gradPooled;
   if (!G.ok) return R_NilValue;
+  // Same #1051 refusal as analyticOuterGrad(): the kernel cannot carry an external
+  // likelihood contribution's theta dependence.  The R caller (vaeGrad) treats NULL
+  // as "declined" and falls back, so this costs speed and not the fit.
+  if (nlmixrContribBreaksAnalyticGrad()) return R_NilValue;
   const int neta = G.neta, nom = G.nom;
   const int np = G.nth + G.nsg + nom;
   if (ebes.ncol() != neta) return R_NilValue;

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -7110,6 +7110,15 @@ static bool analyticOuterGradDirect(double *theta, double *g);
 // with the rest of the kernel below.
 static inline bool declineHere(int site);
 
+// #1051 refusal: record the site, and say why once per fit.
+static inline bool contribDeclineAnalyticGrad(void) {
+  if (!op_focei.warnedContribFallback) {
+    op_focei.warnedContribFallback = 1;
+    Rf_warning("analytic gradient off: external likelihood contribution");
+  }
+  return declineHere(119);
+}
+
 static bool analyticOuterGrad(double *theta, double *g) {
   if (!op_foceiUseAnalyticGrad || !op_foceiFitEnvSet) return false;
   op_focei.calcGrad = 1;
@@ -7120,14 +7129,7 @@ static bool analyticOuterGrad(double *theta, double *g) {
   // is not, so the fit converges to a non-stationary point and reports success.
   // Checked AFTER foceiOfv0() so the registry has actually been cycled at least
   // once and a pure observer is correctly recognized as harmless.
-  if (nlmixrContribBreaksAnalyticGrad()) {
-    declineHere(119);
-    if (!op_focei.warnedContribFallback) {
-      op_focei.warnedContribFallback = 1;
-      Rf_warning("analytic gradient off: external likelihood contribution");
-    }
-    return false;
-  }
+  if (nlmixrContribBreaksAnalyticGrad()) return contribDeclineAnalyticGrad();
   // The all-C++ path.  Preferred because it touches R not at all: the R route below has
   // to build etaObf/omega/.gradTheta as R objects, call into R, have R re-derive the
   // setup and .Call back down, then read etaP back out of the fit env -- every gradient

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -66,6 +66,11 @@ static int _nlmixrNEmLik = 0;
 // What the registered bundles were observed to DO (#1051); see likContribUtil.h.
 std::atomic<int> _nlmixrContribSeen{0};
 std::atomic<int> _nlmixrContribChanged{0};
+// Deliberately NOT reset per fit: a bundle whose contribution happens to be
+// exactly 0.0 for the first few outer iterations (an NN whose output weights
+// start at zero) would otherwise be re-classified as an observer at the start of
+// every fit.  Only a change to the registry -- a different bundle -- invalidates
+// what was observed, and the stale direction is slower, never wrong.
 static inline void nlmixrContribResetObserved(void) {
   _nlmixrContribSeen.store(0, std::memory_order_relaxed);
   _nlmixrContribChanged.store(0, std::memory_order_relaxed);
@@ -164,17 +169,21 @@ static void _testObs(nlmixrLikObs *o) {
   // (_testAddLL above) cannot move an optimum, so it cannot exercise that path.
   if (_testAddLLf != 0.0) {
     *o->llik += _testAddLLf * o->f;
-    if (o->df_deta != NULL) {
+    if (o->df_deta != NULL && o->dLL_deta != NULL) {
       for (int q = 0; q < o->neta; ++q) o->dLL_deta[q] += _testAddLLf * o->df_deta[q];
     }
   }
 }
+// Both setters change what the bundle DOES, so what was observed of it no longer
+// applies (#1051) -- the same invalidation a registry change gets.
 extern "C" SEXP _nlmixr2est_setTestContribAddLL(SEXP v) {
   _testAddLL = Rf_asReal(v);
+  nlmixrContribResetObserved();
   return R_NilValue;
 }
 extern "C" SEXP _nlmixr2est_setTestContribAddLLf(SEXP v) {
   _testAddLLf = Rf_asReal(v);
+  nlmixrContribResetObserved();
   return R_NilValue;
 }
 static const nlmixrLikContrib _testContribBundle = { _testBegin, _testObs, _testEnd };
@@ -182,6 +191,7 @@ extern "C" SEXP _nlmixr2est_registerTestContrib(void) {
   _testSumDLLdf = _testSumErr = _testSumF = _testAddLL = _testAddLLf = 0.0;
   _testNObs = _testNBegin = _testNEnd = 0;
   nlmixrRegisterLikContrib(&_testContribBundle);
+  nlmixrContribResetObserved();   // re-register with the adds zeroed
   return R_NilValue;
 }
 extern "C" SEXP _nlmixr2est_removeTestContrib(void) {
@@ -9751,9 +9761,6 @@ Environment foceiOuter(Environment e){
   op_focei.nFDGradFast=0;
   op_focei.warnedAnalyticFallback=0;
   op_focei.warnedContribFallback=0;
-  // Re-observe what the registered contributors do on THIS fit (#1051): a bundle
-  // can be swapped between fits, and the flags are process globals.
-  nlmixrContribResetObserved();
   if (op_focei.maxOuterIterations > 0){
     for (unsigned int k = op_focei.npars; k--;){
       if (R_FINITE(op_focei.lower[k])){

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -153,7 +153,7 @@ extern "C" SEXP _nlmixr2est_likContribPtrs(void) {
 // test-only contributor (tests/testthat/test-lik-contrib.R): records per-obs
 // values to confirm the hook fires with correct f/dv/r and dLL/df.  Uses global
 // accumulators, so the test runs single-threaded.
-static double _testSumDLLdf, _testSumErr, _testSumF, _testAddLL, _testAddLLf;
+static double _testSumDLLdf, _testSumErr, _testSumF, _testAddLL, _testAddLLf, _testAddDEta;
 static int _testNObs, _testNBegin, _testNEnd;
 static void _testBegin(const nlmixrLikSubj *s) { (void)s; _testNBegin++; }
 static void _testEnd(const nlmixrLikSubj *s) { (void)s; _testNEnd++; }
@@ -173,6 +173,12 @@ static void _testObs(nlmixrLikObs *o) {
       for (int q = 0; q < o->neta; ++q) o->dLL_deta[q] += _testAddLLf * o->df_deta[q];
     }
   }
+  // d(LL)/d(eta) with NO llik term: exercises the other half of the #1051
+  // detector (llAdd == 0.0, dLL_deta != 0), which moves eta* off the base
+  // problem's stationary point and so breaks the analytic gradient just the same.
+  if (_testAddDEta != 0.0 && o->df_deta != NULL && o->dLL_deta != NULL) {
+    for (int q = 0; q < o->neta; ++q) o->dLL_deta[q] += _testAddDEta * o->df_deta[q];
+  }
 }
 // Both setters change what the bundle DOES, so what was observed of it no longer
 // applies (#1051) -- the same invalidation a registry change gets.
@@ -186,9 +192,14 @@ extern "C" SEXP _nlmixr2est_setTestContribAddLLf(SEXP v) {
   nlmixrContribResetObserved();
   return R_NilValue;
 }
+extern "C" SEXP _nlmixr2est_setTestContribAddDEta(SEXP v) {
+  _testAddDEta = Rf_asReal(v);
+  nlmixrContribResetObserved();
+  return R_NilValue;
+}
 static const nlmixrLikContrib _testContribBundle = { _testBegin, _testObs, _testEnd };
 extern "C" SEXP _nlmixr2est_registerTestContrib(void) {
-  _testSumDLLdf = _testSumErr = _testSumF = _testAddLL = _testAddLLf = 0.0;
+  _testSumDLLdf = _testSumErr = _testSumF = _testAddLL = _testAddLLf = _testAddDEta = 0.0;
   _testNObs = _testNBegin = _testNEnd = 0;
   nlmixrRegisterLikContrib(&_testContribBundle);
   nlmixrContribResetObserved();   // re-register with the adds zeroed

--- a/src/likContribUtil.h
+++ b/src/likContribUtil.h
@@ -4,8 +4,20 @@
 // that cycles the external likelihood-contribution registry: likInner0 and
 // vaeDecoderPxzCore in inner.cpp, and the population objective in nlm.cpp.
 #include <float.h>
+#include <atomic>
 #include "censEst.h"
 #include "../inst/include/nlmixr2estLikContrib.h"
+
+// #1051: the analytic outer gradient (foceiControl(fast=TRUE)) re-derives
+// d(objective)/d(theta) from MODEL sensitivities alone, so a contributor that
+// CHANGES the objective -- writes llik, or d(LL)/d(eta), which moves eta* off
+// the base problem's stationary point -- makes it wrong.  A pure observer
+// writes neither and stays exact.  Which one a bundle is cannot be asked of it,
+// so it is observed here, the single place every objective cycles the registry,
+// and read by analyticOuterGrad().  Defined in inner.cpp; reset per fit by
+// foceiOuter() and whenever the registry changes.
+extern std::atomic<int> _nlmixrContribSeen;     // the obs hook has run at least once
+extern std::atomic<int> _nlmixrContribChanged;  // ... and something wrote back
 
 // Exact Gaussian cotangents d(LL)/d(f) and d(LL)/d(r), honoring censoring the
 // same way the base objective does: dCensNormal1 chains the uncensored score
@@ -41,6 +53,18 @@ static inline double nlmixrLikContribObs1(int id, int k, int neta,
   o.f = f; o.dv = dv; o.r = r; o.dLL_df = dLLdf; o.dLL_dr = dLLdr;
   o.df_deta = dfdEta; o.llik = &llAdd; o.dLL_deta = dLLdEta;
   nlmixrLikContribObs(&o);
+  // Relaxed set-once-to-1 from any thread (#1051); never cleared here.
+  _nlmixrContribSeen.store(1, std::memory_order_relaxed);
+  if (llAdd != 0.0) {
+    _nlmixrContribChanged.store(1, std::memory_order_relaxed);
+  } else {
+    for (int q = 0; q < neta; ++q) {
+      if (dLLdEta[q] != 0.0) {
+        _nlmixrContribChanged.store(1, std::memory_order_relaxed);
+        break;
+      }
+    }
+  }
   return llAdd;
 }
 

--- a/tests/testthat/test-lik-contrib-fast-grad.R
+++ b/tests/testthat/test-lik-contrib-fast-grad.R
@@ -1,0 +1,69 @@
+## #1051: foceiControl(fast=TRUE)'s analytic outer gradient re-derives
+## d(objective)/d(theta) from MODEL sensitivities only, so it cannot carry an
+## external likelihood contribution's own theta dependence.  It must decline to
+## finite differences for a contributor that CHANGES the objective, and stay on
+## the fast path for a pure observer (which changes nothing and is exact).
+##
+## The stock test contributor's constant per-observation shift cannot move an
+## optimum, so it cannot show this; `_nlmixr2est_setTestContribAddLLf` adds c*f,
+## which reaches theta through the prediction and supplies its own exact
+## d(LL)/d(eta) -- so the inner mode stays exact and any outer difference is
+## attributable to the outer gradient alone.
+
+test_that("fast=TRUE declines the analytic gradient for a theta-dependent contributor", {
+  skip_on_cran()
+
+  .old <- rxode2::getRxThreads()
+  on.exit(rxode2::setRxThreads(.old), add = TRUE)
+  rxode2::setRxThreads(1L)   # test contributor uses global accumulators
+
+  d <- data.frame(ID = rep(1:3, each = 3),
+                  TIME = rep(c(0.5, 1, 2), 3),
+                  DV = c(1.4, 1.5, 1.3, 1.7, 1.2, 1.6, 1.1, 1.9, 1.5),
+                  EVID = 0L)
+
+  mod <- function() {
+    ini({
+      level <- 0.3
+      etaLevel ~ 0.1
+      error <- fix(0.2)
+    })
+    model({
+      prediction <- exp(level + etaLevel)
+      prediction ~ prop(error)
+    })
+  }
+
+  .run <- function(fast, cc) {
+    .Call("_nlmixr2est_registerTestContrib", PACKAGE = "nlmixr2est")
+    on.exit(.Call("_nlmixr2est_removeTestContrib", PACKAGE = "nlmixr2est"), add = TRUE)
+    .Call("_nlmixr2est_setTestContribAddLLf", cc, PACKAGE = "nlmixr2est")
+    suppressWarnings(.nlmixr(mod, d, est = "focei",
+                             control = foceiControl(print = 0L, fast = fast,
+                                                    calcTables = FALSE)))
+  }
+
+  ## observer only (c = 0): the contributor writes nothing back, so the analytic
+  ## gradient is exact and must still be used
+  .obsT <- .run(TRUE, 0)
+  .obsF <- .run(FALSE, 0)
+  expect_gt(as.integer(.obsT$env$nAnalyticGradDirect), 0L)
+  expect_equal(as.integer(.obsT$env$nFDGradFast), 0L)
+  expect_equal(unname(fixef(.obsT)["level"]), unname(fixef(.obsF)["level"]),
+               tolerance = 1e-3)
+
+  ## theta-dependent contribution: the analytic gradient must decline
+  .cT <- .run(TRUE, -0.5)
+  .cF <- .run(FALSE, -0.5)
+  expect_equal(as.integer(.cT$env$nAnalyticGradDirect), 0L)
+  expect_gt(as.integer(.cT$env$nFDGradFast), 0L)
+
+  ## ...and having declined, fast= now selects the gradient and nothing else:
+  ## before the fix the two arms differed by 5.5e-02 in `level` and 0.88 in objf
+  expect_equal(unname(fixef(.cT)["level"]), unname(fixef(.cF)["level"]),
+               tolerance = 1e-4)
+  expect_equal(.cT$objf, .cF$objf, tolerance = 1e-5)
+
+  ## the contribution really did move the optimum (so the comparison is not vacuous)
+  expect_gt(abs(unname(fixef(.cF)["level"]) - unname(fixef(.obsF)["level"])), 1e-3)
+})

--- a/tests/testthat/test-lik-contrib-fast-grad.R
+++ b/tests/testthat/test-lik-contrib-fast-grad.R
@@ -34,10 +34,11 @@ test_that("fast=TRUE declines the analytic gradient for a theta-dependent contri
     })
   }
 
-  .run <- function(fast, cc) {
+  .run <- function(fast, cc, dEta = 0) {
     .Call("_nlmixr2est_registerTestContrib", PACKAGE = "nlmixr2est")
     on.exit(.Call("_nlmixr2est_removeTestContrib", PACKAGE = "nlmixr2est"), add = TRUE)
     .Call("_nlmixr2est_setTestContribAddLLf", cc, PACKAGE = "nlmixr2est")
+    .Call("_nlmixr2est_setTestContribAddDEta", dEta, PACKAGE = "nlmixr2est")
     suppressWarnings(.nlmixr(mod, d, est = "focei",
                              control = foceiControl(print = 0L, fast = fast,
                                                     calcTables = FALSE)))
@@ -66,4 +67,16 @@ test_that("fast=TRUE declines the analytic gradient for a theta-dependent contri
 
   ## the contribution really did move the optimum (so the comparison is not vacuous)
   expect_gt(abs(unname(fixef(.cF)["level"]) - unname(fixef(.obsF)["level"])), 1e-3)
+
+  ## the OTHER half of the detector: d(LL)/d(eta) with no llik term.  llAdd stays
+  ## exactly 0.0, so this is caught only by the dLL_deta scan -- and it still
+  ## breaks the analytic gradient, which assumes eta* is stationary for the base
+  ## problem.  Only the decline is asserted: a gradient with no matching objective
+  ## leaves the inner problem ill-posed (the reported inner objective is not the
+  ## one the inner score belongs to), so eta* depends on which inner optimizer ran
+  ## -- and `fast=` selects that too, via innerOpt="auto".  Comparing the two arms'
+  ## estimates would be measuring the inner optimizer, not the gradient.
+  .eT <- .run(TRUE, 0, dEta = 0.25)
+  expect_equal(as.integer(.eT$env$nAnalyticGradDirect), 0L)
+  expect_gt(as.integer(.eT$env$nFDGradFast), 0L)
 })


### PR DESCRIPTION
Fixes #1051.

## The bug

`foceiControl(fast=TRUE)`'s analytic outer gradient re-derives
`d(objective)/d(theta)` from the MODEL sensitivities alone. With an external
likelihood contribution registered (`nlmixrRegisterLikContrib`, e.g. from
nlmixr2nn), the contributed term's own theta dependence is invisible to it: the
objective stayed right and the gradient did not, so the optimizer converged to a
point that is not a stationary point of the objective it reports -- and reported
it as converged.

## The fix

A bundle cannot be asked what it does, so it is observed at
`nlmixrLikContribObs1()` (`src/likContribUtil.h`) -- the single place every
objective cycles the registry. Writing back `llik` or `d(LL)/d(eta)` sets a flag;
`analyticOuterGrad()` then declines to the finite-difference gradient (decline
site 119) with a one-time per-fit warning. `foceiGradPooledDirect_()` (the
`est="vae"` entry) is gated the same way, and its R caller already treats NULL as
"declined".

A pure OBSERVER -- nlmixr2nn's weight-gradient capture -- writes neither and
stays on the fast path, where it is already exact. A registered bundle whose obs
hook has not run yet counts as contributing: declining costs speed, running it
costs correctness.

The observation is sticky for as long as the same bundles are registered, and
deliberately NOT reset per fit. Resetting per fit re-classifies a bundle as an
observer at the start of every fit, so a contribution that is exactly 0.0 for the
first outer iterations (an NN whose output weights start at zero) would take the
analytic gradient again each time. Only a registry change invalidates it; a stale
observation is slower, never wrong.

This is direction 1 from the issue. Direction 2 (carry the term) would need
`dC/df` and `dC/dr` back from the contributor, which the ABI does not return, and
leaves the second-order `d(eta*)/d(theta)` question the issue itself calls
unmeasured. The ABI header now documents the consequence of writing back.

## Verification

The issue's own measurement, re-run on this branch (3 subjects x 3 obs,
`prediction <- exp(level+etaLevel)`, `error` fixed, `c = -0.5`, 1 thread):

| arm | level | objf | nAnalyticGradDirect | nFDGradFast |
| --- | --- | --- | --- | --- |
| observer, `fast=TRUE` | 0.3693731 | -16.11279 | 12 | 0 |
| observer, `fast=FALSE` | 0.3693772 | -16.11279 | -- | -- |
| contributor, `fast=TRUE` | 0.3444678 | -3.255302 | **0** | **13** |
| contributor, `fast=FALSE` | 0.3444670 | -3.255302 | -- | -- |

The two contributor arms now agree to 8e-07 in `level` with identical
objectives. Before the fix they differed by 5.5e-02 and 0.88 objf units, in
opposite directions.

## Tests

New `tests/testthat/test-lik-contrib-fast-grad.R` (essential subset, not
batched), plus two new theta-dependent test-contributor modes, both registered by
hand in `src/init.c`:

- `_nlmixr2est_setTestContribAddLLf` -- adds `c*f`, reaching theta through the
  prediction while supplying its own exact `d(LL)/d(eta)`, so the inner mode
  stays exact and any outer difference is the outer gradient's. The stock
  constant shift cannot move an optimum and so could not exercise this at all.
- `_nlmixr2est_setTestContribAddDEta` -- adds only `d(LL)/d(eta)`, leaving
  `llAdd` at exactly 0.0, which is the other half of the detector.

The `dEta` case asserts only the decline, not an estimate comparison: a gradient
with no matching objective leaves the inner problem ill-posed, so its eta* tracks
whichever inner optimizer ran -- and `fast=` selects that too, via
`innerOpt="auto"`. Comparing the arms there measures the inner optimizer, not the
gradient.

## Review

An antigravity (Gemini) review ran on the branch. Three findings:

- **Rejected:** a claimed dropped-contribution bug in `vaeDecoderPxzCore` --
  a misread of the brace structure; `gEta[k] -= cDeta[k]` is inside the
  per-observation loop, so nothing is erased.
- **Accepted as designed:** stale flags carrying across fits. That is the
  stickiness above; the consequence (a bundle that stops contributing without
  re-registering stays on finite differences) is perf-only and documented.
- **Accepted and fixed:** the `dLL_deta`-only detector branch was never
  exercised, since `f > 0` in the `c*f` probe made `llAdd` always nonzero. Hence
  `_nlmixr2est_setTestContribAddDEta`.

It also independently cleared the `dLLdEta == NULL` path when `neta == 0` and the
relaxed-atomic write from inside the OpenMP region (the `parallel for` barrier in
`foceiOfv0` orders it before the main thread's read).
