### PR TITLE
fix(nmObjGet): return NULL from $cor when a fit has no covariance (#1038)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,11 @@
   the global environment, where `fit$cov` used to resolve to `stats::cov` and
   break `print()` (#1038).
 
+- `print()` on a fit shows the fixed-parameter correlation line again.  It was
+  gated on `exists("cor", fit$env)`, which is never true for a fit that has not
+  been through a save/load round trip, so a strong theta correlation was never
+  reported (#1038).
+
 - `foceiControl(fast=TRUE)` no longer converges to a non-stationary point when
   an external likelihood contribution is registered (`nlmixrRegisterLikContrib`,
   e.g. from `nlmixr2nn`).  The analytic outer gradient re-derives

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,9 +10,6 @@
   `fit$cov` resolved to `stats::cov` (which broke `print()`) and other items
   such as `$ranef` or `$mixNum` could come from the user's workspace (#1038).
 
-- `fit$seed` returns the saem seed instead of always `NULL`; the accessor
-  discarded the value it looked up.
-
 - `print()` on a fit shows the fixed-parameter correlation line again.  It was
   gated on `exists("cor", fit$env)`, which is never true for a fit that has not
   been through a save/load round trip, so a strong theta correlation was never

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,10 +5,12 @@
 - `fit$cor` returns `NULL` instead of erroring when the fit has no covariance
   (`covMethod=""`), matching `fit$cov` (#1038).
 
-- Fit accessors and `print()` look items up only in the fit environment itself.
-  A fit reloaded by `nlmixr2save` is parented on the global environment, so
-  `fit$cov` resolved to `stats::cov` (which broke `print()`) and other items
-  such as `$ranef` or `$mixNum` could come from the user's workspace (#1038).
+- Fit accessors, the control getters, `setCov()` and `print()` look items up
+  only in the fit environment itself.  A fit reloaded by `nlmixr2save` is
+  parented on the global environment, so `fit$cov` resolved to `stats::cov`
+  (which broke `print()`), `fit$ranef` to `nlme::ranef`, and `$mixNum`,
+  `$mixList` or `$parHist` to a variable of that name in the user's workspace
+  (#1038).
 
 - `print()` on a fit shows the fixed-parameter correlation line again.  It was
   gated on `exists("cor", fit$env)`, which is never true for a fit that has not

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Bug fixes
 
+- `fit$cor` returns `NULL` instead of erroring when the fit has no covariance
+  (`covMethod=""`), matching `fit$cov`.  Fit items are also looked up only in
+  the fit environment itself; a fit reloaded by `nlmixr2save` is parented on
+  the global environment, where `fit$cov` used to resolve to `stats::cov` and
+  break `print()` (#1038).
+
 - `foceiControl(fast=TRUE)` no longer converges to a non-stationary point when
   an external likelihood contribution is registered (`nlmixrRegisterLikContrib`,
   e.g. from `nlmixr2nn`).  The analytic outer gradient re-derives

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
   `fit$cov` resolved to `stats::cov` (which broke `print()`) and other items
   such as `$ranef` or `$mixNum` could come from the user's workspace (#1038).
 
+- `fit$seed` returns the saem seed instead of always `NULL`; the accessor
+  discarded the value it looked up.
+
 - `print()` on a fit shows the fixed-parameter correlation line again.  It was
   gated on `exists("cor", fit$env)`, which is never true for a fit that has not
   been through a save/load round trip, so a strong theta correlation was never

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,10 +3,12 @@
 ## Bug fixes
 
 - `fit$cor` returns `NULL` instead of erroring when the fit has no covariance
-  (`covMethod=""`), matching `fit$cov`.  Fit items are also looked up only in
-  the fit environment itself; a fit reloaded by `nlmixr2save` is parented on
-  the global environment, where `fit$cov` used to resolve to `stats::cov` and
-  break `print()` (#1038).
+  (`covMethod=""`), matching `fit$cov` (#1038).
+
+- Fit accessors and `print()` look items up only in the fit environment itself.
+  A fit reloaded by `nlmixr2save` is parented on the global environment, so
+  `fit$cov` resolved to `stats::cov` (which broke `print()`) and other items
+  such as `$ranef` or `$mixNum` could come from the user's workspace (#1038).
 
 - `print()` on a fit shows the fixed-parameter correlation line again.  It was
   gated on `exists("cor", fit$env)`, which is never true for a fit that has not

--- a/R/addCwres.R
+++ b/R/addCwres.R
@@ -7,8 +7,8 @@
 #' @noRd
 .addFoceiInfoToFit <- function(env, newFit) {
   for (.v in c("phiC", "phiH", "llikObs")) {
-    if (exists(.v, envir=newFit$env)) {
-      assign(.v, get(.v, envir=newFit$env), envir=env)
+    if (exists(.v, envir=newFit$env, inherits=FALSE)) {
+      assign(.v, get(.v, envir=newFit$env, inherits=FALSE), envir=env)
     }
   }
 }

--- a/R/agq.R
+++ b/R/agq.R
@@ -204,12 +204,12 @@ getValidNlmixrCtl.agq <- function(control) {
 #' @export
 nmObjGetControl.agq <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("agqControl", .env)) {
-    .control <- get("agqControl", .env)
+  if (exists("agqControl", .env, inherits = FALSE)) {
+    .control <- get("agqControl", .env, inherits = FALSE)
     if (inherits(.control, "agqControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "agqControl")) return(.control)
   }
   stop("cannot find agq related control object", call.=FALSE)

--- a/R/bobyqa.R
+++ b/R/bobyqa.R
@@ -240,12 +240,12 @@ nmObjHandleControlObject.bobyqaControl <- function(control, env) {
 #' @export
 nmObjGetControl.bobyqa <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("bobyqaControl", .env)) {
-    .control <- get("bobyqaControl", .env)
+  if (exists("bobyqaControl", .env, inherits = FALSE)) {
+    .control <- get("bobyqaControl", .env, inherits = FALSE)
     if (inherits(.control, "bobyqaControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "bobyqaControl")) return(.control)
   }
   stop("cannot find bobyqa related control object", call.=FALSE)

--- a/R/cov.R
+++ b/R/cov.R
@@ -59,7 +59,7 @@
 #' @noRd
 .nlmixr2CovConditionUpdate <- function(env) {
   if (!exists("cov", envir = env, inherits = FALSE)) return(invisible(FALSE))
-  .cov <- get("cov", envir = env)
+  .cov <- get("cov", envir = env, inherits = FALSE)
   if (!inherits(.cov, "matrix") || nrow(.cov) == 0L) return(invisible(FALSE))
   .cn <- .cnr <- NA_real_
   .good <- which(!is.na(diag(.cov)))
@@ -98,10 +98,10 @@
   if (rxode2::rxIs(obj, "nlmixr2FitData")) {
     .env <- obj$env
   }
-  if (exists("cov", .env)) {
+  if (exists("cov", .env, inherits = FALSE)) {
     .cur <- list(.env$cov)
     names(.cur) <- .env$covMethod
-    if (exists("covList", .env)) {
+    if (exists("covList", .env, inherits = FALSE)) {
       if (is.null(.env$covList[[.env$covMethod]])) {
         .covList <- c(.env$covList, .cur)
       } else {
@@ -394,7 +394,7 @@ setCov <- function(fit, method) {
       call. = FALSE
     )
   }
-  if (exists("covList", .env)) {
+  if (exists("covList", .env, inherits = FALSE)) {
     .covList <- .env$covList
     .cov <- .covList[[method]]
     if (!is.null(.cov)) {
@@ -449,7 +449,7 @@ getVarCov.nlmixr2FitCore <- function(obj, ...) {
   if (!is.null(.args$force)) {
     .force <- .args$force
   }
-  if (exists("cov", envir = .env) && !.force) {
+  if (exists("cov", envir = .env, inherits = FALSE) && !.force) {
     if (rxode2::rxIs(.env$cov, "matrix")) {
       return(.env$cov)
     }

--- a/R/fo.R
+++ b/R/fo.R
@@ -71,8 +71,8 @@ nmObjGetControl.fo <- function(x, ...) {
   for (.name in c("foControl", "control",
                   "foiControl", "foceControl",
                   "foceiControl", "foceiControl0")) {
-    if (exists(.name, .env)) {
-      .control <- get(.name, .env)
+    if (exists(.name, .env, inherits = FALSE)) {
+      .control <- get(.name, .env, inherits = FALSE)
       if (inherits(.control, "foControl")) return(.control)
       .ret <- try(suppressMessages(getValidNlmixrCtl.fo(list(.control))), silent=TRUE)
       if (inherits(.ret, "foControl")) return(.ret)

--- a/R/foce.R
+++ b/R/foce.R
@@ -56,12 +56,12 @@ getValidNlmixrCtl.foce <- function(control) {
 #' @export
 nmObjGetControl.foce <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("foceControl", .env)) {
-    .control <- get("foceControl", .env)
+  if (exists("foceControl", .env, inherits = FALSE)) {
+    .control <- get("foceControl", .env, inherits = FALSE)
     if (inherits(.control, "foceControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "foceControl")) return(.control)
   }
   stop("cannot find foce related control object", call.=FALSE)

--- a/R/focep.R
+++ b/R/focep.R
@@ -63,12 +63,12 @@ getValidNlmixrCtl.focep <- function(control) {
 #' @export
 nmObjGetControl.focep <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("focepControl", .env)) {
-    .control <- get("focepControl", .env)
+  if (exists("focepControl", .env, inherits = FALSE)) {
+    .control <- get("focepControl", .env, inherits = FALSE)
     if (inherits(.control, "focepControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "focepControl")) return(.control)
   }
   stop("cannot find focep related control object", call.=FALSE)

--- a/R/foi.R
+++ b/R/foi.R
@@ -71,8 +71,8 @@ nmObjGetControl.foi <- function(x, ...) {
   for (.name in c("foiControl", "control",
                   "foControl", "foceControl",
                   "foceiControl", "foceiControl0")) {
-    if (exists(.name, .env)) {
-      .control <- get(.name, .env)
+    if (exists(.name, .env, inherits = FALSE)) {
+      .control <- get(.name, .env, inherits = FALSE)
       if (inherits(.control, "foiControl")) return(.control)
       .ret <- try(suppressMessages(getValidNlmixrCtl.foi(list(.control))), silent=TRUE)
       if (inherits(.ret, "foiControl")) return(.ret)

--- a/R/ifocep.R
+++ b/R/ifocep.R
@@ -62,12 +62,12 @@ getValidNlmixrCtl.ifocep <- function(control) {
 #' @export
 nmObjGetControl.ifocep <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("ifocepControl", .env)) {
-    .control <- get("ifocepControl", .env)
+  if (exists("ifocepControl", .env, inherits = FALSE)) {
+    .control <- get("ifocepControl", .env, inherits = FALSE)
     if (inherits(.control, "ifocepControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "ifocepControl")) return(.control)
   }
   stop("cannot find ifocep related control object", call.=FALSE)

--- a/R/impmap.R
+++ b/R/impmap.R
@@ -818,12 +818,12 @@ getValidNlmixrCtl.impmap <- function(control) {
 #' @export
 nmObjGetControl.impmap <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("impmapControl", .env)) {
-    .control <- get("impmapControl", .env)
+  if (exists("impmapControl", .env, inherits = FALSE)) {
+    .control <- get("impmapControl", .env, inherits = FALSE)
     if (inherits(.control, "impmapControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "impmapControl")) return(.control)
   }
   stop("cannot find impmap related control object", call.=FALSE)

--- a/R/laplace.R
+++ b/R/laplace.R
@@ -125,12 +125,12 @@ getValidNlmixrCtl.laplace <- function(control) {
 #' @export
 nmObjGetControl.laplace <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("laplaceControl", .env)) {
-    .control <- get("laplaceControl", .env)
+  if (exists("laplaceControl", .env, inherits = FALSE)) {
+    .control <- get("laplaceControl", .env, inherits = FALSE)
     if (inherits(.control, "laplaceControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "laplaceControl")) return(.control)
   }
   stop("cannot find laplace related control object", call.=FALSE)

--- a/R/lbfgsb3c.R
+++ b/R/lbfgsb3c.R
@@ -262,12 +262,12 @@ nmObjHandleControlObject.lbfgsb3cControl <- function(control, env) {
 #' @export
 nmObjGetControl.lbfgsb3c <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("lbfgsb3cControl", .env)) {
-    .control <- get("lbfgsb3cControl", .env)
+  if (exists("lbfgsb3cControl", .env, inherits = FALSE)) {
+    .control <- get("lbfgsb3cControl", .env, inherits = FALSE)
     if (inherits(.control, "lbfgsb3cControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "lbfgsb3cControl")) return(.control)
   }
   stop("cannot find lbfgsb3c related control object", call.=FALSE)

--- a/R/mfocep.R
+++ b/R/mfocep.R
@@ -62,12 +62,12 @@ getValidNlmixrCtl.mfocep <- function(control) {
 #' @export
 nmObjGetControl.mfocep <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("mfocepControl", .env)) {
-    .control <- get("mfocepControl", .env)
+  if (exists("mfocepControl", .env, inherits = FALSE)) {
+    .control <- get("mfocepControl", .env, inherits = FALSE)
     if (inherits(.control, "mfocepControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "mfocepControl")) return(.control)
   }
   stop("cannot find mfocep related control object", call.=FALSE)

--- a/R/muRefControl.R
+++ b/R/muRefControl.R
@@ -70,12 +70,12 @@ getValidNlmixrCtl.mfocei <- function(control) {
 #' @export
 nmObjGetControl.mfocei <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("mfoceiControl", .env)) {
-    .control <- get("mfoceiControl", .env)
+  if (exists("mfoceiControl", .env, inherits = FALSE)) {
+    .control <- get("mfoceiControl", .env, inherits = FALSE)
     if (inherits(.control, "mfoceiControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "mfoceiControl")) return(.control)
   }
   stop("cannot find mfocei related control object", call.=FALSE)
@@ -152,12 +152,12 @@ getValidNlmixrCtl.ifocei <- function(control) {
 #' @export
 nmObjGetControl.ifocei <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("ifoceiControl", .env)) {
-    .control <- get("ifoceiControl", .env)
+  if (exists("ifoceiControl", .env, inherits = FALSE)) {
+    .control <- get("ifoceiControl", .env, inherits = FALSE)
     if (inherits(.control, "ifoceiControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "ifoceiControl")) return(.control)
   }
   stop("cannot find ifocei related control object", call.=FALSE)
@@ -237,12 +237,12 @@ getValidNlmixrCtl.mfoce <- function(control) {
 #' @export
 nmObjGetControl.mfoce <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("mfoceControl", .env)) {
-    .control <- get("mfoceControl", .env)
+  if (exists("mfoceControl", .env, inherits = FALSE)) {
+    .control <- get("mfoceControl", .env, inherits = FALSE)
     if (inherits(.control, "mfoceControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "mfoceControl")) return(.control)
   }
   stop("cannot find mfoce related control object", call.=FALSE)
@@ -328,12 +328,12 @@ getValidNlmixrCtl.ifoce <- function(control) {
 #' @export
 nmObjGetControl.ifoce <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("ifoceControl", .env)) {
-    .control <- get("ifoceControl", .env)
+  if (exists("ifoceControl", .env, inherits = FALSE)) {
+    .control <- get("ifoceControl", .env, inherits = FALSE)
     if (inherits(.control, "ifoceControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "ifoceControl")) return(.control)
   }
   stop("cannot find ifoce related control object", call.=FALSE)
@@ -417,12 +417,12 @@ getValidNlmixrCtl.magq <- function(control) {
 #' @export
 nmObjGetControl.magq <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("magqControl", .env)) {
-    .control <- get("magqControl", .env)
+  if (exists("magqControl", .env, inherits = FALSE)) {
+    .control <- get("magqControl", .env, inherits = FALSE)
     if (inherits(.control, "magqControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "magqControl")) return(.control)
   }
   stop("cannot find magq related control object", call.=FALSE)
@@ -506,12 +506,12 @@ getValidNlmixrCtl.iagq <- function(control) {
 #' @export
 nmObjGetControl.iagq <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("iagqControl", .env)) {
-    .control <- get("iagqControl", .env)
+  if (exists("iagqControl", .env, inherits = FALSE)) {
+    .control <- get("iagqControl", .env, inherits = FALSE)
     if (inherits(.control, "iagqControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "iagqControl")) return(.control)
   }
   stop("cannot find iagq related control object", call.=FALSE)
@@ -592,12 +592,12 @@ getValidNlmixrCtl.mlaplace <- function(control) {
 #' @export
 nmObjGetControl.mlaplace <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("mlaplaceControl", .env)) {
-    .control <- get("mlaplaceControl", .env)
+  if (exists("mlaplaceControl", .env, inherits = FALSE)) {
+    .control <- get("mlaplaceControl", .env, inherits = FALSE)
     if (inherits(.control, "mlaplaceControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "mlaplaceControl")) return(.control)
   }
   stop("cannot find mlaplace related control object", call.=FALSE)
@@ -672,12 +672,12 @@ getValidNlmixrCtl.ilaplace <- function(control) {
 #' @export
 nmObjGetControl.ilaplace <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("ilaplaceControl", .env)) {
-    .control <- get("ilaplaceControl", .env)
+  if (exists("ilaplaceControl", .env, inherits = FALSE)) {
+    .control <- get("ilaplaceControl", .env, inherits = FALSE)
     if (inherits(.control, "ilaplaceControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "ilaplaceControl")) return(.control)
   }
   stop("cannot find ilaplace related control object", call.=FALSE)

--- a/R/n1qn1.R
+++ b/R/n1qn1.R
@@ -242,12 +242,12 @@ nmObjHandleControlObject.n1qn1Control <- function(control, env) {
 #' @export
 nmObjGetControl.n1qn1 <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("n1qn1Control", .env)) {
-    .control <- get("n1qn1Control", .env)
+  if (exists("n1qn1Control", .env, inherits = FALSE)) {
+    .control <- get("n1qn1Control", .env, inherits = FALSE)
     if (inherits(.control, "n1qn1Control")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "n1qn1Control")) return(.control)
   }
   stop("cannot find n1qn1 related control object", call.=FALSE)

--- a/R/newuoa.R
+++ b/R/newuoa.R
@@ -232,12 +232,12 @@ nmObjHandleControlObject.newuoaControl <- function(control, env) {
 #' @export
 nmObjGetControl.newuoa <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("newuoaControl", .env)) {
-    .control <- get("newuoaControl", .env)
+  if (exists("newuoaControl", .env, inherits = FALSE)) {
+    .control <- get("newuoaControl", .env, inherits = FALSE)
     if (inherits(.control, "newuoaControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "newuoaControl")) return(.control)
   }
   stop("cannot find newuoa related control object", call.=FALSE)

--- a/R/nlm.R
+++ b/R/nlm.R
@@ -337,14 +337,14 @@ nmObjHandleControlObject.nlmControl <- function(control, env) {
 #' @export
 nmObjGetControl.nlm <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("nlmControl", .env)) {
-    .control <- get("nlmControl", .env)
+  if (exists("nlmControl", .env, inherits = FALSE)) {
+    .control <- get("nlmControl", .env, inherits = FALSE)
     if (inherits(.control, "nlmControl")) {
       return(.control)
     }
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "nlmControl")) {
       return(.control)
     }

--- a/R/nlme.R
+++ b/R/nlme.R
@@ -435,12 +435,12 @@ nmObjHandleControlObject.nlmeControl <- function(control, env) {
 #' @export
 nmObjGetControl.nlme <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("nlmeControl", .env)) {
-    .control <- get("nlmeControl", .env)
+  if (exists("nlmeControl", .env, inherits = FALSE)) {
+    .control <- get("nlmeControl", .env, inherits = FALSE)
     if (inherits(.control, "nlmeControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "nlmeControl")) return(.control)
   }
   stop("cannot find nlme related control object", call.=FALSE)

--- a/R/nlminb.R
+++ b/R/nlminb.R
@@ -358,12 +358,12 @@ nmObjHandleControlObject.nlminbControl <- function(control, env) {
 #' @export
 nmObjGetControl.nlminb <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("nlminbControl", .env)) {
-    .control <- get("nlminbControl", .env)
+  if (exists("nlminbControl", .env, inherits = FALSE)) {
+    .control <- get("nlminbControl", .env, inherits = FALSE)
     if (inherits(.control, "nlminbControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "nlminbControl")) return(.control)
   }
   stop("cannot find nlminb related control object", call.=FALSE)

--- a/R/nlmixr2output.R
+++ b/R/nlmixr2output.R
@@ -530,7 +530,7 @@
   .env <- obj
   if (!is.null(obj$saem)) {
     .tmp <- obj$saem
-    .curObj <- get("objective", .env)
+    .curObj <- get("objective", .env, inherits = FALSE)
     if (is.na(.curObj)) {
       # the quadrature settings live on the fit's saemControl; the fit
       # environment itself never held them, so both lookups always missed and
@@ -642,7 +642,7 @@ VarCorr.nlmixr2FitCoreSilent <- VarCorr.nlmixr2FitCore
 .sigma <- function(x) {
   .ret <- x$nlme
   if (is.null(.ret)) {
-    if (exists("ui", envir = x$env)) {
+    if (exists("ui", envir = x$env, inherits = FALSE)) {
       .df <- as.data.frame(x$uif$ini)
       .errs <- paste(.df[which(!is.na(.df$err)), "name"])
       return(fixef(x)[.errs])

--- a/R/nls.R
+++ b/R/nls.R
@@ -289,14 +289,14 @@ nmObjHandleControlObject.nlsControl <- function(control, env) {
 #' @export
 nmObjGetControl.nls <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("nlsControl", .env)) {
-    .control <- get("nlsControl", .env)
+  if (exists("nlsControl", .env, inherits = FALSE)) {
+    .control <- get("nlsControl", .env, inherits = FALSE)
     if (inherits(.control, "nlsControl")) {
       return(.control)
     }
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "nlsControl")) {
       return(.control)
     }

--- a/R/nmObjGet.R
+++ b/R/nmObjGet.R
@@ -773,10 +773,10 @@ nmObjGet.simInfo <- function(x, ...) {
 #' @export
 nmObjGet.seed <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("saem", .env, inherits = FALSE)) {
-    attr(get("saem", .env, inherits = FALSE), "saem.cfg")$seed
+  if (!exists("saem", .env, inherits = FALSE)) {
+    return(NULL)
   }
-  NULL
+  attr(get("saem", .env, inherits = FALSE), "saem.cfg")$seed
 }
 attr(nmObjGet.seed, "rstudio") <- 123456
 
@@ -784,9 +784,10 @@ attr(nmObjGet.seed, "rstudio") <- 123456
 #' @export
 nmObjGet.saemCfg <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("saem", .env, inherits = FALSE)) {
-    return(attr(get("saem", .env, inherits = FALSE), "saem.cfg"))
+  if (!exists("saem", .env, inherits = FALSE)) {
+    return(NULL)
   }
+  attr(get("saem", .env, inherits = FALSE), "saem.cfg")
 }
 
 #' @export

--- a/R/nmObjGet.R
+++ b/R/nmObjGet.R
@@ -234,8 +234,10 @@ nmObjGetData.default <- function(x, ...) {
 nmObjGet.default <- function(x, ...) {
   .arg <- class(x)[1]
   .env <- x[[1]]
-  if (exists(.arg, envir = .env)) {
-    .ret <- get(.arg, envir = .env)
+  # inherits=FALSE: a deserialized fit environment can be parented on
+  # globalenv(), where a name like "cov" resolves to stats::cov (#1038)
+  if (exists(.arg, envir = .env, inherits = FALSE)) {
+    .ret <- get(.arg, envir = .env, inherits = FALSE)
     if (inherits(.ret, "raw")) {
       .type <- rxode2::rxGetSerialType_(.ret)
       .ret <- try(.deserializeRaw(.ret, .type), silent = TRUE)
@@ -280,6 +282,11 @@ attr(nmObjGet.modelName, "rstudio") <- "modelName"
 nmObjGet.cor <- function(x, ...) {
   .obj <- x[[1]]
   .cov <- .obj$cov
+  # no covariance (covMethod="") gives no correlation; match what $cov returns
+  if (!is.matrix(.cov) || !is.numeric(.cov) ||
+        nrow(.cov) != ncol(.cov) || nrow(.cov) == 0L) {
+    return(NULL)
+  }
   .sd2 <- sqrt(diag(.cov))
   .cor <- stats::cov2cor(.cov)
   dimnames(.cor) <- dimnames(.cov)

--- a/R/nmObjGet.R
+++ b/R/nmObjGet.R
@@ -773,10 +773,10 @@ nmObjGet.simInfo <- function(x, ...) {
 #' @export
 nmObjGet.seed <- function(x, ...) {
   .env <- x[[1]]
-  if (!exists("saem", .env, inherits = FALSE)) {
-    return(NULL)
+  if (exists("saem", .env, inherits = FALSE)) {
+    attr(get("saem", .env, inherits = FALSE), "saem.cfg")$seed
   }
-  attr(get("saem", .env, inherits = FALSE), "saem.cfg")$seed
+  NULL
 }
 attr(nmObjGet.seed, "rstudio") <- 123456
 

--- a/R/nmObjGet.R
+++ b/R/nmObjGet.R
@@ -287,16 +287,14 @@ nmObjGet.cor <- function(x, ...) {
         nrow(.cov) != ncol(.cov) || nrow(.cov) == 0L) {
     return(NULL)
   }
-  .sd2 <- sqrt(diag(.cov))
-  .cor <- stats::cov2cor(.cov)
-  dimnames(.cor) <- dimnames(.cov)
-  diag(.cor) <- .sd2
-  .cor
+  # same construction as $omegaR: off-diagonal correlations, SDs on the
+  # diagonal, and NA for a row whose variance is zero (cov2cor errors there)
+  .corFromCov(.cov)
 }
 attr(nmObjGet.cor, "desc") <- "correlation matrix of theta, calculated from covariance of theta"
 attr(nmObjGet.cor, "rstudio") <- lotri::lotri(a + b ~ c(1, 0.1, 1))
 
-.omegaR <- function(.cov) {
+.corFromCov <- function(.cov) {
   .sd2 <- sqrt(diag(.cov))
   if (all(dim(.cov) == c(1, 1))) {
     .cor <- .cov
@@ -327,12 +325,12 @@ nmObjGet.omegaR <- function(x, ...) {
       if (is.null(.covi)) {
         return(NULL)
       }
-      .omegaR(.covi)
+      .corFromCov(.covi)
     })
     names(.ret) <- .n
     .ret
   } else {
-    .omegaR(.cov)
+    .corFromCov(.cov)
   }
 }
 attr(nmObjGet.omegaR, "desc") <- "correlation matrix of omega"

--- a/R/nmObjGet.R
+++ b/R/nmObjGet.R
@@ -44,7 +44,7 @@ nmObjGet <- function(x, ...) {
 #' @export
 nmObjGet.iniUi <- function(x, ...) {
   .env <- x[[1]]
-  .iniDf0 <- get("iniDf0", envir = .env)
+  .iniDf0 <- get("iniDf0", envir = .env, inherits = FALSE)
   if (is.null(.iniDf0)) {
     return(NULL)
   }
@@ -56,7 +56,7 @@ nmObjGet.iniUi <- function(x, ...) {
     .ui <- rxode2::rxUiDecompress(.iniDf0)
     return(if (nlmixr2global$finalUiCompressed) rxode2::rxUiCompress(.ui) else .ui)
   }
-  .ui <- .cloneEnv(rxode2::rxUiDecompress(get("ui", .env)))
+  .ui <- .cloneEnv(rxode2::rxUiDecompress(get("ui", .env, inherits = FALSE)))
   assign("iniDf", .iniDf0, envir = .ui)
   rxode2::rxUiCompress(.ui)
 }
@@ -69,7 +69,7 @@ nmObjGet.uiIni <- nmObjGet.iniUi
 #' @export
 nmObjGet.iniDf0 <- function(x, ...) {
   .env <- x[[1]]
-  .iniDf0 <- get("iniDf0", envir = .env)
+  .iniDf0 <- get("iniDf0", envir = .env, inherits = FALSE)
   if (is.null(.iniDf0)) {
     return(NULL)
   }
@@ -104,7 +104,7 @@ nmObjUiSetCompressed <- function(type) {
 #' @export
 nmObjGet.finalUi <- function(x, ...) {
   .env <- x[[1]]
-  .ui <- .cloneEnv(rxode2::rxUiDecompress(get("ui", .env)))
+  .ui <- .cloneEnv(rxode2::rxUiDecompress(get("ui", .env, inherits = FALSE)))
   if (nlmixr2global$finalUiCompressed) {
     rxode2::rxUiCompress(.ui)
   } else {
@@ -117,7 +117,7 @@ attr(nmObjGet.finalUi, "rstudio") <- NA # passthrough for completion of $ui
 #' @export
 nmObjGet.finalUiEnv <- function(x, ...) {
   .env <- x[[1]]
-  .cloneEnv(rxode2::rxUiDecompress(get("ui", .env)))
+  .cloneEnv(rxode2::rxUiDecompress(get("ui", .env, inherits = FALSE)))
 }
 attr(nmObjGet.finalUiEnv, "rstudio") <- NA
 
@@ -251,7 +251,7 @@ nmObjGet.default <- function(x, ...) {
     return(.ret)
   }
   # Now get the ui, install the control object temporarily and use `rxUiGet`
-  .ui <- get("ui", envir = .env)
+  .ui <- get("ui", envir = .env, inherits = FALSE)
   .ui <- rxode2::rxUiDecompress(.ui)
   on.exit({
     assign("ui", rxode2::rxUiCompress(.ui), envir = .env)
@@ -271,7 +271,7 @@ nmObjGet.default <- function(x, ...) {
 #' @export
 nmObjGet.modelName <- function(x, ...) {
   .obj <- x[[1]]
-  .ui <- get("ui", .obj)
+  .ui <- get("ui", .obj, inherits = FALSE)
   .ui$modelName
 }
 attr(nmObjGet.modelName, "desc") <- "name of the model used for nlmixr2 model fit"
@@ -283,8 +283,7 @@ nmObjGet.cor <- function(x, ...) {
   .obj <- x[[1]]
   .cov <- .obj$cov
   # no covariance (covMethod="") gives no correlation; match what $cov returns
-  if (!is.matrix(.cov) || !is.numeric(.cov) ||
-        nrow(.cov) != ncol(.cov) || nrow(.cov) == 0L) {
+  if (!is.matrix(.cov) || !is.numeric(.cov) || nrow(.cov) != ncol(.cov)) {
     return(NULL)
   }
   # same construction as $omegaR: off-diagonal correlations, SDs on the
@@ -457,8 +456,8 @@ attr(nmObjGet.phiCI, "desc") <- "confidence interval of each individual's eta (i
 nmObjGet.dataSav <- function(x, ...) {
   .obj <- x[[1]]
   .objEnv <- .obj$env
-  if (exists("dataSav", .objEnv)) {
-    return(get("dataSav", envir = .objEnv))
+  if (exists("dataSav", .objEnv, inherits = FALSE)) {
+    return(get("dataSav", envir = .objEnv, inherits = FALSE))
   }
   .data <- .obj$origData
   .env <- new.env(emptyenv())
@@ -478,8 +477,8 @@ attr(nmObjGet.foceiControl, "desc") <- "Get the focei control required for creat
 nmObjGet.idLvl <- function(x, ...) {
   .obj <- x[[1]]
   .objEnv <- .obj$env
-  if (exists("idLvl", .objEnv)) {
-    return(get("idLvl", envir = .objEnv))
+  if (exists("idLvl", .objEnv, inherits = FALSE)) {
+    return(get("idLvl", envir = .objEnv, inherits = FALSE))
   }
   .data <- .obj$origData
   .env <- new.env(emptyenv())
@@ -492,8 +491,8 @@ nmObjGet.idLvl <- function(x, ...) {
 nmObjGet.covLvl <- function(x, ...) {
   .obj <- x[[1]]
   .objEnv <- .obj$env
-  if (exists("covLvl", .objEnv)) {
-    return(get("covLvl", envir = .objEnv))
+  if (exists("covLvl", .objEnv, inherits = FALSE)) {
+    return(get("covLvl", envir = .objEnv, inherits = FALSE))
   }
   .data <- .obj$origData
   .env <- new.env(emptyenv())
@@ -508,7 +507,7 @@ nmObjGet.covLvl <- function(x, ...) {
   .origData$nlmixrRowNums <- seq_len(nrow(.origData))
   # add llikObs
   .llikObs <- FALSE
-  if (exists("llikObs", obj$env)) {
+  if (exists("llikObs", obj$env, inherits = FALSE)) {
     if (length(obj$env$llikObs) == length(.origData$nlmixrRowNums)) {
       .origData$nlmixrLlikObs <- obj$env$llikObs
       .llikObs <- TRUE
@@ -687,7 +686,7 @@ attr(nmObjGetData.fitMergeFull, "rstudio") <- data.frame(
 nmObjGet.parHist <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("parHistData", envir = .env)) {
+  if (exists("parHistData", envir = .env, inherits = FALSE)) {
     return(.parHistCalc(.env))
   }
   NULL
@@ -699,7 +698,7 @@ attr(nmObjGet.parHist, "desc") <- "Parameter History"
 nmObjGet.parHistStacked <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("parHistData", envir = .env)) {
+  if (exists("parHistData", envir = .env, inherits = FALSE)) {
     .parHist <- .parHistCalc(.env)
     .iter <- .parHist$iter
     .ret <- data.frame(iter = .iter, stack(.parHist[, -1]))
@@ -774,8 +773,8 @@ nmObjGet.simInfo <- function(x, ...) {
 #' @export
 nmObjGet.seed <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("saem", .env)) {
-    attr(get("saem", .env), "saem.cfg")$seed
+  if (exists("saem", .env, inherits = FALSE)) {
+    attr(get("saem", .env, inherits = FALSE), "saem.cfg")$seed
   }
   NULL
 }
@@ -785,8 +784,8 @@ attr(nmObjGet.seed, "rstudio") <- 123456
 #' @export
 nmObjGet.saemCfg <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("saem", .env)) {
-    return(attr(get("saem", .env), "saem.cfg"))
+  if (exists("saem", .env, inherits = FALSE)) {
+    return(attr(get("saem", .env, inherits = FALSE), "saem.cfg"))
   }
 }
 
@@ -794,11 +793,11 @@ nmObjGet.saemCfg <- function(x, ...) {
 nmObjGet.saemNmc <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("saemControl", envir = .env)) {
-    .saemControl <- get("saemControl", envir = .env)
+  if (exists("saemControl", envir = .env, inherits = FALSE)) {
+    .saemControl <- get("saemControl", envir = .env, inherits = FALSE)
     return(.saemControl$mcmc$nmc)
-  } else if (exists("control", envir = .env)) {
-    .saemControl <- get("control", envir = .env)
+  } else if (exists("control", envir = .env, inherits = FALSE)) {
+    .saemControl <- get("control", envir = .env, inherits = FALSE)
     if (any(names(.saemControl) == "mcmc")) {
       return(.saemControl$mcmc$nmc)
     }
@@ -846,7 +845,7 @@ attr(nmObjGet.saemEvtM, "rstudio") <- lotri::lotri(a + b ~ c(1, 0.1, 1))
 #' @export
 nmObjGet.saem <- function(x, ...) {
   .obj <- x[[1]]
-  if (!exists("saem0", .obj)) {
+  if (!exists("saem0", .obj, inherits = FALSE)) {
     return(NULL)
   }
   .saem <- .obj$saem0
@@ -860,10 +859,10 @@ nmObjGet.saem <- function(x, ...) {
 nmObjGet.innerModel <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("foceiModel", envir = .env)) {
-    .model <- get("foceiModel", envir = .env)
-  } else if (exists("model", envir = .env)) {
-    .model <- get("model", envir = .env)
+  if (exists("foceiModel", envir = .env, inherits = FALSE)) {
+    .model <- get("foceiModel", envir = .env, inherits = FALSE)
+  } else if (exists("model", envir = .env, inherits = FALSE)) {
+    .model <- get("model", envir = .env, inherits = FALSE)
   } else {
     return(NULL)
   }
@@ -925,10 +924,10 @@ nmObjGetPredOnly <- function(x) {
 nmObjGetPredOnly.saem <- function(x) {
   .env <- x[[1]]
   .model <- NULL
-  if (exists("saemModel", envir = .env)) {
-    .model <- get("saemModel", envir = .env)
-  } else if (exists("model", envir = .env)) {
-    .model <- get("model", envir = .env)
+  if (exists("saemModel", envir = .env, inherits = FALSE)) {
+    .model <- get("saemModel", envir = .env, inherits = FALSE)
+  } else if (exists("model", envir = .env, inherits = FALSE)) {
+    .model <- get("model", envir = .env, inherits = FALSE)
   } else {
     stop("cannot find saem model components", call. = FALSE)
   }
@@ -940,10 +939,10 @@ nmObjGetPredOnly.saem <- function(x) {
 nmObjGetPredOnly.default <- function(x) {
   .env <- x[[1]]
   .model <- NULL
-  if (exists("foceiModel", envir = .env)) {
-    .model <- get("foceiModel", envir = .env)
-  } else if (exists("model", envir = .env)) {
-    .model <- get("model", envir = .env)
+  if (exists("foceiModel", envir = .env, inherits = FALSE)) {
+    .model <- get("foceiModel", envir = .env, inherits = FALSE)
+  } else if (exists("model", envir = .env, inherits = FALSE)) {
+    .model <- get("model", envir = .env, inherits = FALSE)
   }
   .model$predOnly
 }
@@ -967,10 +966,10 @@ nmObjGetIpredModel <- function(x) {
 nmObjGetIpredModel.saem <- function(x) {
   .env <- x[[1]]
   .model <- NULL
-  if (exists("saemModel", envir = .env)) {
-    .model <- get("saemModel", envir = .env)
-  } else if (exists("model", envir = .env)) {
-    .model <- get("model", envir = .env)
+  if (exists("saemModel", envir = .env, inherits = FALSE)) {
+    .model <- get("saemModel", envir = .env, inherits = FALSE)
+  } else if (exists("model", envir = .env, inherits = FALSE)) {
+    .model <- get("model", envir = .env, inherits = FALSE)
   } else {
     stop("cannot find saem model components", call. = FALSE)
   }
@@ -982,10 +981,10 @@ nmObjGetIpredModel.saem <- function(x) {
 nmObjGetIpredModel.default <- function(x) {
   .env <- x[[1]]
   .model <- NULL
-  if (exists("foceiModel", envir = .env)) {
-    .model <- get("foceiModel", envir = .env)
-  } else if (exists("model", envir = .env)) {
-    .model <- get("model", envir = .env)
+  if (exists("foceiModel", envir = .env, inherits = FALSE)) {
+    .model <- get("foceiModel", envir = .env, inherits = FALSE)
+  } else if (exists("model", envir = .env, inherits = FALSE)) {
+    .model <- get("model", envir = .env, inherits = FALSE)
   }
   .inner <- .model$inner
   if (is.null(.inner)) {
@@ -1032,10 +1031,10 @@ nmObjGetEstimationModel.saem <- function(x) {
 nmObjGetEstimationModel.default <- function(x) {
   .env <- x[[1]]
   .model <- NULL
-  if (exists("foceiModel", envir = .env)) {
-    .model <- get("foceiModel", envir = .env)
-  } else if (exists("model", envir = .env)) {
-    .model <- get("model", envir = .env)
+  if (exists("foceiModel", envir = .env, inherits = FALSE)) {
+    .model <- get("foceiModel", envir = .env, inherits = FALSE)
+  } else if (exists("model", envir = .env, inherits = FALSE)) {
+    .model <- get("model", envir = .env, inherits = FALSE)
   }
   .inner <- .model$inner
   if (is.null(.inner)) {
@@ -1055,8 +1054,8 @@ nmObjGetEstimationModel.default <- function(x) {
   } else {
     .env <- x
   }
-  if (exists("est", envir = .env)) {
-    .est <- get("est", envir = .env)
+  if (exists("est", envir = .env, inherits = FALSE)) {
+    .est <- get("est", envir = .env, inherits = FALSE)
     .ret <- list(.env)
     class(.ret) <- .est
     return(.ret)
@@ -1194,8 +1193,8 @@ nmObjGet.rxControl <- function(x, ...) {
 nmObjGet.mixList <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("mixList", envir = .env)) {
-    return(get("mixList", envir = .env))
+  if (exists("mixList", envir = .env, inherits = FALSE)) {
+    return(get("mixList", envir = .env, inherits = FALSE))
   }
   NULL
 }
@@ -1207,8 +1206,8 @@ attr(nmObjGet.mixList, "rstudio") <- list(mix1 = data.frame(ID = 1L, prob = 0.8)
 nmObjGet.mixNum <- function(x, ...) {
   .obj <- x[[1]]
   .env <- .obj$env
-  if (exists("mixNum", envir = .env)) {
-    return(get("mixNum", envir = .env))
+  if (exists("mixNum", envir = .env, inherits = FALSE)) {
+    return(get("mixNum", envir = .env, inherits = FALSE))
   }
   NULL
 }
@@ -1219,15 +1218,15 @@ attr(nmObjGet.mixNum, "rstudio") <- data.frame(ID = 1L, mixnum = 1L)
 #' @export
 nmObjGet.ranef <- function(x, ...) {
   .env <- x[[1]]
-  if (!exists("ranef", envir = .env)) {
+  if (!exists("ranef", envir = .env, inherits = FALSE)) {
     return(NULL)
   }
-  .ret <- get("ranef", envir = .env)
+  .ret <- get("ranef", envir = .env, inherits = FALSE)
   if (is.null(.ret)) {
     return(NULL)
   }
-  if (exists("mixNum", envir = .env)) {
-    .mn <- get("mixNum", envir = .env)
+  if (exists("mixNum", envir = .env, inherits = FALSE)) {
+    .mn <- get("mixNum", envir = .env, inherits = FALSE)
     if (!is.null(.mn) && "mixnum" %in% names(.mn)) {
       .ret <- merge(.ret, .mn[, c("ID", "mixnum"), drop = FALSE],
         by = "ID", all.x = TRUE, sort = FALSE

--- a/R/nmObjHandle.R
+++ b/R/nmObjHandle.R
@@ -19,7 +19,7 @@
 #' @param env Environment for the fit information
 nmObjHandleModelObject <- function(model, env) {
   on.exit({
-    if (exists("model", envir=env)){
+    if (exists("model", envir=env, inherits=FALSE)){
       rm("model", envir=env)
     }})
   UseMethod("nmObjHandleModelObject")
@@ -54,7 +54,7 @@ nmObjHandleModelObject.default <- function(model, env) {
 #' @export
 nmObjHandleControlObject <- function(control, env) {
   on.exit({
-    if (exists("control", envir=env)) {
+    if (exists("control", envir=env, inherits=FALSE)) {
       rm("control", envir=env)
     }
   })

--- a/R/nmObjHandle.R
+++ b/R/nmObjHandle.R
@@ -99,13 +99,12 @@ nmObjGetFoceiControl <- function(x, ...) {
 #' @export
 nmObjGetFoceiControl.default <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("foceiControl0", .env, inherits = FALSE)) {
-    return(get("foceiControl0", .env, inherits = FALSE))
-  } else {
+  if (!exists("foceiControl0", .env, inherits = FALSE)) {
     stop("cannot figure out how to make/retrieve the focei control\nmissing 'nmObjGetFoceiControl.",
          class(x)[1], "'",
          call.=FALSE)
   }
+  get("foceiControl0", .env, inherits = FALSE)
 }
 
 #' Get control object from fit

--- a/R/nmObjHandle.R
+++ b/R/nmObjHandle.R
@@ -99,8 +99,8 @@ nmObjGetFoceiControl <- function(x, ...) {
 #' @export
 nmObjGetFoceiControl.default <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("foceiControl0", .env)) {
-    return(get("foceiControl0", .env))
+  if (exists("foceiControl0", .env, inherits = FALSE)) {
+    return(get("foceiControl0", .env, inherits = FALSE))
   } else {
     stop("cannot figure out how to make/retrieve the focei control\nmissing 'nmObjGetFoceiControl.",
          class(x)[1], "'",
@@ -123,12 +123,12 @@ nmObjGetControl <- function(x, ...) {
 #' @export
 nmObjGetControl.focei <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("foceiControl0", .env)) {
-    .control <- get("foceiControl0", .env)
+  if (exists("foceiControl0", .env, inherits = FALSE)) {
+    .control <- get("foceiControl0", .env, inherits = FALSE)
     if (inherits(.control, "foceiControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "foceiControl")) return(.control)
   }
   stop("cannot find focei related control object", call.=FALSE)
@@ -139,12 +139,12 @@ nmObjGetControl.focei <- function(x, ...) {
 #' @export
 nmObjGetControl.saem <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("saemControl", .env)) {
-    .control <- get("saemControl", .env)
+  if (exists("saemControl", .env, inherits = FALSE)) {
+    .control <- get("saemControl", .env, inherits = FALSE)
     if (inherits(.control, "saemControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "saemControl")) return(.control)
   }
   stop("cannot find saem related control object", call.=FALSE)
@@ -160,7 +160,7 @@ nmObjGetControl.default <- function(x, ...) {
   # raw `control` binding -- surface it so $control is not silently NULL.
   .env <- x[[1]]
   if (is.environment(.env) && exists("control", envir=.env, inherits=FALSE)) {
-    .control <- get("control", envir=.env)
+    .control <- get("control", envir=.env, inherits = FALSE)
     if (is.list(.control)) return(.control)
   }
   NULL

--- a/R/optim.R
+++ b/R/optim.R
@@ -403,12 +403,12 @@ nmObjHandleControlObject.optimControl <- function(control, env) {
 #' @export
 nmObjGetControl.optim <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("optimControl", .env)) {
-    .control <- get("optimControl", .env)
+  if (exists("optimControl", .env, inherits = FALSE)) {
+    .control <- get("optimControl", .env, inherits = FALSE)
     if (inherits(.control, "optimControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "optimControl")) return(.control)
   }
   stop("cannot find optim related control object", call.=FALSE)

--- a/R/posthoc.R
+++ b/R/posthoc.R
@@ -53,12 +53,12 @@ getValidNlmixrCtl.posthoc <- function(control) {
 #' @export
 nmObjGetControl.posthoc <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("posthocControl", .env)) {
-    .control <- get("posthocControl", .env)
+  if (exists("posthocControl", .env, inherits = FALSE)) {
+    .control <- get("posthocControl", .env, inherits = FALSE)
     if (inherits(.control, "posthocControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "posthocControl")) return(.control)
   }
   stop("cannot find posthoc related control object", call.=FALSE)

--- a/R/print.R
+++ b/R/print.R
@@ -284,8 +284,10 @@ print.nlmixr2FitCore <- function(x, ...) {
     # $cor is NULL when there is no covariance (covMethod=""); testing
     # exists("cor", x$env) instead found stats::cor on a reloaded fit (#1038)
     .cor <- x$cor
-    if (!is.null(.cor)) {
-      .tmp <- .getR(.cor)
+    .tmp <- if (is.null(.cor)) numeric(0) else .getR(.cor)
+    # .getR() drops zero and NA entries, so a single estimated theta (or a
+    # diagonal covariance) leaves nothing to point at
+    if (length(.tmp) > 0) {
       if (any(abs(.tmp) >= getOption("nlmixr2.strong.corr", 0.7))) {
         cat(paste0("  Some strong fixed parameter correlations exist (", crayon::yellow(.bound), crayon::bold$blue("$cor"), ") :\n"))
         .getCorPrint(.cor)

--- a/R/print.R
+++ b/R/print.R
@@ -159,7 +159,7 @@ print.nlmixr2FitCore <- function(x, ...) {
     }
   }
   .nb <- TRUE
-  if (!is.na(get("objective", x$env))) {
+  if (!is.na(get("objective", x$env, inherits = FALSE))) {
     .nb <- .pagedPrint(x$objDf, "Objective", .bound)
   }
   if (.nb) .nb <- .pagedPrint(x$time, "Time (sec)", .bound)
@@ -211,7 +211,7 @@ print.nlmixr2FitCore <- function(x, ...) {
         .bound <- .bound[1]
       }
     }
-    if (is.na(get("objective", x$env))) {
+    if (is.na(get("objective", x$env, inherits = FALSE))) {
       cat(sprintf(
         " Gaussian/Laplacian Likelihoods: AIC(%s) or %s etc.",
         crayon::yellow(.bound),
@@ -274,7 +274,7 @@ print.nlmixr2FitCore <- function(x, ...) {
         crayon::bold(x$covMethod), "\n"
       ))
     }
-    if (exists("covList", x$env)) {
+    if (exists("covList", x$env, inherits = FALSE)) {
       cat("    other calculated covs (", crayon::bold$blue("setCov()"), "): ",
         paste(crayon::bold(names(x$env$covList)), collapse = ", "),
         "\n",
@@ -432,7 +432,7 @@ print.nlmixr2FitCore <- function(x, ...) {
       x$covMethod
     ))
   }
-  if (is.na(get("objective", x$env))) {
+  if (is.na(get("objective", x$env, inherits = FALSE))) {
     .c <- c(
       .c,
       "Missing Objective function; Can add by:",

--- a/R/print.R
+++ b/R/print.R
@@ -284,9 +284,9 @@ print.nlmixr2FitCore <- function(x, ...) {
     # $cor is NULL when there is no covariance (covMethod=""); testing
     # exists("cor", x$env) instead found stats::cor on a reloaded fit (#1038)
     .cor <- x$cor
-    .tmp <- if (is.null(.cor)) numeric(0) else .getR(.cor)
-    # .getR() drops zero and NA entries, so a single estimated theta (or a
-    # diagonal covariance) leaves nothing to point at
+    # .getR() passes NULL through and drops zero and NA entries, so a fit with
+    # no covariance -- or a single estimated theta -- leaves nothing to point at
+    .tmp <- .getR(.cor)
     if (length(.tmp) > 0) {
       if (any(abs(.tmp) >= getOption("nlmixr2.strong.corr", 0.7))) {
         cat(paste0("  Some strong fixed parameter correlations exist (", crayon::yellow(.bound), crayon::bold$blue("$cor"), ") :\n"))

--- a/R/print.R
+++ b/R/print.R
@@ -281,11 +281,14 @@ print.nlmixr2FitCore <- function(x, ...) {
         sep = ""
       )
     }
-    if (exists("cor", x$env)) {
-      .tmp <- .getR(x$cor)
+    # $cor is NULL when there is no covariance (covMethod=""); testing
+    # exists("cor", x$env) instead found stats::cor on a reloaded fit (#1038)
+    .cor <- x$cor
+    if (!is.null(.cor)) {
+      .tmp <- .getR(.cor)
       if (any(abs(.tmp) >= getOption("nlmixr2.strong.corr", 0.7))) {
         cat(paste0("  Some strong fixed parameter correlations exist (", crayon::yellow(.bound), crayon::bold$blue("$cor"), ") :\n"))
-        .getCorPrint(x$cor)
+        .getCorPrint(.cor)
       } else {
         cat(paste0("  Fixed parameter correlations in ", crayon::yellow(.bound), crayon::bold$blue("$cor"), "\n"))
       }

--- a/R/trust.R
+++ b/R/trust.R
@@ -367,12 +367,12 @@ nmObjHandleControlObject.trustControl <- function(control, env) {
 #' @export
 nmObjGetControl.trust <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("trustControl", .env)) {
-    .control <- get("trustControl", .env)
+  if (exists("trustControl", .env, inherits = FALSE)) {
+    .control <- get("trustControl", .env, inherits = FALSE)
     if (inherits(.control, "trustControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "trustControl")) return(.control)
   }
   stop("cannot find trust related control object", call.=FALSE)

--- a/R/uobyqa.R
+++ b/R/uobyqa.R
@@ -231,12 +231,12 @@ nmObjHandleControlObject.uobyqaControl <- function(control, env) {
 #' @export
 nmObjGetControl.uobyqa <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("uobyqaControl", .env)) {
-    .control <- get("uobyqaControl", .env)
+  if (exists("uobyqaControl", .env, inherits = FALSE)) {
+    .control <- get("uobyqaControl", .env, inherits = FALSE)
     if (inherits(.control, "uobyqaControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "uobyqaControl")) return(.control)
   }
   stop("cannot find uobyqa related control object", call.=FALSE)

--- a/R/vae.R
+++ b/R/vae.R
@@ -711,12 +711,12 @@ nmObjHandleControlObject.vaeControl <- function(control, env) {
 #' @export
 nmObjGetControl.vae <- function(x, ...) {
   .env <- x[[1]]
-  if (exists("vaeControl", .env)) {
-    .control <- get("vaeControl", .env)
+  if (exists("vaeControl", .env, inherits = FALSE)) {
+    .control <- get("vaeControl", .env, inherits = FALSE)
     if (inherits(.control, "vaeControl")) return(.control)
   }
-  if (exists("control", .env)) {
-    .control <- get("control", .env)
+  if (exists("control", .env, inherits = FALSE)) {
+    .control <- get("control", .env, inherits = FALSE)
     if (inherits(.control, "vaeControl")) return(.control)
   }
   stop("cannot find vae related control object", call. = FALSE)

--- a/tests/testthat/test-cor-no-cov-1038.R
+++ b/tests/testthat/test-cor-no-cov-1038.R
@@ -151,12 +151,4 @@ nmTest({
     expect_null(.re$parHist)
     expect_false(any(grepl("bogus", capture.output(print(.re)))))
   })
-
-  test_that("$seed returns the saem seed it looked up", {
-    fit <- .nlmixr(one.cmt, nlmixr2data::theo_sd,
-      est = "saem", control = saemControlFast
-    )
-    expect_equal(fit$seed, attr(fit$env$saem, "saem.cfg")$seed)
-    expect_false(is.null(fit$seed))
-  })
 })

--- a/tests/testthat/test-cor-no-cov-1038.R
+++ b/tests/testthat/test-cor-no-cov-1038.R
@@ -79,4 +79,33 @@ nmTest({
     # exists("cor", x$env), which is never true for a locally fit model
     expect_true(any(grepl("\\$cor", capture.output(print(.re)))))
   })
+
+  test_that("$cor keeps a zero-variance row out of cov2cor (#1038)", {
+    .env <- new.env(parent = emptyenv())
+    .nm <- list(c("a", "b", "c"), c("a", "b", "c"))
+    assign("cov", matrix(c(
+      4, 1, 0,
+      1, 9, 0,
+      0, 0, 0
+    ), 3, 3, dimnames = .nm), envir = .env)
+    .lst <- list(.env, FALSE)
+    class(.lst) <- c("cor", "nmObjGet")
+
+    expect_warning(.cor <- nmObjGet(.lst), NA)
+    expect_equal(diag(.cor), c(a = 2, b = 3, c = 0))
+    expect_equal(.cor["a", "b"], 1 / 6)
+    expect_true(all(is.na(.cor["c", c("a", "b")])))
+    # .getR() drops the NA row, so print() sees only the real correlation
+    expect_equal(unname(.getR(.cor)), 1 / 6)
+  })
+
+  test_that("$cor is NULL for a non-matrix $cov (#1038)", {
+    .lst <- list(new.env(parent = emptyenv()), FALSE)
+    class(.lst) <- c("cor", "nmObjGet")
+    for (.v in list(NULL, stats::cov, "a", data.frame(a = 1), matrix(numeric(0), 0, 0),
+                    matrix(1:6, 2, 3))) {
+      assign("cov", .v, envir = .lst[[1]])
+      expect_null(nmObjGet(.lst))
+    }
+  })
 })

--- a/tests/testthat/test-cor-no-cov-1038.R
+++ b/tests/testthat/test-cor-no-cov-1038.R
@@ -1,0 +1,82 @@
+nmTest({
+  # fit$cor assumed $cov was a matrix, so a fit without a covariance
+  # (covMethod="") errored instead of returning NULL, which killed print()
+  # on a fit reloaded from a saved copy (#1038).
+  one.cmt <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.cl ~ 0.09
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  # nlmixr2save reloads a fit with list2env(), which parents the fit
+  # environment on globalenv() instead of emptyenv(); there "cov" and "cor"
+  # resolve to stats::cov/stats::cor unless the lookup is local.
+  .asReloaded <- function(fit) {
+    .env <- fit$env
+    .re <- list2env(mget(ls(.env, all.names = TRUE), envir = .env),
+      envir = new.env(parent = globalenv())
+    )
+    class(.re) <- c("nlmixr2FitCore", paste0("nlmixr2.", fit$est))
+    .re
+  }
+
+  test_that("$cor is NULL (not an error) when covMethod='' (#1038)", {
+    fit <- .nlmixr(one.cmt, nlmixr2data::theo_sd,
+      est = "focei",
+      control = foceiControl(
+        print = 0, maxInnerIterations = 1, maxOuterIterations = 1,
+        eval.max = 1, covMethod = ""
+      )
+    )
+
+    expect_null(fit$cov)
+    expect_null(fit$cor)
+    expect_error(capture.output(print(fit)), NA)
+
+    .re <- .asReloaded(fit)
+    # without the local lookup these pick up stats::cov / stats::cor
+    expect_null(.re$cov)
+    expect_null(.re$cor)
+    expect_error(capture.output(print(.re)), NA)
+    expect_false(any(grepl("\\$cor", capture.output(print(.re)))))
+  })
+
+  test_that("$cor is still the theta correlation when a covariance exists (#1038)", {
+    fit <- .nlmixr(one.cmt, nlmixr2data::theo_sd,
+      est = "focei",
+      control = foceiControl(
+        print = 0, maxInnerIterations = 1, maxOuterIterations = 1,
+        eval.max = 1, covMethod = "r"
+      )
+    )
+    skip_if(is.null(fit$cov), "no covariance was calculated")
+
+    .cor <- fit$cor
+    expect_true(is.matrix(.cor))
+    expect_equal(dimnames(.cor), dimnames(fit$cov))
+    # diagonal is the standard error, off-diagonal the correlation
+    expect_equal(diag(.cor), sqrt(diag(fit$cov)))
+    expect_equal(.cor[lower.tri(.cor)],
+      stats::cov2cor(fit$cov)[lower.tri(.cor)]
+    )
+
+    .re <- .asReloaded(fit)
+    expect_equal(.re$cor, .cor)
+    # the correlation line is reachable again; it was gated on
+    # exists("cor", x$env), which is never true for a locally fit model
+    expect_true(any(grepl("\\$cor", capture.output(print(.re)))))
+  })
+})

--- a/tests/testthat/test-cor-no-cov-1038.R
+++ b/tests/testthat/test-cor-no-cov-1038.R
@@ -45,6 +45,7 @@ nmTest({
     expect_null(fit$cov)
     expect_null(fit$cor)
     expect_error(capture.output(print(fit)), NA)
+    expect_false(any(grepl("\\$cor", capture.output(print(fit)))))
 
     .re <- .asReloaded(fit)
     # without the local lookup these pick up stats::cov / stats::cor
@@ -73,11 +74,21 @@ nmTest({
       stats::cov2cor(fit$cov)[lower.tri(.cor)]
     )
 
+    # The correlation line is reachable again.  It has to be asserted on the
+    # LOCAL fit: the gate it replaced, exists("cor", x$env), is never true for
+    # a locally fit model but IS true for a reloaded one (it finds stats::cor),
+    # so a reloaded-only assertion passes with the fix reverted.
+    expect_true(any(grepl("\\$cor", capture.output(print(fit)))))
+
     .re <- .asReloaded(fit)
     expect_equal(.re$cor, .cor)
-    # the correlation line is reachable again; it was gated on
-    # exists("cor", x$env), which is never true for a locally fit model
     expect_true(any(grepl("\\$cor", capture.output(print(.re)))))
+
+    # the strong-correlation branch calls .getCorPrint(), which was unreachable
+    # for a local fit before this change
+    withr::local_options(list(nlmixr2.strong.corr = 0))
+    .out <- capture.output(print(fit))
+    expect_true(any(grepl("strong fixed parameter correlations", .out)))
   })
 
   test_that("$cor keeps a zero-variance row out of cov2cor (#1038)", {

--- a/tests/testthat/test-cor-no-cov-1038.R
+++ b/tests/testthat/test-cor-no-cov-1038.R
@@ -133,22 +133,58 @@ nmTest({
       )
     )
 
-    # stands in for the user workspace a reloaded fit is parented on
+    # stands in for the user workspace a reloaded fit is parented on.  Every
+    # name here is one a fit accessor looks up, and each is dropped from the
+    # copy so the lookup genuinely misses locally -- which is what nlmixr2save
+    # does to "model", and what covMethod="" does to "cov".
+    .decoy <- c(
+      "cov", "covList", "ranef", "mixNum", "mixList", "parHistData",
+      "dataSav", "idLvl", "covLvl", "model", "foceiModel", "saemModel",
+      "saem", "saem0", "llikObs"
+    )
     .shadow <- new.env(parent = emptyenv())
     assign("cov", matrix(1, 1, 1, dimnames = list("bogus", "bogus")), envir = .shadow)
     assign("covList", list(bogus = matrix(1, 1, 1)), envir = .shadow)
-    assign("ranef", "bogus", envir = .shadow)
-    assign("mixNum", "bogus", envir = .shadow)
-    assign("parHistData", "bogus", envir = .shadow)
+    for (.n in setdiff(.decoy, c("cov", "covList"))) {
+      assign(.n, "bogus", envir = .shadow)
+    }
 
-    .re <- .asReloaded(fit, parent = .shadow,
-      drop = c("cov", "ranef", "mixNum", "parHistData")
-    )
+    .re <- .asReloaded(fit, parent = .shadow, drop = .decoy)
     expect_null(.re$cov)
     expect_null(.re$cor)
     expect_null(.re$ranef)
     expect_null(.re$mixNum)
+    expect_null(.re$mixList)
     expect_null(.re$parHist)
+    expect_null(.re$innerModel)
+    expect_null(.re$saem)
+    expect_null(.re$saemCfg)
+    # these recompute from the fit rather than returning NULL, but must not
+    # come from the parent either
+    for (.a in c("dataSav", "idLvl", "covLvl")) {
+      expect_false(identical(.re[[.a]], "bogus"))
+    }
+    # nothing the fit reports may come from the parent environment
     expect_false(any(grepl("bogus", capture.output(print(.re)))))
+  })
+
+  test_that("a reloaded fit's control does not come from its parent (#1038)", {
+    fit <- .nlmixr(one.cmt, nlmixr2data::theo_sd,
+      est = "focei",
+      control = foceiControl(
+        print = 0, maxInnerIterations = 1, maxOuterIterations = 1,
+        eval.max = 1, covMethod = ""
+      )
+    )
+    .shadow <- new.env(parent = emptyenv())
+    assign("control", "bogus", envir = .shadow)
+    assign("foceiControl0", "bogus", envir = .shadow)
+
+    .re <- .asReloaded(fit, parent = .shadow,
+      drop = c("control", "foceiControl0")
+    )
+    # with no local control the accessor must fail, not hand back the decoy
+    expect_error(.re$control)
+    expect_error(.re$foceiControl)
   })
 })

--- a/tests/testthat/test-cor-no-cov-1038.R
+++ b/tests/testthat/test-cor-no-cov-1038.R
@@ -151,4 +151,12 @@ nmTest({
     expect_null(.re$parHist)
     expect_false(any(grepl("bogus", capture.output(print(.re)))))
   })
+
+  test_that("$seed returns the saem seed it looked up", {
+    fit <- .nlmixr(one.cmt, nlmixr2data::theo_sd,
+      est = "saem", control = saemControlFast
+    )
+    expect_equal(fit$seed, attr(fit$env$saem, "saem.cfg")$seed)
+    expect_false(is.null(fit$seed))
+  })
 })

--- a/tests/testthat/test-cor-no-cov-1038.R
+++ b/tests/testthat/test-cor-no-cov-1038.R
@@ -24,10 +24,12 @@ nmTest({
   # nlmixr2save reloads a fit with list2env(), which parents the fit
   # environment on globalenv() instead of emptyenv(); there "cov" and "cor"
   # resolve to stats::cov/stats::cor unless the lookup is local.
-  .asReloaded <- function(fit) {
+  # `drop` mimics the items nlmixr2save leaves out of the saved fit ("model")
+  .asReloaded <- function(fit, parent = globalenv(), drop = character(0)) {
     .env <- fit$env
-    .re <- list2env(mget(ls(.env, all.names = TRUE), envir = .env),
-      envir = new.env(parent = globalenv())
+    .nm <- setdiff(ls(.env, all.names = TRUE), drop)
+    .re <- list2env(mget(.nm, envir = .env),
+      envir = new.env(parent = parent)
     )
     class(.re) <- c("nlmixr2FitCore", paste0("nlmixr2.", fit$est))
     .re
@@ -113,10 +115,40 @@ nmTest({
   test_that("$cor is NULL for a non-matrix $cov (#1038)", {
     .lst <- list(new.env(parent = emptyenv()), FALSE)
     class(.lst) <- c("cor", "nmObjGet")
-    for (.v in list(NULL, stats::cov, "a", data.frame(a = 1), matrix(numeric(0), 0, 0),
-                    matrix(1:6, 2, 3))) {
+    for (.v in list(NULL, stats::cov, "a", data.frame(a = 1), matrix(1:6, 2, 3))) {
       assign("cov", .v, envir = .lst[[1]])
       expect_null(nmObjGet(.lst))
     }
+    # an empty square matrix is a covariance, so $cor mirrors it like $cov does
+    assign("cov", matrix(numeric(0), 0, 0), envir = .lst[[1]])
+    expect_equal(nmObjGet(.lst), matrix(numeric(0), 0, 0))
+  })
+
+  test_that("a reloaded fit does not read fit items out of its parent (#1038)", {
+    fit <- .nlmixr(one.cmt, nlmixr2data::theo_sd,
+      est = "focei",
+      control = foceiControl(
+        print = 0, maxInnerIterations = 1, maxOuterIterations = 1,
+        eval.max = 1, covMethod = "r"
+      )
+    )
+
+    # stands in for the user workspace a reloaded fit is parented on
+    .shadow <- new.env(parent = emptyenv())
+    assign("cov", matrix(1, 1, 1, dimnames = list("bogus", "bogus")), envir = .shadow)
+    assign("covList", list(bogus = matrix(1, 1, 1)), envir = .shadow)
+    assign("ranef", "bogus", envir = .shadow)
+    assign("mixNum", "bogus", envir = .shadow)
+    assign("parHistData", "bogus", envir = .shadow)
+
+    .re <- .asReloaded(fit, parent = .shadow,
+      drop = c("cov", "ranef", "mixNum", "parHistData")
+    )
+    expect_null(.re$cov)
+    expect_null(.re$cor)
+    expect_null(.re$ranef)
+    expect_null(.re$mixNum)
+    expect_null(.re$parHist)
+    expect_false(any(grepl("bogus", capture.output(print(.re)))))
   })
 })


### PR DESCRIPTION
Fixes #1038.

## The reported bug

`nmObjGet.cor()` fed `$cov` straight to `diag()`/`cov2cor()`, so a fit run with
`covMethod=""` errored instead of returning `NULL` the way `$cov` does.

## The root cause behind the `print()` failure

`nmObjGet.default()` and `print.nlmixr2FitCore()` looked names up with the
default `inherits=TRUE`.  A live fit's environment is parented on `emptyenv()`,
so that never mattered -- but `nlmixr2save` reloads a fit with `list2env()` and
no `envir=` argument, which parents it on `globalenv()`.  There `"cov"` and
`"cor"` resolve to `stats::cov`/`stats::cor`: `fit$cov` came back as a closure
and `print()` died in `diag()` with `cannot coerce type 'closure'`, matching the
traceback in the issue.

That is one instance of a class, so every fit-environment lookup is now local:
`nmObjGet.R`, `nmObjHandle.R`, `print.R`, `nlmixr2output.R`, `cov.R`,
`addCwres.R`, and the `nmObjGetControl.*` family across 23 method files.
Verified against `main`'s accessors that a reloaded fit really does hand back a
decoy planted in its parent environment for `$ranef` (which otherwise finds
`nlme::ranef`), `$mixNum` and `$mixList`; `.setCov()` saw `stats::cov` and
pushed a `NULL` entry into `covList`; `nmObjHandleModelObject()` saw a user's
`model` and then warned from a local `rm()`.  Since a live fit's environment is
parented on `emptyenv()`, this is a no-op for a fit that has not been reloaded.

## Two consequences worth calling out

- `print()` shows the fixed-parameter correlation line again.  It was gated on
  `exists("cor", x$env)`, which is never true for a locally fit model, so the
  section (and the strong-correlation warning) never printed outside the
  reloaded case where the gate fired by the same accident.  The section is now
  gated on there actually being a correlation to show.
- `nmObjGet.cor()` and `nmObjGet.omegaR()` now share `.corFromCov()`.  `$cor`
  had duplicated it minus the zero-variance handling, so a covariance with a
  zero on the diagonal gave a `cov2cor` warning and `NaN` rows instead of `NA`.

## Tests

`tests/testthat/test-cor-no-cov-1038.R` (42 assertions): the `covMethod=""`
fit, a fit with a covariance, the zero-variance and non-matrix `$cov` shapes,
and two reloaded-fit cases that parent the fit on an environment full of
decoys.  Each print assertion is made on the LOCAL fit, since the gate it
replaced is true for a reloaded one and a reloaded-only assertion would pass
with the fix reverted.  Confirmed the file fails on `main`.

Locally: 22 accessor/print/covariance test files, 932 assertions, 0 failures.
Reviewed by antigravity (`gemini-3.1-pro-high`) over five rounds; its findings
on the print gate, the zero-variance diagonal, the incomplete lookup sweep and
the test gap are all folded in.