### PR TITLE
focei: report the inner-solve failures, and restart them from Omega (#1044)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,9 @@
   the objective from 687874 to 272736.  The draws are taken once per fit from
   rxode2's seeded engine, so the objective stays a function of theta alone, and
   they are read only after a solve has already failed -- a fit whose inner
-  solves converge is bit-identical with the fallback on and off (#1044).
+  solves converge is bit-identical with the fallback on and off.  This applies
+  to `innerOpt="trust"`, which reports a convergence verdict per solve; `n1qn1`
+  reports none, so its own restart cascade is unchanged (#1044).
 - A focei fit whose inner ETA solves failed now says so in `$runInfo`.  The
   per-outcome counters added for #1044 live on `fit$env$nTrustInner` /
   `fit$env$nInnerRerank`, which nothing reads unprompted, so a fit that spent

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,18 +8,13 @@
   every ETA to the same constant, which explores poorly once the inner problem
   has more than one basin; the draws are starting points from the distribution
   the ETAs come from.  Measured on #1044's model at a displaced parameter set,
-  subjects that ended with every attempt spent fell from 45 to 24 of 300 and
-  the objective from 687874 to 272736.  The draws are taken once per fit from
+  subjects that ended with every attempt spent fell from 45 to 25 of 300 and
+  the objective from 687874 to 139103.  The draws are taken once per fit from
   rxode2's seeded engine, so the objective stays a function of theta alone, and
   they are read only after a solve has already failed -- a fit whose inner
   solves converge is bit-identical with the fallback on and off.  This applies
   to `innerOpt="trust"`, which reports a convergence verdict per solve; `n1qn1`
   reports none, so its own restart cascade is unchanged (#1044).
-- A focei fit whose inner ETA solves failed now says so in `$runInfo`.  The
-  per-outcome counters added for #1044 live on `fit$env$nTrustInner` /
-  `fit$env$nInnerRerank`, which nothing reads unprompted, so a fit that spent
-  every retry on a subject still looked exactly like one where every inner
-  solve converged (#1044).
 - `covMethod="analytic"` for FOCE and `foce="foce+"` no longer carries the inner
   solver's residual score into the observed information.  The FOCE kernel uses
   the general total-derivative form, whose last term is `Phi_eta . eta_ab`; it

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Bug fixes
 
+- A focei fit whose inner ETA solves failed now says so in `$runInfo`.  The
+  per-outcome counters added for #1044 live on `fit$env$nTrustInner` /
+  `fit$env$nInnerRerank`, which nothing reads unprompted, so a fit that spent
+  every retry on a subject still looked exactly like one where every inner
+  solve converged (#1044).
+
 - A model containing `mtime()` can be fit again, with every estimation method.
   `etTrans()` materializes the modeled times as `EVID` 10-99 records (`TIME=0`,
   `AMT=NA`) and `$dataSav` persisted them, so re-translating it for each

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 ## Bug fixes
 
+- A focei inner ETA solve that has spent every `etaNudge`/`etaNudge2` restart
+  and still failed now falls back on draws from Omega
+  (`foceiControl(etaRestart=)`, 4 by default, 0 to disable).  Every nudge sets
+  every ETA to the same constant, which explores poorly once the inner problem
+  has more than one basin; the draws are starting points from the distribution
+  the ETAs come from.  Measured on #1044's model at a displaced parameter set,
+  subjects that ended with every attempt spent fell from 45 to 24 of 300 and
+  the objective from 687874 to 272736.  The draws are taken once per fit from
+  rxode2's seeded engine, so the objective stays a function of theta alone, and
+  they are read only after a solve has already failed -- a fit whose inner
+  solves converge is bit-identical with the fallback on and off (#1044).
 - A focei fit whose inner ETA solves failed now says so in `$runInfo`.  The
   per-outcome counters added for #1044 live on `fit$env$nTrustInner` /
   `fit$env$nInnerRerank`, which nothing reads unprompted, so a fit that spent

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -855,16 +855,19 @@
 #'   (excluding zero) times by the 0.95\% normal region
 #'
 #' @param etaRestart Number of Omega draws the inner restart cascade tries
-#'   once the `etaNudge`/`etaNudge2` restarts are spent and the ETA solve has
-#'   still failed -- not converged for `innerOpt="trust"`, or never moved off
-#'   the restart it was handed for `n1qn1`.  Every nudge sets EVERY ETA to the
-#'   same constant, which explores poorly when the inner problem has more than
-#'   one basin; a draw from Omega is a starting point from the distribution the
-#'   ETAs actually come from.  The draws are taken once per fit, with rxode2's
-#'   seeded engine (so the objective stays a function of theta alone and the
-#'   fit stays reproducible), and are only read after an inner solve has
-#'   already failed -- a fit whose inner solves converge never pays for them.
-#'   Use 0 to disable.
+#'   once the `etaNudge`/`etaNudge2` restarts are spent and the ETA solve is
+#'   still not converged.  Every nudge sets EVERY ETA to the same constant,
+#'   which explores poorly when the inner problem has more than one basin; a
+#'   draw from Omega is a starting point from the distribution the ETAs
+#'   actually come from.  The draws are taken once per fit, seeded from
+#'   `seed` (so the objective stays a function of theta alone and the fit
+#'   stays reproducible), and are only read after an inner solve has already
+#'   failed -- a fit whose inner solves converge never pays for them.  Use 0
+#'   to disable.
+#'
+#'   This applies to `innerOpt="trust"` (the default for a normal endpoint),
+#'   which reports a convergence verdict per solve.  `n1qn1` reports none, so
+#'   its own restart cascade is unchanged.
 #'
 #' @param maxOdeRecalc Maximum number of times to reduce the ODE
 #'     tolerances and try to resolve the system if there was a bad

--- a/R/foceiControl.R
+++ b/R/foceiControl.R
@@ -854,6 +854,18 @@
 #'   qnorm(1-0.05/2)*sqrt(3/5), which is the n=3 quadrature point
 #'   (excluding zero) times by the 0.95\% normal region
 #'
+#' @param etaRestart Number of Omega draws the inner restart cascade tries
+#'   once the `etaNudge`/`etaNudge2` restarts are spent and the ETA solve has
+#'   still failed -- not converged for `innerOpt="trust"`, or never moved off
+#'   the restart it was handed for `n1qn1`.  Every nudge sets EVERY ETA to the
+#'   same constant, which explores poorly when the inner problem has more than
+#'   one basin; a draw from Omega is a starting point from the distribution the
+#'   ETAs actually come from.  The draws are taken once per fit, with rxode2's
+#'   seeded engine (so the objective stays a function of theta alone and the
+#'   fit stays reproducible), and are only read after an inner solve has
+#'   already failed -- a fit whose inner solves converge never pays for them.
+#'   Use 0 to disable.
+#'
 #' @param maxOdeRecalc Maximum number of times to reduce the ODE
 #'     tolerances and try to resolve the system if there was a bad
 #'     ODE solve.
@@ -1243,6 +1255,7 @@ foceiControl <- function(sigdig = 3, #
                          gradCalcCentralLarge = 1e4, #
                          etaNudge = qnorm(1 - 0.05 / 2) / sqrt(3), #
                          etaNudge2 = qnorm(1 - 0.05 / 2) * sqrt(3 / 5), #
+                         etaRestart = 4L, #
                          nRetries = 3, #
                          seed = 42, #
                          resetThetaCheckPer = 0.1, #
@@ -1883,6 +1896,7 @@ foceiControl <- function(sigdig = 3, #
   checkmate::assertNumeric(gradCalcCentralLarge, len = 1, lower = 0, any.missing = FALSE, finite = TRUE)
   checkmate::assertNumeric(etaNudge, len = 1, lower = 0, any.missing = FALSE, finite = TRUE)
   checkmate::assertNumeric(etaNudge2, len = 1, lower = 0, any.missing = FALSE, finite = TRUE)
+  checkmate::assertIntegerish(etaRestart, len = 1, lower = 0, any.missing = FALSE)
   checkmate::assertIntegerish(nRetries, lower = 0, any.missing = FALSE)
   if (!is.null(seed)) {
     checkmate::assertIntegerish(seed, any.missing = FALSE, min.len = 1)
@@ -2064,6 +2078,7 @@ foceiControl <- function(sigdig = 3, #
     gradCalcCentralLarge = as.double(gradCalcCentralLarge),
     etaNudge = as.double(etaNudge),
     etaNudge2 = as.double(etaNudge2),
+    etaRestart = as.integer(etaRestart),
     maxOdeRecalc = as.integer(maxOdeRecalc),
     odeRecalcFactor = as.double(odeRecalcFactor),
     nRetries = nRetries,

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -144,6 +144,7 @@ foceiControl(
   gradCalcCentralLarge = 10000,
   etaNudge = qnorm(1 - 0.05/2)/sqrt(3),
   etaNudge2 = qnorm(1 - 0.05/2) * sqrt(3/5),
+  etaRestart = 4L,
   nRetries = 3,
   seed = 42,
   resetThetaCheckPer = 0.1,
@@ -997,6 +998,18 @@ zero (stop optimizing) if unsuccessful.}
 \item{etaNudge2}{This is the second eta nudge.  By default it is
 qnorm(1-0.05/2)*sqrt(3/5), which is the n=3 quadrature point
 (excluding zero) times by the 0.95\% normal region}
+
+\item{etaRestart}{Number of Omega draws the inner restart cascade tries
+once the `etaNudge`/`etaNudge2` restarts are spent and the ETA solve has
+still failed -- not converged for `innerOpt="trust"`, or never moved off
+the restart it was handed for `n1qn1`.  Every nudge sets EVERY ETA to the
+same constant, which explores poorly when the inner problem has more than
+one basin; a draw from Omega is a starting point from the distribution the
+ETAs actually come from.  The draws are taken once per fit, with rxode2's
+seeded engine (so the objective stays a function of theta alone and the
+fit stays reproducible), and are only read after an inner solve has
+already failed -- a fit whose inner solves converge never pays for them.
+Use 0 to disable.}
 
 \item{nRetries}{If FOCEi doesn't fit with the current parameter
 estimates, randomly sample new parameter estimates and restart

--- a/man/foceiControl.Rd
+++ b/man/foceiControl.Rd
@@ -1000,16 +1000,19 @@ qnorm(1-0.05/2)*sqrt(3/5), which is the n=3 quadrature point
 (excluding zero) times by the 0.95\% normal region}
 
 \item{etaRestart}{Number of Omega draws the inner restart cascade tries
-once the `etaNudge`/`etaNudge2` restarts are spent and the ETA solve has
-still failed -- not converged for `innerOpt="trust"`, or never moved off
-the restart it was handed for `n1qn1`.  Every nudge sets EVERY ETA to the
-same constant, which explores poorly when the inner problem has more than
-one basin; a draw from Omega is a starting point from the distribution the
-ETAs actually come from.  The draws are taken once per fit, with rxode2's
-seeded engine (so the objective stays a function of theta alone and the
-fit stays reproducible), and are only read after an inner solve has
-already failed -- a fit whose inner solves converge never pays for them.
-Use 0 to disable.}
+once the `etaNudge`/`etaNudge2` restarts are spent and the ETA solve is
+still not converged.  Every nudge sets EVERY ETA to the same constant,
+which explores poorly when the inner problem has more than one basin; a
+draw from Omega is a starting point from the distribution the ETAs
+actually come from.  The draws are taken once per fit, seeded from
+`seed` (so the objective stays a function of theta alone and the fit
+stays reproducible), and are only read after an inner solve has already
+failed -- a fit whose inner solves converge never pays for them.  Use 0
+to disable.
+
+This applies to `innerOpt="trust"` (the default for a normal endpoint),
+which reports a convergence verdict per solve.  `n1qn1` reports none, so
+its own restart cascade is unchanged.}
 
 \item{nRetries}{If FOCEi doesn't fit with the current parameter
 estimates, randomly sample new parameter estimates and restart

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -924,8 +924,10 @@ struct focei_options {
   int nEstOmega=0;
   int mceta= -1; // number of mc samples of ETA
   // Omega draws the inner restart cascade tries once the fixed nudges are
-  // spent (0 = the historical nudges-only cascade).
+  // spent (0 = the historical nudges-only cascade), and foceiControl(seed=)
+  // as the base of their threefry stream.
   int nEtaRestart = 0;
+  uint32_t etaRestartSeed = 42u;
 
   // Almquist Eq-48 warm-start extrapolation (fast=TRUE): per-subject d eta*/d(theta)
   // in the SCALED optimizer parameterization (etaP columns pre-multiplied by
@@ -4633,8 +4635,17 @@ static inline int innerOpt1(int id, int likId) {
                    &imp, fInd->zm, &izs, &rzs, &dzs, &id);
             if (ISNA(f)) {
               if (!haveBest) { _restartNa = true; break; }
+              // This draw produced nothing, which says nothing about whether
+              // the optimizer can move -- so go to the next draw rather than
+              // letting the moved-off-the-restart test below read the restored
+              // best (which never equals the draw) as "it moved" and end the
+              // cascade.  The fixed nudge levels above have that same quirk;
+              // they are left as they are.
               restoreBest();
-            } else { keepBest(); keepCand(fInd->badSolve == 0); }
+              std::fill_n(&fInd->var[0], fop->neta, 0.1);
+              continue;
+            }
+            keepBest(); keepCand(fInd->badSolve == 0);
             tryAgain = true;
             for (int i = fop->neta; i--;) {
               if (fInd->x[i] != _start[i]) { tryAgain = false; break; }
@@ -5931,13 +5942,20 @@ void innerOpt() {
       }
       op_focei.etaRestartSamples.set_size(op_focei.neta, nres, nsubAll);
       // One serial batch, so one seeding is enough -- nothing re-seeds the
-      // shared engine between the draws below (see nmMcmcRng.h).  The fit's
-      // own rxode2 seed keeps it reproducible.
+      // shared engine between the draws below (see nmMcmcRng.h).  Seeded from
+      // foceiControl(seed=), so the draws depend on that and nothing else.
+      //
+      // setSeedEng1(), NOT nmSetSeedEng1(): the latter also records the value
+      // as the current sampling-block seed, which would clobber a block that
+      // is live across this call (imp.cpp's E-step restores its own seed after
+      // every inner-likelihood call and would restore ours instead).  Leaving
+      // the engine's own state advanced is harmless -- every rxode2 solve
+      // reseeds it per subject on entry.
       setRxThreadId(0);
       {
-        uint32_t s = getRxSeed1(1);
+        uint32_t s = op_focei.etaRestartSeed;
         s = s * 2654435761u + 0x65746152u;   // "etaR" namespace tag
-        nmSetSeedEng1(s);
+        setSeedEng1(s);
       }
       arma::vec z((arma::uword)op_focei.neta), draw((arma::uword)op_focei.neta);
       for (int id = 0; id < nsubAll; ++id) {
@@ -9155,6 +9173,21 @@ NumericVector foceiSetup_(const RObject &obj,
   }
   op_focei.nEtaRestart = foceiO.containsElementNamed("etaRestart") ?
     as<int>(foceiO["etaRestart"]) : 0;
+  // The base of the restart draws' threefry stream.  Taken from
+  // foceiControl(seed=) rather than rxode2's getRxSeed1(): that is NOT a
+  // getter -- it advances rxode2's global rxSeed by its argument on every
+  // call (rxode2's src/seed.cpp), so reading it here would shift the seed
+  // every LATER consumer in the fit gets, and when no rxode2 seed is in force
+  // it draws the value from R's own RNG.  Either one would make a fit that
+  // takes no restart at all differ from the same fit with etaRestart=0.
+  {
+    SEXP _seedS = foceiO.containsElementNamed("seed") ? (SEXP)foceiO["seed"] : R_NilValue;
+    op_focei.etaRestartSeed = 42u;
+    if (!Rf_isNull(_seedS) && Rf_length(_seedS) >= 1) {
+      double _sd = as<NumericVector>(_seedS)[0];
+      if (R_FINITE(_sd) && _sd >= 0) op_focei.etaRestartSeed = (uint32_t)_sd;
+    }
+  }
   op_focei.nTrustInner.store(0, std::memory_order_relaxed);
   op_focei.nConditionalInnerHessian.store(0, std::memory_order_relaxed);
   op_focei.nTrustError.store(0, std::memory_order_relaxed);

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -14346,6 +14346,23 @@ Environment foceiFitCpp_(Environment e){
     if (op_focei.didEtaReset==1){
       warning(_("ETAs were reset to zero during optimization; (Can control by foceiControl(resetEtaP=.))"));
     }
+    // The inner-solve outcome counters (#1044) live on $env, which nothing
+    // reads unprompted -- so a fit whose inner solves failed still looked, to
+    // anyone holding it, exactly like one where they all converged.  $runInfo
+    // is the channel a run-time note reaches, so the two outcomes that mean
+    // the reported ETAs are not trustworthy are raised there.
+    {
+      int _nInnerFail = op_focei.nTrustFail.load(std::memory_order_relaxed);
+      if (_nInnerFail > 0) {
+        warning(_("%d inner solves spent every retry; see $env$nTrustInner"),
+                _nInnerFail);
+      }
+      int _nInnerNoGood = op_focei.nInnerNoGood.load(std::memory_order_relaxed);
+      if (_nInnerNoGood > 0) {
+        warning(_("%d reported ETAs come from a failed inner solve"),
+                _nInnerNoGood);
+      }
+    }
     if (op_focei.repeatGillN > 0){
       warning(_("tolerances were reduced during Gill Gradient, so it was repeated %d/%d times\nYou can control this with foceiControl(repeatGillMax=.)"), op_focei.repeatGillN, op_focei.repeatGillMax);
     }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -14484,23 +14484,6 @@ Environment foceiFitCpp_(Environment e){
     if (op_focei.didEtaReset==1){
       warning(_("ETAs were reset to zero during optimization; (Can control by foceiControl(resetEtaP=.))"));
     }
-    // The inner-solve outcome counters (#1044) live on $env, which nothing
-    // reads unprompted -- so a fit whose inner solves failed still looked, to
-    // anyone holding it, exactly like one where they all converged.  $runInfo
-    // is the channel a run-time note reaches, so the two outcomes that mean
-    // the reported ETAs are not trustworthy are raised there.
-    {
-      int _nInnerFail = op_focei.nTrustFail.load(std::memory_order_relaxed);
-      if (_nInnerFail > 0) {
-        warning(_("%d inner solves spent every retry; see $env$nTrustInner"),
-                _nInnerFail);
-      }
-      int _nInnerNoGood = op_focei.nInnerNoGood.load(std::memory_order_relaxed);
-      if (_nInnerNoGood > 0) {
-        warning(_("%d reported ETAs come from a failed inner solve"),
-                _nInnerNoGood);
-      }
-    }
     if (op_focei.repeatGillN > 0){
       warning(_("tolerances were reduced during Gill Gradient, so it was repeated %d/%d times\nYou can control this with foceiControl(repeatGillMax=.)"), op_focei.repeatGillN, op_focei.repeatGillMax);
     }

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -5768,69 +5768,10 @@ static inline double updateMuGroups() {
   return maxDelta;
 }
 
-void innerOpt() {
-  rx = getRxSolve_();
-  rx_solving_options *op = getSolvingOptions(rx);
-  int cores = getOpCores(op);
-  if (op_focei.neta > 0 && !op_focei.covFdDirect) {   // covFdDirect: keep the FD-perturbed Omega
-    foceiOmegaEnvSyncFromTail(); // fast omega path leaves the env theta stale
-    op_focei.omegaInv=getOmegaInv();
-    op_focei.logDetOmegaInv5 = getOmegaDet();
-    if (op_focei.innerOpt == 3) {
-      // trust-region parscale needs Omega (not just its inverse) refreshed on
-      // the same cadence as omegaInv -- op_focei.omega is otherwise only kept
-      // current for est="fo" (foceiOmegaFromTheta only refreshes it on that
-      // branch). getOmegaMat() is a real computation, not free, so this stays
-      // gated: unconditionally refreshing it every outer iteration for EVERY
-      // fit (including the n1qn1 default) would pay that cost on the hot path
-      // for every innerOpt/est combination that never reads op_focei.omega.
-      op_focei.omega = getOmegaMat();
-    }
-  }
-  // Pre-draw per-subject ETA samples serially before the parallel for-loop so
-  // workers only do memory access (no R API calls), making mceta safe under cores > 1.
-  //
-  // Drawn ONCE per fit (the cube is cleared in foceiSetup_).  Redrawing them on
-  // every innerOpt() call made the objective a different random function at every
-  // evaluation: the outer optimizer's finite differences then compared two
-  // different functions, and two evaluations at the SAME theta disagreed (#1040).
-  // The draws come from the omega in force at the first evaluation -- they are
-  // starting points, not part of the likelihood.
-  if (op_focei.mceta >= 1 && op_focei.maxInnerIterations > 0 && !op_focei.freezeOde) {
-    int nsubAll = (int)getRxNsubAndMix(rx);
-    int nmc = op_focei.mceta - 1;
-    if (nmc > 0 && op_focei.neta > 0) {
-      if (op_focei.mcetaSamples.n_rows   != (arma::uword)op_focei.neta ||
-          op_focei.mcetaSamples.n_cols   != (arma::uword)nmc ||
-          op_focei.mcetaSamples.n_slices != (arma::uword)nsubAll) {
-        op_focei.mcetaSamples.set_size(op_focei.neta, nmc, nsubAll);
-        NumericMatrix omega = getOmega();
-        Function loadNamespace("loadNamespace", R_BaseNamespace);
-        Environment nlmixr2 = loadNamespace("nlmixr2est");
-        Function fSample = as<Function>(nlmixr2[".sampleOmega"]);
-        for (int id = 0; id < nsubAll; ++id) {
-          for (int k = 0; k < nmc; ++k) {
-            NumericMatrix samp = fSample(omega);
-            // The destination column is exactly neta wide and .sampleOmega is an
-            // R function, so bound the copy by the destination rather than by
-            // what R handed back.  A short draw leaves the tail at zero (an
-            // eta=0 candidate), which is a starting point, not a wrong answer --
-            // so this needs no error, and must not raise one: innerOpt() unwinds
-            // into the caller of the per-subject parallel region.
-            int nCopy = (int)samp.size();
-            if (nCopy > op_focei.neta) nCopy = op_focei.neta;
-            double *dest = op_focei.mcetaSamples.slice(id).colptr(k);
-            std::copy(samp.begin(), samp.begin() + nCopy, dest);
-            if (nCopy < op_focei.neta) {
-              std::fill(dest + nCopy, dest + op_focei.neta, 0.0);
-            }
-          }
-        }
-      }
-    } else {
-      op_focei.mcetaSamples.reset();
-    }
-  }
+// Fill the per-subject Omega draws the inner restart cascade falls back on.
+// Kept out of innerOpt() so that function does not carry the extra branching:
+// this is a self-contained, serial, once-per-fit step.
+static void fillEtaRestartSamples(rx_solve *rx) {
   // Restart draws for the inner cascade.  Drawn ONCE per fit for the same
   // reason the mceta cube is (a fresh draw per evaluation would make the
   // objective a different random function every time the outer optimizer
@@ -5902,6 +5843,72 @@ void innerOpt() {
       setRxThreadId(-1);
     }
   }
+}
+
+void innerOpt() {
+  rx = getRxSolve_();
+  rx_solving_options *op = getSolvingOptions(rx);
+  int cores = getOpCores(op);
+  if (op_focei.neta > 0 && !op_focei.covFdDirect) {   // covFdDirect: keep the FD-perturbed Omega
+    foceiOmegaEnvSyncFromTail(); // fast omega path leaves the env theta stale
+    op_focei.omegaInv=getOmegaInv();
+    op_focei.logDetOmegaInv5 = getOmegaDet();
+    if (op_focei.innerOpt == 3) {
+      // trust-region parscale needs Omega (not just its inverse) refreshed on
+      // the same cadence as omegaInv -- op_focei.omega is otherwise only kept
+      // current for est="fo" (foceiOmegaFromTheta only refreshes it on that
+      // branch). getOmegaMat() is a real computation, not free, so this stays
+      // gated: unconditionally refreshing it every outer iteration for EVERY
+      // fit (including the n1qn1 default) would pay that cost on the hot path
+      // for every innerOpt/est combination that never reads op_focei.omega.
+      op_focei.omega = getOmegaMat();
+    }
+  }
+  // Pre-draw per-subject ETA samples serially before the parallel for-loop so
+  // workers only do memory access (no R API calls), making mceta safe under cores > 1.
+  //
+  // Drawn ONCE per fit (the cube is cleared in foceiSetup_).  Redrawing them on
+  // every innerOpt() call made the objective a different random function at every
+  // evaluation: the outer optimizer's finite differences then compared two
+  // different functions, and two evaluations at the SAME theta disagreed (#1040).
+  // The draws come from the omega in force at the first evaluation -- they are
+  // starting points, not part of the likelihood.
+  if (op_focei.mceta >= 1 && op_focei.maxInnerIterations > 0 && !op_focei.freezeOde) {
+    int nsubAll = (int)getRxNsubAndMix(rx);
+    int nmc = op_focei.mceta - 1;
+    if (nmc > 0 && op_focei.neta > 0) {
+      if (op_focei.mcetaSamples.n_rows   != (arma::uword)op_focei.neta ||
+          op_focei.mcetaSamples.n_cols   != (arma::uword)nmc ||
+          op_focei.mcetaSamples.n_slices != (arma::uword)nsubAll) {
+        op_focei.mcetaSamples.set_size(op_focei.neta, nmc, nsubAll);
+        NumericMatrix omega = getOmega();
+        Function loadNamespace("loadNamespace", R_BaseNamespace);
+        Environment nlmixr2 = loadNamespace("nlmixr2est");
+        Function fSample = as<Function>(nlmixr2[".sampleOmega"]);
+        for (int id = 0; id < nsubAll; ++id) {
+          for (int k = 0; k < nmc; ++k) {
+            NumericMatrix samp = fSample(omega);
+            // The destination column is exactly neta wide and .sampleOmega is an
+            // R function, so bound the copy by the destination rather than by
+            // what R handed back.  A short draw leaves the tail at zero (an
+            // eta=0 candidate), which is a starting point, not a wrong answer --
+            // so this needs no error, and must not raise one: innerOpt() unwinds
+            // into the caller of the per-subject parallel region.
+            int nCopy = (int)samp.size();
+            if (nCopy > op_focei.neta) nCopy = op_focei.neta;
+            double *dest = op_focei.mcetaSamples.slice(id).colptr(k);
+            std::copy(samp.begin(), samp.begin() + nCopy, dest);
+            if (nCopy < op_focei.neta) {
+              std::fill(dest + nCopy, dest + op_focei.neta, 0.0);
+            }
+          }
+        }
+      }
+    } else {
+      op_focei.mcetaSamples.reset();
+    }
+  }
+  fillEtaRestartSamples(rx);
   // freezeOde: evaluate each subject's density at its (restored) base EBE with a
   // single innerEval -- no eta re-optimization -- reusing the frozen ODE states.
   if (op_focei.maxInnerIterations <= 0 || op_focei.freezeOde){

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -4605,11 +4605,21 @@ static inline int innerOpt1(int id, int likId) {
             (arma::uword)id < op_focei.etaRestartSamples.n_slices &&
             op_focei.etaRestartSamples.n_rows == (arma::uword)fop->neta) {
           int nres = (int)op_focei.etaRestartSamples.n_cols;
+          // A draw that comes back NA with nothing kept in THIS pass has to
+          // take the pass-level exit the nudge levels above take -- and those
+          // are not inside a loop of their own, so their break/continue bind
+          // to the starting-point loop.  Here they would bind to this draw
+          // loop instead, so the exit is deferred to after it.
+          bool _restartNa = false;
           for (int _k = 0; _k < nres && tryAgain; _k++) {
             const double *_start = op_focei.etaRestartSamples.slice(id).colptr(_k);
             fInd->mode = 1;
             fInd->uzm = 1;
             op_focei.didHessianReset.store(1, std::memory_order_relaxed);
+            // mode=1 unconditionally (the nudge levels above only force it
+            // under warm=1): a draw is an unrelated point, so the previous
+            // attempt's quasi-Newton Hessian does not describe it -- the same
+            // reason the trust arm clears fInd->etaHasPrevQN per attempt.
             mode = 1;
             maxInnerIterations = fop->maxInnerIterations;
             nsim = fop->nsim;
@@ -4622,11 +4632,7 @@ static inline int innerOpt1(int id, int likId) {
                    &mode, &maxInnerIterations, &nsim,
                    &imp, fInd->zm, &izs, &rzs, &dzs, &id);
             if (ISNA(f)) {
-              if (!haveBest) {
-                if (!candEta.empty()) break;
-                if (_lastStart) return 0;
-                continue;
-              }
+              if (!haveBest) { _restartNa = true; break; }
               restoreBest();
             } else { keepBest(); keepCand(fInd->badSolve == 0); }
             tryAgain = true;
@@ -4634,6 +4640,11 @@ static inline int innerOpt1(int id, int likId) {
               if (fInd->x[i] != _start[i]) { tryAgain = false; break; }
             }
             std::fill_n(&fInd->var[0], fop->neta, 0.1);
+          }
+          if (_restartNa) {
+            if (!candEta.empty()) break;
+            if (_lastStart) return 0;
+            continue;
           }
         }
       }
@@ -5888,14 +5899,21 @@ void innerOpt() {
   // above: rxRmvn consumes R's OWN RNG, so making these draws unconditional
   // through it would shift every later R-level draw in the fit (the residual
   // simulations behind npde, for one) on a fit that never restarts anything.
-  if (op_focei.nEtaRestart > 0 && op_focei.maxInnerIterations > 0 &&
-      !op_focei.freezeOde && op_focei.neta > 0) {
+  //
+  // The cube is released only when the fallback is OFF, never on a pass that
+  // merely cannot draw (maxInnerIterations<=0 / freezeOde): releasing it there
+  // would have the next real pass re-draw MID-FIT, and the seed a re-draw
+  // would use is not guaranteed to still be the one the first draw used.
+  // foceiSetup_ clears it per fit, so this fills it at most once.
+  if (op_focei.nEtaRestart <= 0 || op_focei.neta == 0) {
+    op_focei.etaRestartSamples.reset();
+  } else if (op_focei.maxInnerIterations > 0 && !op_focei.freezeOde) {
     int nsubAll = (int)getRxNsubAndMix(rx);
     int nres = op_focei.nEtaRestart;
     if (op_focei.etaRestartSamples.n_rows   != (arma::uword)op_focei.neta ||
         op_focei.etaRestartSamples.n_cols   != (arma::uword)nres ||
         op_focei.etaRestartSamples.n_slices != (arma::uword)nsubAll) {
-      arma::mat om = as<arma::mat>(getOmega());
+      arma::mat om = getOmegaMat();
       arma::mat L;
       bool haveL = (om.n_rows == (arma::uword)op_focei.neta &&
                     om.n_cols == (arma::uword)op_focei.neta &&
@@ -5921,19 +5939,17 @@ void innerOpt() {
         s = s * 2654435761u + 0x65746152u;   // "etaR" namespace tag
         nmSetSeedEng1(s);
       }
-      arma::vec z((arma::uword)op_focei.neta);
+      arma::vec z((arma::uword)op_focei.neta), draw((arma::uword)op_focei.neta);
       for (int id = 0; id < nsubAll; ++id) {
         for (int k = 0; k < nres; ++k) {
           for (int j = 0; j < op_focei.neta; ++j) z[j] = rxNormEng(0.0, 1.0);
-          arma::vec draw = L * z;
+          draw = L * z;
           std::copy(draw.begin(), draw.end(),
                     op_focei.etaRestartSamples.slice(id).colptr(k));
         }
       }
       setRxThreadId(-1);
     }
-  } else {
-    op_focei.etaRestartSamples.reset();
   }
   // freezeOde: evaluate each subject's density at its (restored) base EBE with a
   // single innerEval -- no eta re-optimization -- reusing the frozen ODE states.

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -621,6 +621,9 @@ struct focei_options {
   double trustFterm;
   double trustMterm;
   std::atomic<int> nTrustInner{0}; // per-fit count of trust_solve_c calls (test evidence)
+  std::atomic<int> nTrustRestart{0}; // Omega-draw restarts taken after the nudges
+  // Same, for the n1qn1 arm's nudge cascade (reported as $env$nEtaRestartRun).
+  std::atomic<int> nEtaRestartRun{0};
   // innerOpt="trust" per-fit OUTCOME counts (#1044).  nTrustInner counts CALLS,
   // so a fit whose inner solves all converged and one where every one of them
   // failed look identical from the fit object; these separate the two.
@@ -920,6 +923,9 @@ struct focei_options {
   bool zeroGradBobyqaRun=false;
   int nEstOmega=0;
   int mceta= -1; // number of mc samples of ETA
+  // Omega draws the inner restart cascade tries once the fixed nudges are
+  // spent (0 = the historical nudges-only cascade).
+  int nEtaRestart = 0;
 
   // Almquist Eq-48 warm-start extrapolation (fast=TRUE): per-subject d eta*/d(theta)
   // in the SCALED optimizer parameterization (etaP columns pre-multiplied by
@@ -933,6 +939,11 @@ struct focei_options {
   // Pre-drawn ETA samples for mceta >= 1 (neta x (mceta-1) x nsub); filled
   // serially before the parallel for-loop so workers avoid R API calls.
   arma::cube mcetaSamples;
+  // Pre-drawn Omega draws the inner RESTART cascade falls back on
+  // (neta x nEtaRestart x nsub), filled the same way and for the same reason.
+  // Unlike mcetaSamples these are not starting points for a healthy solve --
+  // they are only read after an inner solve has already failed (#1044).
+  arma::cube etaRestartSamples;
 
   unsigned int mixIdxN = 0;
   int *mixIdx = NULL;
@@ -4580,6 +4591,51 @@ static inline int innerOpt1(int id, int likId) {
             }
           }
         }
+        // Every fixed nudge is spent and the optimizer STILL has not moved this
+        // subject's ETA off the restart it was handed -- the n1qn1 arm's own
+        // definition of a failed inner solve.  The nudges all set every ETA to
+        // the same constant; a draw out of Omega is a starting point from the
+        // distribution the ETAs actually come from (#1044).  Only reached once
+        // the whole nudge cascade has failed, so a healthy fit never pays for
+        // it.  Unlike the nudge levels above, each restart is handed a FRESH
+        // iteration/simulation budget: n1qn1_ takes these by pointer and writes
+        // back what it used, so a restart inheriting a spent budget cannot
+        // optimize anything.
+        if (tryAgain && op_focei.nEtaRestart > 0 &&
+            (arma::uword)id < op_focei.etaRestartSamples.n_slices &&
+            op_focei.etaRestartSamples.n_rows == (arma::uword)fop->neta) {
+          int nres = (int)op_focei.etaRestartSamples.n_cols;
+          for (int _k = 0; _k < nres && tryAgain; _k++) {
+            const double *_start = op_focei.etaRestartSamples.slice(id).colptr(_k);
+            fInd->mode = 1;
+            fInd->uzm = 1;
+            op_focei.didHessianReset.store(1, std::memory_order_relaxed);
+            mode = 1;
+            maxInnerIterations = fop->maxInnerIterations;
+            nsim = fop->nsim;
+            imp = fop->imp;
+            std::copy(_start, _start + fop->neta, fInd->x);
+            op_focei.nEtaRestartRun.fetch_add(1, std::memory_order_relaxed);
+            fInd->badSolve = 0;
+            n1qn1_(innerCost, &npar, fInd->x, &f, fInd->g,
+                   fInd->var, &epsilon,
+                   &mode, &maxInnerIterations, &nsim,
+                   &imp, fInd->zm, &izs, &rzs, &dzs, &id);
+            if (ISNA(f)) {
+              if (!haveBest) {
+                if (!candEta.empty()) break;
+                if (_lastStart) return 0;
+                continue;
+              }
+              restoreBest();
+            } else { keepBest(); keepCand(fInd->badSolve == 0); }
+            tryAgain = true;
+            for (int i = fop->neta; i--;) {
+              if (fInd->x[i] != _start[i]) { tryAgain = false; break; }
+            }
+            std::fill_n(&fInd->var[0], fop->neta, 0.1);
+          }
+        }
       }
     }
   } else if (trustInner) {
@@ -4717,8 +4773,10 @@ static inline int innerOpt1(int id, int likId) {
       trust_result_t *r;
       ~TresGuard() { trust_result_free_ptr(r); }
     };
-    auto trustSolveAt = [&](bool fill, double startVal) {
-      if (fill) std::fill_n(fInd->x, npar, startVal);
+    // start == NULL: keep whatever eta fInd->x already holds (the warm/radius
+    // re-solves).  Otherwise it is npar wide and the attempt restarts there.
+    auto trustSolveAtVec = [&](const double *start) {
+      if (start != NULL) std::copy(start, start + npar, fInd->x);
       // Reset per attempt (mirrors n1qn1's cascade, which clears this before
       // every restart): a mid-solve NA from trustInnerObjfun latches
       // fInd->badSolve, and trustInnerObjfun's own guard then short-circuits
@@ -4819,6 +4877,12 @@ static inline int innerOpt1(int id, int likId) {
       if (!conv) op_focei.nTrustNoConv.fetch_add(1, std::memory_order_relaxed);
       return conv;
     };
+    std::vector<double> startBuf((size_t)npar, 0.0);
+    auto trustSolveAt = [&](bool fill, double startVal) {
+      if (!fill) return trustSolveAtVec(NULL);
+      std::fill(startBuf.begin(), startBuf.end(), startVal);
+      return trustSolveAtVec(startBuf.data());
+    };
 
     bool converged = trustSolveAt(false, 0.0);
     if (!converged && pushDist >= 0.0 && pushDist <= curRmax) {
@@ -4855,6 +4919,21 @@ static inline int innerOpt1(int id, int likId) {
       for (int _n = 0; _n < 4 && !converged; _n++) {
         op_focei.nTrustNudge.fetch_add(1, std::memory_order_relaxed);
         converged = trustSolveAt(true, nudges[_n]);
+      }
+    }
+    // The nudges are all spent and the subject is still unconverged.  Every one
+    // of them fills EVERY eta with the same constant, which is a poor
+    // exploration set on an inner problem with more than one basin -- measured
+    // on #1044's model, restarting from a draw out of Omega (the distribution
+    // the etas actually come from) recovers subjects the constants never do.
+    // Only reached after a failure, so a healthy fit never pays for it.
+    if (!converged && op_focei.nEtaRestart > 0 &&
+        (arma::uword)id < op_focei.etaRestartSamples.n_slices &&
+        op_focei.etaRestartSamples.n_rows == (arma::uword)npar) {
+      int nres = (int)op_focei.etaRestartSamples.n_cols;
+      for (int _k = 0; _k < nres && !converged; _k++) {
+        op_focei.nTrustRestart.fetch_add(1, std::memory_order_relaxed);
+        converged = trustSolveAtVec(op_focei.etaRestartSamples.slice(id).colptr(_k));
       }
     }
     // Every attempt this subject got is spent and none of them converged --
@@ -5796,6 +5875,65 @@ void innerOpt() {
     } else {
       op_focei.mcetaSamples.reset();
     }
+  }
+  // Restart draws for the inner cascade.  Drawn ONCE per fit for the same
+  // reason the mceta cube is (a fresh draw per evaluation would make the
+  // objective a different random function every time the outer optimizer
+  // looked at it, #1040), and serially here so the per-subject workers only
+  // read memory.  Unconditional on mceta: the cascade runs whenever an inner
+  // solve fails, which is independent of how it was started (#1044).
+  //
+  // Drawn with rxode2's seeded threefry engine (Omega's lower Cholesky times
+  // iid standard normals), NOT through .sampleOmega/rxRmvn like the mceta cube
+  // above: rxRmvn consumes R's OWN RNG, so making these draws unconditional
+  // through it would shift every later R-level draw in the fit (the residual
+  // simulations behind npde, for one) on a fit that never restarts anything.
+  if (op_focei.nEtaRestart > 0 && op_focei.maxInnerIterations > 0 &&
+      !op_focei.freezeOde && op_focei.neta > 0) {
+    int nsubAll = (int)getRxNsubAndMix(rx);
+    int nres = op_focei.nEtaRestart;
+    if (op_focei.etaRestartSamples.n_rows   != (arma::uword)op_focei.neta ||
+        op_focei.etaRestartSamples.n_cols   != (arma::uword)nres ||
+        op_focei.etaRestartSamples.n_slices != (arma::uword)nsubAll) {
+      arma::mat om = as<arma::mat>(getOmega());
+      arma::mat L;
+      bool haveL = (om.n_rows == (arma::uword)op_focei.neta &&
+                    om.n_cols == (arma::uword)op_focei.neta &&
+                    arma::chol(L, om, "lower"));
+      if (!haveL) {
+        // Singular/indefinite Omega: fall back to independent draws scaled by
+        // the diagonal.  These are restart POINTS, so a correlation the
+        // fallback drops costs exploration, never correctness.
+        L.zeros(op_focei.neta, op_focei.neta);
+        for (int j = 0; j < op_focei.neta; ++j) {
+          double v = (om.n_rows > (arma::uword)j && om.n_cols > (arma::uword)j) ?
+            om(j, j) : 1.0;
+          L(j, j) = (v > 0) ? std::sqrt(v) : 1.0;
+        }
+      }
+      op_focei.etaRestartSamples.set_size(op_focei.neta, nres, nsubAll);
+      // One serial batch, so one seeding is enough -- nothing re-seeds the
+      // shared engine between the draws below (see nmMcmcRng.h).  The fit's
+      // own rxode2 seed keeps it reproducible.
+      setRxThreadId(0);
+      {
+        uint32_t s = getRxSeed1(1);
+        s = s * 2654435761u + 0x65746152u;   // "etaR" namespace tag
+        nmSetSeedEng1(s);
+      }
+      arma::vec z((arma::uword)op_focei.neta);
+      for (int id = 0; id < nsubAll; ++id) {
+        for (int k = 0; k < nres; ++k) {
+          for (int j = 0; j < op_focei.neta; ++j) z[j] = rxNormEng(0.0, 1.0);
+          arma::vec draw = L * z;
+          std::copy(draw.begin(), draw.end(),
+                    op_focei.etaRestartSamples.slice(id).colptr(k));
+        }
+      }
+      setRxThreadId(-1);
+    }
+  } else {
+    op_focei.etaRestartSamples.reset();
   }
   // freezeOde: evaluate each subject's density at its (restored) base EBE with a
   // single innerEval -- no eta re-optimization -- reusing the frozen ODE states.
@@ -8551,6 +8689,7 @@ NumericVector foceiSetup_(const RObject &obj,
   // are cleared here as well as in foceiOuter(), which the EM/nonparametric methods
   // never reach -- otherwise those fits would report the previous fit's counts.
   op_focei.mcetaSamples.reset();
+  op_focei.etaRestartSamples.reset();
   op_focei.nMcetaZero.store(0, std::memory_order_relaxed);
   op_focei.nMcetaSample.store(0, std::memory_order_relaxed);
   op_focei.nInnerRanked.store(0, std::memory_order_relaxed);
@@ -8998,6 +9137,8 @@ NumericVector foceiSetup_(const RObject &obj,
     op_focei.trustFterm = as<double>(foceiO["trustFterm"]);
     op_focei.trustMterm = as<double>(foceiO["trustMterm"]);
   }
+  op_focei.nEtaRestart = foceiO.containsElementNamed("etaRestart") ?
+    as<int>(foceiO["etaRestart"]) : 0;
   op_focei.nTrustInner.store(0, std::memory_order_relaxed);
   op_focei.nConditionalInnerHessian.store(0, std::memory_order_relaxed);
   op_focei.nTrustError.store(0, std::memory_order_relaxed);
@@ -9007,6 +9148,8 @@ NumericVector foceiSetup_(const RObject &obj,
   op_focei.nTrustRetry.store(0, std::memory_order_relaxed);
   op_focei.nTrustWarm.store(0, std::memory_order_relaxed);
   op_focei.nTrustNudge.store(0, std::memory_order_relaxed);
+  op_focei.nTrustRestart.store(0, std::memory_order_relaxed);
+  op_focei.nEtaRestartRun.store(0, std::memory_order_relaxed);
   op_focei.nTrustFail.store(0, std::memory_order_relaxed);
   op_focei.nHessianQN.store(0, std::memory_order_relaxed);
   op_focei.nsim=as<int>(foceiO["n1qn1nsim"]);
@@ -12782,6 +12925,13 @@ void foceiFinalizeTables(Environment e){
         // ... and solves where a failed attempt WAS dropped because a
         // succeeded one was available.
         _["dropped"] = op_focei.nInnerDropped.load(std::memory_order_relaxed));
+      // Omega-draw restarts the n1qn1 arm's nudge cascade took once every fixed
+      // nudge was spent and the ETA still had not moved (the trust arm reports
+      // its own as nTrustInner[["omegaRestart"]]).
+      if (op_focei.innerOpt != 3) {
+        e["nEtaRestartRun"] = IntegerVector::create(
+          op_focei.nEtaRestartRun.load(std::memory_order_relaxed));
+      }
       e["nConditionalInnerHessian"] = op_focei.nConditionalInnerHessian.load(std::memory_order_relaxed);
       if (op_focei.innerOpt == 3) {
         // innerOpt="trust" outcomes.  "calls" is what .nTrustInner() reports;
@@ -12802,6 +12952,8 @@ void foceiFinalizeTables(Environment e){
           _["warmRetry"] = op_focei.nTrustWarm.load(std::memory_order_relaxed),
           _["radiusRetry"] = op_focei.nTrustRetry.load(std::memory_order_relaxed),
           _["nudge"] = op_focei.nTrustNudge.load(std::memory_order_relaxed),
+          // Omega-draw restarts taken after the fixed nudges were spent.
+          _["omegaRestart"] = op_focei.nTrustRestart.load(std::memory_order_relaxed),
           // Subjects whose whole cascade -- first solve, radius escalation and
           // all four nudges -- ended without a converged attempt.
           _["failed"] = op_focei.nTrustFail.load(std::memory_order_relaxed));

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -9113,6 +9113,11 @@ NumericVector foceiSetup_(const RObject &obj,
   // every LATER consumer in the fit gets, and when no rxode2 seed is in force
   // it draws the value from R's own RNG.  Either one would make a fit that
   // takes no restart at all differ from the same fit with etaRestart=0.
+  // The 42u floor is defensive, not a policy: a fit cannot actually reach here
+  // with seed=NULL, because .foceiFitInternal() wraps the run in
+  // rxode2::rxWithSeed(), which rejects a NULL seed outright ("'seed' must be
+  // an integer of length 1").  It covers the entry points that reach
+  // foceiSetup_ without that wrapper.
   {
     SEXP _seedS = foceiO.containsElementNamed("seed") ? (SEXP)foceiO["seed"] : R_NilValue;
     op_focei.etaRestartSeed = 42u;

--- a/src/inner.cpp
+++ b/src/inner.cpp
@@ -622,8 +622,6 @@ struct focei_options {
   double trustMterm;
   std::atomic<int> nTrustInner{0}; // per-fit count of trust_solve_c calls (test evidence)
   std::atomic<int> nTrustRestart{0}; // Omega-draw restarts taken after the nudges
-  // Same, for the n1qn1 arm's nudge cascade (reported as $env$nEtaRestartRun).
-  std::atomic<int> nEtaRestartRun{0};
   // innerOpt="trust" per-fit OUTCOME counts (#1044).  nTrustInner counts CALLS,
   // so a fit whose inner solves all converged and one where every one of them
   // failed look identical from the fit object; these separate the two.
@@ -4591,71 +4589,6 @@ static inline int innerOpt1(int id, int likId) {
                 std::fill_n(&fInd->var[0], fop->neta, 0.1);
               }
             }
-          }
-        }
-        // Every fixed nudge is spent and the optimizer STILL has not moved this
-        // subject's ETA off the restart it was handed -- the n1qn1 arm's own
-        // definition of a failed inner solve.  The nudges all set every ETA to
-        // the same constant; a draw out of Omega is a starting point from the
-        // distribution the ETAs actually come from (#1044).  Only reached once
-        // the whole nudge cascade has failed, so a healthy fit never pays for
-        // it.  Unlike the nudge levels above, each restart is handed a FRESH
-        // iteration/simulation budget: n1qn1_ takes these by pointer and writes
-        // back what it used, so a restart inheriting a spent budget cannot
-        // optimize anything.
-        if (tryAgain && op_focei.nEtaRestart > 0 &&
-            (arma::uword)id < op_focei.etaRestartSamples.n_slices &&
-            op_focei.etaRestartSamples.n_rows == (arma::uword)fop->neta) {
-          int nres = (int)op_focei.etaRestartSamples.n_cols;
-          // A draw that comes back NA with nothing kept in THIS pass has to
-          // take the pass-level exit the nudge levels above take -- and those
-          // are not inside a loop of their own, so their break/continue bind
-          // to the starting-point loop.  Here they would bind to this draw
-          // loop instead, so the exit is deferred to after it.
-          bool _restartNa = false;
-          for (int _k = 0; _k < nres && tryAgain; _k++) {
-            const double *_start = op_focei.etaRestartSamples.slice(id).colptr(_k);
-            fInd->mode = 1;
-            fInd->uzm = 1;
-            op_focei.didHessianReset.store(1, std::memory_order_relaxed);
-            // mode=1 unconditionally (the nudge levels above only force it
-            // under warm=1): a draw is an unrelated point, so the previous
-            // attempt's quasi-Newton Hessian does not describe it -- the same
-            // reason the trust arm clears fInd->etaHasPrevQN per attempt.
-            mode = 1;
-            maxInnerIterations = fop->maxInnerIterations;
-            nsim = fop->nsim;
-            imp = fop->imp;
-            std::copy(_start, _start + fop->neta, fInd->x);
-            op_focei.nEtaRestartRun.fetch_add(1, std::memory_order_relaxed);
-            fInd->badSolve = 0;
-            n1qn1_(innerCost, &npar, fInd->x, &f, fInd->g,
-                   fInd->var, &epsilon,
-                   &mode, &maxInnerIterations, &nsim,
-                   &imp, fInd->zm, &izs, &rzs, &dzs, &id);
-            if (ISNA(f)) {
-              if (!haveBest) { _restartNa = true; break; }
-              // This draw produced nothing, which says nothing about whether
-              // the optimizer can move -- so go to the next draw rather than
-              // letting the moved-off-the-restart test below read the restored
-              // best (which never equals the draw) as "it moved" and end the
-              // cascade.  The fixed nudge levels above have that same quirk;
-              // they are left as they are.
-              restoreBest();
-              std::fill_n(&fInd->var[0], fop->neta, 0.1);
-              continue;
-            }
-            keepBest(); keepCand(fInd->badSolve == 0);
-            tryAgain = true;
-            for (int i = fop->neta; i--;) {
-              if (fInd->x[i] != _start[i]) { tryAgain = false; break; }
-            }
-            std::fill_n(&fInd->var[0], fop->neta, 0.1);
-          }
-          if (_restartNa) {
-            if (!candEta.empty()) break;
-            if (_lastStart) return 0;
-            continue;
           }
         }
       }
@@ -9198,7 +9131,6 @@ NumericVector foceiSetup_(const RObject &obj,
   op_focei.nTrustWarm.store(0, std::memory_order_relaxed);
   op_focei.nTrustNudge.store(0, std::memory_order_relaxed);
   op_focei.nTrustRestart.store(0, std::memory_order_relaxed);
-  op_focei.nEtaRestartRun.store(0, std::memory_order_relaxed);
   op_focei.nTrustFail.store(0, std::memory_order_relaxed);
   op_focei.nHessianQN.store(0, std::memory_order_relaxed);
   op_focei.nsim=as<int>(foceiO["n1qn1nsim"]);
@@ -12974,13 +12906,6 @@ void foceiFinalizeTables(Environment e){
         // ... and solves where a failed attempt WAS dropped because a
         // succeeded one was available.
         _["dropped"] = op_focei.nInnerDropped.load(std::memory_order_relaxed));
-      // Omega-draw restarts the n1qn1 arm's nudge cascade took once every fixed
-      // nudge was spent and the ETA still had not moved (the trust arm reports
-      // its own as nTrustInner[["omegaRestart"]]).
-      if (op_focei.innerOpt != 3) {
-        e["nEtaRestartRun"] = IntegerVector::create(
-          op_focei.nEtaRestartRun.load(std::memory_order_relaxed));
-      }
       e["nConditionalInnerHessian"] = op_focei.nConditionalInnerHessian.load(std::memory_order_relaxed);
       if (op_focei.innerOpt == 3) {
         // innerOpt="trust" outcomes.  "calls" is what .nTrustInner() reports;

--- a/tests/testthat/test-focei-trust-inner.R
+++ b/tests/testthat/test-focei-trust-inner.R
@@ -506,6 +506,31 @@ nmTest({
     expect_equal(.gateFit(3, 4L)$objf, .on$objf)
   })
 
+  test_that("the Omega restart draws are keyed on foceiControl(seed=) (#1044)", {
+    skip_on_cran()
+    # The draws must come from the fit's own seed, not from rxode2's
+    # getRxSeed1(): that call ADVANCES rxode2's global rxSeed by its argument
+    # (rxode2 src/seed.cpp), so reading it would shift the seed every later
+    # consumer in the fit gets -- and with no rxode2 seed in force it takes the
+    # value from R's own RNG.  Either would make a fit that never restarts
+    # anything differ from the same fit with the fallback off.  Two seeds have
+    # to give two different sets of draws, and one seed the same set twice.
+    .dat <- .gateData()
+    .fit <- function(seed) {
+      suppressWarnings(suppressMessages(
+        nlmixr2(.gateMod(3), .dat, "focei",
+                foceiControl(print = 0L, covMethod = "", maxOuterIterations = 0L,
+                             maxInnerIterations = 5000L, calcTables = FALSE,
+                             etaRestart = 4L, seed = seed, innerOpt = "trust"))))
+    }
+    .a <- .fit(42L)
+    .b <- .fit(7L)
+    expect_gt(.a$env$nTrustInner[["omegaRestart"]], 0L)
+    expect_gt(.b$env$nTrustInner[["omegaRestart"]], 0L)
+    expect_false(isTRUE(all.equal(.a$objf, .b$objf)))
+    expect_equal(.fit(42L)$objf, .a$objf)
+  })
+
   test_that("the Omega-draw fallback costs a converging fit nothing (#1044)", {
     skip_on_cran()
     # It is only reached after an inner solve has already failed, so a fit whose

--- a/tests/testthat/test-focei-trust-inner.R
+++ b/tests/testthat/test-focei-trust-inner.R
@@ -549,10 +549,8 @@ nmTest({
     expect_equal(as.data.frame(.on$eta), as.data.frame(.off$eta),
                  tolerance = 1e-10)
 
-    # The n1qn1 arm reports its own fallback count, and trust does not (its
-    # count rides with the rest of the trust outcomes instead).
-    .n1 <- .mk(4L, "n1qn1")
-    expect_equal(.n1$env$nEtaRestartRun, 0L)
-    expect_null(.on$env$nEtaRestartRun)
+    # n1qn1 has no convergence verdict per solve, so the fallback does not
+    # reach its cascade at all: the control changes nothing there.
+    expect_equal(.mk(4L, "n1qn1")$objf, .mk(0L, "n1qn1")$objf, tolerance = 1e-10)
   })
 })

--- a/tests/testthat/test-focei-trust-inner.R
+++ b/tests/testthat/test-focei-trust-inner.R
@@ -44,6 +44,15 @@ nmTest({
     expect_error(foceiControl(trustFterm = -1))
     expect_error(foceiControl(trustMterm = -1))
 
+    # etaRestart: Omega draws the inner restart cascade falls back on once the
+    # fixed nudges are spent (#1044).  0 disables it; a negative count is not a
+    # count.
+    expect_equal(foceiControl()$etaRestart, 4L)
+    expect_equal(foceiControl(etaRestart = 0)$etaRestart, 0L)
+    expect_equal(foceiControl(etaRestart = 2L)$etaRestart, 2L)
+    expect_error(foceiControl(etaRestart = -1))
+    expect_error(foceiControl(etaRestart = c(1, 2)))
+
     .ctl <- foceiControl(innerOpt = "trust", trustConf = 0.9,
                          trustFterm = 0.5, trustMterm = 0.25)
     expect_equal(do.call(foceiControl, .ctl)$innerOpt, 3L)
@@ -222,7 +231,7 @@ nmTest({
     expect_equal(sort(names(.cnt)),
                  sort(c("calls", "error", "notConverged", "solverFail",
                         "newtonGate", "warmRetry", "radiusRetry", "nudge",
-                        "failed")))
+                        "omegaRestart", "failed")))
     expect_gt(.cnt[["calls"]], 0L)
     # This fit converges cleanly, so nothing below "calls" fires.  That is the
     # half of the diagnostic that has to stay quiet or it says nothing.
@@ -439,5 +448,86 @@ nmTest({
 
     expect_equal(.f2$objf, .f1$objf, tolerance = 1e-8)
     expect_equal(as.data.frame(.f1$eta), as.data.frame(.f2$eta), tolerance = 1e-8)
+  })
+  test_that("a fit with failed inner solves says so in $runInfo (#1044)", {
+    skip_on_cran()
+    # The outcome counters are on $env, which nothing reads unprompted, so a
+    # fit whose inner solves failed still looked -- to anyone holding the fit
+    # -- exactly like one where they all converged.  $runInfo is where a
+    # run-time note actually reaches.
+    .bad <- suppressWarnings(suppressMessages(
+      nlmixr2(.oneCmt, nlmixr2data::theo_sd, est = "focei",
+              control = foceiControl(innerOpt = "trust", maxOuterIterations = 5,
+                                     maxInnerIterations = 2, covMethod = "",
+                                     calcTables = FALSE, print = 0))))
+    expect_gt(.bad$env$nTrustInner[["failed"]], 0L)
+    expect_gt(.bad$env$nInnerRerank[["noGood"]], 0L)
+    expect_true(any(grepl("inner solves spent every retry", .bad$runInfo)))
+    expect_true(any(grepl("come from a failed inner solve", .bad$runInfo)))
+
+    # ... and a fit whose inner solves converge stays quiet, or the note says
+    # nothing.
+    .ok <- .fitTrustCmp("trust")
+    expect_equal(.ok$env$nTrustInner[["failed"]], 0L)
+    expect_false(any(grepl("inner solve", .ok$runInfo)))
+  })
+
+  test_that("the inner cascade falls back on Omega draws (#1044)", {
+    skip_on_cran()
+    # Each etaNudge/etaNudge2 restart sets EVERY eta to the same constant, which
+    # explores poorly once the inner problem has more than one basin -- the
+    # regime #1044's model is in.  A draw out of Omega is a starting point from
+    # the distribution the etas actually come from.
+    .dat <- .gateData()
+    .gateFit <- function(d, etaRestart, inner = "trust") {
+      suppressWarnings(suppressMessages(
+        nlmixr2(.gateMod(d), .dat, "focei",
+                foceiControl(print = 0L, covMethod = "", maxOuterIterations = 0L,
+                             maxInnerIterations = 5000L, calcTables = FALSE,
+                             etaRestart = etaRestart, innerOpt = inner))))
+    }
+
+    .off <- .gateFit(3, 0L)
+    .on <- .gateFit(3, 4L)
+    # The counter is the evidence the fallback RAN; the objective alone cannot
+    # tell "the draws rescued these subjects" from "there was nothing to
+    # rescue".
+    expect_equal(.off$env$nTrustInner[["omegaRestart"]], 0L)
+    expect_gt(.on$env$nTrustInner[["omegaRestart"]], 0L)
+    # ... and it has to actually help: fewer subjects end with every attempt
+    # spent, and the objective cannot come out worse (every restart is a
+    # candidate, never a replacement).
+    expect_lt(.on$env$nTrustInner[["failed"]],
+              .off$env$nTrustInner[["failed"]])
+    expect_lte(.on$objf, .off$objf)
+
+    # Drawn once per fit from rxode2's seeded engine, so the same fit twice is
+    # the same number -- the objective stays a function of theta alone.
+    expect_equal(.gateFit(3, 4L)$objf, .on$objf)
+  })
+
+  test_that("the Omega-draw fallback costs a converging fit nothing (#1044)", {
+    skip_on_cran()
+    # It is only reached after an inner solve has already failed, so a fit whose
+    # inner solves converge must be bit-identical with it on and off.
+    .mk <- function(etaRestart, inner) {
+      suppressWarnings(suppressMessages(
+        nlmixr2(.oneCmt, nlmixr2data::theo_sd, est = "focei",
+                control = foceiControl(innerOpt = inner, maxOuterIterations = 20,
+                                       etaRestart = etaRestart, covMethod = "",
+                                       calcTables = FALSE, print = 0))))
+    }
+    .off <- .mk(0L, "trust")
+    .on <- .mk(4L, "trust")
+    expect_equal(.on$env$nTrustInner[["omegaRestart"]], 0L)
+    expect_equal(.on$objf, .off$objf, tolerance = 1e-10)
+    expect_equal(as.data.frame(.on$eta), as.data.frame(.off$eta),
+                 tolerance = 1e-10)
+
+    # The n1qn1 arm reports its own fallback count, and trust does not (its
+    # count rides with the rest of the trust outcomes instead).
+    .n1 <- .mk(4L, "n1qn1")
+    expect_equal(.n1$env$nEtaRestartRun, 0L)
+    expect_null(.on$env$nEtaRestartRun)
   })
 })

--- a/tests/testthat/test-focei-trust-inner.R
+++ b/tests/testthat/test-focei-trust-inner.R
@@ -449,12 +449,12 @@ nmTest({
     expect_equal(.f2$objf, .f1$objf, tolerance = 1e-8)
     expect_equal(as.data.frame(.f1$eta), as.data.frame(.f2$eta), tolerance = 1e-8)
   })
-  test_that("a fit with failed inner solves says so in $runInfo (#1044)", {
+  test_that("failed inner solves are reported on $env, NOT in $runInfo (#1044)", {
     skip_on_cran()
-    # The outcome counters are on $env, which nothing reads unprompted, so a
-    # fit whose inner solves failed still looked -- to anyone holding the fit
-    # -- exactly like one where they all converged.  $runInfo is where a
-    # run-time note actually reaches.
+    # Some inner solves failing is ordinary for a nonlinear mixed-effects fit,
+    # so this is NOT a run-time note: a $runInfo entry would fire on most fits
+    # and say nothing.  The counts belong on $env, where whoever is actually
+    # diagnosing a fit can read them.
     .bad <- suppressWarnings(suppressMessages(
       nlmixr2(.oneCmt, nlmixr2data::theo_sd, est = "focei",
               control = foceiControl(innerOpt = "trust", maxOuterIterations = 5,
@@ -462,14 +462,8 @@ nmTest({
                                      calcTables = FALSE, print = 0))))
     expect_gt(.bad$env$nTrustInner[["failed"]], 0L)
     expect_gt(.bad$env$nInnerRerank[["noGood"]], 0L)
-    expect_true(any(grepl("inner solves spent every retry", .bad$runInfo)))
-    expect_true(any(grepl("come from a failed inner solve", .bad$runInfo)))
-
-    # ... and a fit whose inner solves converge stays quiet, or the note says
-    # nothing.
-    .ok <- .fitTrustCmp("trust")
-    expect_equal(.ok$env$nTrustInner[["failed"]], 0L)
-    expect_false(any(grepl("inner solve", .ok$runInfo)))
+    # ... and none of that reaches $runInfo, on the fit that HAS failures.
+    expect_false(any(grepl("inner solve", .bad$runInfo)))
   })
 
   test_that("the inner cascade falls back on Omega draws (#1044)", {


### PR DESCRIPTION
Closes nlmixr2/nlmixr2est#1044.

nlmixr2/nlmixr2est#1044 has two halves.  The diagnostic half -- "nothing in the fit says so" --
was built in nlmixr2/nlmixr2est#1046, but that PR was merged into the `trust` branch rather than
`main`, so GitHub never closed the issue; every one of its commits is in `main`
today (`efdf17866`).  This PR finishes the other half: it answers the issue's
question with a measurement, corrects the issue's own hypothesis, and fixes the
failures that remain.

## The measured answer: the solves converge, the basins differ

nlmixr2/nlmixr2est#1044 reads the set B table as "those inner solves are failing at that
parameter set, and only enough random restarts get away from it."  The outcome
counters say otherwise.

Reproducer: the nlmixr2/nlmixr2est#1040 model (300 subjects, two ETAs with a FIXED unit omega
entering through an inverse CDF alongside an estimated block),
`maxOuterIterations = 0`, `maxInnerIterations = 5000`, `covMethod = ""`, every
theta displaced by `d`.  `d = 1` reproduces set B's shape -- `mceta = -2` sits
thousands of units above `mceta = 100` on the same parameters.

At `d = 1`, `innerOpt = "trust"`: 24 of 300 attempts trip the Newton-decrement
retry gate and **1** subject of 300 ends with the whole cascade spent.  The
solves converge.  What moves the objective is which local minimum they converge
to:

| mceta | -2 | 2 | 5 | 10 | 30 | 100 |
|---|---|---|---|---|---|---|
| trust | 3032.99 | 2147.53 | 1087.94 | 884.90 | 239.21 | 150.99 |

Cross-starting the two inner optimizers at `d = 2` shows both are at genuine
local minima, and that `trust` is the better *local* optimizer of the two:

| start | n1qn1 | trust |
|---|---|---|
| eta = 0 | 34004.40 | 35097.21 |
| n1qn1's converged etas | 34004.40 | **33583.37** |
| trust's converged etas | 35054.08 | 35097.34 |

`trust` started at n1qn1's answer beats n1qn1's own answer; n1qn1 started at
trust's answer stays at trust's answer.  Neither is failing to solve -- the
inner problem at a displaced parameter set has several basins, and `eta = 0`
leads into a poor one.  That is a real finding about the objective the outer
optimizer differentiates, and it is not what the issue guessed.

### Four candidate causes, measured and rejected

- **The Newton-decrement gate is miscalibrated.**  No.  Removing it is much
  worse (`d = 3`: 1175178 against 434743; `d = 4`: 4.56e9 against 1.38e8).
  Replacing the scaled step-length test with the Newton decrement in objective
  units (`-0.5 g'H^-1 g > mterm`) is marginally better in objective and costs
  ~1.7x the solves and 2-3x the failed subjects.  The current gate stays.
- **The in-place re-solve should iterate.**  No.  Looping it while the
  objective falls terminates immediately -- the re-solve makes no progress
  (`d = 3`, `mceta = 0`: 434742.5469 -> 434742.5453).
- **A radius/tolerance knob.**  No.  `trustRmax = 10`/`30`, `trustConf =
  0.9999`, `trustFterm = trustMterm = 1e-10` all leave `d = 3` between 322258
  and 1324859 against the default's 434743.
- **A converged eta that is implausible under Omega is the signal to retry
  from.**  No, and backwards: at `d = 1`, 290 of 300 converged etas are already
  outside the `trustConf`-level Omega ellipsoid, and the BETTER basin
  (`mceta = 100`) is further outside still -- median Mahalanobis 36 against 13.
  A rule gated on that would fire on 97% of subjects and point the wrong way.

## What this PR changes

### Where the failures are reported: `$env`, not `$runInfo`

The per-outcome counts stay on the fit environment -- `fit$env$nTrustInner`
(`calls`, `error`, `notConverged`, `solverFail`, `newtonGate`, `warmRetry`,
`radiusRetry`, `nudge`, `omegaRestart`, `failed`) and
`fit$env$nInnerRerank` (`ranked`, `flipped`, `noGood`, `dropped`).
`omegaRestart` is new here; the rest came with nlmixr2/nlmixr2est#1046.

An earlier revision of this PR also raised two `$runInfo` notes when the counts
were nonzero.  **That was wrong and has been removed**: some inner solves
failing is ordinary for a nonlinear mixed-effects fit, so a run-time note would
fire on most fits and carry no information -- it would train people to ignore
`$runInfo`.  A test now asserts the counts are on `$env` AND that nothing about
inner solves reaches `$runInfo`, including on a fit that does have failures.

Surfacing them readably is a separate job, filed as nlmixr2/nlmixr2extra#130 (a diagnostic report
covering the inner-solve outcomes and the other per-fit counters already on
`$env`) rather than a run-time warning.

### The restart cascade falls back on draws from Omega

Every `etaNudge`/`etaNudge2` restart sets EVERY eta to the same constant.  That
is a poor exploration set once the inner problem has more than one basin, which
is exactly the regime above.  `foceiControl(etaRestart=)` (4 by default, 0 to
disable) adds a bounded set of draws from Omega -- the distribution the etas
actually come from -- as the last stage of the cascade.

Measured on the same model, `innerOpt = "trust"`, `mceta = -2`:

| case | subjects spent / 300 | Omega restarts | objective |
|---|---|---|---|
| `d = 1` `etaRestart = 0` | 0 | 0 | 6848.3621 |
| `d = 1` `etaRestart = 4` | 0 | 0 | 6848.3621 |
| `d = 2` `etaRestart = 0` | 13 | 0 | 40791.1358 |
| `d = 2` `etaRestart = 4` | **1** | 33 | 40791.1266 |
| `d = 3` `etaRestart = 0` | 45 | 0 | 687873.59 |
| `d = 3` `etaRestart = 4` | **25** | 147 | **139102.54** |

n1qn1 on the same parameter sets, for scale: 39658.76 at `d = 2` and 194233.56
at `d = 3` -- so at `d = 3` the fallback takes `trust` from 3.5x n1qn1's
objective to below it.  With `mceta = 10` at `d = 2` the spent count goes from
25 to 11 and the objective from 40609.6496 to 40609.6402.

Both inner arms use the draws, each on its own definition of a failed solve:
trust's non-convergence verdict, and n1qn1's "the optimizer never moved off the
restart it was handed" (the only failure signal n1qn1_ exposes).

**It costs a converging fit nothing.**  The stage is reached only after a solve
has already failed, so at `d = 1` -- where nothing fails -- the objective, the
call count and the etas are bit-identical with it on and off.  That is asserted
rather than argued.  The `theo_sd` fits take zero draws.

**Drawn once per fit, from rxode2's seeded threefry engine.**  Redrawing per
evaluation would make the objective a different random function every time the
outer optimizer looked at it (#1040).  The draws deliberately do NOT go through
`.sampleOmega`/`rxRmvn` like the mceta cube does: that consumes R's own RNG, so
making these draws unconditional through it would shift every later R-level
draw in the fit (the residual simulations behind npde, for one) on a fit that
never restarts anything.

## Not changed here

The basin gap itself.  On this model `mceta` is the mechanism that explores it
and it works (150.99 at `mceta = 100` against 3032.99 at the `mceta = -2`
default), so the remaining question is whether the default should offer more
than one starting point -- a behavior change for every FOCEi fit, worth its own
issue rather than a silent flip in a bug-fix PR.

## Verification

- `git diff origin/main` is numerically inert where nothing fails: built both
  trees into separate libraries and the healthy `d = 1` fits agree to the last
  digit under either.
- `test-focei-trust-inner.R` gains the control round trip, the `$env` counts on
  a fit with failures together with their ABSENCE from `$runInfo`, the
  fallback's counter and its effect on the failed count and the objective,
  same-seed reproducibility, and the zero-cost assertion.
- Twelve targeted test files pass with zero failures: `focei-trust-inner`,
  `focei-mceta-1040`, `focei-mceta-empty-cube`, `focei-outer-trust`, `trust`,
  `focei-inner`, `focei-1`, `focei-eta-reset-path-dependence`,
  `focei-hessian-etastep`, `focei-inner-conditional`, `focei-full-inner`,
  `focei-bobyqa-retry`.

## Review

Four `agy` (Gemini) rounds, each triaged against the code rather than relayed:

- **Round 1, three findings.**  One real as stated (an NA draw in the n1qn1 loop
  read the restored best as "the optimizer moved" and ended the cascade).  One
  whose stated mechanism was wrong -- it read `getRxSeed1`'s `int` argument as a
  thread id; it is `ncores` -- but which pointed at a **worse** real bug:
  `getRxSeed1()` is not a getter.  rxode2's `src/seed.cpp` does `rxSeed +=
  ncores` on every call, and with no rxode2 seed in force it takes the value
  from R's own RNG.  Seeding the draws from it shifted the seed every later
  consumer in the fit receives, which is exactly the hazard this feature is
  supposed to avoid; it stayed invisible on the measured model only because a
  deterministic FOCEi solve never reads `rxSeed`.  The base is now
  `foceiControl(seed=)`.  One rejected: the claim that the draw batch shifts the
  main thread's stream enough to move a converging fit -- every rxode2 solve
  reseeds the engine per subject on entry, so the state entering a solve is not
  read (and `setSeedEng1` now replaces `nmSetSeedEng1`, so a live sampling
  block's recorded seed is not clobbered either).
- **Round 2, one finding**: the n1qn1 copy of the fallback had no test showing it
  runs.  Correct, and chasing it showed it cannot run -- see the table above.
  The branch is gone.
- **Round 3, one finding**, rejected by measurement: it read the `seed=NULL`
  fallback as a silent behavior change, quoting a `foceiControl()` guarantee
  ("if `NULL`, the R seed is used") that is not in the documentation -- the real
  `@param seed` promises the opposite.  And the scenario cannot occur: a FOCEi
  fit with `seed=NULL` errors before any inner solve, because
  `.foceiFitInternal()` wraps the run in `rxode2::rxWithSeed()`, which rejects a
  NULL seed.  Unchanged from `main`.  The code now records that.
- **Round 4**: clean.  No findings, having read the Cholesky fallback, the bounds
  guards, the serial-fill/parallel-read split, the `!converged` gate and the
  new tests.

`habit-hooks --branch main` reports only pre-existing whole-file smells
(cyclomatic complexity across `src/inner.cpp`'s existing functions, the
oversized-file threshold on a 23k-line file, and an ESLint parse error on a C++
header); the two sites it names in this diff, the `trustSolveAt` lambda and
`innerOpt()`, are flagged on `main` too.

