### PR TITLE
saem: report a fix()ed eta variance as the value it was fixed at (#1073)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Bug fixes
 
+- `saem` reports a `fix()`ed eta variance as the value it was fixed at. The
+  reported omega was snapshotted before the fixed values were restored, so it
+  carried the M-step's unconstrained estimate instead -- `fix(0.3)` came back as
+  0.318 while the fit itself correctly sampled with 0.3 (#1073).
 - `covMethod="analytic"` for FOCE and `foce="foce+"` no longer carries the inner
   solver's residual score into the observed information.  The FOCE kernel uses
   the general total-derivative form, whose last term is `Phi_eta . eta_ab`; it

--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -3519,6 +3519,12 @@ public:
       // fix before diagonals are enforced
       if (Gamma2_phi1fixed==1 && kiter > (unsigned int)(nb_fixOmega)) {
         Gamma2_phi1.elem(Gamma2_phi1fixedIx) = Gamma2_phi1fixedValues(Gamma2_phi1fixedIx);
+        // Gamma2_phi1Report is what the fit REPORTS, and it was snapshotted
+        // above -- before this restore -- so a fix()ed variance came back as
+        // the M-step's unconstrained estimate: fix(0.3) reported as 0.318
+        // while the sampler correctly used 0.3 (#1073).  Only the fixed cells
+        // are touched; every other reported value stays exactly as it was.
+        Gamma2_phi1Report.elem(Gamma2_phi1fixedIx) = Gamma2_phi1fixedValues(Gamma2_phi1fixedIx);
       }
 
       if (kiter<=(unsigned int)(nb_correl)) {

--- a/tests/testthat/test-saem-fixed-omega-report-1073.R
+++ b/tests/testthat/test-saem-fixed-omega-report-1073.R
@@ -79,6 +79,16 @@ nmTest({
               saemControl(nBurn = 20, nEm = 20, print = 0, seed = 42,
                           calcTables = FALSE, covMethod = "sa", nSaCov = 20L))))
     expect_equal(unname(.fit$omega["eta.ka", "eta.ka"]), 0.3)
+    # ... and the whole reported matrix still comes from the snapshot, not from
+    # the covariance phase's fluctuating iterations.  Checking only the fixed
+    # cell would pass even with the snapshot/restore of Gamma2_phi1Report
+    # dropped, because the M-step rewrites that cell every iteration anyway --
+    # it is the ESTIMATED entries that would drift.
+    .noCov <- suppressWarnings(suppressMessages(
+      nlmixr2(.fixMuMod, nlmixr2data::theo_sd, "saem",
+              saemControl(nBurn = 20, nEm = 20, print = 0, seed = 42,
+                          calcTables = FALSE, covMethod = ""))))
+    expect_equal(unname(.fit$omega), unname(.noCov$omega))
   })
 
   test_that("a non-mu-referenced eta's fix()ed variance is reported too", {

--- a/tests/testthat/test-saem-fixed-omega-report-1073.R
+++ b/tests/testthat/test-saem-fixed-omega-report-1073.R
@@ -1,0 +1,79 @@
+nmTest({
+  # #1073: the reported omega was snapshotted into Gamma2_phi1Report BEFORE the
+  # fix()ed-value restore (and before the variance floors), so a fix()ed eta
+  # variance came back as the M-step's unconstrained estimate.  The sampler was
+  # always right -- only the report was wrong, which is the hard kind to notice.
+
+  .fixMuMod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      eta.ka ~ fix(0.3)
+      eta.cl ~ 0.1
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  # the same thing for an eta that is NOT `theta + eta`, so it is carried
+  # through nonMuEtas rather than mu-referenced -- the drift was never about
+  # how the eta is parameterized
+  .fixNonMuMod <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      rxz.eta.ka ~ fix(1)
+      eta.cl ~ 0.1
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + 0.3 * logit(pnorm(rxz.eta.ka)))
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  .ctl <- function() {
+    saemControl(nBurn = 20, nEm = 20, print = 0, seed = 42, calcTables = FALSE,
+                covMethod = "")
+  }
+
+  test_that("a fix()ed eta variance is reported as the value it was fixed at", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(.fixMuMod, nlmixr2data::theo_sd, "saem", .ctl())))
+    expect_equal(unname(.fit$omega["eta.ka", "eta.ka"]), 0.3)
+    # the estimated one still moved, so the fit is not simply echoing ini()
+    expect_false(isTRUE(all.equal(unname(.fit$omega["eta.cl", "eta.cl"]), 0.1)))
+
+    # The reported matrix and the one the sampler used must agree ON THE FIXED
+    # CELL.  That comparison, not fit$omega alone, is what catches a
+    # regression: fit$omega cannot tell "fixed at 0.3" from "estimated and
+    # landed near 0.3".  Only the fixed cells are compared because the report
+    # is deliberately left alone elsewhere -- a floored or PD-repaired variance
+    # still reports its pre-repair value.
+    .w <- which(diag(.fit$saem$Gamma2_phi1) == 0.3)
+    expect_equal(length(.w), 1L)
+    expect_equal(.fit$saem$Gamma2_phi1Report[.w, .w], .fit$saem$Gamma2_phi1[.w, .w])
+  })
+
+  test_that("a non-mu-referenced eta's fix()ed variance is reported too", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(.fixNonMuMod, nlmixr2data::theo_sd, "saem", .ctl())))
+    expect_equal(unname(.fit$omega["rxz.eta.ka", "rxz.eta.ka"]), 1)
+    .w <- which(diag(.fit$saem$Gamma2_phi1) == 1)
+    expect_equal(length(.w), 1L)
+    expect_equal(.fit$saem$Gamma2_phi1Report[.w, .w], .fit$saem$Gamma2_phi1[.w, .w])
+  })
+})

