### PR TITLE
fix(cov): the FOCE/foce+ observed information must not carry the inner solver's residual (#1056)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 ## Bug fixes
 
+- `covMethod="analytic"` for FOCE and `foce="foce+"` no longer carries the inner
+  solver's residual score into the observed information.  The FOCE kernel uses
+  the general total-derivative form, whose last term is `Phi_eta . eta_ab`; it
+  evaluated `Phi_eta` in full, but the FOCE inner problem zeroes
+  `S_FOCE = Omega^-1 eta + sum(q0 a)` by construction, so only the interaction
+  remainder `Phi_f - q0` belongs there.  The rest was the inner tolerance
+  multiplied by a term that is not small.  The FOCE assemblers also re-solved
+  each subject's EBE before building R, where the FOCEI assembler uses the fit's
+  own; they now agree.  On an additive model, where the two methods must
+  coincide, the `foce+` and FOCEI observed informations agreed to 1.2e-2 at the
+  same EBEs and now agree to 1.1e-13 (#1056).
 - A model containing `mtime()` can be fit again, with every estimation method.
   `etTrans()` materializes the modeled times as `EVID` 10-99 records (`TIME=0`,
   `AMT=NA`) and `$dataSav` persisted them, so re-translating it for each

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -346,15 +346,14 @@
   .idCode <- if (is.factor(ids)) as.integer(ids) else match(ids, sort(unique(ids)))
   R <- matrix(0, np, np)
   if (.foce) {
-    # FOCE cov: the per-subject eta=0 population solve + EBE re-solve + 3rd-order Shi FD3 stay
-    # in R (inherently per-subject), then ONE OpenMP C++ call (foceiRAllFoceFR_) sums the
+    # FOCE cov: the per-subject eta=0 population solve + 3rd-order Shi FD3 stay in R
+    # (inherently per-subject), then ONE OpenMP C++ call (foceiRAllFoceFR_) sums the
     # observed information over subjects.  The frozen-R0 sensitivities are resolved per subject
     # (nonmem: aRe/ARe=0, aRc/ARc/R0 from E0; foce+: all from the eta-hat solve E).
     nsub <- length(ids); Elist <- vector("list", nsub); E0list <- vector("list", nsub)
     eta0list <- vector("list", nsub); nobsAll <- integer(nsub)
     # BATCHED (f,R) FOCE/foce+ solves: the eta=0 population solve (nonmem frozen R0) is batched,
-    # the EBE re-solve stays per-subject (Newton), then ONE batched SolveAllFD3 delivers f/a/A/Ath
-    # AND R/aR/AR for all subjects (withR=FALSE: FOCE reads R/aR/AR from the base solve + Ath, but
+    # then ONE batched SolveAllFD3 delivers f/a/A/Ath AND R/aR/AR for all subjects (withR=FALSE: FOCE reads R/aR/AR from the base solve + Ath, but
     # never AthR).  foce+ (foceType=1) keeps the live R (no eta=0 solve).  Per-subject Shi fallback.
     .obsAll <- lapply(seq_len(nsub), function(i) { .s <- .byId[[as.character(.idCode[i])]]
       if (is.null(.s) || nrow(.s) == 0L) NULL else .s[.s$EVID == 0, , drop = FALSE] })
@@ -549,9 +548,8 @@
   .idCode <- if (is.factor(ids)) as.integer(ids) else match(ids, sort(unique(ids)))
   # Batch the 3rd-order solve across ALL subjects (FOCEI *and* FOCE, no IOV rescale) so both take
   # the IDENTICAL method and both get the speedup (1 + 2*neta population solves vs the per-subject
-  # Shi's O(nsub*neta)).  CORRECTED FOCE freezes R0 at the eta=0 population solve (batched) and
-  # re-solves each EBE (per-subject Newton, censoring-aware) to S_FOCE=0; that eta0 matrix feeds
-  # the batched FD3.  foce+ keeps the live R (no eta=0 solve).  Per-subject Shi is the fallback.
+  # Shi's O(nsub*neta)).  CORRECTED FOCE freezes R0 at the eta=0 population solve (batched);
+  # foce+ keeps the live R (no eta=0 solve).  Per-subject Shi is the fallback.
   .obsAll <- lapply(seq_along(ids), function(i) { .s <- .byId[[as.character(.idCode[i])]]
     if (is.null(.s) || nrow(.s) == 0L) NULL else .s[.s$EVID == 0, , drop = FALSE] })
   if (any(vapply(.obsAll, is.null, logical(1L)))) return(NULL)   # unmatched subject -> caller FD
@@ -2391,8 +2389,8 @@ E_ARelm <- function(E, l, m, fp) if (fp) E$AR[, l, m] else 0
 }
 
 #' Base subject solve: `f` plus the 1st/2nd analytic sensitivities (`a`, `A`), no
-#' 3rd-order Shi tensor.  Shared by [.foceiAnalyticSolveSubjectFD3] (which adds `Ath`)
-#' and the FOCE EBE re-solve (which needs only `a`/`A`).  Muffles benign solver
+#' 3rd-order Shi tensor.  Shared by [.foceiAnalyticSolveSubjectFD3] (which adds `Ath`),
+#' the AGQ node solves and the VAE decoder.  Muffles benign solver
 #' warnings (a real error returns `NULL` -> FD fallback); the nrow guard bails when an
 #' EVID==2/covariate-update row shares an obs timestamp (would misalign f against y).
 #' @noRd

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -353,8 +353,9 @@
     nsub <- length(ids); Elist <- vector("list", nsub); E0list <- vector("list", nsub)
     eta0list <- vector("list", nsub); nobsAll <- integer(nsub)
     # BATCHED (f,R) FOCE/foce+ solves: the eta=0 population solve (nonmem frozen R0) is batched,
-    # then ONE batched SolveAllFD3 delivers f/a/A/Ath AND R/aR/AR for all subjects (withR=FALSE: FOCE reads R/aR/AR from the base solve + Ath, but
-    # never AthR).  foce+ (foceType=1) keeps the live R (no eta=0 solve).  Per-subject Shi fallback.
+    # then ONE batched SolveAllFD3 delivers f/a/A/Ath AND R/aR/AR for all subjects
+    # (withR=FALSE: FOCE reads R/aR/AR from the base solve + Ath, but never AthR).
+    # foce+ (foceType=1) keeps the live R (no eta=0 solve).  Per-subject Shi fallback.
     .obsAll <- lapply(seq_len(nsub), function(i) { .s <- .byId[[as.character(.idCode[i])]]
       if (is.null(.s) || nrow(.s) == 0L) NULL else .s[.s$EVID == 0, , drop = FALSE] })
     if (any(vapply(.obsAll, is.null, logical(1L))))
@@ -1838,13 +1839,10 @@
   ae <- a[, ei, drop = FALSE]
   isD <- function(p) p <= ndirP; dOf <- function(p) dirP[p]; omc <- function(p) p - ndirP
   # ---- Phi (data) tensors: H=Phi_etaeta, gPhi=Phi_eta (aRe eta-block) ----
-  # The inner problem zeroes S_FOCE = Omega^-1 eta + sum(q0 a) (q0 = rf), so all that
-  # survives Phi_eta at the FOCE EBE is the variance chain sum(rR aRe).  Subtract S
-  # SYMBOLICALLY instead of evaluating Phi_eta and leaning on the inner residual being
-  # small: it is only at the inner solver's tolerance and it multiplies eta_ab, which is
-  # not small.  Zero for frozen-R FOCE (aRe=0) and for any eta-independent R (additive),
-  # where this kernel then reduces EXACTLY to the FOCEI envelope form.
-  gPhi <- vapply(ei, function(l) sum(rR * aRe[, l]), numeric(1))   # Phi_eta - S_FOCE
+  # Phi_eta MINUS the inner score S_FOCE = Omega^-1 eta + sum(q0 a) (q0 = rf), which the
+  # inner problem zeroes: subtracting it symbolically keeps the residual out of R (#1056).
+  # Zero for frozen-R FOCE (aRe=0) and any eta-independent R -> the FOCEI envelope form.
+  gPhi <- vapply(ei, function(l) sum(rR * aRe[, l]), numeric(1))
   H <- Oi; for (l in ei) for (m in ei)
     H[l, m] <- H[l, m] + sum(rff * a[, l] * a[, m] + rfR * (a[, l] * aRe[, m] + aRe[, l] * a[, m]) +
                               rRR * aRe[, l] * aRe[, m] + rf * A[, l, m] + rR * E_ARelm(E, l, m, .fp))
@@ -2247,13 +2245,11 @@ E_ARelm <- function(E, l, m, fp) if (fp) E$AR[, l, m] else 0
   # ---- Phi (data) pieces: FULL rho derivatives ----
   H <- Oi; for (l in ei) for (m in ei) H[l, m] <- H[l, m] + sum(rd$r2 * a[, l] * a[, m] + rd$r1 * A[, l, m])  # Phi_etaeta
   Ndat <- matrix(0, neta, ndir); for (l in ei) for (d in di) Ndat[l, d] <- sum(rd$r2 * a[, l] * a[, d] + rd$r1 * A[, l, d])  # Phi_(eta,theta)
-  # Phi_eta at the FOCE EBE.  The inner problem zeroes S_FOCE = Omega^-1 eta + sum(q0 a),
-  # so all that survives Phi_eta is the interaction remainder Phi_f - q0.  Subtract it
-  # SYMBOLICALLY rather than evaluating Phi_eta and leaning on the inner residual being
-  # small: the residual is only at the inner solver's tolerance and it multiplies eta_ab,
-  # which is not small.  Identically zero for frozen-R FOCE and for any eta-independent R
-  # (additive), where this kernel then reduces EXACTLY to the FOCEI envelope form.
-  gPhi <- vapply(ei, function(l) sum((rd$r1 - qd$q0) * a[, l]), numeric(1))  # Phi_eta - S_FOCE
+  # Phi_eta MINUS the inner score S_FOCE = Omega^-1 eta + sum(q0 a), which the inner problem
+  # zeroes: subtracting it symbolically leaves the interaction remainder Phi_f - q0 and keeps
+  # the inner solver's residual (which multiplies a not-small eta_ab) out of R (#1056).  Zero
+  # for frozen-R FOCE and any eta-independent R (additive) -> the FOCEI envelope form exactly.
+  gPhi <- vapply(ei, function(l) sum((rd$r1 - qd$q0) * a[, l]), numeric(1))
 
   # ---- FOCE inner (EBE) pieces: q-based Jacobian S_eta = Hf and its 3-tensor ----
   Hf <- Oi; for (l in ei) for (m in ei) Hf[l, m] <- Hf[l, m] + sum(qd$q1 * a[, l] * a[, m] + qd$q0 * A[, l, m])  # S_eta = Hf

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -337,7 +337,10 @@
     return(.foceiAnalyticFallback("an augmented model without rx_r_"))
   np <- ndirP + omd$nom; Oi <- solve(Om)
   etav <- paste0("ETA_", seq_len(neta), "_")
-  .foce <- identical(as.integer(interaction), 0L)      # FOCE re-solves EBEs to S_FOCE=0
+  # FOCE (interaction=0).  Like FOCEI, the covariance is formed at the FIT's EBEs: they are
+  # part of its solution (fit$objf was evaluated at them), and re-optimizing them here would
+  # give the curvature of an idealized objective the reported fit does not sit on.
+  .foce <- identical(as.integer(interaction), 0L)
   .fp <- identical(as.integer(foceType), 1L)           # foce+ keeps the live conditional R
   .byId <- split(data, as.character(data$ID))
   .idCode <- if (is.factor(ids)) as.integer(ids) else match(ids, sort(unique(ids)))
@@ -365,10 +368,7 @@
       .ns0 <- ncol(E0all[[1L]]$Rsig)
       if (!is.null(.ns0) && .ns0 > 0L) E0all <- lapply(E0all, function(.E0) .foceiAnalyticExpandSigma(.E0, .ns0, neta, NULL, NULL, .sigSel))
     }
