### PR TITLE
fix(mtime): differentiate a modeled time that moves with an estimated parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,10 @@
   which made every derivative through the boundary zero -- the EBEs for an eta
   the boundary depends on stayed pinned at their initial values, and
   `foceiControl(fast=TRUE)` reported a gradient of exactly `0` for the theta.
+- A model that declares `mtime(v)` and also assigns `v` as an ordinary variable
+  is refused instead of silently using the declared value.  The declaration is
+  re-emitted at the top of every generated model, so a later `mtime()` reading
+  `v` got the declared value where `rxode2` gives it the reassigned one.
 - `fit$cor` returns `NULL` instead of erroring when the fit has no covariance
   (`covMethod=""`), matching `fit$cov` (#1038).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,14 @@
   modeled times survive estimation and the mtime variable stays defined.  The
   extra records the solve regenerates are also kept out of the fit's output
   table and out of the `nlme` objective (#919).
+- An `mtime()` whose time depends on an estimated parameter (a boundary that
+  moves with a theta or an eta) now contributes to the sensitivities.  The
+  declaration is loaded into `symengine` as an ordinary assignment, so the
+  switch time is differentiated like the same branch written in place
+  (`ifelse(t < exp(tsw), ...)`); it used to reach `symengine` as a free symbol,
+  which made every derivative through the boundary zero -- the EBEs for an eta
+  the boundary depends on stayed pinned at their initial values, and
+  `foceiControl(fast=TRUE)` reported a gradient of exactly `0` for the theta.
 - `fit$cor` returns `NULL` instead of erroring when the fit has no covariance
   (`covMethod=""`), matching `fit$cov` (#1038).
 

--- a/R/focei.R
+++ b/R/focei.R
@@ -1326,6 +1326,15 @@ attr(rxUiGet.foceiModel0ll, "rstudio") <- quote(rxModelVars({}))
   .lines <- unlist(strsplit(paste(newmod, collapse = "\n"), "\n", fixed = TRUE))
   .lhs <- .rxLineLhs(.lines)
   .mtIdx <- grep(.rxMtimeRe, .lines)
+  # An mtime VARIABLE that the model also assigns as an ordinary variable has
+  # two values, and only the declaration's reaches the top of the generated
+  # model -- a later `mtime()` reading it would silently get the declared value
+  # where rxode2 gives it the reassigned one.  Refuse, same as above.
+  .reAssigned <- names(.rhs)[names(.rhs) %in% .lhs[!is.na(.lhs)]]
+  if (length(.reAssigned) > 0L) {
+    stop("mtime(", .reAssigned[1L], ") is also assigned as an ordinary ",
+         "variable; rename one", call. = FALSE)
+  }
   for (.i in seq_along(.rhs)) {
     .dep <- .rxMtimeDeps(.lines, .lhs, .mtIdx[.i], .rhs[[.i]])
     .bad <- unique(.lhs[!is.na(.lhs) & .lhs %in% .dep &

--- a/R/focei.R
+++ b/R/focei.R
@@ -1265,6 +1265,36 @@ attr(rxUiGet.foceiModel0ll, "rstudio") <- quote(rxModelVars({}))
   .seen
 }
 
+#' Rewrite `mtime()` declarations as plain assignments for the symengine load
+#'
+#' `rxode2::rxS()` keeps only the mtime VARIABLE, never its right hand side, so
+#' the modeled time is a free symbol and every derivative taken through it is
+#' zero.  A boundary that moves with an estimated parameter
+#' (`mtime(tsw5) <- exp(tsw)`, used as `ifelse(t < tsw5, ...)`) then contributes
+#' nothing to the sensitivities, while the same branch written out in place
+#' (`ifelse(t < exp(tsw), ...)`) is differentiated normally.  Loading the
+#' declaration as a suppressed assignment lets the chain rule reach the
+#' parameter; `.rxMtimeAssign()` re-emits the declaration itself, so the solver
+#' still stops at the modeled time.
+#'
+#' `~` not `=`: the variable is an intermediate of the loaded model, and an `=`
+#' would add an output column to every model generated from it.
+#'
+#' @param newmod normalized rxode2 model text
+#' @return the same text with each `mtime(v) = rhs` replaced by `v ~ rhs`
+#' @author Matthew L. Fidler
+#' @noRd
+.rxMtimeToAssign <- function(newmod) {
+  .lines <- unlist(strsplit(paste(newmod, collapse = "\n"), "\n", fixed = TRUE))
+  .w <- grep(.rxMtimeRe, .lines)
+  if (length(.w) == 0L) {
+    return(newmod)
+  }
+  .lines[.w] <- paste0(sub(.rxMtimeRe, "\\1", .lines[.w]), "~",
+                       sub(.rxMtimeRe, "\\3", .lines[.w]), ";")
+  paste(.lines, collapse = "\n")
+}
+
 #' Store the model's `mtime()` declarations on its symengine environment
 #'
 #' The right hand side is expanded THROUGH the symengine environment so it
@@ -1283,9 +1313,11 @@ attr(rxUiGet.foceiModel0ll, "rstudio") <- quote(rxModelVars({}))
     return(invisible(NULL))
   }
   # Expand in a CHILD of the symengine environment, never in it: one mtime may
-  # reference an earlier one, and rxS() left those variables unbound (it drops
-  # the assignment, not just its value), so bind them to themselves here rather
-  # than adding them to the environment every other generated model reads.
+  # reference an earlier one, and that reference has to stay a reference to the
+  # DECLARATION being re-emitted above it, so bind every mtime variable to
+  # itself here -- shadowing the value .rxMtimeToAssign() gave it -- rather than
+  # re-expanding it inline or adding names to the environment every other
+  # generated model reads.
   # rxS() keeps only each variable's FINAL value, so expanding against it is the
   # value at the END of the model.  That is the value at the declaration only
   # while nothing the right hand side depends on is assigned again afterwards --
@@ -1418,7 +1450,10 @@ attr(rxUiGet.foceiModel0ll, "rstudio") <- quote(rxModelVars({}))
       .malert("loading into {.pkg symengine} environment...")
     }
   }
-  .ret <- rxode2::rxS(newmod, TRUE, promoteLinSens = promoteLinSens)
+  # mtime() is loaded as an ordinary assignment so derivatives can reach a
+  # modeled time that moves with an estimated parameter (see .rxMtimeToAssign);
+  # the declaration itself is restored by .rxMtimeAssign() below.
+  .ret <- rxode2::rxS(.rxMtimeToAssign(newmod), TRUE, promoteLinSens = promoteLinSens)
   if (inherits(.ret$rx_r_, "numeric")) {
     assign("rx_r_", symengine::S(as.character(.ret$rx_r_)), envir = .ret)
   }

--- a/tests/testthat/test-mtime-fit.R
+++ b/tests/testthat/test-mtime-fit.R
@@ -84,6 +84,14 @@ nmTest({
     .ui <- rxode2::rxUiDecompress(.mk(c(.base, "t1 <- 10", "mtime(tx) <- t1",
       "t1 <- 20", "kmult <- ifelse(t < tx, 1.0, 2.0) * t1 / 20", .tail))())
     expect_error(.ui$focei, "assigns again after it")
+
+    # ...and an mtime VARIABLE the model also assigns as an ordinary variable
+    # has two values, only one of which reaches the top of the generated model:
+    # plain rxode2 gives the second mtime 101 here, the hoisted declaration
+    # would give it 3
+    .ui <- rxode2::rxUiDecompress(.mk(c(.base, "mtime(t5) <- 2", "t5 <- 100",
+      "mtime(t6) <- t5 + 1", "kmult <- ifelse(t < t6, 1.0, 2.0)", .tail))())
+    expect_error(.ui$focei, "also assigned as an ordinary variable")
   })
 
   test_that("an emitted mtime() line resolves in every generated model", {

--- a/tests/testthat/test-mtime-fit.R
+++ b/tests/testthat/test-mtime-fit.R
@@ -252,6 +252,10 @@ nmTest({
     # of the same model's prediction
     .sens <- function(useMtime, h=1e-4) {
       .inner <- rxode2::rxUiDecompress(.mkSw(useMtime)())$focei$inner
+      # loading the declaration as an assignment must not turn the modeled time
+      # into an output column: that would shift the positional lhs layout
+      # inner.cpp reads
+      if (useMtime) expect_false("tsw5" %in% rxode2::rxModelVars(.inner)$lhs)
       .at <- function(.e) {
         .p <- stats::setNames(c(.th, .e),
                               c(paste0("THETA[", 1:5, "]"), "ETA[1]"))

--- a/tests/testthat/test-mtime-fit.R
+++ b/tests/testthat/test-mtime-fit.R
@@ -223,4 +223,86 @@ nmTest({
     .ref <- nlmixr2(.mk(FALSE), .theo, est="nlme", control=.ctl)
     expect_equal(.fit$objf, .ref$objf, tolerance=1e-2)
   })
+
+  test_that("a moving boundary: mtime() sensitivities match the in-place switch", {
+    skip_on_cran()
+    # An mtime() whose time depends on an estimated parameter is a moving
+    # discontinuity in the right hand side.  rxS() drops the declaration, so the
+    # switch time reached symengine as a free symbol and the boundary term was
+    # silently lost -- the eta sensitivity came back identically zero and every
+    # EBE for that eta stayed pinned at its initial value.  The reference is the
+    # same switch written in place, which has always carried the term.
+    .mkSw <- function(useMtime) {
+      .bdy <- c("ka <- exp(tka)", "cl <- exp(tcl)", "v <- exp(tv)",
+                if (useMtime) c("mtime(tsw5) <- exp(tsw + eta.sw)",
+                                "kmult <- ifelse(t < tsw5, 1.0, 2.0)")
+                else "kmult <- ifelse(t < exp(tsw + eta.sw), 1.0, 2.0)",
+                "d/dt(depot) <- -ka * depot",
+                "d/dt(center) <- ka * depot - kmult * cl / v * center",
+                "cp <- center / v", "cp ~ add(add.sd)")
+      eval(parse(text=paste0(
+        "function() {\n ini({tka <- 0.45; tcl <- -3.2; tv <- -1; tsw <- ", log(4),
+        "; eta.sw ~ 0.2; add.sd <- 0.7})\n model({\n",
+        paste(.bdy, collapse="\n"), "\n })\n}")))
+    }
+    .grid <- seq(0, 12, by=0.25)
+    .ev <- rxode2::et(rxode2::et(amt=4.02, cmt="depot"), .grid)
+    .th <- c(0.45, -3.2, -1, log(4), 0.7)
+    # d(pred)/d(eta) off the generated inner model, against central differences
+    # of the same model's prediction
+    .sens <- function(useMtime, h=1e-4) {
+      .inner <- rxode2::rxUiDecompress(.mkSw(useMtime)())$focei$inner
+      .at <- function(.e) {
+        .p <- stats::setNames(c(.th, .e),
+                              c(paste0("THETA[", 1:5, "]"), "ETA[1]"))
+        .s <- suppressWarnings(
+          rxode2::rxSolve(.inner, .p, .ev, returnType="data.frame",
+                          atol=1e-10, rtol=1e-10))
+        # the mtime record is an extra row whose time MOVES with the eta, so
+        # keep the requested grid to compare like with like
+        .s <- .s[.s$time %in% .grid, ]
+        .s[!duplicated(.s$time, fromLast=TRUE), ]
+      }
+      .s0 <- .at(0); .sp <- .at(h); .sm <- .at(-h)
+      data.frame(time=.s0$time,
+                 analytic=.s0[["rx__sens_rx_pred__BY_ETA_1___"]],
+                 fd=(.sp$rx_pred_ - .sm$rx_pred_) / (2 * h))
+    }
+    .mt <- .sens(TRUE)
+    .ref <- .sens(FALSE)
+    # the boundary term is there at all
+    expect_gt(max(abs(.mt$analytic)), 1)
+    # ...and is the same term the in-place switch gets
+    expect_equal(.mt$analytic, .ref$analytic, tolerance=1e-8)
+    # ...and it is the right term: agrees with central differences away from the
+    # smoothing window symengine puts around the branch
+    .w <- .mt$time >= 4 + 0.25          # the switch is at exp(tsw) = 4
+    expect_equal(.mt$analytic[.w], .mt$fd[.w], tolerance=0.01)
+  })
+
+  test_that("a moving boundary: the EBEs match the in-place switch", {
+    skip_on_cran()
+    .mkSw <- function(useMtime) {
+      .bdy <- c("ka <- exp(tka + eta.ka)", "cl <- exp(tcl)", "v <- exp(tv)",
+                if (useMtime) c("mtime(tsw5) <- exp(tsw + eta.sw)",
+                                "kmult <- ifelse(t < tsw5, 1.0, 2.0)")
+                else "kmult <- ifelse(t < exp(tsw + eta.sw), 1.0, 2.0)",
+                "d/dt(depot) <- -ka * depot",
+                "d/dt(center) <- ka * depot - kmult * cl / v * center",
+                "cp <- center / v", "cp ~ add(add.sd)")
+      eval(parse(text=paste0(
+        "function() {\n ini({tka <- 0.45; tcl <- -3.2; tv <- -1; tsw <- ", log(4),
+        "; eta.ka ~ 0.1; eta.sw ~ 0.2; add.sd <- 0.7})\n model({\n",
+        paste(.bdy, collapse="\n"), "\n })\n}")))
+    }
+    .ctl <- foceiControl(print=0L, covMethod="", sigdig=4, calcTables=FALSE,
+                         maxOuterIterations=0L, maxInnerIterations=300L)
+    .fit <- nlmixr2(.mkSw(TRUE), .theo, est="focei", control=.ctl)
+    .ref <- nlmixr2(.mkSw(FALSE), .theo, est="focei", control=.ctl)
+    # the inner problem can move the eta the boundary depends on: a zero
+    # sensitivity leaves every one of these at 0
+    expect_gt(max(abs(.fit$eta$eta.sw)), 0.05)
+    expect_equal(.fit$eta$eta.sw, .ref$eta$eta.sw, tolerance=0.01)
+    expect_equal(.fit$objf, .ref$objf, tolerance=1e-5)
+  })
 })

--- a/tests/testthat/test-mtime.R
+++ b/tests/testthat/test-mtime.R
@@ -41,6 +41,49 @@ nmTest({
     expect_equal(.addMtimeLines("d/dt(x)=-a*x", .s), "d/dt(x)=-a*x")
   })
 
+  test_that(".rxMtimeToAssign() loads the declaration as a suppressed assignment", {
+    # no mtime: the text is handed to rxS() untouched
+    expect_equal(.rxMtimeToAssign("d/dt(depot)=-ka*depot;\n"),
+                 "d/dt(depot)=-ka*depot;\n")
+    expect_equal(.rxMtimeToAssign("mtime(t5)=5;\nd/dt(x)=-a*x;"),
+                 "t5~5;\nd/dt(x)=-a*x;")
+    # every declaration form, and `~` so no generated model gains an output column
+    expect_equal(.rxMtimeToAssign("mtime(t5)~5;\nmtime(tx)=2*THETA[1];"),
+                 "t5~5;\ntx~2*THETA[1];")
+  })
+
+  test_that("a modeled time that moves with a parameter is differentiated", {
+    # A boundary that moves with an estimated parameter contributes to the
+    # sensitivities.  rxS() drops the mtime() right hand side, so the switch time
+    # used to reach symengine as a free symbol and every derivative through it was
+    # zero -- silently, and only for the mtime() spelling.  The reference is the
+    # same switch written out in place, which has always been differentiated.
+    .mkSw <- function(useMtime) {
+      .bdy <- c("ka <- exp(tka)", "cl <- exp(tcl)", "v <- exp(tv)",
+                if (useMtime) c("mtime(tsw5) <- exp(tsw + eta.sw)",
+                                "kmult <- ifelse(t < tsw5, 1.0, 2.0)")
+                else "kmult <- ifelse(t < exp(tsw + eta.sw), 1.0, 2.0)",
+                "d/dt(depot) <- -ka * depot",
+                "d/dt(center) <- ka * depot - kmult * cl / v * center",
+                "cp <- center / v", "cp ~ add(add.sd)")
+      eval(parse(text=paste0(
+        "function() {\n ini({tka <- 0.45; tcl <- -3.2; tv <- -1; tsw <- 1.386;",
+        " eta.sw ~ 0.1; add.sd <- 0.7})\n model({\n",
+        paste(.bdy, collapse="\n"), "\n })\n}")))
+    }
+    .ddt <- function(useMtime) {
+      .s <- rxode2::rxUiDecompress(.mkSw(useMtime)())$loadPruneSens
+      get("rx__d_dt_center__", .s)
+    }
+    .mt <- .ddt(TRUE)
+    # the loaded equation is the in-place one: the switch time is its expansion,
+    # not an opaque name
+    expect_equal(paste(.mt), paste(.ddt(FALSE)))
+    expect_match(paste(.mt), "rxLt(t, exp(ETA_1_ + THETA_4_))", fixed=TRUE)
+    # ...so the eta reaches the branch and the derivative is not identically zero
+    expect_false(paste(symengine::D(.mt, symengine::S("ETA_1_"))) == "0")
+  })
+
   test_that(".rxMtimeDeps() walks back through the preceding assignments", {
     .lines <- c("a=1;", "b=a+2;", "mtime(tx)=b;", "c=3;")
     .lhs <- .rxLineLhs(.lines)

--- a/tests/testthat/test-mtime.R
+++ b/tests/testthat/test-mtime.R
@@ -138,6 +138,9 @@ nmTest({
     .df <- as.data.frame(.fit)
     expect_equal(nrow(.df), sum(.theo$EVID == 0))
     expect_false(anyNA(.df$DV))
+    # the declaration is emitted suppressed, so the mtime variable is not an
+    # output of the solve and does not reach the table either
+    expect_false("t5" %in% names(.df))
 
     # PRED at eta=0 must reproduce an independent rxode2 solve.  The reference is
     # plain rxode2 model text writing the same switch with a literal 5 instead of


### PR DESCRIPTION
Follow-up to #919.  An `mtime()` whose modeled time depends on an estimated
parameter is a boundary that MOVES with that parameter, and none of that
movement was reaching the sensitivities.

`rxode2::rxS()` keeps only the mtime VARIABLE and discards its right hand side,
so a switch time written as `mtime(tsw5) <- exp(tsw)` arrived in the symengine
environment as a free symbol: every derivative taken through it was zero.  The
same branch written in place -- `ifelse(t < exp(tsw), ...)` -- has always been
differentiated, so this was specific to the `mtime()` spelling and silent.

Measured on `theo_sd` with a clearance multiplier switching at `exp(tsw)`:

| | before | after |
| --- | --- | --- |
| eta sensitivity vs central differences | max abs error 3.156 of max abs 3.156 (the whole term) | 0.0229, bit-identical to the in-place `ifelse` form |
| EBEs for the eta the boundary depends on | all 0 (max 1.4e-06), objf 9187.288 | -0.13 to 0.10, objf 9186.04 against the reference's 9186.035 |
| `foceiControl(fast=TRUE)`, theta-driven switch | accepted the model, reported `d(objf)/d(tsw) = 0` against a central difference of 87.45 | declines to finite differences, like the in-place form |
| constant `mtime(t5) <- 5` | | unchanged: same objective, same analytic gradient, analytic path still taken |

## What changed

`.rxMtimeToAssign()` rewrites each `mtime(v) = rhs` to `v ~ rhs` in the text
handed to `rxS()`, so the switch time is an ordinary expression and the chain
rule reaches the parameter.  `.rxMtimeAssign()` still re-emits the real
declaration into every generated model, so the solver keeps stopping at the
modeled time, and `~` keeps the variable out of the generated models' output
columns.

A second, pre-existing hole is closed while in here: a model that declares
`mtime(v)` and also assigns `v` as an ordinary variable is now refused.  Only
the declaration's value reaches the top of the generated model, so
`mtime(t5)=2; t5=100; mtime(t6)=t5+1` gave `t6=3` where plain `rxode2` gives
101.  That predates this branch -- reverting the boundary fix reproduces the
same emission -- and it now errors with a rename hint, matching the neighbouring
"assigns again after it" guard.

## Tests

`test-mtime.R` (essential): `.rxMtimeToAssign()` unit coverage, and -- without
compiling anything -- the loaded `d/dt(center)` for the mtime spelling is now
textually identical to the in-place one and its `ETA_1_` derivative is not
zero.  `test-mtime-fit.R` (weekly batch): sensitivity parity with the in-place
form, agreement with central differences away from the smoothing window
symengine puts around the branch, EBE and objective parity, and the new guard.
Every new assertion was checked to FAIL with the pre-fix `.loadSymengine`
patched back in.

`test-mtime.R` 32 pass, `test-mtime-fit.R` 47 pass, `test-focei-inner.R` 5 pass,
against an `R CMD INSTALL` build.

## Known, not changed here

The dependency guard in `.rxMtimeAssign()` walks the full transitive closure, so
it also refuses some models it could handle: `a<-1; b<-a+1; mtime(tx)<-b; a<-2`
expands correctly to `mtime(tx)~2` but is rejected.  Narrowing it to direct
names alone is NOT correct either -- `t1<-10; mtime(tx)<-t1; t1<-20` then
silently emits 20 where rxode2 gives 10.  The precise rule is a union (level-1
names reassigned after the declaration, plus names still free in the expansion
that are assigned after it) and wants its own tests; today's behavior fails
loudly with a rename hint, so it is left for a separate change.
