### PR TITLE
Calculate CWRES for any fit reporting the focei objective function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -102,6 +102,14 @@
   The parameter table is now refreshed from the covariance actually installed
   (nlmixr2extra#125).
 
+- `addCwres()` works on a fit whose objective function already is the focei (or
+  foce) one and that has no CWRES, instead of stopping with "objective function
+  'FOCEi' already present".  It now adds the residual columns and leaves the
+  objective function row the fit already carries alone.  The table step also
+  calculates CWRES for any fit reporting that objective function, since
+  `addCwres()` is the only way to add them later and the estimation methods
+  sharing the focei objective function have to supply them up front.
+
 ## New features
 
 - Added a native analytical outer Hessian for fast Gaussian FOCE/FOCE+/FOCEI/AGQ fits, using

--- a/NEWS.md
+++ b/NEWS.md
@@ -102,13 +102,17 @@
   The parameter table is now refreshed from the covariance actually installed
   (nlmixr2extra#125).
 
-- `addCwres()` works on a fit whose objective function already is the focei (or
-  foce) one and that has no CWRES, instead of stopping with "objective function
-  'FOCEi' already present".  It now adds the residual columns and leaves the
-  objective function row the fit already carries alone.  The table step also
-  calculates CWRES for any fit reporting that objective function, since
-  `addCwres()` is the only way to add them later and the estimation methods
-  sharing the focei objective function have to supply them up front.
+- `addCwres()` works on a fit that already reports the focei (or foce)
+  objective function and has no CWRES, instead of stopping with "objective
+  function 'FOCEi' already present".  `setOfv(fit, "focei")` adds that
+  objective function row without the residual columns, so
+  `setOfv(fit, "focei")` followed by `addCwres(fit)` -- and any estimation
+  method that reports the focei objective function of its own, such as the
+  `nlmixr2bayes` methods run with `ofv="focei"` -- had no way to add CWRES at
+  all.  `addCwres()` now adds the residual columns and leaves the objective
+  function row the fit already carries alone.  The table step also calculates
+  CWRES for any fit whose own objective function is already the focei one,
+  since there is no way to add them afterwards.
 
 ## New features
 

--- a/R/addCwres.R
+++ b/R/addCwres.R
@@ -99,7 +99,14 @@ addCwres <- function(fit, focei=TRUE, updateObject = TRUE, envir = parent.frame(
     .addFoceiInfoToFit(.env, .newFit)
     .objDf <- .newFit$objDf
     .type <- rownames(.objDf)
-    nlmixrAddObjectiveFunctionDataFrame(.new, .objDf, .type)
+    .curObjDf <- .new$objDf
+    # A fit that already reports this objective function (an estimation method
+    # whose own objective function is the focei/foce one) only needs the columns;
+    # asking for the row again is an error.  An uncalculated row is replaced.
+    if (!any(rownames(.curObjDf) == .type) ||
+          (nrow(.curObjDf) == 1L && is.na(.curObjDf$OBJF[[1]]))) {
+      nlmixrAddObjectiveFunctionDataFrame(.new, .objDf, .type)
+    }
     if (updateObject) {
       nlmixrUpdateObject(.new, .objName, envir, .origFitEnv)
     }

--- a/R/resid.R
+++ b/R/resid.R
@@ -513,13 +513,42 @@ nmObjGet.foceiThetaEtaParameters <- function(x, ...) {
   data
 }
 
+#' Does the fit already report a calculated focei-family objective function?
+#'
+#' `addCwres()` attaches the CWRES columns together with the objective function
+#' row it calculates ("FOCEi", or "FOCE"/"lFOCEi" for `focei=FALSE`) and cannot
+#' add a row the fit already has, so a fit reporting one has to calculate CWRES
+#' in its own table step.  An uncalculated (NA) objective function is replaced
+#' rather than appended, so it does not count.
+#'
+#' @param fit fit environment
+#' @return `TRUE` when `addCwres()` could not add CWRES to this fit later
+#' @author Matthew L. Fidler
+#' @noRd
+.foceiObjfWithoutCwres <- function(fit) {
+  # read the fit environment directly; the `$` fallback for a name the
+  # environment does not have re-derives it from the ui, which is not free
+  .objDf <- if (is.environment(fit)) {
+    if (exists("objDf", envir=fit, inherits=FALSE)) {
+      get("objDf", envir=fit, inherits=FALSE)
+    } else {
+      NULL
+    }
+  } else {
+    fit$objDf
+  }
+  if (!is.data.frame(.objDf)) return(FALSE)
+  if (!any(rownames(.objDf) %in% c("FOCEi", "lFOCEi", "FOCE"))) return(FALSE)
+  any(!is.na(.objDf$OBJF))
+}
+
 .calcTables <- function(fit, data=fit$dataSav, thetaEtaParameters=fit$foceiThetaEtaParameters,
                         table=tableControl(), keep=NULL) {
   keep <- unique(c(keep, "nlmixrRowNums"))
 
   if (!inherits(table, "tableControl")) table <- do.call(tableControl, table)
   if (is.null(table$cwres)) {
-    table$cwres <- !is.null(fit$innerModel)
+    table$cwres <- !is.null(fit$innerModel) || .foceiObjfWithoutCwres(fit)
   }
   if (table$cwres) {
     fit$innerModelForce

--- a/tests/testthat/test-addCwres.R
+++ b/tests/testthat/test-addCwres.R
@@ -110,4 +110,46 @@ nmTest({
     expect_equal(sum(rownames(fit2$objDf) == "FOCEi"), 1L)
     expect_equal(fit2$objDf["FOCEi", "OBJF"], fit$objDf["FOCEi", "OBJF"])
   })
+
+  test_that("addCwres() still works after setOfv(fit, 'focei')", {
+    # setOfv() adds the focei objective function row WITHOUT the residual
+    # columns (calcTables=FALSE), which used to leave addCwres() no way to add
+    # them afterwards.  A fresh fit, not a shared fixture: setOfv() writes into
+    # the fit environment in place.
+    one.compartment <- function() {
+      ini({
+        tka <- log(1.57)
+        tcl <- log(2.72)
+        tv <- log(31.5)
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+    fit <- .nlmixr(one.compartment, theo_sd, est = "saem",
+                   control = saemControlFast)
+    expect_false("CWRES" %in% names(fit))
+
+    suppressMessages(setOfv(fit, "focei"))
+    # now a CALCULATED focei objective function row with no CWRES
+    expect_true("FOCEi" %in% rownames(fit$objDf))
+    .objf <- fit$objDf["FOCEi", "OBJF"]
+    expect_false(is.na(.objf))
+    expect_false("CWRES" %in% names(fit))
+
+    fit2 <- suppressMessages(addCwres(fit, updateObject = FALSE))
+    expect_true("CWRES" %in% names(fit2))
+    expect_equal(sum(rownames(fit2$objDf) == "FOCEi"), 1L)
+    expect_equal(fit2$objDf["FOCEi", "OBJF"], .objf)
+  })
 })

--- a/tests/testthat/test-addCwres.R
+++ b/tests/testthat/test-addCwres.R
@@ -56,4 +56,58 @@ nmTest({
 
     expect_error(suppressMessages(addCwres(test_run001)), NA)
   })
+
+  test_that(".foceiObjfWithoutCwres() flags the fits addCwres() cannot fix later", {
+    .objDf <- function(rn, objf) {
+      .d <- data.frame(OBJF = objf, AIC = objf, BIC = objf,
+                       "Log-likelihood" = -objf / 2, check.names = FALSE)
+      row.names(.d) <- rn
+      .d
+    }
+    # these are the rows addCwres() itself would add, so it could not add them twice
+    expect_true(.foceiObjfWithoutCwres(list(objDf = .objDf("FOCEi", 100))))
+    expect_true(.foceiObjfWithoutCwres(list(objDf = .objDf("lFOCEi", 100))))
+    expect_true(.foceiObjfWithoutCwres(list(objDf = .objDf("FOCE", 100))))
+    # an uncalculated objective function is replaced by addCwres(), not appended
+    expect_false(.foceiObjfWithoutCwres(list(objDf = .objDf("FOCEi", NA_real_))))
+    # a quadrature/FO row does not collide with the row addCwres() adds
+    expect_false(.foceiObjfWithoutCwres(list(objDf = .objDf("Laplace", 100))))
+    expect_false(.foceiObjfWithoutCwres(list(objDf = .objDf("FO", 100))))
+    expect_false(.foceiObjfWithoutCwres(list(objDf = NULL)))
+  })
+
+  test_that("addCwres() works on a focei fit whose table skipped CWRES", {
+    one.compartment <- function() {
+      ini({
+        tka <- log(1.57)
+        tcl <- log(2.72)
+        tv <- log(31.5)
+        eta.ka ~ 0.6
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+    fit <- .nlmixr(one.compartment, theo_sd, est = "focei",
+                   control = foceiControlFast,
+                   table = tableControl(cwres = FALSE))
+    # the fit reports the very objective function addCwres() adds, and has no CWRES
+    expect_true("FOCEi" %in% rownames(fit$objDf))
+    expect_false("CWRES" %in% names(fit))
+
+    fit2 <- suppressMessages(addCwres(fit, updateObject = FALSE))
+    expect_true("CWRES" %in% names(fit2))
+    # the objective function row is not duplicated (and not lost)
+    expect_equal(sum(rownames(fit2$objDf) == "FOCEi"), 1L)
+    expect_equal(fit2$objDf["FOCEi", "OBJF"], fit$objDf["FOCEi", "OBJF"])
+  })
 })


### PR DESCRIPTION
## The problem

`addCwres()` attaches the CWRES columns *together with* the objective function row it calculates, and `nlmixrAddObjectiveFunctionDataFrame()` (`R/nlmixrAddObjectiveFunction.R:44`) stops on a row the fit already has. So a fit that reports the FOCEi (or FOCE) objective function and has no CWRES could never get them — `addCwres()` is the only way to add them later, and it refused.

Reachable today with no exotic setup, on stock 7.0.3:

```r
fit <- nlmixr2(model, data, est = "saem", control = saemControl(...))
setOfv(fit, "focei")
addCwres(fit)
#> Error : objective function 'FOCEi' already present
```

```
after saem:   rows=FOCE   OBJF=NA        CWRES=FALSE
after setOfv: rows=FOCEi  OBJF=188.567   CWRES=FALSE
addCwres:     ERROR: objective function 'FOCEi' already present
```

`setOfv(fit, "focei")` runs `.setOfvFo()` with `calcTables = FALSE`, so it lands a **calculated** FOCEi row on a fit that has **no CWRES** — exactly the state `addCwres()` refuses.

## Where this bit

Every eta-bearing estimation method was surveyed on theo_sd; none produces a calculated focei row without CWRES straight out of the fit:

| method | objDf row | CWRES |
|---|---|---|
| focei / foce / posthoc | FOCEi (+FOCE) | yes |
| imp / impmap / qrpem | FOCEi | yes |
| npag / npb | FOCEi | yes |
| vae / emvi / fbvi | FOCEi (+est row) | yes |
| saem | FOCE, OBJF `NA` | no — fine, an NA row is *replaced*, not appended |
| nlme | nlme | no — fine, different row |

The trap is entered afterwards, by `setOfv()`. It is also what the `nlmixr2bayes` methods hit by default: they finalize through `nlmixr2CreateOutputFromUi()` with `$model` set to `ui$ebe`, whose `$inner` is `NULL` by construction (`rxUiGet.getEBEEnv` drops `..inner`), so the table step produces no CWRES — and `stanControl(ofv=)`, defaulting to `"focei"`, then calls `setOfv()`.

## The change

- **`R/addCwres.R`** — skip the objective-row add when the fit already carries that row, attaching only the residual columns. A single uncalculated (`NA`) row is still replaced, as before, so saem and nlme are unaffected.
- **`R/resid.R`** — `.calcTables()` defaults CWRES on for any fit whose own objective function is already the focei one, rather than only for one that happens to carry an inner model (which is what `nlmixr2CreateOutputFromUi()` gives a method supplying only `$model$predOnly`). New `.foceiObjfWithoutCwres()` keys on the rows `addCwres()` itself would add (`FOCEi`/`lFOCEi`/`FOCE`) and treats an all-`NA` row as still addable.

After:

```
after setOfv: rows=FOCEi  OBJF=188.567   CWRES=FALSE
addCwres:     OK  CWRES=TRUE  rows=FOCEi
```

Objective value preserved, no duplicated row.

## Verification

Against an `-O2` install in a scratch library:

- `test-addCwres.R` — **22/22** (includes 3 new tests: the row classification, a `tableControl(cwres=FALSE)` round trip, and the saem→`setOfv`→`addCwres` regression)
- `test-cwres.R` — 32/32
- `test-table-cmt.R` — 16/16
- `test-npde.R` — 21/21
- `test-resid-ode-fallback.R` — 7/7

0 failures. The `setOfv` regression test uses a fresh fit rather than a shared fixture, since `setOfv()` writes into the fit environment in place.

habit-hooks reports nothing from this diff (its `R/resid.R` findings are all pre-existing functions untouched here).

## Related

nlmixr2/nlmixr2bayes#17 makes those methods calculate CWRES up front when `ofv = "focei"`, so `addCwres()` is never needed there. That PR stands alone against released nlmixr2est; this one is the general fix.