### PR TITLE
fix(saem): keep the analytic Omega SEs when splicing the linearized FIM (#1022)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,13 @@
   Omega block still takes the whole block from the linearized FIM, because the
   Louis score only ever sees the diagonal of Omega (#1022).
 
+- `saemControl(covMethod="sa"|"fim")` no longer reports a standard error for a
+  `fix()`ed additive residual error.  The SAEM kernel fills an endpoint's
+  residual slot whether or not the value is estimated, so a fixed `add.sd` came
+  back with a covariance row -- printed as a back-transformed 95% interval on a
+  value the fit never estimated -- and the remaining parameters were given the
+  marginal instead of the conditional information.  Found while fixing #1022.
+
 - `foceiControl(fast=TRUE)` no longer converges to a non-stationary point when
   an external likelihood contribution is registered (`nlmixrRegisterLikContrib`,
   e.g. from `nlmixr2nn`).  The analytic outer gradient re-derives

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 ## Bug fixes
 
+- `saemControl(covMethod="sa"|"fim")` keeps its own Omega standard errors on a
+  diagonal-Omega model.  The variance parameters the analytic FIM cannot cover
+  (a non-additive endpoint's residual error) are still taken from the
+  linearized FIM, but that splice replaced the WHOLE variance block, so a
+  near-singular residual pair propagated into the Omega rows -- on a
+  two-endpoint `add()+prop()` / `add()` model `om.eta.ka` reported an SE of 560
+  against an estimate of 1.1, where the analytic FIM gives 0.51.  A declared
+  Omega block still takes the whole block from the linearized FIM, because the
+  Louis score only ever sees the diagonal of Omega (#1022).
+
 - `foceiControl(fast=TRUE)` no longer converges to a non-stationary point when
   an external likelihood contribution is registered (`nlmixrRegisterLikContrib`,
   e.g. from `nlmixr2nn`).  The analytic outer gradient re-derives

--- a/R/saem.R
+++ b/R/saem.R
@@ -827,11 +827,45 @@
   dimnames(.cm) <- list(.tn, .tn)
   .miss <- .miss[.miss %in% .tn]
   if (length(.miss) == 0L) return(.cov)
+  .saemSpliceBlock(.cov, .cm, .miss)
+}
+#' Append parameters a SAEM covariance does not have as their own block
+#'
+#' Both splices add the parameters the analytic FIM could not supply from the
+#' linearized FIM block-diagonally, with zero cross-terms to the rows already
+#' present (the linearized FIM is itself block-diagonal between the fixed-effect
+#' and variance blocks, so no cross-term is discarded within a block).
+#' @param .cov covariance to extend
+#' @param .src covariance carrying the missing rows
+#' @param .miss names to splice in (all present in `.src`)
+#' @return `.cov` extended by the `.miss` block
+#' @noRd
+.saemSpliceBlock <- function(.cov, .src, .miss) {
+  .rn <- rownames(.cov)
   .fn <- c(.rn, .miss)
   .full <- matrix(0, length(.fn), length(.fn), dimnames = list(.fn, .fn))
   .full[.rn, .rn] <- .cov
-  .full[.miss, .miss] <- .cm[.miss, .miss, drop = FALSE]
+  .full[.miss, .miss] <- .src[.miss, .miss, drop = FALSE]
   .full
+}
+#' The linearized FIM's variance block (blocB), or `NULL`
+#'
+#' `calc.COV()` returns the structural-theta covariance with the inverted
+#' variance block (all Omega variances/covariances + residual parameters) as its
+#' `varCov` attribute.  This is the guarded accessor: `NULL` whenever `covFull`
+#' is off, the linearization fails, or the block is missing/non-finite.
+#' @param env saem fit environment
+#' @return named variance covariance matrix, or `NULL`
+#' @noRd
+.saemLinFimVarBlock <- function(env) {
+  if (!isTRUE(rxode2::rxGetControl(env$ui, "covFull", TRUE))) return(NULL)
+  .saem <- env$saem
+  attr(.saem, "env") <- env
+  .cm <- suppressWarnings(tryCatch(calc.COV(.saem), error = function(e) NULL))
+  if (is.null(.cm) || inherits(.cm, "try-error")) return(NULL)
+  .vc <- attr(.cm, "varCov")
+  if (is.null(.vc) || !is.matrix(.vc) || !all(is.finite(.vc))) return(NULL)
+  .vc
 }
 #' Splice the linearized-FIM variance block into a fim/sa covariance
 #'
@@ -859,26 +893,16 @@
 #' @return covariance with the linFim variance block spliced in, or `.cov` unchanged
 #' @noRd
 .saemSpliceLinFimVar <- function(.cov, env) {
-  if (!isTRUE(rxode2::rxGetControl(env$ui, "covFull", TRUE))) return(.cov)
-  .saem <- env$saem
-  attr(.saem, "env") <- env
-  .cm <- suppressWarnings(tryCatch(calc.COV(.saem), error = function(e) NULL))
-  if (is.null(.cm) || inherits(.cm, "try-error")) return(.cov)
-  .vc <- attr(.cm, "varCov")
-  if (is.null(.vc) || !is.matrix(.vc) || !all(is.finite(.vc))) return(.cov)
+  .vc <- .saemLinFimVarBlock(env)
+  if (is.null(.vc)) return(.cov)
   .vn <- colnames(.vc)
   .rn <- rownames(.cov)
   .miss <- .vn[!(.vn %in% .rn)]
   if (length(.miss) == 0L) return(.cov)     # analytic already covers the variance block
   if (!any(grepl("^cov\\.", .vn))) {
     # diagonal Omega: keep the analytic block (and its theta cross-terms) and splice
-    # only the missing residual parameters, as a block, the same way
-    # .saemSplicePhi0Theta splices a missing theta
-    .fn <- c(.rn, .miss)
-    .full <- matrix(0, length(.fn), length(.fn), dimnames = list(.fn, .fn))
-    .full[.rn, .rn] <- .cov
-    .full[.miss, .miss] <- .vc[.miss, .miss, drop = FALSE]
-    return(.full)
+    # only the missing residual parameters
+    return(.saemSpliceBlock(.cov, .vc, .miss))
   }
   # keep the simulation structural-theta block; take the whole variance block from linFim
   .th <- .rn[!(.rn %in% .vn) & !grepl("^om\\.|^cov\\.", .rn)]

--- a/R/saem.R
+++ b/R/saem.R
@@ -667,15 +667,20 @@
 #' endpoint's residual is `fix()`ed, but a fixed value is not estimated, so the
 #' slot is dropped before inverting the same way a fixed theta's row is
 #' (`calc.COV`'s variance block excludes it too).
+#'
+#' `nb_param = nphi1 + nlambda + nResidEp` with the residual slots LAST, so the
+#' block starts at `.np - nendpnt` -- taken from the matrix itself rather than
+#' from a theta+Omega row count, because dropping the wrong row here would
+#' silently remove an Omega row instead.
 #' @param .idf model `iniDf`
 #' @param .predDf model `predDf`
-#' @param .base number of FIM rows ahead of the residual block (theta + Omega diag)
 #' @param .np FIM dimension
 #' @return integer FIM positions to drop, possibly empty
 #' @noRd
-.saemFimFixedResidSlots <- function(.idf, .predDf, .base, .np) {
+.saemFimFixedResidSlots <- function(.idf, .predDf, .np) {
   .nEp <- length(.predDf$cond)
-  if (.nEp == 0L || .np < .base + .nEp) return(integer(0))
+  if (.nEp == 0L || .np <= .nEp) return(integer(0))
+  .base <- .np - .nEp
   .base + which(vapply(seq_len(.nEp), function(.i) {
     .rows <- .idf[which(.idf$condition == paste(.predDf$cond[.i]) & !is.na(.idf$err)), ,
                   drop = FALSE]
@@ -770,7 +775,7 @@
   .nEta <- length(.etaN)
   .zeroRows <- which(apply(.H, 1L, function(.r) all(.r == 0)))
   .drop <- Reduce(union, list(which(.fx), match(.phi0Nm, .tn), .zeroRows,
-                              .saemFimFixedResidSlots(.idf, .predDf, .nth + .nEta, .np)))
+                              .saemFimFixedResidSlots(.idf, .predDf, .np)))
   .keep <- if (length(.drop) > 0L) seq_len(.np)[-.drop] else seq_len(.np)
   if (length(.keep) == 0L) return(NULL)
   .C <- suppressWarnings(tryCatch(solve(.H[.keep, .keep, drop = FALSE]), error = function(e) NULL))
@@ -791,13 +796,15 @@
     .jac <- c(.jac, .omVar[seq_len(.nEta)])
   }
   # per-endpoint additive residual: src/saem.cpp lays out one log-sigma2 slot per
-  # endpoint (in .predDf$cond order, matching resMat's rows), right after the
-  # theta+Omega-diag block -- d(sd)/d(log sigma2) = 0.5 sd.  Only a PURE additive,
+  # endpoint (in .predDf$cond order, matching resMat's rows) as the LAST nendpnt
+  # rows of nb_param -- d(sd)/d(log sigma2) = 0.5 sd.  Only a PURE additive,
   # estimated endpoint has a real slot; any other endpoint's slot was dropped above
   # (all-zero row, or fix()ed) and simply has no surviving column to select here.
+  # The base comes from .np, the same way .saemFimFixedResidSlots derives it, so
+  # the row dropped and the row read are always the same one.
   .nEp <- length(.predDf$cond)
-  if (.nEp > 0L && .np >= .nth + .nEta + .nEp) {
-    .base <- .nth + .nEta
+  if (.nEp > 0L && .np > .nEp) {
+    .base <- .np - .nEp
     for (.i in seq_len(.nEp)) {
       .sub <- .orig2sub[.base + .i]
       if (is.na(.sub)) next
@@ -892,6 +899,47 @@
   if (is.null(.vc) || !is.matrix(.vc) || !all(is.finite(.vc))) return(NULL)
   .vc
 }
+#' Reported row order for a SAEM fim/sa covariance
+#'
+#' Structural thetas in `iniDf` order, then the Omega rows, then the residual
+#' parameters in `iniDf` order, so the order does not depend on which rows the
+#' splices happened to append.  Each name is classified from `iniDf` FIRST: a
+#' theta or residual a user named `cov.tka`/`om.err` matches the Omega name
+#' prefix as well, and a name landing in two groups would duplicate its row and
+#' column and hand back a singular matrix.  Names no group claims keep their
+#' original position, at the end.
+#' @param .rn current covariance rownames
+#' @param .idf model `iniDf`
+#' @return `.rn` permuted -- the same set, each name exactly once
+#' @noRd
+.saemCovRowOrder <- function(.rn, .idf) {
+  .thOrd <- .idf$name[!is.na(.idf$ntheta) & is.na(.idf$err)]
+  .thOrd <- .thOrd[.thOrd %in% .rn]
+  .resOrd <- .idf$name[!is.na(.idf$err)]
+  .resOrd <- .resOrd[.resOrd %in% .rn]
+  .omOrd <- .rn[grepl("^om\\.|^cov\\.", .rn) & !(.rn %in% c(.thOrd, .resOrd))]
+  .ord <- unique(c(.thOrd, .omOrd, .resOrd))
+  c(.ord, .rn[!(.rn %in% .ord)])
+}
+#' Is the fitted Omega diagonal (so the Louis Omega score is valid)?
+#'
+#' `d1_loggamma2_phi1` (`src/saem.cpp`) divides element-wise by the DIAGONAL of
+#' `Gamma2_phi1`, so the analytic FIM's Omega information only describes a
+#' diagonal Omega.  Asked of the fitted matrix rather than of the names
+#' `calc.COV` built, because a `fix()`ed off-diagonal carries no `cov.` name
+#' (`.foceiOmegaPairs` drops fixed elements) yet still invalidates the score.  An
+#' unreadable Omega answers `FALSE`, which keeps the wholesale splice.
+#' @param env saem fit environment
+#' @return `TRUE` only when Omega is known to be diagonal
+#' @noRd
+.saemOmegaIsDiagonal <- function(env) {
+  .om <- tryCatch(as.matrix(env$saem$Gamma2_phi1), error = function(e) NULL)
+  if (!is.matrix(.om) || nrow(.om) == 0L || nrow(.om) != ncol(.om) ||
+        !all(is.finite(.om))) {
+    return(FALSE)
+  }
+  nrow(.om) == 1L || !any(.om[upper.tri(.om)] != 0)
+}
 #' Splice the linearized-FIM variance block into a fim/sa covariance
 #'
 #' The analytic (simulation) FIM reliably covers theta + diagonal Omega + additive
@@ -901,10 +949,11 @@
 #' `calc.COV` (blocB), which handles them via the marginal covariance.  Filling a
 #' dropped slot from linFim is the intended design, not a leak (#1022).
 #'
-#' How much is taken depends on whether Omega is diagonal, because the Louis score
-#' divides by the DIAGONAL of `Gamma2_phi1` only (`d1_loggamma2_phi1`, `src/saem.cpp`):
+#' How much is taken depends on whether Omega is diagonal
+#' (`.saemOmegaIsDiagonal`), because the Louis score divides by the DIAGONAL of
+#' `Gamma2_phi1` only (`d1_loggamma2_phi1`, `src/saem.cpp`):
 #'
-#' * a declared Omega block -- the analytic Omega information ignores the
+#' * a non-diagonal Omega -- the analytic Omega information ignores the
 #'   off-diagonals, so only the structural-theta block is kept and the WHOLE variance
 #'   block comes from linFim.
 #' * a diagonal Omega -- the analytic FIM covers every Omega variance correctly, so
@@ -924,13 +973,18 @@
   .rn <- rownames(.cov)
   .miss <- .vn[!(.vn %in% .rn)]
   if (length(.miss) == 0L) return(.cov)     # analytic already covers the variance block
-  if (!any(grepl("^cov\\.", .vn))) {
+  if (.saemOmegaIsDiagonal(env)) {
     # diagonal Omega: keep the analytic block (and its theta cross-terms) and splice
     # only the missing residual parameters
     return(.saemSpliceBlock(.cov, .vc, .miss))
   }
-  # keep the simulation structural-theta block; take the whole variance block from linFim
-  .th <- .rn[!(.rn %in% .vn) & !grepl("^om\\.|^cov\\.", .rn)]
+  # keep the simulation structural-theta block; take the whole variance block from
+  # linFim.  Which rows are thetas comes from iniDf, not from an "om./cov." name
+  # prefix: a structural theta a user happened to name cov.tka matches that prefix
+  # and would be dropped from the reported covariance entirely.
+  .idf <- env$ui$iniDf
+  .thNm <- .idf$name[!is.na(.idf$ntheta) & is.na(.idf$err)]
+  .th <- .rn[.rn %in% .thNm & !(.rn %in% .vn)]
   .fn <- c(.th, .vn)
   .full <- matrix(0, length(.fn), length(.fn), dimnames = list(.fn, .fn))
   if (length(.th) > 0L) .full[.th, .th] <- .cov[.th, .th, drop = FALSE]
@@ -988,14 +1042,7 @@
       # is consumed, but a predictable row order is still worth keeping).  The
       # variance rows are ordered the same way, so the order does not depend on
       # which rows the two splices happened to append either.
-      .rn0 <- rownames(.cov)
-      .thOrd <- .ui$iniDf$name[!is.na(.ui$iniDf$ntheta) & is.na(.ui$iniDf$err)]
-      .thOrd <- .thOrd[.thOrd %in% .rn0]
-      .omOrd <- .rn0[grepl("^om\\.|^cov\\.", .rn0)]
-      .resOrd <- .ui$iniDf$name[!is.na(.ui$iniDf$err)]
-      .resOrd <- .resOrd[.resOrd %in% .rn0]
-      .ord <- c(.thOrd, .omOrd, .resOrd)
-      .ord <- c(.ord, .rn0[!(.rn0 %in% .ord)])
+      .ord <- .saemCovRowOrder(rownames(.cov), .ui$iniDf)
       .cov <- .cov[.ord, .ord, drop = FALSE]
       # finalization needs a structural-theta cov; stash the full matrix and install
       # it after the fit is built (.saemInstallFullCov).  The control covMethod is reset

--- a/R/saem.R
+++ b/R/saem.R
@@ -936,11 +936,18 @@
       # [phi1 mu][phi0 mu], not iniDf/model order -- reorder the reported theta
       # block back to iniDf order so it does not depend on which parameters
       # happen to be mu-referenced (names carry identity everywhere this cov
-      # is consumed, but a predictable row order is still worth keeping)
+      # is consumed, but a predictable row order is still worth keeping).  The
+      # variance rows are ordered the same way, so the order does not depend on
+      # which rows the two splices happened to append either.
+      .rn0 <- rownames(.cov)
       .thOrd <- .ui$iniDf$name[!is.na(.ui$iniDf$ntheta) & is.na(.ui$iniDf$err)]
-      .thOrd <- .thOrd[.thOrd %in% rownames(.cov)]
-      .rest <- rownames(.cov)[!(rownames(.cov) %in% .thOrd)]
-      .cov <- .cov[c(.thOrd, .rest), c(.thOrd, .rest), drop = FALSE]
+      .thOrd <- .thOrd[.thOrd %in% .rn0]
+      .omOrd <- .rn0[grepl("^om\\.|^cov\\.", .rn0)]
+      .resOrd <- .ui$iniDf$name[!is.na(.ui$iniDf$err)]
+      .resOrd <- .resOrd[.resOrd %in% .rn0]
+      .ord <- c(.thOrd, .omOrd, .resOrd)
+      .ord <- c(.ord, .rn0[!(.rn0 %in% .ord)])
+      .cov <- .cov[.ord, .ord, drop = FALSE]
       # finalization needs a structural-theta cov; stash the full matrix and install
       # it after the fit is built (.saemInstallFullCov).  The control covMethod is reset
       # to its default during finalization, so record the intended label separately.

--- a/R/saem.R
+++ b/R/saem.R
@@ -661,6 +661,27 @@
 .saemSaCov <- function(env) {
   .saemFimToCov(env$saem$HaSa, env)
 }
+#' Kernel FIM slots belonging to a `fix()`ed additive residual
+#'
+#' `src/saem.cpp` fills an endpoint's log-sigma2 slot whether or not that
+#' endpoint's residual is `fix()`ed, but a fixed value is not estimated, so the
+#' slot is dropped before inverting the same way a fixed theta's row is
+#' (`calc.COV`'s variance block excludes it too).
+#' @param .idf model `iniDf`
+#' @param .predDf model `predDf`
+#' @param .base number of FIM rows ahead of the residual block (theta + Omega diag)
+#' @param .np FIM dimension
+#' @return integer FIM positions to drop, possibly empty
+#' @noRd
+.saemFimFixedResidSlots <- function(.idf, .predDf, .base, .np) {
+  .nEp <- length(.predDf$cond)
+  if (.nEp == 0L || .np < .base + .nEp) return(integer(0))
+  .base + which(vapply(seq_len(.nEp), function(.i) {
+    .rows <- .idf[which(.idf$condition == paste(.predDf$cond[.i]) & !is.na(.idf$err)), ,
+                  drop = FALSE]
+    nrow(.rows) == 1L && isTRUE(.rows$fix)
+  }, logical(1)))
+}
 #' Invert a SAEM Fisher Information Matrix into a reported-scale covariance
 #'
 #' Shared by `covMethod="sa"` (converged FIM `saem$HaSa`) and `covMethod="fim"`
@@ -733,30 +754,36 @@
   #    1/gamma2_phi0 -> Inf.  The caller splices a real SE in from the
   #    linearized FIM (.saemSplicePhi0Theta).
   #  - the fixed theta rows: nothing to report for a known, not estimated,
-  #    value.
+  #    value.  A fix()ed additive residual's slot goes with them
+  #    (.saemFimFixedResidSlots) -- the kernel fills it whether or not the
+  #    value is estimated, so left in it both reported an SE (and a CI) for a
+  #    fixed parameter and gave every other parameter the marginal instead of
+  #    the conditional information.
   #  - any all-zero row: src/saem.cpp gives a non-additive endpoint's
   #    residual slot (and a general-log-likelihood endpoint) an exactly-zero
   #    row/col in every entry, which would make the full matrix singular
   #    (its column is zero too: Ha/HaSa is symmetric and d2logk/D11 never
   #    write a cross term into an excluded slot).
+  .idf <- .ui$iniDf
+  .predDf <- .ui$predDf
+  .etaN <- tryCatch(.foceiEtaThetaMap(.ui)$etaNames, error = function(e) NULL)
+  .nEta <- length(.etaN)
   .zeroRows <- which(apply(.H, 1L, function(.r) all(.r == 0)))
-  .drop <- Reduce(union, list(which(.fx), match(.phi0Nm, .tn), .zeroRows))
+  .drop <- Reduce(union, list(which(.fx), match(.phi0Nm, .tn), .zeroRows,
+                              .saemFimFixedResidSlots(.idf, .predDf, .nth + .nEta, .np)))
   .keep <- if (length(.drop) > 0L) seq_len(.np)[-.drop] else seq_len(.np)
   if (length(.keep) == 0L) return(NULL)
   .C <- suppressWarnings(tryCatch(solve(.H[.keep, .keep, drop = FALSE]), error = function(e) NULL))
   if (is.null(.C) || !all(is.finite(.C))) return(NULL)
   .orig2sub <- rep(NA_integer_, .np)
   .orig2sub[.keep] <- seq_along(.keep)
-  .idf <- .ui$iniDf
   # structural theta block (natural scale; H[1:nth] rows are .tn)
   .ini <- .idf[is.na(.idf$err) & !is.na(.idf$ntheta) & !.idf$fix, "name"]
   if (length(.ui$mixProbs) > 0) .ini <- .ini[!(.ini %in% .ui$mixProbs)]
   .ini <- .ini[.ini %in% .tn]
   .idx <- match(.ini, .tn); .nm <- .ini; .jac <- rep(1, length(.ini))
   # diagonal Omega block: log-variance -> variance, d(var)/d(log var) = var
-  .etaN <- tryCatch(.foceiEtaThetaMap(.ui)$etaNames, error = function(e) NULL)
   .omVar <- tryCatch(diag(as.matrix(.saem$Gamma2_phi1)), error = function(e) NULL)
-  .nEta <- length(.etaN)
   if (.nEta > 0L && !is.null(.omVar) && length(.omVar) >= .nEta &&
         .np >= .nth + .nEta) {
     .idx <- c(.idx, .nth + seq_len(.nEta))
@@ -765,11 +792,9 @@
   }
   # per-endpoint additive residual: src/saem.cpp lays out one log-sigma2 slot per
   # endpoint (in .predDf$cond order, matching resMat's rows), right after the
-  # theta+Omega-diag block -- d(sd)/d(log sigma2) = 0.5 sd.  Only a PURE additive
-  # endpoint (a single iniDf residual row with err=="add") has a real slot; any
-  # other endpoint's slot was dropped above (all-zero row) and simply has no
-  # surviving column to select here.
-  .predDf <- .ui$predDf
+  # theta+Omega-diag block -- d(sd)/d(log sigma2) = 0.5 sd.  Only a PURE additive,
+  # estimated endpoint has a real slot; any other endpoint's slot was dropped above
+  # (all-zero row, or fix()ed) and simply has no surviving column to select here.
   .nEp <- length(.predDf$cond)
   if (.nEp > 0L && .np >= .nth + .nEta + .nEp) {
     .base <- .nth + .nEta

--- a/R/saem.R
+++ b/R/saem.R
@@ -837,11 +837,23 @@
 #'
 #' The analytic (simulation) FIM reliably covers theta + diagonal Omega + additive
 #' residuals, but not off-diagonal Omega covariances or proportional/combined residual
-#' error (the complete-data Louis correction is unstable when BSV dominates).  For those
-#' models this keeps the simulation-based structural-theta block and takes the full
-#' variance block (all Omega variances/covariances + residual parameters) from linFim's
-#' `calc.COV` (blocB), which handles them correctly via the marginal covariance.  Models
-#' the analytic FIM already covers in full are returned unchanged.
+#' error: `src/saem.cpp` gives a non-additive endpoint's residual slot an exactly-zero
+#' row (`.saemFimToCov` drops it), so those parameters are taken from linFim's
+#' `calc.COV` (blocB), which handles them via the marginal covariance.  Filling a
+#' dropped slot from linFim is the intended design, not a leak (#1022).
+#'
+#' How much is taken depends on whether Omega is diagonal, because the Louis score
+#' divides by the DIAGONAL of `Gamma2_phi1` only (`d1_loggamma2_phi1`, `src/saem.cpp`):
+#'
+#' * a declared Omega block -- the analytic Omega information ignores the
+#'   off-diagonals, so only the structural-theta block is kept and the WHOLE variance
+#'   block comes from linFim.
+#' * a diagonal Omega -- the analytic FIM covers every Omega variance correctly, so
+#'   only the variance parameters it could not supply are spliced in.  Replacing the
+#'   whole block here used to hand back linFim's marginal Omega SEs instead, which a
+#'   near-singular residual pair inflates by orders of magnitude (#1022).
+#'
+#' Models the analytic FIM already covers in full are returned unchanged.
 #' @param .cov analytic fim/sa covariance (theta + whatever variance params it covers)
 #' @param env saem fit environment
 #' @return covariance with the linFim variance block spliced in, or `.cov` unchanged
@@ -855,9 +867,20 @@
   .vc <- attr(.cm, "varCov")
   if (is.null(.vc) || !is.matrix(.vc) || !all(is.finite(.vc))) return(.cov)
   .vn <- colnames(.vc)
-  if (all(.vn %in% rownames(.cov))) return(.cov)     # analytic already covers the variance block
-  # keep the simulation structural-theta block; take the whole variance block from linFim
   .rn <- rownames(.cov)
+  .miss <- .vn[!(.vn %in% .rn)]
+  if (length(.miss) == 0L) return(.cov)     # analytic already covers the variance block
+  if (!any(grepl("^cov\\.", .vn))) {
+    # diagonal Omega: keep the analytic block (and its theta cross-terms) and splice
+    # only the missing residual parameters, as a block, the same way
+    # .saemSplicePhi0Theta splices a missing theta
+    .fn <- c(.rn, .miss)
+    .full <- matrix(0, length(.fn), length(.fn), dimnames = list(.fn, .fn))
+    .full[.rn, .rn] <- .cov
+    .full[.miss, .miss] <- .vc[.miss, .miss, drop = FALSE]
+    return(.full)
+  }
+  # keep the simulation structural-theta block; take the whole variance block from linFim
   .th <- .rn[!(.rn %in% .vn) & !grepl("^om\\.|^cov\\.", .rn)]
   .fn <- c(.th, .vn)
   .full <- matrix(0, length(.fn), length(.fn), dimnames = list(.fn, .fn))

--- a/tests/testthat/test-saem-cov-sa.R
+++ b/tests/testthat/test-saem-cov-sa.R
@@ -511,6 +511,36 @@ nmTest({
     expect_true(is.finite(f2$parFixedDf["add2.sd", "SE"]) && f2$parFixedDf["add2.sd", "SE"] > 0)
   })
 
+  test_that("a fix()ed additive residual gets no fim/sa covariance row", {
+    # src/saem.cpp fills an endpoint's log-sigma2 slot whether or not that
+    # endpoint's residual is estimated, and only the all-zero (non-additive) and
+    # fixed-theta rows were dropped before inverting.  So a fix()ed add.sd came
+    # back with an SE -- printed as a back-transformed 95% CI on a value the fit
+    # never estimated -- and every other parameter got the marginal rather than
+    # the conditional information.
+    m <- function() {
+      ini({ tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- fix(0.7)
+            eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1 })
+      model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+              linCmt() ~ add(add.sd) })
+    }
+    f <- .nlmixr(m, theo_sd, est = "saem",
+                 control = saemControl(nBurn = 100, nEm = 120, print = 0, seed = 1L,
+                                       covMethod = "sa", nSaCov = 200))
+    skip_if_not(identical(f$covMethod, "sa"))
+    # dropped before inverting, so it is in neither the pre-splice analytic
+    # matrix nor the reported covariance
+    expect_false("add.sd" %in% rownames(.saemFimToCov(f$saem$HaSa, f$env)))
+    expect_false("add.sd" %in% rownames(f$cov))
+    expect_true(is.na(f$parFixedDf["add.sd", "SE"]))
+    expect_equal(unname(f$parFixed["add.sd", "SE"]), "FIXED")
+    # printed as the point value alone -- no interval
+    expect_false(grepl("(", f$parFixed["add.sd", "Back-transformed(95%CI)"], fixed = TRUE))
+    # the estimated parameters still get real SEs from the reduced matrix
+    expect_true(all(sqrt(diag(f$cov))[c("tka", "tcl", "tv")] > 1e-3))
+    expect_true(all(c("om.eta.ka", "om.eta.cl", "om.eta.v") %in% rownames(f$cov)))
+  })
+
   test_that(".saemLlObsMask refuses to guess rather than mis-score (#871)", {
     .ix <- c(1L, 1L, 2L, 2L)
     # res.mod present: per-observation, res.mod == 0 marks the ll() endpoint

--- a/tests/testthat/test-saem-cov-sa.R
+++ b/tests/testthat/test-saem-cov-sa.R
@@ -511,6 +511,74 @@ nmTest({
     expect_true(is.finite(f2$parFixedDf["add2.sd", "SE"]) && f2$parFixedDf["add2.sd", "SE"] > 0)
   })
 
+  test_that(".saemCovRowOrder never duplicates a row (theta/Omega name clash)", {
+    # The Omega rows are recognized by an "om."/"cov." name prefix, which a
+    # structural theta or residual parameter is free to match.  A name counted in
+    # two groups would appear twice in the ordering vector, and cov[.ord, .ord]
+    # would then duplicate its row AND column -- a bigger, singular matrix.
+    .idf <- data.frame(name = c("cov.tka", "tcl", "add.sd"),
+                       ntheta = c(1L, 2L, 3L),
+                       err = c(NA_character_, NA_character_, "add"),
+                       stringsAsFactors = FALSE)
+    .rn <- c("tcl", "om.eta.cl", "add.sd", "cov.tka")
+    .ord <- .saemCovRowOrder(.rn, .idf)
+    expect_equal(anyDuplicated(.ord), 0L)
+    expect_equal(sort(.ord), sort(.rn))
+    # theta (iniDf order) -> Omega -> residual; cov.tka stays a theta
+    expect_equal(.ord, c("cov.tka", "tcl", "om.eta.cl", "add.sd"))
+    # ... and a residual named om.err stays with the residuals
+    .idf2 <- data.frame(name = c("tka", "om.err"), ntheta = c(1L, 2L),
+                        err = c(NA_character_, "add"), stringsAsFactors = FALSE)
+    expect_equal(.saemCovRowOrder(c("om.eta.ka", "om.err", "tka"), .idf2),
+                 c("tka", "om.eta.ka", "om.err"))
+    # a name no group claims keeps its place, at the end
+    expect_equal(.saemCovRowOrder(c("tka", "zz"), .idf2), c("tka", "zz"))
+  })
+
+  test_that(".saemOmegaIsDiagonal asks the fitted Omega, not linFim's names", {
+    # Which splice branch runs is decided here.  It must read the fitted
+    # Gamma2_phi1: .foceiOmegaPairs drops FIXED Omega elements, so a model with a
+    # fix()ed off-diagonal produces no "cov." name in calc.COV's variance block
+    # while still breaking the Louis score's diagonal-only assumption.
+    # A plain list stands in for the fit environment ($ resolves the same way).
+    expect_true(.saemOmegaIsDiagonal(list(saem = list(Gamma2_phi1 = diag(c(0.3, 0.1))))))
+    expect_true(.saemOmegaIsDiagonal(list(saem = list(Gamma2_phi1 = matrix(0.3, 1, 1)))))
+    expect_false(.saemOmegaIsDiagonal(
+      list(saem = list(Gamma2_phi1 = matrix(c(0.3, 0.05, 0.05, 0.1), 2, 2)))))
+    # unreadable Omega -> FALSE, which keeps the (previous) wholesale splice
+    expect_false(.saemOmegaIsDiagonal(list(saem = list(Gamma2_phi1 = NULL))))
+    expect_false(.saemOmegaIsDiagonal(list()))
+    expect_false(.saemOmegaIsDiagonal(list(saem = list(Gamma2_phi1 = matrix(NA_real_, 2, 2)))))
+  })
+
+  test_that(".saemFimFixedResidSlots takes the residual block from the END of nb_param", {
+    # nb_param = nphi1 + nlambda + nendpnt with the residual slots LAST, so the
+    # base is derived from the matrix size.  Getting it from a theta+Omega row
+    # count instead would drop an Omega row when the two disagree.
+    .idf <- data.frame(name = c("tka", "add.sd", "add2.sd"),
+                       condition = c(NA_character_, "cp", "pca"),
+                       err = c(NA_character_, "add", "add"),
+                       fix = c(FALSE, TRUE, FALSE),
+                       stringsAsFactors = FALSE)
+    .predDf <- data.frame(cond = c("cp", "pca"), stringsAsFactors = FALSE)
+    # 4 theta + 3 eta + 2 endpoints: the residual slots are 8 and 9, cp is fixed
+    expect_equal(.saemFimFixedResidSlots(.idf, .predDf, 9L), 8L)
+    .idf$fix <- c(FALSE, FALSE, TRUE)
+    expect_equal(.saemFimFixedResidSlots(.idf, .predDf, 9L), 9L)
+    .idf$fix <- c(FALSE, TRUE, TRUE)
+    expect_equal(.saemFimFixedResidSlots(.idf, .predDf, 9L), c(8L, 9L))
+    .idf$fix <- c(FALSE, FALSE, FALSE)
+    expect_equal(.saemFimFixedResidSlots(.idf, .predDf, 9L), integer(0))
+    # a combined endpoint has two iniDf rows: not a single fixed additive slot
+    .idf2 <- rbind(.idf, data.frame(name = "prop.sd", condition = "cp", err = "prop",
+                                    fix = TRUE, stringsAsFactors = FALSE))
+    expect_equal(.saemFimFixedResidSlots(.idf2, .predDf, 9L), integer(0))
+    # degenerate sizes are no-ops rather than negative indices
+    expect_equal(.saemFimFixedResidSlots(.idf, .predDf, 2L), integer(0))
+    expect_equal(.saemFimFixedResidSlots(.idf, data.frame(cond = character(0)), 9L),
+                 integer(0))
+  })
+
   test_that("a fix()ed additive residual gets no fim/sa covariance row", {
     # src/saem.cpp fills an endpoint's log-sigma2 slot whether or not that
     # endpoint's residual is estimated, and only the all-zero (non-additive) and
@@ -539,6 +607,34 @@ nmTest({
     # the estimated parameters still get real SEs from the reduced matrix
     expect_true(all(sqrt(diag(f$cov))[c("tka", "tcl", "tv")] > 1e-3))
     expect_true(all(c("om.eta.ka", "om.eta.cl", "om.eta.v") %in% rownames(f$cov)))
+
+    # multi-endpoint: dropping the FIRST endpoint's slot must not move the
+    # SECOND endpoint's.  The residual block is the last nendpnt rows of
+    # nb_param, so both the drop and the read derive their base from the matrix
+    # size; taking it from a theta+Omega row count instead could disagree and
+    # report one endpoint's variance under the other's name.
+    pkpdFix <- function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45; tslope <- 1
+        eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1
+        add.sd <- fix(0.7); add2.sd <- 5
+      })
+      model({
+        ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        slope <- exp(tslope); cp <- linCmt(); pca <- slope * cp
+        cp ~ add(add.sd)
+        pca ~ add(add2.sd)
+      })
+    }
+    fm <- .nlmixr(pkpdFix, warfarin, est = "saem",
+                  control = saemControl(nBurn = 150, nEm = 200, print = 0, seed = 1L,
+                                        covMethod = "sa", nSaCov = 300))
+    skip_if_not(identical(fm$covMethod, "sa"))
+    expect_false("add.sd" %in% rownames(fm$cov))
+    expect_true("add2.sd" %in% rownames(fm$cov))
+    expect_true(is.finite(fm$parFixedDf["add2.sd", "SE"]) &&
+                  fm$parFixedDf["add2.sd", "SE"] > 0)
+    expect_true(is.na(fm$parFixedDf["add.sd", "SE"]))
   })
 
   test_that(".saemLlObsMask refuses to guess rather than mis-score (#871)", {

--- a/tests/testthat/test-saem-cov-sa.R
+++ b/tests/testthat/test-saem-cov-sa.R
@@ -146,7 +146,11 @@ nmTest({
     # The analytic FIM cannot reliably do off-diagonal Omega or non-additive residuals;
     # those variance params are spliced from linFim's blocB.  On a block-Omega model the
     # sa covariance must include cov.<eta>.<eta>, and every variance-block SE must equal
-    # linFim's varCov computed on the same fit (theta stays simulation-based).
+    # linFim's varCov computed on the same fit (theta stays simulation-based) -- a
+    # declared Omega block replaces the WHOLE variance block, because the Louis score
+    # divides by the diagonal of Gamma2_phi1 only and so never saw the off-diagonals.
+    # A diagonal-Omega model keeps its analytic Omega block instead (#1022); that half
+    # is asserted in the multi-endpoint (#893) test below.
     blk <- function() {
       ini({
         tka <- 0.45; tcl <- 1; tv <- 3.45; add.sd <- 0.7
@@ -468,9 +472,9 @@ nmTest({
       # Which slots the ANALYTIC FIM itself can supply is what the dropped
       # zero row decides, and that is deterministic: assert it on the
       # pre-splice matrix.  The reported $cov is not the place for this --
-      # .saemSpliceLinFimVar replaces the whole variance block from linFim
-      # whenever calc.COV succeeds, which puts add.sd/prop.sd back, so
-      # asserting their ABSENCE there was really asserting that the splice
+      # .saemSpliceLinFimVar fills the dropped slot from linFim whenever
+      # calc.COV succeeds, which puts add.sd/prop.sd back (by design, #1022),
+      # so asserting their ABSENCE there was really asserting that the splice
       # had failed.
       .an <- .saemFimToCov(f2$saem$HaSa, f2$env)
       expect_true("add2.sd" %in% rownames(.an))
@@ -478,6 +482,27 @@ nmTest({
       expect_false("prop.sd" %in% rownames(.an))
       # the pure-additive slot survives into the reported cov either way
       expect_true("add2.sd" %in% rownames(f2$cov))
+
+      # #1022: Omega is DIAGONAL here, so the splice must supply ONLY the two
+      # residual parameters the analytic FIM could not (the zeroed cp slot) and
+      # leave the analytic Omega block alone.  Taking the whole variance block
+      # from linFim instead -- what it used to do -- propagates the
+      # near-singular (add.sd, prop.sd) pair into the Omega rows: om.eta.ka's
+      # SE read 560 against an Omega estimate of 1.1, where the analytic FIM
+      # says 0.51.
+      .saem <- f2$saem
+      attr(.saem, "env") <- f2$env
+      .vc <- attr(suppressWarnings(suppressMessages(calc.COV(.saem))), "varCov")
+      .om <- c("om.eta.ka", "om.eta.cl", "om.eta.v")
+      expect_true(all(.om %in% rownames(.an)) && all(.om %in% rownames(.vc)))
+      .seRep <- sqrt(diag(f2$cov))
+      # the mechanism: Omega SEs are the ANALYTIC ones, the spliced residuals
+      # are linFim's
+      expect_equal(unname(.seRep[.om]), unname(sqrt(diag(.an))[.om]), tolerance = 1e-8)
+      expect_equal(unname(.seRep[c("add.sd", "prop.sd")]),
+                   unname(sqrt(diag(.vc))[c("add.sd", "prop.sd")]), tolerance = 1e-8)
+      # and a bound the pre-fix value (SE 560 on an Omega of 1.1) fails outright
+      expect_true(all(.seRep[.om] < 5 * diag(f2$omega)[c("eta.ka", "eta.cl", "eta.v")]))
     }
     # the pure-additive endpoint's SE is real regardless (its slot was never
     # dropped); the combined endpoint's SE depends on the linFim splice


### PR DESCRIPTION
Closes #1022.

## What #1022 asked

The two `expect_false()` lines in `test-saem-cov-sa.R` failed because the
`linFim` splice reinstated `add.sd`/`prop.sd` after the per-endpoint FIM had
deliberately zeroed that endpoint's slot. The issue left two possibilities open:
the assertions are stale, or the splice is wrong to fill a zeroed slot.

**Answer: the assertions were stale for those two rows** (moved onto the
pre-splice matrix in 6d5f1dc2d, which is why the file is green on `main` today) --
filling a dropped residual slot from the linearized FIM IS the design, and
`src/saem.cpp`'s `nb_param` comment says so. But the issue's closing
observation -- "the SEs it produces are large ... the shape you would expect from
inverting a near-singular block" -- was pointing at something real, one row over.

## The actual defect

`.saemSpliceLinFimVar()` replaced the **entire** variance block with the
linearized FIM's `blocB` as soon as any one variance parameter was missing from
the analytic (Louis) FIM. On a diagonal-Omega model that also threw away the
Omega variances the analytic FIM covers correctly, and the near-singular
`(add.sd, prop.sd)` pair then propagated into those rows. On #1022's own fit:

| | `om.eta.ka` | `om.eta.cl` | `om.eta.v` |
|---|---|---|---|
| estimate | 1.098 | 0.573 | 0.0143 |
| analytic FIM SE | 0.506 | 0.245 | 0.00686 |
| reported (linFim block) SE | **559.9** | **73.3** | 0.113 |

An SE of 560 on an estimate of 1.1. The reported covariance stayed positive
definite, so nothing caught it. What makes that model expose it: `prop.sd`
converges onto its lower boundary (1.2e-6), which leaves `(add.sd, prop.sd)`
correlated -0.983 in the linearized variance block -- inverting it inflates
everything it touches, and the Omega rows only touched it because the splice had
replaced them.

Now the diagonal-Omega case keeps the analytic block (with its theta
cross-terms) and splices in only the parameters it could not supply. A declared
Omega block still takes the whole variance block from the linearized FIM,
because the Louis score divides element-wise by the diagonal of `Gamma2_phi1`
(`d1_loggamma2_phi1`, `src/saem.cpp`) and so never saw the off-diagonals. On
that fit the condition number of the reported covariance drops from 2.6e8 to
1.1e6; on a well-identified model the two estimators agree to ~1% (`om.eta.ka`
0.182 analytic vs 0.181 linFim vs 0.219 FOCEi), which is why this was invisible
until a badly-conditioned residual pair showed up.

## Also fixed, found on the way

- **A `fix()`ed additive residual got a covariance row.** The kernel fills an
  endpoint's `log-sigma2` slot whether or not the value is estimated, and only
  all-zero rows and fixed *theta* rows were dropped. So a fixed `add.sd` printed
  as `add.sd 0.700 FIXED FIXED 0.700 (0.608, 0.792)` -- a 95% interval on a value
  the fit never estimated -- and every other parameter got the marginal instead
  of the conditional information. `calc.COV()`'s variance block has always
  excluded a fixed residual; the analytic path now matches.

## Antigravity review

Two rounds. Round 1 caught a bug introduced by the first commit and one latent
one, both confirmed by reading the code and fixed here:

- the new variance-row ordering classified every `^om\.|^cov\.` name as an Omega
  row *and* kept it in its `iniDf` group, so a theta a user named `cov.tka` was
  listed twice and `.cov[.ord, .ord]` duplicated its row and column -- a larger,
  singular matrix. Ordering is now `.saemCovRowOrder()`, classified from `iniDf`
  first, unit tested on exactly that clash.
- the same prefix test decided diagonal-vs-block Omega from the *names*
  `calc.COV()` built, which a residual named `cov.err` would flip. That is now
  `.saemOmegaIsDiagonal()`, reading the fitted `Gamma2_phi1` -- which also covers
  a case no name test could see: `.foceiOmegaPairs()` drops FIXED Omega elements,
  so a `fix()`ed off-diagonal produced no `cov.` name while still invalidating
  the Louis score.

Its two other points were checked and rejected: `.orig2sub` insulates the
remaining endpoints from a dropped slot (an absent slot resolves to `NA` and is
skipped without shifting anything), and `union()` already dedupes a slot that is
both all-zero and fixed. Its open coverage request (multi-endpoint alignment
with the first endpoint fixed) is now a test.

Separately, the residual block's base is derived from `nb_param - nendpnt` -- the
kernel puts the residual slots last -- in both the drop and the read, rather
than from a theta+Omega row count the two could disagree on.

## Verification

`test-saem-cov-sa.R` plus 15 further saem/covariance/parameter-table files, all
green. `habit-hooks --branch main` reports nothing attributable to this branch
(the two remaining high-complexity functions, `.saemFimToCov` 67 and
`.saemCalcCov` 49, are unchanged from `main`; the new helpers are all <= 14).