-    eta0Mat <- .foceiAnalyticFoceEbeBatch(am, th, ebes, .idCode, data, .obsAll, .obsT, etav, Oi, neta,
-                                          solveTol, foceType = foceType, E0all = E0all)   # batched EBE re-solve
-    if (is.null(eta0Mat))
-      return(.foceiAnalyticFallback("an EBE re-solve that will not solve"))
+    eta0Mat <- ebes                                    # the fit's own EBEs -- see .foce above
     .batch <- !nzchar(Sys.getenv("FOCEI_NO_FD3_BATCH"))
     .EsAll <- if (.batch) .foceiAnalyticSolveAllFD3(am, th, eta0Mat, .idCode, data, .obsT, tol = solveTol, withR = FALSE,
                                                    sigSel = .sigSel) else NULL
@@ -533,7 +533,8 @@
   .ag <- if (.nAGQ > 1L) .agq(neta, .nAGQ) else NULL
   np <- nth + nsg + omd$nom
   etav <- paste0("ETA_", seq_len(neta), "_")
-  .foce <- identical(as.integer(interaction), 0L)     # FOCE re-solves EBEs to S_FOCE=0
+  # FOCE (interaction=0); the covariance uses the fit's own EBEs -- see .foceiAnalyticAssembleRFR
+  .foce <- identical(as.integer(interaction), 0L)
   # IOV reparameterization to xi = w * eta (unit occasion eta -> variance w^2): the
   # augmented model is solved at the ACTUAL (Param A) EBEs, then the occasion-eta
   # sensitivities are rescaled by 1/w (iovDirScale) and their EBEs by w (etaScale)
@@ -561,15 +562,7 @@
     E0List <- .foceiAnalyticSolveAll(am, th, matrix(0, length(ids), neta), .idCode, data, .obsT, solveTol)
     if (is.null(E0List)) return(NULL)
   }
