### PR TITLE
fix(focei): make a lost jump event-sensitivity shape loud (#1016)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@
 
 ## Bug fixes
 
+- A focei fit of a model whose dosing depends on an eta -- `f()`, `alag()`,
+  `rate()`, `dur()` -- now says so when rxode2's analytic event ("jump")
+  sensitivities cannot be installed, instead of silently returning a fit whose
+  dosing etas never left their initial values while their omegas stayed finite.
+  The event-sensitivity mode already rides with the cached model bundle; it now
+  also survives a second deflate/inflate round trip, and the model bundle
+  records which etas enter a dosing expression so the fit can tell a model that
+  needs the jumps from one that does not (#1016).
+
 - `foceiControl(fast=TRUE)` no longer converges to a non-stationary point when
   an external likelihood contribution is registered (`nlmixrRegisterLikContrib`,
   e.g. from `nlmixr2nn`).  The analytic outer gradient re-derives

--- a/R/focei.R
+++ b/R/focei.R
@@ -2190,23 +2190,49 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
   ## correct and the finite-difference fallback must be turned OFF -- otherwise
   ## the jump-corrected sensitivity is computed but never used.  Leaving the
   ## flags at zero routes every parameter through the analytic innerOde sensitivity.
-  if (!identical(.eventSens, "jump")) {
-    for (.v in s$..eventVars) {
-      .vars <- as.character(get(.v, envir = s))
-      .vars <- rxode2::rxGetModel(paste0("rx_lhs=", rxode2::rxFromSE(.vars)))$params
-      for (.v2 in .vars) {
-        .reg <- rex::rex(start, "ETA[", capture(any_numbers), "]", end)
-        if (regexpr(.reg, .v2) != -1) {
-          .num <- as.numeric(sub(.reg, "\\1", .v2))
-          .eventEta[.num] <- 1L
-        }
-        .reg <- rex::rex(start, "THETA[", capture(any_numbers), "]", end)
-        if (regexpr(.reg, .v2) != -1) {
-          .num <- as.numeric(sub(.reg, "\\1", .v2))
-          .eventTheta[.num] <- 1L
+  ##
+  ## The flags are computed in BOTH modes.  `eventEtaAll` records which etas enter
+  ## a dosing expression at all, independent of the mode, so the fit can tell
+  ## "this model needs the jump sensitivities" from "this model has no dosing
+  ## etas" and refuse to run a jump fit silently without them (#1016).  Only
+  ## `eventEta`/`eventTheta` -- the finite-difference switches C++ reads -- are
+  ## zeroed under "jump".
+  ##
+  ## Under "jump" this scan is new work that used to be skipped, so it must not
+  ## be able to turn a building model into a failing one: a scan error there
+  ## leaves the flags at zero, which is exactly what the guarded code did.  In
+  ## "fd" the flags ARE the fallback switches, so an error still propagates.
+  .scan <- try(
+    {
+      for (.v in s$..eventVars) {
+        .vars <- as.character(get(.v, envir = s))
+        .vars <- rxode2::rxGetModel(paste0("rx_lhs=", rxode2::rxFromSE(.vars)))$params
+        for (.v2 in .vars) {
+          .reg <- rex::rex(start, "ETA[", capture(any_numbers), "]", end)
+          if (regexpr(.reg, .v2) != -1) {
+            .num <- as.numeric(sub(.reg, "\\1", .v2))
+            .eventEta[.num] <- 1L
+          }
+          .reg <- rex::rex(start, "THETA[", capture(any_numbers), "]", end)
+          if (regexpr(.reg, .v2) != -1) {
+            .num <- as.numeric(sub(.reg, "\\1", .v2))
+            .eventTheta[.num] <- 1L
+          }
         }
       }
-    }
+      TRUE
+    },
+    silent = TRUE
+  )
+  if (inherits(.scan, "try-error")) {
+    if (!identical(.eventSens, "jump")) stop(attr(.scan, "condition"))
+    .eventEta[] <- 0L
+    .eventTheta[] <- 0L
+  }
+  .eventEtaAll <- .eventEta
+  if (identical(.eventSens, "jump")) {
+    .eventEta[] <- 0L
+    .eventTheta[] <- 0L
   }
   pred.opt <- NULL
   ## Build the inner (sensitivity) model with the requested event-sensitivity
@@ -2365,7 +2391,9 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
     log.etas = .nullInt(s$..extraEta[["exp"]]),
     extraProps = s$..extraTheta,
     eventTheta = .eventTheta,
-    eventEta = .eventEta
+    eventEta = .eventEta,
+    ## which etas enter a dosing expression, regardless of eventSens mode (#1016)
+    eventEtaAll = .eventEtaAll
     ## ,
     ## cache.file=cache.file
   )
@@ -2551,7 +2579,8 @@ rxUiGet.foceiModelDigest <- function(x, ...) {
   ## before the event-sensitivity mode was recorded rehydrates every
   ## sensitivity model in "fd" mode -- silently zeroing the dosing-parameter
   ## sensitivities.  Version 2: .foceiModelCacheDeflate() stores eventSens.
-  .cacheFormat <- 2L
+  ## Version 3: the bundle gained eventEtaAll (#1016), which a v2 entry lacks.
+  .cacheFormat <- 3L
   digest::digest(c(
     all(is.na(.iniDf$neta1)), .combSens, .linCmtCarry, .pkgVersion, .cacheFormat,
     rxode2::rxGetControl(.ui, "interaction", 1L),
@@ -2614,13 +2643,18 @@ attr(rxUiGet.foceiModelCache, "rstudio") <- "file"
 .foceiModelCacheInflate <- function(el) {
   if (inherits(el, "nlmixr2estFoceiNorm")) {
     .es <- el$eventSens
-    return(suppressMessages(suppressWarnings(
+    .mod <- suppressMessages(suppressWarnings(
       if (is.null(.es)) {
         rxode2::rxode2(el$norm)
       } else {
         rxode2::rxode2(el$norm, eventSens = .es)
       }
-    )))
+    ))
+    ## Replay the tag too, so an inflated bundle deflates back to the same
+    ## thing; without it a re-deflate would store eventSens = NULL and the
+    ## next inflate would drop the mode again (#1016).
+    if (!is.null(.es)) attr(.mod, "nlmixr2estEventSens") <- .es
+    return(.mod)
   }
   if (inherits(el, "rxode2")) {
     return(rxode2::rxLoad(el))
@@ -3596,6 +3630,19 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       rxode2::rxEventSensLoadModel(.ret$model$inner),
       error = function(e) FALSE
     )
+    ## A model whose f()/alag()/rate()/dur() depends on an eta gets that eta's
+    ## sensitivity ONLY from the jump injection.  If the shape does not install,
+    ## the sensitivity is exactly zero and nothing errors: the eta never leaves
+    ## its initial value while its omega stays finite (#1016).  That was a
+    ## rehydrated inner model built in "fd" mode; the mode now rides with the
+    ## cached bundle, so this is a tripwire -- say it instead of returning a
+    ## silently wrong fit.
+    if (!isTRUE(.esLoaded) &&
+      isTRUE(any(.ret$model$eventEtaAll == 1L))) {
+      warning("dosing-parameter (f/alag) event sensitivities not loaded",
+        call. = FALSE
+      )
+    }
     if (isTRUE(.esLoaded)) {
       ## Tell the C++ core which model the event path is now bound to.  handle_evid
       ## sizes its scratch from the effective neq but calls the INSTALLED model's

--- a/R/focei.R
+++ b/R/focei.R
@@ -3628,6 +3628,15 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
   ## stay silent rather than warn about every model without dosing etas.  NA:
   ## the scan that builds it failed on a model that DOES dose through
   ## f()/alag()/rate()/dur(), so a dosing eta cannot be ruled out -- warn.
+  ##
+  ## ETAS ONLY, deliberately.  A dosing expression built from THETAs alone is
+  ## NOT affected by a missing inner shape: the inner model carries eta
+  ## sensitivities only, a theta gradient comes from the outer re-solve (or from
+  ## the separately built augmented model, whose shape C++ installs itself), and
+  ## the bundle's eventTheta is read nowhere in src/.  Measured: poisoning the
+  ## stored mode for a model with f()/alag() on thetas alone reproduces the fit
+  ## exactly -- same objective, every theta to the last digit.  Warning on it
+  ## would be a false alarm.
   if (is.null(.eta)) return(invisible(FALSE))
   if (!anyNA(.eta) && !any(.eta == 1L)) return(invisible(FALSE))
   warning("dosing-parameter (f/alag) event sensitivities not loaded",

--- a/R/focei.R
+++ b/R/focei.R
@@ -2200,9 +2200,10 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
   ##
   ## Under "jump" this scan is new work that used to be skipped, so it must not
   ## be able to turn a building model into a failing one: a scan error there
-  ## leaves the flags at zero, which is exactly what the guarded code did.  In
-  ## "fd" the flags ARE the fallback switches, so an error still propagates.
-  .scan <- try(
+  ## leaves the C++ flags at zero, which is exactly what the guarded code did,
+  ## and records eventEtaAll as unknown rather than as "none" (below).  In "fd"
+  ## the flags ARE the fallback switches, so an error still propagates.
+  .scanErr <- tryCatch(
     {
       for (.v in s$..eventVars) {
         .vars <- as.character(get(.v, envir = s))
@@ -2220,16 +2221,23 @@ attr(rxUiGet.predDfFocei, "rstudio") <- NA
           }
         }
       }
-      TRUE
+      NULL
     },
-    silent = TRUE
+    error = function(e) e
   )
-  if (inherits(.scan, "try-error")) {
-    if (!identical(.eventSens, "jump")) stop(attr(.scan, "condition"))
+  .eventEtaAll <- .eventEta
+  if (!is.null(.scanErr)) {
+    ## The loop only runs when the model HAS dosing modifiers, so an error here
+    ## means "this model doses through f()/alag()/rate()/dur() and which etas
+    ## reach them could not be resolved" -- NOT "no dosing etas".  Recording it
+    ## as zeros would let the fit-time tripwire conclude the jumps do not matter
+    ## and stay silent, which is the very thing it exists to prevent, so it is
+    ## recorded as unknown instead.
+    if (!identical(.eventSens, "jump")) stop(.scanErr)
     .eventEta[] <- 0L
     .eventTheta[] <- 0L
+    .eventEtaAll[] <- NA_integer_
   }
-  .eventEtaAll <- .eventEta
   if (identical(.eventSens, "jump")) {
     .eventEta[] <- 0L
     .eventTheta[] <- 0L
@@ -3605,11 +3613,23 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
 #'
 #' @param esLoaded What `rxEventSensLoadModel()` returned.
 #' @param model The focei model bundle (for `eventEtaAll`).
+#' @param eventSens The fit's resolved `eventSens`.  Only `"jump"` asks for the
+#'   analytic sensitivities, so only `"jump"` can be missing them -- an `"fd"`
+#'   fit never installs a shape and its dosing etas go through the C++
+#'   finite-difference fallback instead.  The mode is checked here rather than
+#'   only at the call site so the helper cannot be reused into a false alarm.
 #' @return invisibly `TRUE` when it warned, `FALSE` otherwise
 #' @noRd
-.foceiEventSensWarn <- function(esLoaded, model) {
+.foceiEventSensWarn <- function(esLoaded, model, eventSens = "jump") {
+  if (!identical(eventSens, "jump")) return(invisible(FALSE))
   if (isTRUE(esLoaded)) return(invisible(FALSE))
-  if (!isTRUE(any(model$eventEtaAll == 1L))) return(invisible(FALSE))
+  .eta <- model$eventEtaAll
+  ## NULL: a bundle from before the field existed, so nothing is established --
+  ## stay silent rather than warn about every model without dosing etas.  NA:
+  ## the scan that builds it failed on a model that DOES dose through
+  ## f()/alag()/rate()/dur(), so a dosing eta cannot be ruled out -- warn.
+  if (is.null(.eta)) return(invisible(FALSE))
+  if (!anyNA(.eta) && !any(.eta == 1L)) return(invisible(FALSE))
   warning("dosing-parameter (f/alag) event sensitivities not loaded",
     call. = FALSE
   )
@@ -3656,7 +3676,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       rxode2::rxEventSensLoadModel(.ret$model$inner),
       error = function(e) FALSE
     )
-    .foceiEventSensWarn(.esLoaded, .ret$model)
+    .foceiEventSensWarn(.esLoaded, .ret$model, .eventSens)
     if (isTRUE(.esLoaded)) {
       ## Tell the C++ core which model the event path is now bound to.  handle_evid
       ## sizes its scratch from the effective neq but calls the INSTALLED model's

--- a/R/focei.R
+++ b/R/focei.R
@@ -3590,6 +3590,32 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
 }
 
 .thetaReset <- new.env(parent = emptyenv())
+#' Warn when a "jump" fit could not install the event-sensitivity shape
+#'
+#' A model whose `f()`/`alag()`/`rate()`/`dur()` depends on an eta gets that
+#' eta's sensitivity ONLY from rxode2's jump injection.  When the shape does
+#' not install the sensitivity is exactly zero and nothing errors: the eta
+#' never leaves its initial value while its omega stays finite, which is the
+#' nlmixr2est#1016 symptom.  That came from a rehydrated inner model built in
+#' "fd" mode; the mode now rides with the cached bundle, so this is a tripwire
+#' -- say it rather than return a silently wrong fit.
+#'
+#' Silent when the model has no dosing etas (nothing depends on the jumps) or
+#' when the shape did install.
+#'
+#' @param esLoaded What `rxEventSensLoadModel()` returned.
+#' @param model The focei model bundle (for `eventEtaAll`).
+#' @return invisibly `TRUE` when it warned, `FALSE` otherwise
+#' @noRd
+.foceiEventSensWarn <- function(esLoaded, model) {
+  if (isTRUE(esLoaded)) return(invisible(FALSE))
+  if (!isTRUE(any(model$eventEtaAll == 1L))) return(invisible(FALSE))
+  warning("dosing-parameter (f/alag) event sensitivities not loaded",
+    call. = FALSE
+  )
+  invisible(TRUE)
+}
+
 #' Internal focei fit function in R
 #'
 #' @param .ret Internal focei environment
@@ -3630,19 +3656,7 @@ attr(rxUiGet.foceiOptEnv, "rstudio") <- emptyenv()
       rxode2::rxEventSensLoadModel(.ret$model$inner),
       error = function(e) FALSE
     )
-    ## A model whose f()/alag()/rate()/dur() depends on an eta gets that eta's
-    ## sensitivity ONLY from the jump injection.  If the shape does not install,
-    ## the sensitivity is exactly zero and nothing errors: the eta never leaves
-    ## its initial value while its omega stays finite (#1016).  That was a
-    ## rehydrated inner model built in "fd" mode; the mode now rides with the
-    ## cached bundle, so this is a tripwire -- say it instead of returning a
-    ## silently wrong fit.
-    if (!isTRUE(.esLoaded) &&
-      isTRUE(any(.ret$model$eventEtaAll == 1L))) {
-      warning("dosing-parameter (f/alag) event sensitivities not loaded",
-        call. = FALSE
-      )
-    }
+    .foceiEventSensWarn(.esLoaded, .ret$model)
     if (isTRUE(.esLoaded)) {
       ## Tell the C++ core which model the event path is now bound to.  handle_evid
       ## sizes its scratch from the effective neq but calls the INSTALLED model's

--- a/tests/testthat/test-focei-event-eta-1016.R
+++ b/tests/testthat/test-focei-event-eta-1016.R
@@ -98,6 +98,10 @@ nmTest({
     # the shape installed -- nothing to say
     expect_false(.foceiEventSensWarn(TRUE, .b))
     expect_silent(.foceiEventSensWarn(TRUE, .b))
+    # an "fd" fit never installs a shape; its dosing etas go through the C++
+    # finite-difference fallback, so a missing shape there is not a defect
+    expect_false(.foceiEventSensWarn(FALSE, .b, "fd"))
+    expect_silent(.foceiEventSensWarn(FALSE, .b, "fd"))
     # it did not, and this model's etas need it: the fit would otherwise leave
     # eta.f/eta.lag where they started with no diagnostic at all
     expect_warning(
@@ -113,6 +117,16 @@ nmTest({
     )
     # a model with no dosing eta does not depend on the jumps, so it stays quiet
     .b$eventEtaAll <- c(0L, 0L, 0L)
+    expect_false(.foceiEventSensWarn(FALSE, .b))
+    expect_silent(.foceiEventSensWarn(FALSE, .b))
+    # unknown is NOT quiet: the scan that fills eventEtaAll only runs on a model
+    # that doses through f()/alag()/rate()/dur(), so a failed scan cannot be
+    # read as "no dosing etas" -- that would silence the tripwire on exactly the
+    # models it exists for
+    .b$eventEtaAll <- c(NA_integer_, NA_integer_, NA_integer_)
+    expect_warning(expect_true(.foceiEventSensWarn(FALSE, .b)))
+    # a bundle from before the field existed establishes nothing either way
+    .b$eventEtaAll <- NULL
     expect_false(.foceiEventSensWarn(FALSE, .b))
     expect_silent(.foceiEventSensWarn(FALSE, .b))
   })
@@ -166,6 +180,42 @@ nmTest({
     # and they did not collapse: with the jumps gone both fits sat at ~1e-9
     expect_gt(max(abs(.f1$eta$eta.f)), 1e-3)
     expect_gt(max(abs(.f2$eta$eta.f)), 1e-3)
+  })
+
+  test_that("a fit whose cached bundle lost the mode says so (#1016)", {
+    skip_on_cran()
+    .dat <- .evEtaDat()
+    .ctl <- foceiControl(
+      print = 0, maxOuterIterations = 0L, covMethod = "",
+      calcTables = FALSE, sigdig = 6, etaNudge = 0, etaNudge2 = 0
+    )
+    .msg <- "event sensitivities not loaded"
+    # healthy first: the assertion below has to be able to come out either way
+    .ok <- .nlmixr(.evEtaMod, .dat, est = "focei", control = .ctl)
+    expect_false(any(grepl(.msg, .ok$runInfo)))
+
+    # now reproduce #1016 itself end to end.  The bundle is cached as model
+    # TEXT plus the mode that built it; before the fix the mode was not stored,
+    # so every fit after the first rehydrated the inner model in "fd" mode.
+    # Poisoning the stored mode is exactly that state.
+    .ui <- rxode2::.copyUi(suppressMessages(nlmixr2est::nlmixr2(.evEtaMod)))
+    assign("control", .ctl, envir = .ui)
+    .cacheFile <- .ui$foceiModelCache
+    on.exit(unlink(.cacheFile), add = TRUE)
+    expect_true(file.exists(.cacheFile))
+    .store <- readRDS(.cacheFile)
+    expect_equal(.store$inner$eventSens, "jump")
+    .store$inner$eventSens <- "fd"
+    saveRDS(.store, .cacheFile)
+
+    # the fit still runs and still returns -- that is the whole problem -- so
+    # the only thing that tells anyone is the note on $runInfo
+    .bad <- .nlmixr(.evEtaMod, .dat, est = "focei", control = .ctl)
+    expect_true(any(grepl(.msg, .bad$runInfo)))
+    # and it is the #1016 answer: the dosing etas did not move (reported as
+    # ~9e-09 on the issue's own model; the healthy fit below is 100x larger)
+    expect_lt(max(abs(.bad$eta$eta.f)), 1e-5)
+    expect_gt(max(abs(.ok$eta$eta.f)), 1e-3)
   })
 
 })

--- a/tests/testthat/test-focei-event-eta-1016.R
+++ b/tests/testthat/test-focei-event-eta-1016.R
@@ -1,0 +1,171 @@
+# Event-modifier (f()/alag()) eta sensitivities -- nlmixr2est#1016.
+#
+# The reported symptom was a fit that left every f()/alag() eta at ~1e-9 while
+# their omegas stayed finite, deterministically on the SECOND and later fits of
+# a model in one R session.  The cause was the focei model bundle: it is cached
+# as model TEXT and rehydrated with rxode2(), and eventSens is not recoverable
+# from a compiled model, so the first fit built the jump models and every later
+# one rebuilt them in "fd" mode.  Nothing errored -- the dosing-parameter
+# sensitivity was simply zero, so those etas had no reason to move.
+#
+# What these tests pin, from the bottom up:
+#   1. the cached-bundle round trip keeps the mode AND the shape still installs;
+#   2. the inner model's d(pred)/d(eta) for a dosing eta matches central
+#      differences (so the jumps are not merely present but right);
+#   3. a repeat fit in one session gives the same etas as the first, and the
+#      dosing etas are not collapsed.
+# (1) and (3) are what regress if the mode is ever dropped again.
+
+nmTest({
+
+  .evEtaMod <- function() {
+    ini({
+      tka <- log(1.2)
+      tcl <- log(2)
+      tv <- log(20)
+      tf <- -0.5
+      tlag <- log(0.5)
+      eta.cl ~ 0.1
+      eta.f ~ 0.1
+      eta.lag ~ 0.1
+      add.sd <- 0.5
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl) * exp(eta.cl)
+      v <- exp(tv)
+      f(depot) <- expit(tf + eta.f)
+      alag(depot) <- exp(tlag + eta.lag)
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - (cl / v) * central
+      cp <- central / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  # non-uniform dose/observation spacing (uniform spacing has hidden pairing
+  # bugs in this area before)
+  .evEtaDat <- function(nid = 4L) {
+    do.call(rbind, lapply(seq_len(nid), function(i) {
+      tim <- c(0, 3, 7, 15, 24, 30, 41, 50) + (i - 1) * 0.5
+      data.frame(
+        id = i, time = tim, amt = c(100, 0, 100, 0, 100, 0, 100, 0),
+        evid = c(1, 0, 1, 0, 1, 0, 1, 0), cmt = 1,
+        dv = c(0, 1.7, 2.4, 1.1, 2.9, 2.2, 3.1, 1.8) + 0.1 * i
+      )
+    }))
+  }
+
+  .evEtaBundle <- function(eventSens) {
+    .ui <- rxode2::.copyUi(suppressMessages(nlmixr2est::nlmixr2(.evEtaMod)))
+    assign("control", foceiControl(eventSens = eventSens), envir = .ui)
+    suppressMessages(suppressWarnings(.ui$foceiModel))
+  }
+
+  test_that("a dosing eta is flagged in eventEtaAll in both eventSens modes", {
+    skip_on_cran()
+    # eta.cl is not a dosing parameter; eta.f and eta.lag are
+    for (.es in c("jump", "fd")) {
+      .b <- .evEtaBundle(.es)
+      expect_equal(as.integer(.b$eventEtaAll), c(0L, 1L, 1L))
+    }
+    # the finite-difference switches C++ reads stay off under "jump" (the
+    # analytic jump sensitivity is computed, so the FD fallback must not run)
+    expect_equal(as.integer(.evEtaBundle("jump")$eventEta), c(0L, 0L, 0L))
+    expect_equal(as.integer(.evEtaBundle("fd")$eventEta), c(0L, 1L, 1L))
+  })
+
+  test_that("the cached bundle round trip keeps the jump shape (#1016)", {
+    skip_on_cran()
+    .inner <- .evEtaBundle("jump")$inner
+    expect_equal(attr(.inner, "nlmixr2estEventSens"), "jump")
+    # deflate/inflate is what every fit after the first one does
+    .rt <- .foceiModelCacheInflate(.foceiModelCacheDeflate(.inner))
+    expect_equal(attr(.rt, "nlmixr2estEventSens"), "jump")
+    # and it round trips again -- an inflated bundle must not deflate to NULL
+    .rt2 <- .foceiModelCacheInflate(.foceiModelCacheDeflate(.rt))
+    expect_equal(attr(.rt2, "nlmixr2estEventSens"), "jump")
+    # the point of the mode: the event-sensitivity shape still installs.  This
+    # is the exact call .foceiFitInternal makes before the C++ solve loop, and
+    # it returned FALSE for a rehydrated bundle before the fix.
+    on.exit(rxode2::rxEventSensDeactivate(), add = TRUE)
+    expect_true(isTRUE(rxode2::rxEventSensLoadModel(.rt2)))
+  })
+
+  test_that("a jump fit that lost its shape says so (#1016)", {
+    skip_on_cran()
+    .b <- .evEtaBundle("jump")
+    # the shape installed -- nothing to say
+    expect_false(.foceiEventSensWarn(TRUE, .b))
+    expect_silent(.foceiEventSensWarn(TRUE, .b))
+    # it did not, and this model's etas need it: the fit would otherwise leave
+    # eta.f/eta.lag where they started with no diagnostic at all
+    expect_warning(
+      expect_true(.foceiEventSensWarn(FALSE, .b)),
+      "event sensitivities not loaded"
+    )
+    # the warning reaches the user through $runInfo, which renders one bullet
+    # per line
+    expect_lt(
+      nchar(tryCatch(.foceiEventSensWarn(FALSE, .b),
+        warning = function(w) conditionMessage(w)
+      )), 75
+    )
+    # a model with no dosing eta does not depend on the jumps, so it stays quiet
+    .b$eventEtaAll <- c(0L, 0L, 0L)
+    expect_false(.foceiEventSensWarn(FALSE, .b))
+    expect_silent(.foceiEventSensWarn(FALSE, .b))
+  })
+
+  test_that("dosing-eta sensitivities match central differences (#1016)", {
+    skip_on_cran()
+    .m <- .evEtaBundle("jump")$inner
+    .ev <- .evEtaDat(1L)
+    .p <- c(
+      `THETA[1]` = log(1.2), `THETA[2]` = log(2), `THETA[3]` = log(20),
+      `THETA[4]` = -0.5, `THETA[5]` = log(0.5), `THETA[6]` = 0.5,
+      `ETA[1]` = 0.3, `ETA[2]` = -0.2, `ETA[3]` = 0.1
+    )
+    .slv <- function(q) {
+      suppressWarnings(rxode2::rxSolve(.m,
+        params = q, events = .ev, returnType = "data.frame",
+        atol = 1e-12, rtol = 1e-12
+      ))
+    }
+    .r0 <- .slv(.p)
+    .h <- 1e-4
+    for (.k in 2:3) { # ETA[2] = f(), ETA[3] = alag()
+      .en <- paste0("ETA[", .k, "]")
+      .a <- .p
+      .a[.en] <- .a[.en] + .h
+      .b <- .p
+      .b[.en] <- .b[.en] - .h
+      .fd <- (.slv(.a)$rx_pred_ - .slv(.b)$rx_pred_) / (2 * .h)
+      .an <- .r0[[paste0("rx__sens_rx_pred__BY_ETA_", .k, "___")]]
+      # not merely nonzero: right.  Without the jumps .an is exactly 0.
+      expect_gt(max(abs(.an)), 1e-3)
+      expect_lt(max(abs(.an - .fd)) / max(abs(.fd)), 1e-4)
+    }
+  })
+
+  test_that("a repeat fit keeps its f()/alag() etas (#1016)", {
+    skip_on_cran()
+    .dat <- .evEtaDat()
+    .ctl <- foceiControl(
+      print = 0, maxOuterIterations = 0L, covMethod = "",
+      calcTables = FALSE, sigdig = 6, etaNudge = 0, etaNudge2 = 0
+    )
+    .f1 <- .nlmixr(.evEtaMod, .dat, est = "focei", control = .ctl)
+    # the second fit of a model in one session is the one that read the cached
+    # bundle -- it lost the jump mode, and with it every dosing-eta gradient
+    .f2 <- .nlmixr(.evEtaMod, .dat, est = "focei", control = .ctl)
+    expect_equal(.f2$objective, .f1$objective, tolerance = 1e-6)
+    expect_equal(as.matrix(.f2$eta[, -1]), as.matrix(.f1$eta[, -1]),
+      tolerance = 1e-5
+    )
+    # and they did not collapse: with the jumps gone both fits sat at ~1e-9
+    expect_gt(max(abs(.f1$eta$eta.f)), 1e-3)
+    expect_gt(max(abs(.f2$eta$eta.f)), 1e-3)
+  })
+
+})

--- a/tests/testthat/test-focei-event-eta-1016.R
+++ b/tests/testthat/test-focei-event-eta-1016.R
@@ -218,4 +218,60 @@ nmTest({
     expect_gt(max(abs(.ok$eta$eta.f)), 1e-3)
   })
 
+  # dosing built from THETAs alone: the tripwire is eta-scoped on purpose, and
+  # this is why.  A missing inner shape cannot change such a fit -- the inner
+  # model carries eta sensitivities only, a theta gradient comes from the outer
+  # re-solve, and the bundle's eventTheta is read nowhere in src/ -- so warning
+  # on it would be a false alarm on every model with a modeled lag and no eta
+  # on it.
+  .evThetaMod <- function() {
+    ini({
+      tka <- log(1.2)
+      tcl <- log(2)
+      tv <- log(20)
+      tf <- -0.5
+      tlag <- log(0.5)
+      eta.cl ~ 0.1
+      add.sd <- 0.5
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl) * exp(eta.cl)
+      v <- exp(tv)
+      f(depot) <- expit(tf)
+      alag(depot) <- exp(tlag)
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - (cl / v) * central
+      cp <- central / v
+      cp ~ add(add.sd)
+    })
+  }
+
+  test_that("dosing on thetas alone is untouched by a lost shape (#1016)", {
+    skip_on_cran()
+    .dat <- .evEtaDat()
+    .ctl <- foceiControl(
+      print = 0, maxOuterIterations = 20L, covMethod = "",
+      calcTables = FALSE, sigdig = 5, etaNudge = 0, etaNudge2 = 0
+    )
+    .ui <- rxode2::.copyUi(suppressMessages(nlmixr2est::nlmixr2(.evThetaMod)))
+    assign("control", .ctl, envir = .ui)
+    .cacheFile <- .ui$foceiModelCache
+    on.exit(unlink(.cacheFile), add = TRUE)
+    .ok <- .nlmixr(.evThetaMod, .dat, est = "focei", control = .ctl)
+    # no eta enters a dosing expression, so there is nothing for the jumps to
+    # carry into the inner problem
+    .store <- readRDS(.cacheFile)
+    expect_equal(as.integer(.store$eventEtaAll), 0L)
+
+    .store$inner$eventSens <- "fd"
+    saveRDS(.store, .cacheFile)
+    .bad <- .nlmixr(.evThetaMod, .dat, est = "focei", control = .ctl)
+    # identical fit, to the last digit -- measured max abs theta difference 0
+    expect_equal(.bad$objective, .ok$objective, tolerance = 1e-10)
+    expect_equal(.bad$theta, .ok$theta, tolerance = 1e-10)
+    # so it must stay quiet
+    expect_false(any(grepl("event sensitivities not loaded", .bad$runInfo)))
+  })
+
 })

--- a/tests/testthat/test-focei-lincmt-carry-jump-fit.R
+++ b/tests/testthat/test-focei-lincmt-carry-jump-fit.R
@@ -73,20 +73,20 @@ cp = central/v", function(i) {
   etaO <- as.matrix(fO$eta[, -1])
   expect_lt(max(abs(etaC - etaO)), 2e-3)
   # This used to run two independent 200-iteration fits and compare their
-  # converged objectives.  That comparison is not restorable: the ODE
-  # reference is only trustworthy as the FIRST ODE fit in an R session.
-  # Every later one loses its f()/alag() eta sensitivities -- the event
-  # etas collapse to ~1e-9 and it converges elsewhere (nlmixr2est#1016),
-  # deterministically by position in the session (nlmixr2est#1015).  Both
-  # are pre-existing and unrelated to the carry (bisected across the
-  # linCmt stack).  So `fO` above is the one ODE reference this test may
-  # use, and what replaces the converged comparison is a FIXED-POINT
-  # surface check that needs no reference and no optimizer at all: freeze
+  # converged objectives.  That comparison was dropped when the ODE
+  # reference was only trustworthy as the FIRST ODE fit in an R session:
+  # every later one lost its f()/alag() eta sensitivities and converged
+  # elsewhere (nlmixr2est#1016).  #1016 is fixed -- the event-sensitivity
+  # mode now rides with the cached model bundle, so repeated ODE fits in
+  # one session agree (test-focei-event-eta-1016.R pins that) -- but the
+  # fixed-point check that replaced it is the better test and stays: it
+  # needs no reference and no optimizer at all.  Freeze
   # theta+omega (finalUi) and eta (etaMat) with both iteration caps at 0.
   # FOCEi's objective carries a Laplace log|H| term built from the eta
   # sensitivities, so the carry still moves it with the etas held --
   # which is exactly what this PR is responsible for.  Do not reinstate
-  # the converged-objective comparison.
+  # the converged-objective comparison: it was a weaker check even before
+  # #1016 made it unusable.
   .fixedObj <- function(ui, carry) {
     .em <- as.matrix(fC$eta[, setdiff(names(fC$eta), "ID"), drop = FALSE])
     .ctl <- nlmixr2est::foceiControl(


### PR DESCRIPTION
Closes #1016.

## What #1016 was

A focei fit of a model whose dosing depends on an eta -- `f()`, `alag()`,
`rate()`, `dur()` -- left those etas at ~1e-9 while their omegas stayed
finite, deterministically on the SECOND and later fits of a model in one R
session.

The cause is settled: the focei model bundle is cached as model TEXT and
rehydrated with `rxode2()`, and `eventSens` is not recoverable from a compiled
model, so the first fit of a session built the jump models and every later one
rebuilt them in `"fd"` mode. Without the jump injection a dosing eta's
sensitivity is exactly zero, so the inner problem has no reason to move it.
`f783ba4f6` fixed that by carrying the mode with the cached bundle.

## The symptom is gone -- measured, not assumed

Three identical 200-iteration fits of the issue's own ODE arm (`linToOde()`,
`useLinCmt = FALSE`, 6 subjects) in one session:

| fit in session | objf | max&#124;eta.f&#124; | max&#124;eta.lag&#124; |
|---|---|---|---|
| 1 | -29.4305 | 7.58e-02 | 1.44e-02 |
| 2 | -29.4305 | 7.58e-02 | 1.44e-02 |
| 3 | -29.4305 | 7.58e-02 | 1.44e-02 |

and the issue's own "what would settle it" check: the inner model's
`d(pred)/d(eta)` for the `f()` and `alag()` etas matches central differences to
~1e-8 (it is exactly 0 without the jumps), and the inner optimizer reaches the
true per-subject minimum -- verified against a brute-force `optim()` on an
independently integrated individual objective, agreeing for all 6 subjects.

## What this PR adds

What was missing is anything that would catch it coming back, and any signal at
all when it does:

- **the tripwire.** `.foceiEventSensWarn()` warns when `"jump"` was asked for,
  the model has dosing etas, and `rxEventSensLoadModel()` declines. That is the
  whole failure mode -- nothing errors today, the answer is just wrong.
- **`eventEtaAll`.** The dosing-parameter scan that builds
  `eventEta`/`eventTheta` now runs in both `eventSens` modes and its result is
  kept, so the fit can tell "this model needs the jumps" from "this model has
  no dosing etas". The finite-difference switches C++ reads are still zeroed
  under `"jump"`, so no fit changes behaviour. A scan error under `"jump"` is
  recorded as NA (unknown) -- not as zeros, which would silence the tripwire on
  exactly the models it exists for -- and leaves the C++ flags at zero rather
  than failing a build that used to work.
- **idempotent rehydration.** `.foceiModelCacheInflate()` replays the
  `eventSens` tag onto the rebuilt model, so an inflated bundle deflates back to
  the same thing instead of losing the mode on a second round trip.
- **cache format 3**, since a v2 entry has no `eventEtaAll`.
- **`test-focei-event-eta-1016.R`** (39 assertions, ~13s, essential subset):
  the bundle round trip keeps the mode and still installs the shape (twice), the
  dosing-eta sensitivities match central differences, the tripwire fires only
  when it should and fits in `$runInfo`'s one line, two fits in one session
  agree without collapsing, and -- end to end -- a fit whose cached bundle has
  its stored mode poisoned to `"fd"` reports the note on `$runInfo` while its
  dosing etas collapse exactly as #1016 described.

## Verification

- The tests catch the bug: with the `eventSens` replay removed from
  `.foceiModelCacheInflate()`, 10 assertions fail. Equality of the two fits
  alone does **not** catch it (both read the same broken cache), which is why
  the non-collapse assertions are there.
- The `f()`+`alag()` ODE fit is bit-identical before and after this change, in
  both `eventSens` modes.
- 85 focei/foce/fo/agq/laplace/posthoc/ebe/sens/lag/cov test files, 8587
  assertions, 0 failures; a 16-file subset re-run against the final code, 0
  failures.
- `habit-hooks --branch main` reports a strict subset of main's own findings on
  `R/focei.R` -- no new item. CodeFactor on this PR: no issues found.
- Three rounds of independent (Gemini/antigravity) review. Round 1 found three
  real issues, all fixed here. Round 2's two findings were rejected by
  measurement (below). Round 3 found nothing.

## Rejected from review, with the measurement

Round 2 argued the tripwire is scoped wrong: a model whose `f()`/`alag()` is
built from THETAs alone would be silently broken by a missing shape. Built that
model and poisoned the stored mode, 20 outer iterations:

| | objf | tka | tcl | tv | tf | tlag |
|---|---|---|---|---|---|---|
| healthy | -8.568276 | 1.59727 | 0.07214 | 3.02032 | -0.57680 | -0.52249 |
| poisoned | -8.568276 | 1.59727 | 0.07214 | 3.02032 | -0.57680 | -0.52249 |

Max abs theta difference 0. The proposed mechanism does not hold either:
`eventTheta` occurs zero times in `src/`, so zeroing it under `"jump"` cannot
make C++ expect an analytic jump sensitivity -- the inner model carries eta
sensitivities only, and a theta gradient comes from the outer re-solve or from
the augmented model whose shape C++ installs itself. Warning there would be a
false alarm on every model with a modeled lag and no eta on it. The eta scoping
is now documented on the helper and pinned by a test.

## Noted, not fixed

`eventSens="fd"` (the non-default legacy path) converges to a worse inner
optimum than `"jump"` on this model -- measured per subject against the same
brute-force minimizer, `"jump"` hits it and `"fd"` misses by up to 0.12 in
`eta.f`. That is the finite-difference fallback's accuracy, not the collapse
#1016 describes, and the default path is correct; it is left alone here and is
worth its own issue.