--- a/tests/testthat/test-saem-fixed-omega-report-1073.R
+++ b/tests/testthat/test-saem-fixed-omega-report-1073.R
@@ -66,6 +66,21 @@ nmTest({
     expect_equal(.fit$saem$Gamma2_phi1Report[.w, .w], .fit$saem$Gamma2_phi1[.w, .w])
   })
 
+  test_that("the SA covariance phase does not undo the fixed report", {
+    skip_on_cran()
+    skip_if_not_installed("nlmixr2data")
+    # covMethod="sa" (the default) runs nSaCov extra iterations after the fit
+    # and restores the converged estimate from a snapshot afterwards.
+    # Gamma2_phi1Report is part of that snapshot, so the restore is a second
+    # way the reported fixed value could be lost; covMethod="" skips the phase
+    # entirely and would never exercise it.
+    .fit <- suppressWarnings(suppressMessages(
+      nlmixr2(.fixMuMod, nlmixr2data::theo_sd, "saem",
+              saemControl(nBurn = 20, nEm = 20, print = 0, seed = 42,
+                          calcTables = FALSE, covMethod = "sa", nSaCov = 20L))))
+    expect_equal(unname(.fit$omega["eta.ka", "eta.ka"]), 0.3)
+  })
+
   test_that("a non-mu-referenced eta's fix()ed variance is reported too", {
     skip_on_cran()
     skip_if_not_installed("nlmixr2data")

--- a/tests/testthat/test-saem-fixed-omega-report-1073.R
+++ b/tests/testthat/test-saem-fixed-omega-report-1073.R
@@ -69,21 +69,23 @@ nmTest({
   test_that("the SA covariance phase does not undo the fixed report", {
     skip_on_cran()
     skip_if_not_installed("nlmixr2data")
-    # covMethod="sa" (the default) runs nSaCov extra iterations after the fit
-    # and restores the converged estimate from a snapshot afterwards.
-    # Gamma2_phi1Report is part of that snapshot, so the restore is a second
-    # way the reported fixed value could be lost; covMethod="" skips the phase
-    # entirely and would never exercise it.
+    # covMethod="sa" is the default, and it runs nSaCov extra iterations after
+    # the fit; covMethod="" skips them entirely, so the other tests here never
+    # see that phase at all.
+    #
+    # This does NOT exercise the _savGamma2_phi1Report snapshot/restore around
+    # the phase: the gain is frozen at zero there (`pas`/`pash` are zero-padded,
+    # src/saem.cpp), so the sufficient statistics and hence Gamma2_phi1 do not
+    # move, and neutering the restore leaves both assertions below passing
+    # (measured).  What it does establish is the user-visible invariant -- the
+    # phase must not change the reported omega, fixed cell or otherwise.
     .fit <- suppressWarnings(suppressMessages(
       nlmixr2(.fixMuMod, nlmixr2data::theo_sd, "saem",
               saemControl(nBurn = 20, nEm = 20, print = 0, seed = 42,
                           calcTables = FALSE, covMethod = "sa", nSaCov = 20L))))
     expect_equal(unname(.fit$omega["eta.ka", "eta.ka"]), 0.3)
-    # ... and the whole reported matrix still comes from the snapshot, not from
-    # the covariance phase's fluctuating iterations.  Checking only the fixed
-    # cell would pass even with the snapshot/restore of Gamma2_phi1Report
-    # dropped, because the M-step rewrites that cell every iteration anyway --
-    # it is the ESTIMATED entries that would drift.
+    # ... and the estimated entries are untouched by the phase too, not just
+    # the fixed one.
     .noCov <- suppressWarnings(suppressMessages(
       nlmixr2(.fixMuMod, nlmixr2data::theo_sd, "saem",
               saemControl(nBurn = 20, nEm = 20, print = 0, seed = 42,


### PR DESCRIPTION
Closes #1073.

## The bug

A `fix()`ed eta variance was reported as something other than the value it was
fixed at:

```r
eta.ka ~ fix(0.3)
#> fit$omega["eta.ka", "eta.ka"] == 0.318324
```

The fit itself was correct. Read straight off it:

```
Gamma2_phi1       (live, what the sampler used): 0.300000
Gamma2_phi1Report (what the fit reports):        0.318324
```

## Where

In the omega M-step (`src/saem.cpp`), within one iteration:

1. `Gamma2_phi1 = G1`, masked by `covstruct1`
2. **`Gamma2_phi1Report = Gamma2_phi1;`** -- the reporting snapshot
3. the "msaem" split-ETA floor, then the `Gmin`/`minv` floor
4. `Gamma2_phi1.elem(Gamma2_phi1fixedIx) = Gamma2_phi1fixedValues(...)` -- the
   fix()ed-value restore
5. `if (kiter <= nb_correl) Gamma2_phi1 = diagmat(Gamma2_phi1)`

The snapshot at 2 precedes the restore at 4, and `.getSaemOmega()` prefers
`Gamma2_phi1Report`, so the pre-restore value is what reached `fit$omega`.

Not specific to a mu-referenced eta: a `nonMuEtas` eta drifted the same way
(`fix(1)` reported as 1.15578), so it is not about how the eta is
parameterized.

## The fix

The restore now writes the fixed cells into `Gamma2_phi1Report` as well. For a
model with no fixed omega entry `Gamma2_phi1fixed` is 0 and nothing changes at
all, so the blast radius is exactly the cells the user fixed.

### Why not just move the snapshot later

That was the first version, and it is wrong for a different reason. Taking the
snapshot after step 5 also reports the *floored* values, and on the
near-singular omega in `test-saem-nearpd.R` (smallest eigenvalue ~5e-10,
off-diagonals ~1e-25) that flips the `rxSymInvChol` parameter count and the fit
dies with `theta has to have 9 elements`. That fragility is pre-existing and is
deliberately left alone here -- this PR reports what the sampler used for the
cells the user fixed, and changes nothing else. It is now tracked as #1079,
with the root cause in nlmixr2/rxode2#1365: `rxSymInvCholCreate()` refuses a
positive-definite Omega whose zero pattern is not block-decomposable, and the
`chol()` guard in `R/focei.R` does not test for that.

## Testing

`tests/testthat/test-saem-fixed-omega-report-1073.R`, for a mu-referenced and a
non-mu-referenced fixed eta. Each asserts the reported value *and* that the
report agrees with the live `Gamma2_phi1` on the fixed cell -- `fit$omega`
alone cannot tell "fixed at 0.3" from "estimated and landed near 0.3". 4 of its
5 assertions fail against `main` (verified by reverting `src/saem.cpp` and
rebuilding).

Every `test-saem-*.R`, `test-mix.R` and `test-iov*.R` file passes -- 39 files,
0 failures.

Reviewed with antigravity (gemini-3.1-pro-high), clean on correctness in the
last two rounds. It raised two test-strength points, both acted on: the SA
covariance phase (the default `covMethod`) was untested, and the comment on
that test claimed to exercise the `_savGamma2_phi1Report` snapshot/restore. It
does not -- the gain is frozen at zero during that phase, so nothing drifts;
neutering the restore leaves the test passing (measured, then the comment was
corrected to say what the test does establish).

Two further suggestions were checked and rejected: a `fix(0)` variance never
reaches the kernel (`.getZeroEtasFromModel()` drops such an eta in
pre-processing, and `.configsaem()` refuses a non-positive fixed variance), and
the divergence between a fixed off-diagonal and `diagmat()` under
`nb_correl >= niter` is pre-existing -- the report disagreed with the live
matrix there before this change too.