-  eta0Mat <- ebes
-  if (.foce) for (i in seq_along(ids)) {              # FOCE EBE re-solve (per-subject Newton)
-    .o <- .obsAll[[i]]
-    .e0 <- .foceiAnalyticFoceEbe(am, th, ebes[i, ], .byId[[as.character(.idCode[i])]], .o$TIME, .o$DV, etav,
-                                 if (is.null(E0List[[i]])) NULL else E0List[[i]]$R, Oi, neta, solveTol,
-                                 foceType = foceType, cens = .o$CENS, limit = .o$LIMIT)
-    if (is.null(.e0)) return(NULL)
-    eta0Mat[i, ] <- .e0
-  }
+  eta0Mat <- ebes                                      # the fit's own EBEs -- see .foce above
   .batch <- !rescale && !nzchar(Sys.getenv("FOCEI_NO_FD3_BATCH"))
   .EsAll <- NULL
   if (.batch) {
@@ -2467,104 +2460,6 @@ E_ARelm <- function(E, l, m, fp) if (fp) E$AR[, l, m] else 0
   if (isTRUE(aug$hasTrans))
     .out$trans <- list(yj = .d$rx_tyj_, lambda = .d$rx_tlambda_, low = .d$rx_tlow_, hi = .d$rx_thi_)
   .out
-}
-
-#' Re-solve one subject's EBE to the FOCE inner stationary point S_FOCE = sum(q a)
-#' + Omega^-1 eta = 0 (q = -eps/R) via Newton on the FOCE inner Hessian
-#' Hf = sum(q' a a' + q A) + Omega^-1, starting from the stored eta `eta0`.
-#' nlmixr's stored FOCE-combined EBEs do NOT satisfy S_FOCE=0 (an estimation-side
-#' inconsistency), so R must be formed at the re-solved eta.  For additive/FOCEI the
-#' stored eta is already stationary (|S_FOCE| < `skip`) -> returns `eta0` unchanged
-#' (byte no-op).  `NULL` on a solve/Newton failure -> caller falls back to FD.
-#' @noRd
-.foceiAnalyticFoceEbe <- function(aug, th, eta0, s, times, y, etav, R0, Oi, neta, tol,
-                                  maxit = 30L, skip = 1e-3, conv = 1e-9,
-                                  foceType = 0L, cens = NULL, limit = NULL) {
-  ei <- seq_len(neta)
-  # interaction-free FOCE inner gradient/curvature from (f,R0): q0 = -(y-f)/R0 = rho_f,
-  # q1 = 1/R0 = rho_ff.  For censored (M2/M3/M4) observations q0/q1 are the EXACT censored
-  # rho_f/rho_ff at the frozen R0 (censNormalPartials_) so the re-solved eta* is the censored
-  # FOCE stationary point.  foce+ (foceType=1) uses the live conditional R at the trial eta;
-  # nonmem freezes R0 at the eta=0 population value passed in.
-  .fp <- identical(as.integer(foceType), 1L) || is.null(R0)
-  # censored (M2/M3/M4) per-obs CENS + LIMIT (NA/NULL -> uncensored) and the censored-obs index
-  .cv <- if (is.null(cens)) integer(length(y)) else as.integer(ifelse(is.na(cens), 0L, cens))
-  .lv <- if (is.null(limit)) rep(NA_real_, length(y)) else as.numeric(limit)
-  .cw <- which(.cv != 0 | is.finite(.lv))              # censored observations
-  .SH <- function(eta) {                               # FOCE S_FOCE and its Jacobian Hf at eta
-    E <- .foceiAnalyticSolveFA(aug, c(th, setNames(eta, etav)), s, times, tol = tol)
-    if (is.null(E)) return(NULL)
-    yt <- .foceiAnalyticTbsY(y, E$trans)               # DV -> rx_pred_ (transformed) scale; no-op if untransformed
-    R0e <- if (.fp) E$R else R0
-    q0 <- -(yt - E$f) / R0e; q1 <- 1 / R0e
-    if (length(.cw)) {                                 # censored: exact rho_f/rho_ff at frozen R0
-      .limt <- .foceiAnalyticTbsY(.lv, E$trans)        # transform the censoring bound like the DV
-      .cp <- censNormalPartials_(.cv, yt, .limt, E$f, R0e, 2L)
-      q0[.cw] <- .cp[.cw, 1]; q1[.cw] <- .cp[.cw, 3]   # cp[,1]=rho_f, cp[,3]=rho_ff
-    }
-    S <- as.numeric(Oi %*% eta); for (l in ei) S[l] <- S[l] + sum(q0 * E$a[, l])
-    Hf <- Oi; for (l in ei) for (m in ei) Hf[l, m] <- Hf[l, m] + sum(q1 * E$a[, l] * E$a[, m] + q0 * E$A[, l, m])
-    list(S = S, Hf = Hf)
-  }
-  eta <- eta0
-  sh <- .SH(eta); if (is.null(sh)) return(NULL)
-  if (!all(is.finite(sh$S))) return(NULL)              # unsolvable subject -> non-finite score
-  if (max(abs(sh$S)) < skip) return(eta0)              # already FOCE-stationary (additive/FOCEI) -> no-op
-  for (it in seq_len(maxit)) {
-    step <- tryCatch(solve(sh$Hf, sh$S), error = function(e) NULL)
-    if (is.null(step)) return(NULL)
-    eta <- eta - step
-    sh <- .SH(eta); if (is.null(sh)) return(NULL)
-    if (!all(is.finite(sh$S))) return(NULL)            # unsolvable subject -> non-finite score
-    if (max(abs(sh$S)) < conv) break
-  }
-  if (max(abs(sh$S)) >= conv) return(NULL)               # Newton did not converge -> FD fallback
-  eta
-}
-
-#' Batched FOCE/foce+ EBE re-solve: the same interaction-free Newton as
-#' [.foceiAnalyticFoceEbe] but over ALL subjects at once via [.foceiAnalyticSolveAll]
-#' (one batched solve per Newton iteration instead of per-subject SolveFA).  Bit-identical
-#' to the per-subject Newton; avoids the per-subject solve entirely (needed for the shared
-#' `dirs` model, which solves batched but not per-subject in the fit's cov-hook context) and
-#' is faster.  Returns the nsub x neta eta-hat matrix, or NULL if any subject fails to converge.
-#' @noRd
-.foceiAnalyticFoceEbeBatch <- function(am, th, ebes, ids, data, obsAll, obsTimes, etav, Oi, neta, tol,
-                                       foceType = 0L, E0all = NULL, maxit = 30L, skip = 1e-3, conv = 1e-9) {
-  nsub <- nrow(ebes); ei <- seq_len(neta)
-  .fp <- identical(as.integer(foceType), 1L) || is.null(E0all)
-  Y  <- lapply(obsAll, function(.o) .o$DV)
-  CV <- lapply(obsAll, function(.o) if (is.null(.o$CENS)) integer(length(.o$DV)) else as.integer(ifelse(is.na(.o$CENS), 0L, .o$CENS)))
-  LV <- lapply(obsAll, function(.o) if (is.null(.o$LIMIT)) rep(NA_real_, length(.o$DV)) else as.numeric(.o$LIMIT))
-  .SHi <- function(E, eta_i, i) {                        # S_FOCE + Hf for subject i (censored-aware)
-    yt <- .foceiAnalyticTbsY(Y[[i]], E$trans)
-    R0e <- if (.fp) E$R else E0all[[i]]$R
-    q0 <- -(yt - E$f) / R0e; q1 <- 1 / R0e
-    .cw <- which(CV[[i]] != 0 | is.finite(LV[[i]]))
-    if (length(.cw)) { .limt <- .foceiAnalyticTbsY(LV[[i]], E$trans)
-      .cp <- censNormalPartials_(CV[[i]], yt, .limt, E$f, R0e, 2L); q0[.cw] <- .cp[.cw, 1]; q1[.cw] <- .cp[.cw, 3] }
-    S <- as.numeric(Oi %*% eta_i); for (l in ei) S[l] <- S[l] + sum(q0 * E$a[, l])
-    Hf <- Oi; for (l in ei) for (m in ei) Hf[l, m] <- Hf[l, m] + sum(q1 * E$a[, l] * E$a[, m] + q0 * E$A[, l, m])
-    list(S = S, Hf = Hf)
-  }
-  eta <- ebes; active <- rep(TRUE, nsub)
-  for (it in seq_len(maxit + 1L)) {                      # it=1 evaluates at eta0 (skip test), then Newton steps
-    Es <- .foceiAnalyticSolveAll(am, th, eta, ids, data, obsTimes, tol)
-    if (is.null(Es)) return(NULL)
-    for (i in which(active)) {
-      sh <- .SHi(Es[[i]], eta[i, ], i)
-      # a subject that cannot be solved gives a non-finite score; max(abs(S)) is then NA
-      # and the test below would error rather than fall back
-      if (!all(is.finite(sh$S))) return(NULL)
-      if (max(abs(sh$S)) < (if (it == 1L) skip else conv)) { active[i] <- FALSE; next }
-      if (it == maxit + 1L) return(NULL)                 # did not converge -> FD fallback
-      step <- tryCatch(solve(sh$Hf, sh$S), error = function(e) NULL); if (is.null(step)) return(NULL)
-      eta[i, ] <- eta[i, ] - step
-    }
-    if (!any(active)) break
-  }
-  if (any(active)) return(NULL)
-  eta
 }
 
 #' Compute the full analytic FOCEI covariance (theta + sigma + Omega) for a fitted

