### PR TITLE
saem: refuse a random effect with no population parameter of its own (#1047)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Bug fixes
 
+- `saem` refuses a model whose random effect is added to no population
+  parameter, naming the random effects, instead of fitting the model without
+  them and then failing with "subscript out of bounds" while assembling the
+  reported omega at the end of the run (#1047).
 - A model containing `mtime()` can be fit again, with every estimation method.
   `etTrans()` materializes the modeled times as `EVID` 10-99 records (`TIME=0`,
   `AMT=NA`) and `$dataSav` persisted them, so re-translating it for each

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,11 @@
 
 ## Bug fixes
 
-- `saem` refuses a model whose random effect is added to no population
-  parameter, naming the random effects, instead of fitting the model without
-  them and then failing with "subscript out of bounds" while assembling the
-  reported omega at the end of the run (#1047).
+- `saem` refuses a model whose random effect has no population parameter of its
+  own -- added to none, or sharing one with another random effect -- naming the
+  random effects, instead of fitting the model without them and then failing
+  with "subscript out of bounds" while assembling the reported omega at the end
+  of the run (#1047).
 - A model containing `mtime()` can be fit again, with every estimation method.
   `etTrans()` materializes the modeled times as `EVID` 10-99 records (`TIME=0`,
   `AMT=NA`) and `$dataSav` persisted them, so re-translating it for each

--- a/R/saem.R
+++ b/R/saem.R
@@ -567,6 +567,24 @@
   invisible()
 }
 
+#' Random effects that saem has no population parameter for
+#'
+#' saem parameterizes a random effect by the phi (population) parameter it is
+#' added to, so an eta paired with none has no phi1 column at all.  It is then
+#' silently dropped from `model$omega` -- an `NA` index in a matrix assignment
+#' is a no-op in R -- and the model is fitted without that random effect.
+#'
+#' @param ui rxode2 ui
+#' @return character vector of the diagonal eta names with no phi parameter
+#' @author Matthew L. Fidler
+#' @noRd
+.saemEtaNoPhi <- function(ui) {
+  .iniDf <- ui$iniDf
+  .etas <- .iniDf[!is.na(.iniDf$neta1), ]
+  .etas <- .etas$name[.etas$neta1 == .etas$neta2]
+  .etas[is.na(ui$saemEtaTrans)]
+}
+
 #' Refuse a model whose random effect saem has no parameter for
 #'
 #' saem parameterizes a random effect by the population parameter it is added

--- a/R/saem.R
+++ b/R/saem.R
@@ -585,7 +585,12 @@
   .etas <- .iniDf[!is.na(.iniDf$neta1), ]
   .etas <- .etas$name[.etas$neta1 == .etas$neta2]
   .tr <- ui$saemEtaTrans
-  .etas[is.na(.tr) | duplicated(.tr)]
+  # Report the WHOLE colliding group, not just the repeats: which eta of the
+  # group the kernel keeps is not well defined -- `saemEtaNames` labels the
+  # shared column with the LAST of them while `saemOmegaTrans` maps the FIRST
+  # onto it -- so blaming one of the two would name an arbitrary half.
+  .shared <- .tr %in% .tr[duplicated(.tr)]
+  .etas[is.na(.tr) | .shared]
 }
 
 #' Refuse a model whose random effect saem has no parameter for

--- a/R/saem.R
+++ b/R/saem.R
@@ -567,6 +567,28 @@
   invisible()
 }
 
+#' Refuse a model whose random effect saem has no parameter for
+#'
+#' saem parameterizes a random effect by the population parameter it is added
+#' to (`theta + eta`), or carries it through `nonMuEtas`.  An eta paired with
+#' neither owns no phi1 column, so it is silently dropped from the kernel's
+#' `model$omega` and never sampled -- the model that gets fitted is not the
+#' model that was written, and the only symptom is a "subscript out of bounds"
+#' when the reported omega is assembled at the very end of the run (#1047).
+#'
+#' @param ui rxode2 ui
+#' @return Nothing, called for the error side effect
+#' @author Matthew L. Fidler
+#' @noRd
+.saemAssertEtaPhi <- function(ui) {
+  .bad <- .saemEtaNoPhi(ui)
+  if (length(.bad) == 0L) return(invisible())
+  stop("random effect(s) are not added to any population parameter, so 'saem' ",
+       "cannot sample them: ", paste(.bad, collapse=", "),
+       "\nas a work-around put the random effect on a simple 'theta + eta' line",
+       call.=FALSE)
+}
+
 #' Get SAEM omega
 #'
 #' @param env Environment that has ui and saem in it
@@ -588,6 +610,14 @@
   # Gamma2_phi1Report is the reporting-only pooled BSV for split ETAs; falls
   # back to Gamma2_phi1 for older cached fits without the field.
   .curOme <- if (!is.null(.saem$Gamma2_phi1Report)) .saem$Gamma2_phi1Report else .saem$Gamma2_phi1
+  # Backstop for #1047: .saemAssertEtaPhi() refuses such a model up front, so
+  # reaching here means the UI's etas and the kernel's phi1 block disagree.
+  .off <- is.na(.etaTrans) | .etaTrans > nrow(.curOme)
+  if (any(.off)) {
+    stop("saem reported no variance for random effect(s): ",
+         paste(.etaNames[.off], collapse=", "),
+         call.=FALSE)
+  }
   .mat <- nlme::random.effects(.saem)
   .mat2 <- .mat[, .etaTrans, drop = FALSE]
   colnames(.mat2) <- .etaNames
@@ -1671,6 +1701,7 @@ nlmixr2Est.saem <- function(env, ...) {
   rxode2::assertRxUiIovNoCor(.ui, " for the estimation routine 'saem'",
                              .var.name=.ui$modelName)
   rxode2::assertRxUiMixedOnly(.ui, .noRandomEffectMsg("saem"), .var.name=.ui$modelName)
+  .saemAssertEtaPhi(.ui)
   rxode2::warnRxBounded(.ui, " which are ignored in 'saem'", .var.name=.ui$modelName)
   if (length(.ui$mixProbs) > 0) {
     message("mixture SAEM computation scales with the number of sub-populations")

--- a/R/saem.R
+++ b/R/saem.R
@@ -630,7 +630,10 @@
   .curOme <- if (!is.null(.saem$Gamma2_phi1Report)) .saem$Gamma2_phi1Report else .saem$Gamma2_phi1
   # Backstop for #1047: .saemAssertEtaPhi() refuses such a model up front, so
   # reaching here means the UI's etas and the kernel's phi1 block disagree.
-  .off <- is.na(.etaTrans) | .etaTrans > nrow(.curOme)
+  # A missing Gamma2_phi1 has to be counted as zero columns: `x > nrow(NULL)`
+  # is logical(0), so comparing against it would make every eta look in range.
+  .nOme <- if (is.matrix(.curOme)) nrow(.curOme) else 0L
+  .off <- is.na(.etaTrans) | .etaTrans > .nOme
   if (any(.off)) {
     stop("saem reported no variance for random effect(s): ",
          paste(.etaNames[.off], collapse=", "),

--- a/R/saem.R
+++ b/R/saem.R
@@ -570,26 +570,30 @@
 #' Random effects that saem has no population parameter for
 #'
 #' saem parameterizes a random effect by the phi (population) parameter it is
-#' added to, so an eta paired with none has no phi1 column at all.  It is then
-#' silently dropped from `model$omega` -- an `NA` index in a matrix assignment
-#' is a no-op in R -- and the model is fitted without that random effect.
+#' added to and gives that phi ONE Gamma2_phi1 column, so a random effect has
+#' no column of its own in two cases: it is paired with no phi at all, or it
+#' shares a phi with an earlier random effect.  Either way it is silently
+#' dropped from `model$omega` -- an `NA` or repeated index in a matrix
+#' assignment writes nothing new -- and the model is fitted without it.
 #'
 #' @param ui rxode2 ui
-#' @return character vector of the diagonal eta names with no phi parameter
+#' @return character vector of the diagonal eta names with no phi column
 #' @author Matthew L. Fidler
 #' @noRd
 .saemEtaNoPhi <- function(ui) {
   .iniDf <- ui$iniDf
   .etas <- .iniDf[!is.na(.iniDf$neta1), ]
   .etas <- .etas$name[.etas$neta1 == .etas$neta2]
-  .etas[is.na(ui$saemEtaTrans)]
+  .tr <- ui$saemEtaTrans
+  .etas[is.na(.tr) | duplicated(.tr)]
 }
 
 #' Refuse a model whose random effect saem has no parameter for
 #'
 #' saem parameterizes a random effect by the population parameter it is added
-#' to (`theta + eta`), or carries it through `nonMuEtas`.  An eta paired with
-#' neither owns no phi1 column, so it is silently dropped from the kernel's
+#' to (`theta + eta`), or carries it through `nonMuEtas`, and gives that phi
+#' one phi1 column.  An eta paired with no phi, or sharing one with another
+#' eta, owns no column, so it is silently dropped from the kernel's
 #' `model$omega` and never sampled -- the model that gets fitted is not the
 #' model that was written, and the only symptom is a "subscript out of bounds"
 #' when the reported omega is assembled at the very end of the run (#1047).
@@ -601,9 +605,9 @@
 .saemAssertEtaPhi <- function(ui) {
   .bad <- .saemEtaNoPhi(ui)
   if (length(.bad) == 0L) return(invisible())
-  stop("random effect(s) are not added to any population parameter, so 'saem' ",
+  stop("random effect(s) have no population parameter of their own, so 'saem' ",
        "cannot sample them: ", paste(.bad, collapse=", "),
-       "\nas a work-around put the random effect on a simple 'theta + eta' line",
+       "\nas a work-around put each on its own simple 'theta + eta' line",
        call.=FALSE)
 }
 

--- a/R/saemRxUiGet.R
+++ b/R/saemRxUiGet.R
@@ -223,7 +223,8 @@ rxUiGet.saemOmegaTrans <- function(x, ...) {
   .c <- 1
   for (i in .o) {
     # An eta with no phi parameter (NA) owns no Gamma2_phi1 column, so it gets
-    # no slot either; handing it one indexes past the matrix (#1047).
+    # no slot either.  Handing it a dense rank is what used to index past the
+    # matrix in .getSaemOmega() (#1047).
     if (is.na(.etaTrans[i])) next
     .etaTrans2[i] <- .c
     .c <- .c + 1

--- a/R/saemRxUiGet.R
+++ b/R/saemRxUiGet.R
@@ -233,25 +233,6 @@ rxUiGet.saemOmegaTrans <- function(x, ...) {
 #attr(rxUiGet.saemOmegaTrans, "desc") <- "Get the saem omega to UI omega translation"
 attr(rxUiGet.saemOmegaTrans, "rstudio") <- c(1L, 3L)
 
-#' Random effects that saem has no population parameter for
-#'
-#' saem parameterizes a random effect by the phi (population) parameter it is
-#' added to, so an eta paired with none has no phi1 column at all.  It is then
-#' silently dropped from `model$omega` -- an `NA` index in a matrix assignment
-#' is a no-op in R -- and the model is fitted without that random effect.
-#'
-#' @param ui rxode2 ui
-#' @return character vector of the diagonal eta names with no phi parameter
-#' @author Matthew L. Fidler
-#' @noRd
-.saemEtaNoPhi <- function(ui) {
-  .iniDf <- ui$iniDf
-  .etas <- .iniDf[!is.na(.iniDf$neta1), ]
-  .etas <- .etas$name[.etas$neta1 == .etas$neta2]
-  .etas[is.na(ui$saemEtaTrans)]
-}
-
-
 #' @export
 rxUiGet.saemOmegaShare <- function(x, ...) {
   .ui <- x[[1]]

--- a/R/saemRxUiGet.R
+++ b/R/saemRxUiGet.R
@@ -222,6 +222,9 @@ rxUiGet.saemOmegaTrans <- function(x, ...) {
   .etaTrans2 <- .etaTrans
   .c <- 1
   for (i in .o) {
+    # An eta with no phi parameter (NA) owns no Gamma2_phi1 column, so it gets
+    # no slot either; handing it one indexes past the matrix (#1047).
+    if (is.na(.etaTrans[i])) next
     .etaTrans2[i] <- .c
     .c <- .c + 1
   }
@@ -229,6 +232,24 @@ rxUiGet.saemOmegaTrans <- function(x, ...) {
 }
 #attr(rxUiGet.saemOmegaTrans, "desc") <- "Get the saem omega to UI omega translation"
 attr(rxUiGet.saemOmegaTrans, "rstudio") <- c(1L, 3L)
+
+#' Random effects that saem has no population parameter for
+#'
+#' saem parameterizes a random effect by the phi (population) parameter it is
+#' added to, so an eta paired with none has no phi1 column at all.  It is then
+#' silently dropped from `model$omega` -- an `NA` index in a matrix assignment
+#' is a no-op in R -- and the model is fitted without that random effect.
+#'
+#' @param ui rxode2 ui
+#' @return character vector of the diagonal eta names with no phi parameter
+#' @author Matthew L. Fidler
+#' @noRd
+.saemEtaNoPhi <- function(ui) {
+  .iniDf <- ui$iniDf
+  .etas <- .iniDf[!is.na(.iniDf$neta1), ]
+  .etas <- .etas$name[.etas$neta1 == .etas$neta2]
+  .etas[is.na(ui$saemEtaTrans)]
+}
 
 
 #' @export

--- a/tests/testthat/test-saem-eta-no-phi-1047.R
+++ b/tests/testthat/test-saem-eta-no-phi-1047.R
@@ -158,6 +158,70 @@ nmTest({
     }
   })
 
+  # Two mixture components' random effects on ONE population parameter.  This
+  # is the shape that reproduced #1047 end to end: saem ran every iteration and
+  # then died with "subscript out of bounds" assembling the reported omega.
+  .mixOnePhiMod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      p1 <- 0.5
+      eta.cl1 ~ 0.3
+      eta.cl2 ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka)
+      cl <- mix(exp(tcl + eta.cl1), p1, exp(tcl + eta.cl2))
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  # The spelling saem DOES support: one population parameter per component, so
+  # each random effect owns a phi1 column and the pooled reporting omega
+  # (Gamma2_phi1Report) has something to pool.
+  .mixSplitMod <- function() {
+    ini({
+      tka <- 0.45
+      tcl1 <- 1
+      tcl2 <- 1.6
+      tv <- 3.45
+      p1 <- 0.5
+      eta.cl1 ~ 0.3
+      eta.cl2 ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka)
+      cl <- mix(exp(tcl1 + eta.cl1), p1, exp(tcl2 + eta.cl2))
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  test_that("the #1047 model is refused before it fits, and its working twin is not", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    .ctl <- saemControl(nBurn = 5, nEm = 5, print = 0, calcTables = FALSE,
+                        covMethod = "")
+    # saemEtaNames() collapses the two onto one slot, so the kernel only ever
+    # knew about the second -- the first was never sampled
+    .ui <- rxode2::rxUiDecompress(rxode2::rxode2(.mixOnePhiMod))
+    expect_equal(.ui$saemEtaTrans, c(2L, 2L))
+    expect_equal(.ui$saemEtaNames, "eta.cl2")
+    expect_error(
+      suppressMessages(nlmixr2(.mixOnePhiMod, nlmixr2data::theo_sd, "saem", .ctl)),
+      "eta.cl2")
+
+    .ui2 <- rxode2::rxUiDecompress(rxode2::rxode2(.mixSplitMod))
+    expect_equal(.ui2$saemEtaTrans, c(2L, 3L))
+    expect_equal(.saemEtaNoPhi(.ui2), character(0))
+    .fit <- suppressMessages(nlmixr2(.mixSplitMod, nlmixr2data::theo_sd, "saem", .ctl))
+    expect_s3_class(.fit, "nlmixr2FitCore")
+  })
+
   test_that(".getSaemOmega() reports the mismatch instead of running off the end", {
     # Gamma2_phi1 one column short of the UI's etas: the backstop for a
     # disagreement the up-front check did not catch.

--- a/tests/testthat/test-saem-eta-no-phi-1047.R
+++ b/tests/testthat/test-saem-eta-no-phi-1047.R
@@ -70,6 +70,34 @@ nmTest({
     expect_error(nlmixr2Est.saem(.env), "eta.occ")
   })
 
+  # Two random effects mu-referenced to the SAME population parameter: saem
+  # gives a phi one Gamma2_phi1 column, so only the first is sampled.
+  .sharedPhiMod <- function() {
+    ini({
+      tka <- 0.45
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tka + eta.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  test_that("two etas on one population parameter are refused, not silently merged", {
+    .ui <- rxode2::rxUiDecompress(rxode2::rxode2(.sharedPhiMod))
+    # both map to tka, so the model gets ONE phi1 column for the two of them
+    expect_equal(.ui$saemEtaTrans, c(1L, 1L))
+    expect_equal(sum(diag(.ui$saemModelOmega)), 1)
+    # the second is the one with no column of its own
+    expect_equal(.saemEtaNoPhi(.ui), "eta.cl")
+    expect_error(.saemAssertEtaPhi(.ui), "eta.cl")
+  })
+
   test_that("the gate does not refuse a model whose eta simply is not mu-referenced", {
     # Every one of these fits today: rxode2 records an eta that is not
     # `theta + eta` in `nonMuEtas`, which `saemParamsToEstimate()` appends to

--- a/tests/testthat/test-saem-eta-no-phi-1047.R
+++ b/tests/testthat/test-saem-eta-no-phi-1047.R
@@ -162,6 +162,9 @@ nmTest({
       .ui <- rxode2::rxUiDecompress(rxode2::rxode2(.f))
       expect_equal(.saemEtaNoPhi(.ui), character(0))
       expect_false(anyNA(.ui$saemOmegaTrans))
+      # assert the GATE, not just what it reads: a gate broken to refuse
+      # everything would sail past the two lines above
+      expect_silent(.saemAssertEtaPhi(.ui))
     }
   })
 

--- a/tests/testthat/test-saem-eta-no-phi-1047.R
+++ b/tests/testthat/test-saem-eta-no-phi-1047.R
@@ -1,0 +1,85 @@
+nmTest({
+  # #1047: saem parameterizes a random effect by the population parameter it is
+  # added to, so an eta paired with none owns no Gamma2_phi1 column.  It was
+  # then silently dropped from the kernel's `model$omega` -- `m[NA, NA] <- 1` is
+  # a no-op in R -- and never sampled, so the fit ran on a model without that
+  # random effect and only died at the very end, assembling the reported omega,
+  # with "subscript out of bounds".
+
+  # A non-mu eta on a non-"id" condition: rxode2's mu-ref downgrade only
+  # records "id" etas into `nonMuEtas`, so this one is left with no phi.
+  .noPhiMod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.occ ~ 0.1 | occ
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + 0.3 * logit(pnorm(eta.occ)))
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  .muMod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  test_that("an eta with no phi parameter is named, not given a slot", {
+    .ui <- rxode2::rxUiDecompress(rxode2::rxode2(.noPhiMod))
+    # the eta maps to no saem population parameter at all
+    expect_equal(.ui$saemEtaTrans, c(1L, NA_integer_))
+    # ... and therefore owns no Gamma2_phi1 column.  Handing it the dense rank 2
+    # is what indexed past a 1x1 matrix.
+    expect_equal(.ui$saemOmegaTrans, c(1L, NA_integer_))
+    expect_equal(.saemEtaNoPhi(.ui), "eta.occ")
+
+    .ui2 <- rxode2::rxUiDecompress(rxode2::rxode2(.muMod))
+    expect_equal(.ui2$saemOmegaTrans, c(1L, 2L))
+    expect_equal(.saemEtaNoPhi(.ui2), character(0))
+  })
+
+  test_that("saem refuses such a model up front, naming the random effect", {
+    .ui <- rxode2::rxUiDecompress(rxode2::rxode2(.noPhiMod))
+    expect_error(.saemAssertEtaPhi(.ui), "eta.occ")
+    expect_error(.saemAssertEtaPhi(.ui), "cannot sample")
+    .ok <- rxode2::rxUiDecompress(rxode2::rxode2(.muMod))
+    expect_silent(.saemAssertEtaPhi(.ok))
+
+    # the check is wired into the estimation method, so it fires before any
+    # iteration rather than after the whole run
+    .env <- new.env(parent=emptyenv())
+    .env$ui <- .ui
+    expect_error(nlmixr2Est.saem(.env), "eta.occ")
+  })
+
+  test_that(".getSaemOmega() reports the mismatch instead of running off the end", {
+    # Gamma2_phi1 one column short of the UI's etas: the backstop for a
+    # disagreement the up-front check did not catch.
+    .env <- new.env(parent=emptyenv())
+    .env$ui <- rxode2::rxUiDecompress(rxode2::rxode2(.muMod))
+    .env$saem <- list(Gamma2_phi1=matrix(0.6, 1, 1))
+    expect_error(.getSaemOmega(.env), "eta.cl")
+    expect_error(.getSaemOmega(.env), "no variance")
+
+    .env$ui <- rxode2::rxUiDecompress(rxode2::rxode2(.noPhiMod))
+    expect_error(.getSaemOmega(.env), "eta.occ")
+  })
+})

--- a/tests/testthat/test-saem-eta-no-phi-1047.R
+++ b/tests/testthat/test-saem-eta-no-phi-1047.R
@@ -70,6 +70,66 @@ nmTest({
     expect_error(nlmixr2Est.saem(.env), "eta.occ")
   })
 
+  test_that("the gate does not refuse a model whose eta simply is not mu-referenced", {
+    # Every one of these fits today: rxode2 records an eta that is not
+    # `theta + eta` in `nonMuEtas`, which `saemParamsToEstimate()` appends to
+    # the phi list, so the eta DOES own a phi1 column.  Refusing any of them
+    # would be a regression, not a fix.
+    .shared <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.x ~ 0.6
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.x)
+        cl <- exp(tcl + eta.x)
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .mixShared <- function() {
+      ini({
+        tka1 <- 0.45
+        tka2 <- 0.8
+        tcl <- 1
+        tv <- 3.45
+        p1 <- 0.5
+        eta.ka ~ 0.6
+        add.sd <- 0.7
+      })
+      model({
+        ka <- mix(exp(tka1 + eta.ka), p1, exp(tka2 + eta.ka))
+        cl <- exp(tcl)
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    .muCov <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        cl.wt <- 0.1
+        eta.cl ~ 0.3
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl + cl.wt * WT + eta.cl)
+        v <- exp(tv)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    for (.f in list(.shared, .mixShared, .muCov)) {
+      .ui <- rxode2::rxUiDecompress(rxode2::rxode2(.f))
+      expect_equal(.saemEtaNoPhi(.ui), character(0))
+      expect_false(anyNA(.ui$saemOmegaTrans))
+    }
+  })
+
   test_that(".getSaemOmega() reports the mismatch instead of running off the end", {
     # Gamma2_phi1 one column short of the UI's etas: the backstop for a
     # disagreement the up-front check did not catch.
@@ -81,5 +141,12 @@ nmTest({
 
     .env$ui <- rxode2::rxUiDecompress(rxode2::rxode2(.noPhiMod))
     expect_error(.getSaemOmega(.env), "eta.occ")
+
+    # A missing Gamma2_phi1 has to count as zero columns.  `x > nrow(NULL)` is
+    # logical(0), so comparing the ranks against it makes every eta look in
+    # range and the message is lost again.
+    .env$ui <- rxode2::rxUiDecompress(rxode2::rxode2(.muMod))
+    .env$saem <- list()
+    expect_error(.getSaemOmega(.env), "eta.ka, eta.cl")
   })
 })

--- a/tests/testthat/test-saem-eta-no-phi-1047.R
+++ b/tests/testthat/test-saem-eta-no-phi-1047.R
@@ -105,11 +105,13 @@ nmTest({
     expect_error(.saemAssertEtaPhi(.ui), "eta.ka, eta.cl")
   })
 
-  test_that("the gate does not refuse a model whose eta simply is not mu-referenced", {
-    # Every one of these fits today: rxode2 records an eta that is not
-    # `theta + eta` in `nonMuEtas`, which `saemParamsToEstimate()` appends to
-    # the phi list, so the eta DOES own a phi1 column.  Refusing any of them
-    # would be a regression, not a fix.
+  test_that("the gate does not refuse the models it must not", {
+    # Every one of these fits today.  The first two are NOT `theta + eta`, and
+    # rxode2 records such an eta in `nonMuEtas`, which `saemParamsToEstimate()`
+    # appends to the phi list, so they still own a phi1 column; the third is an
+    # ordinary mu-referenced covariate, whose slope is dropped from the phi
+    # list while the eta's own theta is not.  Refusing any of them would be a
+    # regression, not a fix.
     .shared <- function() {
       ini({
         tka <- 0.45

--- a/tests/testthat/test-saem-eta-no-phi-1047.R
+++ b/tests/testthat/test-saem-eta-no-phi-1047.R
@@ -1,10 +1,12 @@
 nmTest({
   # #1047: saem parameterizes a random effect by the population parameter it is
-  # added to, so an eta paired with none owns no Gamma2_phi1 column.  It was
-  # then silently dropped from the kernel's `model$omega` -- `m[NA, NA] <- 1` is
-  # a no-op in R -- and never sampled, so the fit ran on a model without that
-  # random effect and only died at the very end, assembling the reported omega,
-  # with "subscript out of bounds".
+  # added to and gives that phi ONE Gamma2_phi1 column, so an eta paired with no
+  # phi -- or sharing one with another eta -- owns no column.  It was then
+  # silently dropped from the kernel's `model$omega` (`m[NA, NA] <- 1` is a
+  # no-op in R, and a repeated index writes the same cell twice) and never
+  # sampled, so the fit ran on a model without that random effect and only died
+  # at the very end, assembling the reported omega, with "subscript out of
+  # bounds".
 
   # A non-mu eta on a non-"id" condition: rxode2's mu-ref downgrade only
   # records "id" etas into `nonMuEtas`, so this one is left with no phi.
@@ -93,9 +95,14 @@ nmTest({
     # both map to tka, so the model gets ONE phi1 column for the two of them
     expect_equal(.ui$saemEtaTrans, c(1L, 1L))
     expect_equal(sum(diag(.ui$saemModelOmega)), 1)
-    # the second is the one with no column of its own
-    expect_equal(.saemEtaNoPhi(.ui), "eta.cl")
-    expect_error(.saemAssertEtaPhi(.ui), "eta.cl")
+    # BOTH are named: which of the two the kernel keeps is not well defined --
+    # saemEtaNames() labels the shared column with the last, saemOmegaTrans()
+    # maps the first onto it -- so naming one of them would name an arbitrary
+    # half of the problem
+    expect_equal(.saemEtaNoPhi(.ui), c("eta.ka", "eta.cl"))
+    expect_equal(.ui$saemEtaNames, "eta.cl")
+    expect_equal(.ui$saemOmegaTrans, c(1L, 2L))
+    expect_error(.saemAssertEtaPhi(.ui), "eta.ka, eta.cl")
   })
 
   test_that("the gate does not refuse a model whose eta simply is not mu-referenced", {
@@ -213,7 +220,7 @@ nmTest({
     expect_equal(.ui$saemEtaNames, "eta.cl2")
     expect_error(
       suppressMessages(nlmixr2(.mixOnePhiMod, nlmixr2data::theo_sd, "saem", .ctl)),
-      "eta.cl2")
+      "eta.cl1, eta.cl2")
 
     .ui2 <- rxode2::rxUiDecompress(rxode2::rxode2(.mixSplitMod))
     expect_equal(.ui2$saemEtaTrans, c(2L, 3L))


### PR DESCRIPTION
Closes #1047.

## The bug

`saem` parameterizes a random effect by the population parameter (phi) it is
added to, and the kernel gives that phi **one** `Gamma2_phi1` column. A random
effect that owns no column of its own is silently dropped:

- `rxUiGet.saemModelOmega()` builds `model$omega` with
  `mat[etaTrans[i], etaTrans[i]] <- 1`. In R **`m[NA, NA] <- 1` is a silent
  no-op** (not an error), and a repeated index just writes the same cell twice,
  so neither case adds a column.
- `.configsaem()` then takes `i1 <- grep(1, diag(covstruct))`, so `Gamma2_phi1`
  is narrower than the UI's eta count.
- `.getSaemOmega()` indexed `Gamma2_phi1` through `ui$saemOmegaTrans`, a **dense**
  rank over *all* of the UI's etas, so the missing eta got a rank that ran off
  the end.

The visible symptom was `Error: subscript out of bounds` after every iteration
had run. The invisible one is worse: the eta was never sampled, so the fit that
got that far was of a different model than the one written.

Two shapes reach this:

1. **No phi at all** (`saemEtaTrans` is `NA`) -- the case in #1047, where
   rxode2's mu-ref downgrade left a latent eta out of `nonMuEtas`.
2. **Two etas sharing one phi.** This one reproduces on `main` today:

   ```r
   cl <- mix(exp(tcl + eta.cl1), p1, exp(tcl + eta.cl2))
   ```

   Both mu-reference `tcl`, so there is one phi1 column for the two of them.
   `saemEtaNames()` labels that column with the *last* eta while
   `saemOmegaTrans()` maps the *first* onto it -- the fit runs, then dies with
   "subscript out of bounds".

## The fix

- `.saemAssertEtaPhi()` stops in `nlmixr2Est.saem()`, **before any iteration**,
  naming the random effects: those with no phi, and every member of a group
  sharing one (which of a colliding pair the kernel keeps is not well defined,
  so naming one of them would name an arbitrary half).
- `rxUiGet.saemOmegaTrans()` keeps `NA` for an unmapped eta instead of handing
  it a dense rank it has no column for.
- `.getSaemOmega()` reports the mismatch as a backstop. A missing `Gamma2_phi1`
  counts as zero columns -- `x > nrow(NULL)` is `logical(0)`, which would have
  made every eta look in range.

The spelling `saem` does support -- one population parameter per mixture
component -- still fits, and is asserted as such.

## Testing

`tests/testthat/test-saem-eta-no-phi-1047.R` (34 assertions, ~7s, stays in the
essential CI subset): the gate's two shapes, the end-to-end mixture repro, the
`.getSaemOmega()` backstop including the `NULL` case, and three models the gate
must not refuse (a shared eta, a shared eta across mixture components, an
ordinary mu-referenced covariate) asserted against the gate itself.

Every `test-saem-*.R`, `test-iov*.R`, `test-mu*.R`, `test-mix.R`, `test-nlme*.R`
file passes -- 42 files, 0 failures -- against rxode2 main.

(The 4 failures in `test-saem-mix.R` and 1 in `test-mix.R` I first saw were a
stale locally installed rxode2, built before nlmixr2/rxode2#1358 was merged, and
not a defect on either side. The installed build carried the same version number
as the source, so only its build date gave it away.)

Reviewed with antigravity (gemini-3.1-pro-high) until clean; it found the
shared-phi case, the `NULL` `Gamma2_phi1` hole, and the arbitrary-half naming.
