### PR TITLE
fix(focei): a stalled FOCE+ EBE polish is not a failed likelihood (#1069)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,17 @@
   own; they now agree.  On an additive model, where the two methods must
   coincide, the `foce+` and FOCEI observed informations agreed to 1.2e-2 at the
   same EBEs and now agree to 1.1e-13 (#1056).
+- `est="focep"` (`foce="foce+"`) converges at the default `sigdig`.  FOCE+ polishes
+  the inner optimizer's eta onto the truncated-score root it defines its EBE by, and
+  that polish stops once the score reaches the noise floor the solve tolerance buys --
+  near `1e-3` at the default `sigdig=3`, well above the `1e-9` it asked for.  A
+  subject that stalled there reported its likelihood as `NA`, which the outer search
+  read as a cliff: on `theo_sd` it stopped 4.8 objective units high (121.560 against
+  116.804) with the omegas barely off their starting values, and the observed
+  information at that point had a negative eigenvalue so `covMethod="analytic"`
+  refused to install it.  The polish is now best-effort -- the eta it was handed is
+  the inner optimizer's own answer and is always usable, so every exit path keeps the
+  best point found and evaluates the likelihood there (#1069).
 - `saem` refuses a model whose random effect has no population parameter of its
   own -- added to none, or sharing one with another random effect -- naming the
   random effects, instead of fitting the model without them and then failing

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -3758,10 +3758,6 @@ static bool focePlusRefinementRequired() {
       op_focei.freezeOde || op_focei.neta == 0);
 }
 
-static bool focePlusSmallStep(double norm, double decrement) {
-  return norm < 1e-3 && decrement >= 0 && decrement <= 1e-9;
-}
-
 static bool focePlusScore(arma::vec &at, arma::vec &out, int id) {
   auto *ind = &inds_focei[id];
   ind->setup = 0; ++ind->nInnerF; ++ind->nInnerG;
@@ -3793,34 +3789,41 @@ static bool focePlusBacktrack(arma::vec &x, arma::vec &g, const arma::vec &step,
   return false;
 }
 
+// Polishing only: the eta handed in is the inner optimizer's own answer and is
+// always usable.  Refusing to drive the score any closer to zero is therefore
+// not a failure -- `focePlusBacktrack` accepts nothing but a strict decrease in
+// the score norm, so it stops exactly when the score has reached the noise floor
+// the solve tolerance buys, and `x` is the best point seen on every exit.
+// Reporting that as NA instead poisoned the objective (#1069): at the default
+// sigdig=3 the floor sits near 1e-3, so every subject that reached it lost its
+// likelihood and the outer search read a spurious cliff.
 static bool refineFocePlusEta(double *eta, int id) {
   if (!focePlusRefinementRequired()) return true;
   auto *ind = &inds_focei[id];
   arma::vec x(eta,op_focei.neta), g(op_focei.neta);
-  auto score = [&](arma::vec &at, arma::vec &out) {
-    return focePlusScore(at,out,id);
-  };
   auto finish = [&]() {
     std::copy(x.begin(),x.end(),eta); ind->setup = 0;
     return R_FINITE(likInner0(eta,id));
   };
   try {
-    if (!score(x,g)) return false;
-    for (int iteration = 0; iteration < std::min(100,op_focei.maxInnerIterations); ++iteration) {
-      double norm = arma::abs(g).max();
-      if (norm < 1e-9) return finish();
-      arma::mat jacobian(x.n_elem,x.n_elem);
-      if (!focePlusScoreJacobian(x,jacobian,id)) return false;
-      arma::vec step;
-      if (!arma::solve(step,jacobian,g) || !step.is_finite()) return false;
-      bool accepted = focePlusBacktrack(x,g,step,norm,id);
-      if (!accepted) {
-        double decrement = arma::dot(g,step);
-        return focePlusSmallStep(norm,decrement) && finish();
+    if (focePlusScore(x,g,id)) {
+      for (int iteration = 0; iteration < std::min(100,op_focei.maxInnerIterations); ++iteration) {
+        double norm = arma::abs(g).max();
+        if (norm < 1e-9) break;
+        arma::mat jacobian(x.n_elem,x.n_elem);
+        if (!focePlusScoreJacobian(x,jacobian,id)) break;
+        arma::vec step;
+        if (!arma::solve(step,jacobian,g) || !step.is_finite()) break;
+        if (!focePlusBacktrack(x,g,step,norm,id)) break;
       }
     }
-    return arma::abs(g).max() < 1e-9 && finish();
-  } catch (...) { return false; }
+  } catch (...) {
+  }
+  try {
+    return finish();
+  } catch (...) {
+    return false;
+  }
 }
 
 double LikInner2(double *eta, int likId, int id) {

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -3789,6 +3789,20 @@ static bool focePlusBacktrack(arma::vec &x, arma::vec &g, const arma::vec &step,
   return false;
 }
 
+// Newton on the truncated score, starting from `x`/`g`.  Every way out is the
+// same way out: stop iterating and leave `x` at the last accepted iterate.
+static void focePlusNewton(arma::vec &x, arma::vec &g, int id) {
+  for (int iteration = 0; iteration < std::min(100,op_focei.maxInnerIterations); ++iteration) {
+    double norm = arma::abs(g).max();
+    if (norm < 1e-9) return;                                  // at the root
+    arma::mat jacobian(x.n_elem,x.n_elem);
+    if (!focePlusScoreJacobian(x,jacobian,id)) return;        // a probe would not solve
+    arma::vec step;
+    if (!arma::solve(step,jacobian,g) || !step.is_finite()) return;
+    if (!focePlusBacktrack(x,g,step,norm,id)) return;         // at the noise floor
+  }
+}
+
 // Polishing only: the eta handed in is the inner optimizer's own answer and is
 // always usable.  Refusing to drive the score any closer to zero is therefore
 // not a failure -- `focePlusBacktrack` accepts nothing but a strict decrease in
@@ -3804,26 +3818,13 @@ static bool refineFocePlusEta(double *eta, int id) {
   if (!focePlusRefinementRequired()) return true;
   auto *ind = &inds_focei[id];
   arma::vec x(eta,op_focei.neta), g(op_focei.neta);
-  auto finish = [&]() {
-    std::copy(x.begin(),x.end(),eta); ind->setup = 0;
-    return R_FINITE(likInner0(eta,id));
-  };
   try {
-    if (focePlusScore(x,g,id)) {
-      for (int iteration = 0; iteration < std::min(100,op_focei.maxInnerIterations); ++iteration) {
-        double norm = arma::abs(g).max();
-        if (norm < 1e-9) break;
-        arma::mat jacobian(x.n_elem,x.n_elem);
-        if (!focePlusScoreJacobian(x,jacobian,id)) break;
-        arma::vec step;
-        if (!arma::solve(step,jacobian,g) || !step.is_finite()) break;
-        if (!focePlusBacktrack(x,g,step,norm,id)) break;
-      }
-    }
+    if (focePlusScore(x,g,id)) focePlusNewton(x,g,id);
   } catch (...) {
   }
   try {
-    return finish();
+    std::copy(x.begin(),x.end(),eta); ind->setup = 0;
+    return R_FINITE(likInner0(eta,id));
   } catch (...) {
     return false;
   }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -3793,8 +3793,11 @@ static bool focePlusBacktrack(arma::vec &x, arma::vec &g, const arma::vec &step,
 // always usable.  Refusing to drive the score any closer to zero is therefore
 // not a failure -- `focePlusBacktrack` accepts nothing but a strict decrease in
 // the score norm, so it stops exactly when the score has reached the noise floor
-// the solve tolerance buys, and `x` is the best point seen on every exit.
-// Reporting that as NA instead poisoned the objective (#1069): at the default
+// the solve tolerance buys, and `x` is the best ITERATE the search accepted on
+// every exit path.  (Not the best point EVALUATED: `focePlusScoreJacobian`'s
+// x +/- h probes are derivative samples taken at a fixed step, not candidate
+// steps, so one that happens to score lower is not adopted.)
+// Reporting a stall as NA instead poisoned the objective (#1069): at the default
 // sigdig=3 the floor sits near 1e-3, so every subject that reached it lost its
 // likelihood and the outer search read a spurious cliff.
 static bool refineFocePlusEta(double *eta, int id) {

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1321,6 +1321,12 @@ nmTest({
     # can be identified (in BOTH the analytic and the gold FD), so >= not >
     expect_gte(sum(fin), 4L)
     expect_equal(unname(seA[fin]), unname(seG[fin]), tolerance = 5e-3)
+    # This bound is also what guards `refineFocePlusEta()` (src/inner.cpp), the Newton
+    # polish that puts the fit's EBEs on the truncated-score root the gold FD re-solves
+    # to 1e-12.  Measured with the polish disabled, the same comparison gives relBig
+    # 0.252 and an SE gap of 7.5% (and one direction stops being identified), against
+    # 5.9e-06 and 3.1e-06 with it -- three orders of margin, so deleting the polish
+    # fails here rather than passing quietly.
   })
 
   test_that("est='focep' installs the full analytic covariance", {
@@ -1331,6 +1337,12 @@ nmTest({
     # subject's likelihood as NA, and the observed information at that stalled point had a
     # real negative eigenvalue, so the PD gate refused to install it.  Pinning sigdig would
     # hide a return of that.
+    #
+    # The polish stops at the solve's noise floor at this sigdig, so the score it leaves
+    # is ~1e-3 rather than 0, and the analytic assemblers drop it as if it were 0.  That
+    # costs what the tolerance buys and no more: against the gold FD above, this model
+    # gives 2.7e-3 relative on the significant entries of R and 2.5e-4 on the SEs at
+    # sigdig 3, 1.0e-4 / 1.4e-5 at 4, and 5.9e-6 / 3.1e-6 at 6.
     fit <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focep",
               focepControl(print = 0L, covMethod = "analytic", covFull = TRUE))))
     expect_lt(fit$objf, 118)

--- a/tests/testthat/test-cov-analytic.R
+++ b/tests/testthat/test-cov-analytic.R
@@ -1326,14 +1326,14 @@ nmTest({
   test_that("est='focep' installs the full analytic covariance", {
     skip_on_cran()
     skip_if_not_installed("nlmixr2data")
-    # sigdig is pinned because the DEFAULT (3) does not converge here: bobyqa stalls at
-    # objf 121.560 against 116.804 at sigdig 4+, and the fit says so ("last objective
-    # function was not at minimum").  The observed information there has a real negative
-    # eigenvalue, so the PD gate refuses to install it -- correctly.  This test is about the
-    # analytic route being reachable from est="focep", not about that optimizer stall
-    # (#1069), so it asks at a point that IS a minimum.
+    # Runs at the DEFAULT sigdig on purpose: #1069 stalled here at objf 121.560 (against
+    # 116.804) because a FOCE+ EBE polish that reached the solve's noise floor reported the
+    # subject's likelihood as NA, and the observed information at that stalled point had a
+    # real negative eigenvalue, so the PD gate refused to install it.  Pinning sigdig would
+    # hide a return of that.
     fit <- suppressWarnings(suppressMessages(nlmixr(.cov_one_cmt, nlmixr2data::theo_sd, "focep",
-              focepControl(print = 0L, covMethod = "analytic", covFull = TRUE, sigdig = 4))))
+              focepControl(print = 0L, covMethod = "analytic", covFull = TRUE))))
+    expect_lt(fit$objf, 118)
     expect_identical(.covBaseName(fit$covMethod), "analytic")
     expect_true(any(grepl("^om\\.", rownames(fit$cov))))
     .se <- sqrt(diag(fit$cov))

--- a/tests/testthat/test-focei-foce-plus.R
+++ b/tests/testthat/test-focei-foce-plus.R
@@ -88,4 +88,35 @@ nmTest({
     expect_lt(abs(fM$objective - ref$objective), 8)
     expect_lt(abs(fI$objective - ref$objective), 8)
   })
+
+  test_that("a stalled FOCE+ EBE polish does not poison the objective (#1069)", {
+    # FOCE+ polishes the inner optimizer's eta onto the truncated-score root it
+    # defines its EBE by.  That polish stops once the score reaches the noise floor
+    # the solve tolerance buys -- near 1e-3 at the DEFAULT sigdig=3 -- and used to
+    # report the subject's likelihood as NA when it did.  Run at the default on
+    # purpose: pinning sigdig is what hid this.
+    .m <- function() {
+      ini({ tka <- log(1.5); tcl <- log(2.7); tv <- log(31.5)
+            eta.ka ~ 0.6; eta.cl ~ 0.3; eta.v ~ 0.1; add.sd <- 0.7 })
+      model({ ka <- exp(tka + eta.ka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        d/dt(depot)  <- -ka * depot
+        d/dt(center) <-  ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd) })
+    }
+    fit <- suppressWarnings(suppressMessages(
+      nlmixr(.m, d, "focep", focepControl(print = 0L, calcTables = FALSE, covMethod = ""))))
+    # The stall cost 4.8 objective units: bobyqa stopped at 121.560 with the omegas
+    # barely off their starting values, against 116.80 here and 116.82 for est="foce".
+    expect_lt(fit$objf, 118)
+    # The mechanism, not just the answer.  A subject whose likelihood came back NA
+    # was penalized to ~300 while its neighbourhood sat near 130, and the cliff that
+    # left in the outer objective is what stopped the search.  Nothing the search
+    # sees may be worse than its own starting point by that kind of margin.
+    .o <- fit$parHist$objf
+    expect_lt(max(.o), .o[1] + 25)
+    # ... and the omegas have to have actually moved (the stall left eta.ka at 0.56
+    # against 0.40 here, because every probe that raised it read as a cliff).
+    expect_lt(fit$omega[["eta.ka", "eta.ka"]], 0.5)
+  })
 })


### PR DESCRIPTION
Fixes #1069.

## What was wrong

`est="focep"` (`foce="foce+"`) stopped 4.8 objective units high at the default
`sigdig=3` on `theo_sd`: objf **121.560** against **116.804** at `sigdig >= 4`,
with the omegas barely off their starting values, `$runInfo` reporting "last
objective function was not at minimum", and the observed information carrying a
real negative eigenvalue (min eig -307.9) so `covMethod="analytic"` refused to
install it.

The cause is not bobyqa and not the outer tolerances.  FOCE+ defines its EBE by
the truncated-score root with the live conditional R, and because the inner
optimizer minimizes a value whose reported gradient is that truncated score, its
stopping point is not exactly that root.  `refineFocePlusEta()` (added with the
analytic FOCE+ curvature) polishes it with a Newton iteration on the score.

That polish asked for `|score|_inf < 1e-9`, with a `norm < 1e-3 && 0 <=
decrement <= 1e-9` escape hatch.  Its backtracking line search accepts nothing
but a strict decrease in the score norm, so it stops exactly when the score
reaches the noise floor the solve tolerance buys -- at `sigdig=3` that floor is
near `1e-3`, above both gates.  Every subject that reached it had its likelihood
reported as `NA_REAL`.

Instrumented on the issue's own repro: **1933 refinements, 60 hard failures**,
all on one subject, stalling at `norm = 0.0023-0.0048` with `decrement = 2e-7`.
Those NAs are the cliffs that stopped the search -- outer iteration 7 probed
`omega(eta.ka)` upward and read **328.5** against a neighbourhood near 133, so
bobyqa's interpolation model learned that direction was catastrophic and never
moved the omegas again.

`sigdig=4` worked only because its floor sits a decade lower.

## The fix

The eta handed to the polish is the inner optimizer's own answer and is always
usable, so the polish is now best-effort.  Backtracking only ever accepts a
strict decrease, so the current point is the best one seen on every exit path;
each exit now keeps it and evaluates the likelihood there instead of returning
a failure.  The `focePlusSmallStep()` gate is gone -- a stall IS the stopping
criterion, detected rather than guessed at with constants calibrated to one
`sigdig`.

## Result

| | before | after |
|---|---|---|
| `focep` objf, sigdig=3 | 121.5601 (155 outer iters) | **116.8087** (78) |
| `focep` objf, sigdig=4 | 116.8038 | 116.8038 |
| min eig(analytic R), sigdig=3 | -307.9 (analytic refused) | **+27.4** (installs) |
| worst outer evaluation | 328.5 | 138.7 |
| `est="foce"` / `"focei"`, sigdig=3 | 116.8239 | 116.8239 |

`outerOpt="nlminb"` at `sigdig=3` moves from 119.42 to 116.8250 and
`outerOpt="lbfgsb3c"` from 116.8077 to 116.8598, i.e. the cliffs were derailing
more than bobyqa.

## Tests

- `test-focei-foce-plus.R`: new #1069 regression at the DEFAULT sigdig -- objf
  under 118, no outer evaluation more than 25 units above its own start (the
  NA-poisoned probes sat at ~300 against a neighbourhood near 130), and
  `omega(eta.ka)` actually off its start.
- `test-cov-analytic.R`: the `est='focep'` analytic-covariance test drops the
  `sigdig = 4` pin it carried while #1069 was open, as that issue asked.

Green locally, 1065 assertions over 16 files: `cov-analytic`,
`cov-analytic-defaults`, `focei-foce-plus`, `focei-fast-methods`,
`focei-fast-methods-fit`, `mfocei`, `foceiLik`, `focei-ptrs`,
`focei-foce-stride`, `focei-family-control`, `focei-fast-grad`,
`agq-fast-grad`, `focei-full-inner`, `focei-outer-trust`,
`focei-ll-fast-grad`, `lik-contrib-fast-grad`, `fitSim`.