--- a/R/foceiCovAnalytic.R
+++ b/R/foceiCovAnalytic.R
@@ -1847,7 +1847,13 @@
   ae <- a[, ei, drop = FALSE]
   isD <- function(p) p <= ndirP; dOf <- function(p) dirP[p]; omc <- function(p) p - ndirP
   # ---- Phi (data) tensors: H=Phi_etaeta, gPhi=Phi_eta (aRe eta-block) ----
-  gPhi <- as.numeric(Oi %*% ehat); for (l in ei) gPhi[l] <- gPhi[l] + sum(rf * a[, l] + rR * aRe[, l])
+  # The inner problem zeroes S_FOCE = Omega^-1 eta + sum(q0 a) (q0 = rf), so all that
+  # survives Phi_eta at the FOCE EBE is the variance chain sum(rR aRe).  Subtract S
+  # SYMBOLICALLY instead of evaluating Phi_eta and leaning on the inner residual being
+  # small: it is only at the inner solver's tolerance and it multiplies eta_ab, which is
+  # not small.  Zero for frozen-R FOCE (aRe=0) and for any eta-independent R (additive),
+  # where this kernel then reduces EXACTLY to the FOCEI envelope form.
+  gPhi <- vapply(ei, function(l) sum(rR * aRe[, l]), numeric(1))   # Phi_eta - S_FOCE
   H <- Oi; for (l in ei) for (m in ei)
     H[l, m] <- H[l, m] + sum(rff * a[, l] * a[, m] + rfR * (a[, l] * aRe[, m] + aRe[, l] * a[, m]) +
                               rRR * aRe[, l] * aRe[, m] + rf * A[, l, m] + rR * E_ARelm(E, l, m, .fp))
@@ -2250,7 +2256,13 @@ E_ARelm <- function(E, l, m, fp) if (fp) E$AR[, l, m] else 0
   # ---- Phi (data) pieces: FULL rho derivatives ----
   H <- Oi; for (l in ei) for (m in ei) H[l, m] <- H[l, m] + sum(rd$r2 * a[, l] * a[, m] + rd$r1 * A[, l, m])  # Phi_etaeta
   Ndat <- matrix(0, neta, ndir); for (l in ei) for (d in di) Ndat[l, d] <- sum(rd$r2 * a[, l] * a[, d] + rd$r1 * A[, l, d])  # Phi_(eta,theta)
-  gPhi <- as.numeric(Oi %*% ehat); for (l in ei) gPhi[l] <- gPhi[l] + sum(rd$r1 * a[, l])  # Phi_eta (nonzero at eta-hat_FOCE)
+  # Phi_eta at the FOCE EBE.  The inner problem zeroes S_FOCE = Omega^-1 eta + sum(q0 a),
+  # so all that survives Phi_eta is the interaction remainder Phi_f - q0.  Subtract it
+  # SYMBOLICALLY rather than evaluating Phi_eta and leaning on the inner residual being
+  # small: the residual is only at the inner solver's tolerance and it multiplies eta_ab,
+  # which is not small.  Identically zero for frozen-R FOCE and for any eta-independent R
+  # (additive), where this kernel then reduces EXACTLY to the FOCEI envelope form.
+  gPhi <- vapply(ei, function(l) sum((rd$r1 - qd$q0) * a[, l]), numeric(1))  # Phi_eta - S_FOCE
 
   # ---- FOCE inner (EBE) pieces: q-based Jacobian S_eta = Hf and its 3-tensor ----
   Hf <- Oi; for (l in ei) for (m in ei) Hf[l, m] <- Hf[l, m] + sum(qd$q1 * a[, l] * a[, m] + qd$q0 * A[, l, m])  # S_eta = Hf

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -263,7 +263,7 @@
   nom <- length(dOiEst); np <- nth + nsg + nom
   ae <- a[, ei, drop = FALSE]
   # Phi_eta (nonzero at the FOCE eta*): rho_f df/deta + rho_R dR0/deta (aRe=0 for nonmem)
-  gPhi <- as.numeric(Oi %*% ehat)
+  gPhi <- as.numeric(Oi %*% ehat)     # Phi_eta in full -- see .foceiAnalyticSubjectGradFoce
   for (l in ei) gPhi[l] <- gPhi[l] + sum(rho_f * a[, l] + rho_R * aRe[, l])
   # FOCE inner Hessian Hf (interaction-free), its Nf, and the determinant Ht = Oi + sum(a a/R0)
   Hf <- Oi; Nf <- matrix(0, neta, ndir); Ht <- Oi
@@ -373,6 +373,11 @@
   a0 <- if (.cf0) E0$a else NULL
   fq <- if (.cf0) list(qf0 = evf(.fc$f0$qf0), pFf0 = evf(.fc$f0$pFf0), rhof0 = evf(.fc$f0$rhof0)) else NULL
   # Phi_eta (nonzero at the FOCE eta*), FOCE inner Hessian Hf, its Nf, determinant Ht
+  # Phi_eta in FULL, deliberately: unlike the covariance kernel (which subtracts the inner
+  # score S_FOCE symbolically, since it is zero at the EBE and only injects the inner
+  # tolerance into R -- #1056), the outer gradient is evaluated DURING the search, where the
+  # inner problem has a bounded iteration budget and the outer optimizer's own finite
+  # differences see Phi_eta as it actually is.  Keep it.
   gPhi <- as.numeric(Oi %*% ehat); for (l in ei) gPhi[l] <- gPhi[l] + sum(rd$r1 * a[, l])
   Hf <- Oi; for (l in ei) for (m in ei) Hf[l, m] <- Hf[l, m] + sum(qd$q1 * a[, l] * a[, m] + qd$q0 * A[, l, m])
   HfInv <- solve(Hf)

--- a/R/foceiGradAnalytic.R
+++ b/R/foceiGradAnalytic.R
@@ -373,11 +373,10 @@
   a0 <- if (.cf0) E0$a else NULL
   fq <- if (.cf0) list(qf0 = evf(.fc$f0$qf0), pFf0 = evf(.fc$f0$pFf0), rhof0 = evf(.fc$f0$rhof0)) else NULL
   # Phi_eta (nonzero at the FOCE eta*), FOCE inner Hessian Hf, its Nf, determinant Ht
-  # Phi_eta in FULL, deliberately: unlike the covariance kernel (which subtracts the inner
-  # score S_FOCE symbolically, since it is zero at the EBE and only injects the inner
-  # tolerance into R -- #1056), the outer gradient is evaluated DURING the search, where the
-  # inner problem has a bounded iteration budget and the outer optimizer's own finite
-  # differences see Phi_eta as it actually is.  Keep it.
+  # Phi_eta in FULL, deliberately.  The covariance kernel subtracts the inner score S_FOCE
+  # (zero at the EBE, so it only injects the inner tolerance -- #1056); the outer gradient is
+  # evaluated DURING the search, against an inner solve on a bounded iteration budget, so it
+  # keeps Phi_eta as the objective's own finite differences see it.
   gPhi <- as.numeric(Oi %*% ehat); for (l in ei) gPhi[l] <- gPhi[l] + sum(rd$r1 * a[, l])
   Hf <- Oi; for (l in ei) for (m in ei) Hf[l, m] <- Hf[l, m] + sum(qd$q1 * a[, l] * a[, m] + qd$q0 * A[, l, m])
   HfInv <- solve(Hf)

--- a/src/foceiGrad.cpp
+++ b/src/foceiGrad.cpp
@@ -1001,12 +1001,10 @@ arma::mat foceiRSubjectFoceFR_(const arma::mat& a, const arma::cube& A, const ar
       v += rff[o] * a(o, l) * a(o, m) + rfR[o] * (a(o, l) * aRe(o, m) + aRe(o, l) * a(o, m)) +
         rRR[o] * aRe(o, l) * aRe(o, m) + rf[o] * A(o, l, m) + rR[o] * ARe(o, l, m);
     H(l, m) += v; }
-  // The inner problem zeroes S_FOCE = Omega^-1 eta + sum(q0 a) (q0 = rf), so all that
-  // survives Phi_eta at the FOCE EBE is the variance chain sum(rR aRe).  Subtracting S
-  // symbolically keeps this term free of the inner solver's residual, which is only at
-  // its tolerance yet multiplies eta_ab.  Zero for frozen-R FOCE (aRe=0) and for any
-  // eta-independent R, where this reduces EXACTLY to the FOCEI envelope form.
-  vec gPhi(neta, fill::zeros);                        // Phi_eta - S_FOCE
+  // Phi_eta MINUS the inner score S_FOCE = Omega^-1 eta + sum(q0 a) (q0 = rf), which the
+  // inner problem zeroes: subtracting it symbolically keeps the residual out of R (#1056).
+  // Zero for frozen-R FOCE (aRe=0) and any eta-independent R -> the FOCEI envelope form.
+  vec gPhi(neta, fill::zeros);
   for (int l = 0; l < neta; l++) { double v = 0.0; for (int o = 0; o < nobs; o++) v += rR[o] * aRe(o, l); gPhi[l] = v; }
   // ---- FOCE inner (EBE) tensors: interaction-free q-based Hf/Nf/Tnf ----
   mat Hf = Oi; mat Nf(neta, ndir, fill::zeros);

--- a/src/foceiGrad.cpp
+++ b/src/foceiGrad.cpp
@@ -1001,8 +1001,13 @@ arma::mat foceiRSubjectFoceFR_(const arma::mat& a, const arma::cube& A, const ar
       v += rff[o] * a(o, l) * a(o, m) + rfR[o] * (a(o, l) * aRe(o, m) + aRe(o, l) * a(o, m)) +
         rRR[o] * aRe(o, l) * aRe(o, m) + rf[o] * A(o, l, m) + rR[o] * ARe(o, l, m);
     H(l, m) += v; }
-  vec gPhi = Oi * ehat;
-  for (int l = 0; l < neta; l++) { double v = 0.0; for (int o = 0; o < nobs; o++) v += rf[o] * a(o, l) + rR[o] * aRe(o, l); gPhi[l] += v; }
+  // The inner problem zeroes S_FOCE = Omega^-1 eta + sum(q0 a) (q0 = rf), so all that
+  // survives Phi_eta at the FOCE EBE is the variance chain sum(rR aRe).  Subtracting S
+  // symbolically keeps this term free of the inner solver's residual, which is only at
+  // its tolerance yet multiplies eta_ab.  Zero for frozen-R FOCE (aRe=0) and for any
+  // eta-independent R, where this reduces EXACTLY to the FOCEI envelope form.
+  vec gPhi(neta, fill::zeros);                        // Phi_eta - S_FOCE
+  for (int l = 0; l < neta; l++) { double v = 0.0; for (int o = 0; o < nobs; o++) v += rR[o] * aRe(o, l); gPhi[l] = v; }
   // ---- FOCE inner (EBE) tensors: interaction-free q-based Hf/Nf/Tnf ----
   mat Hf = Oi; mat Nf(neta, ndir, fill::zeros);
   for (int l = 0; l < neta; l++) {

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1037,9 +1037,11 @@ nmTest({
   # comparing a FOCEI fit's R against a gold built at a DIFFERENT (FOCE) fit's estimates -- a
   # convergence confound, not an assembly defect.  At one common point the FOCEI and FOCE
   # analytic R agree to 1.3e-5 with identical eigenvalues, and both reproduce the gold.  The
-  # residual FOCEI error that did survive (3.9e-3) was the stored EBEs solving Phi_eta = 0 only
-  # to the fit's inner tolerance, which the envelope/Schur data term assumes exactly; the engine
-  # now re-solves them and the error drops to 7.7e-5.  This is the acceptance gate for that.
+  # residual FOCEI error that did survive was the stored EBEs solving Phi_eta = 0 only to the
+  # fit's inner tolerance, which the envelope/Schur data term assumes exactly.  That is an
+  # estimation-side gap and the covariance does not paper over it by re-optimizing the fit's
+  # EBEs (PR #1060); the gold below re-solves at every perturbed psi, so the agreement this
+  # asserts is the acceptance gate at a sigdig where the two are close.
   #
   # 12 subjects (theo_sd unreplicated) do not identify the off-diagonal, so a couple of SEs are
   # NaN in BOTH the analytic and the gold -- as in the FOCE gold test below, the criterion is
@@ -1292,8 +1294,14 @@ nmTest({
   test_that("est='focep' installs the full analytic covariance", {
     skip_on_cran()
     skip_if_not_installed("nlmixr2data")
+    # sigdig is pinned because the DEFAULT (3) does not converge here: bobyqa stalls at
+    # objf 121.560 against 116.804 at sigdig 4+, and the fit says so ("last objective
+    # function was not at minimum").  The observed information there has a real negative
+    # eigenvalue, so the PD gate refuses to install it -- correctly.  This test is about the
+    # analytic route being reachable from est="focep", not about that optimizer stall
+    # (#1069), so it asks at a point that IS a minimum.
     fit <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focep",
-              focepControl(print = 0L, covMethod = "analytic", covFull = TRUE))))
+              focepControl(print = 0L, covMethod = "analytic", covFull = TRUE, sigdig = 4))))
     expect_identical(.covBaseName(fit$covMethod), "analytic")
     expect_true(any(grepl("^om\\.", rownames(fit$cov))))
     .se <- sqrt(diag(fit$cov))

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -366,12 +366,13 @@ nmTest({
     expect_true(any(grepl("^om\\.", rownames(fit$cov))))
   })
 
-  test_that("foce+ (live-R) additive analytic R equals the FOCEI analytic R at the same EBEs", {
+  test_that("FOCE and foce+ additive analytic R equal the FOCEI analytic R at the same EBEs", {
     skip_on_cran()
     skip_if_not_installed("nlmixr2data")
     # Additive error: R = sa^2 is constant, so live vs frozen R and the FOCEI interaction
-    # term all coincide, and the FOCE inner problem IS the FOCEI one.  At the same EBEs the
-    # two kernels must therefore agree to machine precision -- see #1056, where they did not.
+    # term all coincide, and the FOCE inner problem IS the FOCEI one.  At the same EBEs all
+    # three kernels must therefore agree to machine precision -- see #1056, where the live-R
+    # (foce+) one did not.
     #
     # Two things separated them, both now fixed.  The FOCE kernel's general total-derivative
     # form ends in Phi_eta . eta_ab; Phi_eta was evaluated in full, but the inner problem
@@ -394,15 +395,22 @@ nmTest({
                            etaMat = .em, maxInnerIterations = 0L))))
     # the pinning has to have worked, or the comparison below is not about the kernels
     expect_equal(as.matrix(fitP$eta[, -1, drop = FALSE]), as.matrix(fitI$eta[, -1, drop = FALSE]))
+    # the frozen-R ("nonmem") FOCE variant takes the same kernel with aRe = 0, so pin it too
+    fitF <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
+              foceiControl(sigdig = 4, print = 0L, covMethod = "", maxOuterIterations = 0L,
+                           interaction = FALSE, etaMat = .em, maxInnerIterations = 0L))))
+    expect_equal(as.matrix(fitF$eta[, -1, drop = FALSE]), as.matrix(fitI$eta[, -1, drop = FALSE]))
     # not positive definite on this model+point, so the PD gate warns and leaves fit$cov
     # alone; the R matrix (what this compares) is returned either way
     rP <- suppressWarnings(foceiCovAnalytic(fitP)); rI <- suppressWarnings(foceiCovAnalytic(fitI))
+    rF <- suppressWarnings(foceiCovAnalytic(fitF))
     expect_false(is.null(rP)); expect_identical(rP$method, "analytic")
-    expect_false(is.null(rI))
+    expect_false(is.null(rI)); expect_identical(rF$method, "analytic")
     .fin <- is.finite(rP$se) & is.finite(rI$se)
     expect_gt(sum(.fin), 3L)
     expect_equal(unname(rP$se[.fin]), unname(rI$se[.fin]), tolerance = 1e-10)
     expect_lt(max(abs(rP$R - rI$R) / (abs(rI$R) + 1e-8)), 1e-10)
+    expect_lt(max(abs(rF$R - rI$R) / (abs(rI$R) + 1e-8)), 1e-10)
   })
 
   test_that("foce+ and FOCEI additive analytic R converge as the inner solve tightens", {

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -366,31 +366,34 @@ nmTest({
     expect_true(any(grepl("^om\\.", rownames(fit$cov))))
   })
 
-  test_that("foce+ (live-R) additive analytic R equals the FOCEI analytic R at the same theta", {
+  test_that("foce+ (live-R) additive analytic R equals the FOCEI analytic R at the same EBEs", {
     skip_on_cran()
     skip_if_not_installed("nlmixr2data")
     # Additive error: R = sa^2 is constant, so live vs frozen R and the FOCEI interaction
-    # term all coincide.  maxOuterIterations=0 evaluates both at the identical initial
-    # theta, and the two fits' EBEs agree to 6.9e-09, so what is left is the two KERNELS.
+    # term all coincide, and the FOCE inner problem IS the FOCEI one.  At the same EBEs the
+    # two kernels must therefore agree to machine precision -- see #1056, where they did not.
     #
-    # They do not agree entrywise, and cannot: the FOCE/foce+ kernel uses the general
-    # total-derivative form, which carries sum(gPhi . eta_ab), while the FOCEI kernel uses
-    # the envelope/Schur form, which drops that term because it assumes Phi_eta = 0.  The
-    # fit's stored EBEs sit at |Phi_eta| ~ 2e-3 (the inner solver's own tolerance), so the
-    # dropped term is exactly what separates the two.  Both kernels are right about their
-    # own assumption; the gap MEASURES how far the stored EBEs are from stationary, and it
-    # closes only when the inner solve gets tighter -- not something the covariance step
-    # should paper over by re-solving the fit's EBEs.
+    # Two things separated them, both now fixed.  The FOCE kernel's general total-derivative
+    # form ends in Phi_eta . eta_ab; Phi_eta was evaluated in full, but the inner problem
+    # zeroes S_FOCE by construction, so only the interaction remainder Phi_f - q0 belongs
+    # there (identically zero here) and the S part was the inner solver's own residual times
+    # a not-small eta_ab.  And the FOCE assembler re-solved the EBEs while the FOCEI one used
+    # the fit's; the covariance now uses the fit's on both routes.
     #
-    # So assert what a user sees -- the standard errors -- and bound the raw R difference at
-    # what it measures.  Measured: the raw R gap is 1.2e-2, on the numerically small
-    # [add.sd, tka] entry; the theta and sigma SEs agree to ~1e-5, and the loosest SE
-    # (om.eta.ka, 0.41166 vs 0.41211) to 1.1e-3.
-    fitP <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
-              foceiControl(sigdig = 4, print = 0L, covMethod = "", maxOuterIterations = 0L,
-                           interaction = FALSE, foce = "foce+"))))
+    # etaMat + maxInnerIterations=0 pins the foce+ fit to the FOCEI fit's EBEs, which is what
+    # isolates the KERNELS.  Two independent fits would not do it: foce+ refines its EBEs to
+    # the truncated-score root during estimation (focePlusRefinementRequired, src/inner.cpp)
+    # and FOCEI does not, so at sigdig=4 the two fits sit 1.2e-3 apart in eta -- an
+    # estimation-side difference that has nothing to do with the covariance kernels.
     fitI <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
               foceiControl(sigdig = 4, print = 0L, covMethod = "", maxOuterIterations = 0L))))
+    .em <- as.matrix(fitI$eta[, -1, drop = FALSE]); dimnames(.em) <- NULL
+    fitP <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
+              foceiControl(sigdig = 4, print = 0L, covMethod = "", maxOuterIterations = 0L,
+                           interaction = FALSE, foce = "foce+",
+                           etaMat = .em, maxInnerIterations = 0L))))
+    # the pinning has to have worked, or the comparison below is not about the kernels
+    expect_equal(as.matrix(fitP$eta[, -1, drop = FALSE]), as.matrix(fitI$eta[, -1, drop = FALSE]))
     # not positive definite on this model+point, so the PD gate warns and leaves fit$cov
     # alone; the R matrix (what this compares) is returned either way
     rP <- suppressWarnings(foceiCovAnalytic(fitP)); rI <- suppressWarnings(foceiCovAnalytic(fitI))
@@ -398,8 +401,34 @@ nmTest({
     expect_false(is.null(rI))
     .fin <- is.finite(rP$se) & is.finite(rI$se)
     expect_gt(sum(.fin), 3L)
-    expect_equal(unname(rP$se[.fin]), unname(rI$se[.fin]), tolerance = 2e-3)
-    expect_lt(max(abs(rP$R - rI$R) / (abs(rI$R) + 1e-8)), 2e-2)
+    expect_equal(unname(rP$se[.fin]), unname(rI$se[.fin]), tolerance = 1e-10)
+    expect_lt(max(abs(rP$R - rI$R) / (abs(rI$R) + 1e-8)), 1e-10)
+  })
+
+  test_that("foce+ and FOCEI additive analytic R converge as the inner solve tightens", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    # The companion to the test above: two INDEPENDENT fits do not land on the same EBEs
+    # (foce+ refines its own, FOCEI does not), so their observed informations differ by
+    # whatever that eta gap buys.  What must hold is that the gap is the inner tolerance and
+    # nothing structural -- i.e. it shrinks with sigdig.  Measured 1.1e-2 (sigdig 4) ->
+    # 7.5e-5 (sigdig 7) on the raw R, 1.1e-3 -> 4.7e-6 on the SEs.
+    .fitBoth <- function(sd) {
+      .p <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
+             foceiControl(sigdig = sd, print = 0L, covMethod = "", maxOuterIterations = 0L,
+                          interaction = FALSE, foce = "foce+"))))
+      .i <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
+             foceiControl(sigdig = sd, print = 0L, covMethod = "", maxOuterIterations = 0L))))
+      .rp <- suppressWarnings(foceiCovAnalytic(.p)); .ri <- suppressWarnings(foceiCovAnalytic(.i))
+      .f <- is.finite(.rp$se) & is.finite(.ri$se)
+      c(R = max(abs(.rp$R - .ri$R) / (abs(.ri$R) + 1e-8)),
+        se = max(abs(.rp$se[.f] - .ri$se[.f]) / (abs(.ri$se[.f]) + 1e-8)))
+    }
+    .g4 <- .fitBoth(4); .g7 <- .fitBoth(7)
+    expect_lt(.g4[["R"]], 2e-2)
+    expect_lt(.g7[["R"]], 5e-4)          # measured 7.5e-5
+    expect_lt(.g7[["se"]], 5e-5)         # measured 4.7e-6
+    expect_lt(.g7[["R"]], .g4[["R"]])
   })
 
   # Wang 2007 monoexponential IV bolus: predictions 10*exp(-ke*t) are bounded away from

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -383,8 +383,8 @@ nmTest({
     # etaMat + maxInnerIterations=0 pins the foce+ fit to the FOCEI fit's EBEs, which is what
     # isolates the KERNELS.  Two independent fits would not do it: foce+ refines its EBEs to
     # the truncated-score root during estimation (focePlusRefinementRequired, src/inner.cpp)
-    # and FOCEI does not, so at sigdig=4 the two fits sit 1.2e-3 apart in eta -- an
-    # estimation-side difference that has nothing to do with the covariance kernels.
+    # and FOCEI does not, so at sigdig=4 the two fits sit 1.2e-3 apart in eta (plain FOCE,
+    # which does not refine, sits 6.9e-09 away) -- estimation side, not the kernels.
     fitI <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
               foceiControl(sigdig = 4, print = 0L, covMethod = "", maxOuterIterations = 0L))))
     .em <- as.matrix(fitI$eta[, -1, drop = FALSE]); dimnames(.em) <- NULL
@@ -408,11 +408,13 @@ nmTest({
   test_that("foce+ and FOCEI additive analytic R converge as the inner solve tightens", {
     skip_on_cran()
     skip_if_not_installed("nlmixr2data")
-    # The companion to the test above: two INDEPENDENT fits do not land on the same EBEs
-    # (foce+ refines its own, FOCEI does not), so their observed informations differ by
-    # whatever that eta gap buys.  What must hold is that the gap is the inner tolerance and
-    # nothing structural -- i.e. it shrinks with sigdig.  Measured 1.1e-2 (sigdig 4) ->
-    # 7.5e-5 (sigdig 7) on the raw R, 1.1e-3 -> 4.7e-6 on the SEs.
+    # The companion to the test above: two INDEPENDENT fits do not land on the same EBEs, so
+    # their observed informations differ by whatever that eta gap buys.  It is foce+ that
+    # moves -- at the same theta, plain FOCE's EBEs match FOCEI's to 6.9e-09 while foce+'s
+    # differ by 1.2e-03, because foce+ alone refines its EBEs to the truncated-score root
+    # during estimation (focePlusRefinementRequired, src/inner.cpp).  What must hold is that
+    # the gap is the inner tolerance and nothing structural -- i.e. it shrinks with sigdig.
+    # Measured 1.1e-2 (sigdig 4) -> 7.5e-5 (sigdig 7) on the raw R, 1.1e-3 -> 4.7e-6 on SEs.
     .fitBoth <- function(sd) {
       .p <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focei",
              foceiControl(sigdig = sd, print = 0L, covMethod = "", maxOuterIterations = 0L,

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -431,6 +431,28 @@ nmTest({
     expect_lt(.g7[["R"]], .g4[["R"]])
   })
 
+  test_that("foce+ and FOCEI agree on the censored additive (f,R) cov at the same EBEs", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    # The companion to the test above for the OTHER assembler: censoring routes both FOCEI
+    # and foce+ to the general (f,R) path and its C++ kernel (foceiRSubjectFoceFR_), which
+    # carried the same Phi_eta term.  The error is still additive, so R does not depend on
+    # eta (aRe = 0) and the two observed informations must coincide at the same EBEs.
+    .d <- nlmixr2data::theo_sd
+    .d$CENS <- ifelse(.d$DV < 2 & .d$EVID == 0, 1L, 0L); .d$DV[.d$CENS == 1] <- 2
+    fitI <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, .d, "focei",
+              foceiControl(sigdig = 4, print = 0L, covMethod = "", maxOuterIterations = 0L))))
+    .em <- as.matrix(fitI$eta[, -1, drop = FALSE]); dimnames(.em) <- NULL
+    fitP <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, .d, "focei",
+              foceiControl(sigdig = 4, print = 0L, covMethod = "", maxOuterIterations = 0L,
+                           interaction = FALSE, foce = "foce+",
+                           etaMat = .em, maxInnerIterations = 0L))))
+    expect_equal(as.matrix(fitP$eta[, -1, drop = FALSE]), as.matrix(fitI$eta[, -1, drop = FALSE]))
+    rP <- suppressWarnings(foceiCovAnalytic(fitP)); rI <- suppressWarnings(foceiCovAnalytic(fitI))
+    expect_identical(rP$method, "analytic"); expect_identical(rI$method, "analytic")
+    expect_lt(max(abs(rP$R - rI$R) / (abs(rI$R) + 1e-8)), 1e-8)
+  })
+
   # Wang 2007 monoexponential IV bolus: predictions 10*exp(-ke*t) are bounded away from
   # zero at every observation, so pure proportional error is genuinely in analytic scope.
   .cov_wang_prop <- function() {


### PR DESCRIPTION
Closes #1056.

## What #1056 turned out to be

Two separate things, both real.

### 1. The FOCE kernel carried the inner solver's residual score

The FOCE/`foce+` observed information uses the general total-derivative form

```
R_ab = Phi_ab + Phi_aeta eta_b + Phi_beta eta_a + eta_a' Phi_etaeta eta_b + Phi_eta . eta_ab
```

and evaluated `Phi_eta` in full. But the FOCE inner problem zeroes
`S_FOCE = Omega^-1 eta + sum(q0 a)` by construction, so the only part of
`Phi_eta` that belongs in that last term is the interaction remainder
`Phi_f - q0` (for the `(f,R)` kernel, the variance chain `rho_R . dR/deta`).
What was left over was the inner solver's own residual -- at its tolerance, not
zero -- multiplying `eta_ab`, which is not small.

Subtracting `S_FOCE` symbolically is exact and costs nothing. On an ADDITIVE
model the remainder is identically zero, so the FOCE kernel reduces EXACTLY to
the FOCEI envelope/Schur form, which is what #1056 said it must.

### 2. The FOCE assemblers re-solved the fit's EBEs; the FOCEI one does not

PR #1060 removed the FOCEI EBE refinement on the grounds that the EBEs are part
of the fit's solution -- `fit$objf` was evaluated at them -- and re-optimizing
them inside the covariance step gives the curvature of an idealized objective the
reported fit does not sit on. The FOCE side kept doing it. Both routes now use
the fit's own EBEs.

This is a no-op wherever the re-solve's `skip` gate already fired. On the
combined-error `theo_sd` fixture a forced Newton moves the stored FOCE EBEs by
2.7e-05 at `sigdig = 4` and 4.5e-07 at `sigdig = 6` -- pure inner tolerance, not
a systematic estimation-side inconsistency, so nothing is lost by not chasing it
here.

## Measured

At the same EBEs, `foce+` vs FOCEI analytic observed information, additive
`theo_sd`:

| | max relative difference in R |
| --- | --- |
| before | 1.0e-02 |
| after | **1.1e-13** |

End to end through two real fits pinned to the same EBEs
(`etaMat=` + `maxInnerIterations = 0`): 1.07e-13 on R, 3.6e-15 on the SEs. The
frozen-R ("nonmem") variant, pinned the same way, also lands at 1.1e-13.

Two INDEPENDENT fits still differ, and that part is not the covariance: `foce+`
refines its EBEs to the truncated-score root during estimation
(`focePlusRefinementRequired`, `src/inner.cpp`) and FOCEI does not, so at
`sigdig = 4` they sit 1.2e-3 apart in eta -- while plain FOCE, which does not
refine, sits 6.9e-09 from FOCEI. That gap is the inner tolerance and shrinks with
it (raw R 1.1e-2 at sigdig 4 -> 7.5e-5 at sigdig 7).

## The outer gradient is deliberately NOT changed

`.foceiAnalyticSubjectGradFoce` / `foceiGradSubjectFoceFR_` keep the full
`Phi_eta`. The covariance is formed once, at the end, and wants the curvature of
the objective as a mathematical function; the outer gradient is evaluated DURING
the search, against an inner solve on a bounded iteration budget, and is what the
outer optimizer's own finite differences are compared against. Both sites now say
so.

## Tests

- the #1056 test is rewritten to isolate the KERNELS -- the `foce+` and frozen-R
  ("nonmem") FOCE fits are pinned to the FOCEI fit's EBEs with `etaMat=` +
  `maxInnerIterations = 0`, and the observed informations are asserted equal to
  1e-10 rather than "within 2e-2";
- a companion test that two independent fits converge as `sigdig` tightens, which
  is what the remaining (estimation-side) gap actually is;
- a censored additive test covering the OTHER assembler -- censoring routes both
  routes to the general `(f,R)` path and its C++ kernel, which carried the same
  term;
- the gold-FD FOCEI / FOCE / `foce+` comparisons are unchanged and still pass.

## One pre-existing failure fixed out of the way

`est='focep' installs the full analytic covariance` was failing on `main`: at the
DEFAULT `sigdig = 3`, `est="focep"` stalls at objf 121.560 against 116.804 at
`sigdig = 4` (`$runInfo`: "last objective function was not at minimum"), so its
observed information is legitimately indefinite and the PD gate from #1060
refuses to install it. That is a `foce+` optimizer problem, filed separately as
**#1069**; the test pins `sigdig = 4` and points there.

## Review

An Antigravity (`gemini-3.1-pro-high`) review of the diff raised no correctness
findings -- it checked the `Phi_eta - S_FOCE` algebra in all three kernels, the
censored path, the C++ hunk's memory safety, the EBE-re-solve removal, IOV
rescaling and the fallback logic. Its one finding was coverage: the pinned-EBE
tests covered `foce+` but not the frozen-R variant. Verified by measurement
(pinned 1.1e-13, unpinned 4.7e-07) and added.

Local runs, all green: `cov-analytic` (230 assertions), `focei-foce-plus`,
`focei-fast-grad`, `focei-outer-hessian-family`, `focei-outer-hessian-censor`,
`focei-outer-hessian-nlminb-fit`, `focei-cens-t-fit`, `focei-ptrs`,
`agq-fast-grad`, `cov-condition`, `agq-cov`, `cov-decouple-saimp`,
`cov-scope-swap`, `saem-cov-analytic`.
